### PR TITLE
Improve Jackson dependency declaration

### DIFF
--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -93,7 +93,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <!-- TEST -->

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -121,7 +121,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -112,7 +112,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/csv/pom.xml
+++ b/extensions/csv/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-csv</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/extensions/hadoop-dist/pom.xml
+++ b/extensions/hadoop-dist/pom.xml
@@ -93,31 +93,6 @@
         </plugins>
     </build>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jaxb-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
@@ -146,7 +121,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/hadoop/pom.xml
+++ b/extensions/hadoop/pom.xml
@@ -94,7 +94,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-csv</artifactId>
-            <version>${jackson.version}</version>
             <scope>provided</scope> <!-- part of hazelcast-jet-csv, which user needs to have on CP -->
         </dependency>
 

--- a/extensions/kinesis/pom.xml
+++ b/extensions/kinesis/pom.xml
@@ -70,7 +70,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <!-- TEST -->

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -580,13 +580,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -466,18 +466,15 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jr</groupId>
             <artifactId>jackson-jr-objects</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jr</groupId>
             <artifactId>jackson-jr-annotation-support</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.snakeyaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,8 @@
         <guava.version>30.1.1-jre</guava.version>
         <hadoop.version>3.3.4</hadoop.version>
         <h2.version>2.1.214</h2.version>
-        <jackson.version>2.13.4</jackson.version>
+        <!-- The Jackson version must match the version in EE, if you change this you must send EE PR as well -->
+        <jackson.version>2.13.4.20221013</jackson.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jline.version>3.21.0</jline.version>
         <jms.api.version>2.0.1</jms.api.version>


### PR DESCRIPTION
Jackson sometimes releases micro-patch for a CVE, e.g. 2.13.4.2.

This version is not available for all Jackson modules, only for the affected module. The bom with this version is published in format x.y.z.YYYYMMDD.

We import Jackson bom in root pom.xml, but we use ${jackson.version} property in some modules. This means we can't use single version property when we need to use such bom.

This PR changes remove all uses of ${jackson.version} property apart from the bom import. All Jackson dependency declarations are without version, using the version imported by bom in the root pom.xml.

Users declaring a dependency on a module also correctly get the version from the bom, e.g. project declaring a dependency on `hazelcast-jet-cdc-debezium`, which has a dependency on jackson-annotations has the following in its dependencies:

```
[INFO]    \- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.4:compile
```

The version is taken from the bom.

Addresses CVEs from #22407 in direct and transitive dependencies, where Jackson isn't shaded by the 3rd party.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

Backports to 5.0, 5.1, 5.2.