### PR TITLE
Remove EE tests artifact from compatibility tests [HZ-1675]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
@@ -43,7 +43,6 @@ public class HazelcastVersionLocator {
         OS_TEST_JAR("/com/hazelcast/hazelcast/%1$s/hazelcast-%1$s-tests.jar", false, true, "hazelcast"),
         SQL_JAR("/com/hazelcast/hazelcast-sql/%1$s/hazelcast-sql-%1$s.jar", false, false, "hazelcast-sql"),
         EE_JAR("/com/hazelcast/hazelcast-enterprise/%1$s/hazelcast-enterprise-%1$s.jar", true, false, "hazelcast-enterprise"),
-        EE_TEST_JAR("/com/hazelcast/hazelcast-enterprise/%1$s/hazelcast-enterprise-%1$s-tests.jar", true, true, "hazelcast-enterprise"),
         ;
         private final String path;
         private final boolean enterprise;
@@ -79,7 +78,6 @@ public class HazelcastVersionLocator {
         }
         if (enterprise) {
             files.put(Artifact.EE_JAR, locateArtifact(Artifact.EE_JAR, version, target));
-            files.put(Artifact.EE_TEST_JAR, locateArtifact(Artifact.EE_TEST_JAR, version, target));
         }
         return files;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
@@ -34,7 +34,6 @@ import java.util.Map;
 
 import static com.google.common.io.Files.toByteArray;
 import static com.hazelcast.test.starter.HazelcastVersionLocator.Artifact.EE_JAR;
-import static com.hazelcast.test.starter.HazelcastVersionLocator.Artifact.EE_TEST_JAR;
 import static com.hazelcast.test.starter.HazelcastVersionLocator.Artifact.OS_JAR;
 import static com.hazelcast.test.starter.HazelcastVersionLocator.Artifact.OS_TEST_JAR;
 import static org.junit.Assert.assertEquals;
@@ -57,8 +56,6 @@ public class HazelcastVersionLocatorTest {
         assertHash(files.get(OS_TEST_JAR), "220509ece9fc152525c91ba7c75ce600", "OS tests");
 
         assertHash(files.get(EE_JAR), "765816e628ca4ca57d5bd7387e761eaa", "EE");
-
-        assertHash(files.get(EE_TEST_JAR), "162bcb2412570845e6fd91ee61b54f94", "EE tests");
     }
 
     private void assertHash(File file, String expectedHash, String label) throws Exception {


### PR DESCRIPTION
EE tests artifact is not published since 5.2.0 so it cannot be included in compatibility tests classpath.