### PR TITLE
Fix incorrect IMPOSE_ORDER usage checking [HZ-1150]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
@@ -757,13 +757,8 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
         }
 
         WatermarkKeysAssigner wmKeysAssigner = new WatermarkKeysAssigner(physicalRel);
-        // we should assign watermark keys also for bounded jobs, but due to the
-        // issue in key assigner we only do it for unbounded
-        // See https://github.com/hazelcast/hazelcast/issues/21984
-        if (OptUtils.isUnbounded(physicalRel)) {
-            wmKeysAssigner.assignWatermarkKeys();
-            logger.finest("Watermark keys assigned");
-        }
+        wmKeysAssigner.assignWatermarkKeys();
+        logger.finest("Watermark keys assigned");
 
         CreateDagVisitor visitor = new CreateDagVisitor(nodeEngine, parameterMetadata, wmKeysAssigner, usedViews);
         physicalRel.accept(visitor);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
@@ -786,7 +786,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
         private final RelNode rootRel;
         private String message;
 
-        public ExecutionStopperFinder(RelNode rootRel) {
+        ExecutionStopperFinder(RelNode rootRel) {
             this.rootRel = rootRel;
         }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -256,6 +256,10 @@ public interface SqlConnector {
      * }</pre>
      * Then the projection will be {@code {1}} and the predicate will be {@code
      * {2}=10}.
+     * <p>
+     * If the implementation cannot generate watermarks, it should throw, if the
+     * {@code eventTimePolicyProvider} is not null. Streaming sources should
+     * support it, batch sources don't have to.
      *
      * @param table                   the table object
      * @param predicate               SQL expression to filter the rows

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -29,6 +29,7 @@ import com.hazelcast.jet.sql.impl.schema.HazelcastTable;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.JetSqlRow;
@@ -275,7 +276,6 @@ public class JdbcSqlConnector implements SqlConnector {
         }
     }
 
-
     @Nonnull
     @Override
     public Vertex fullScanReader(
@@ -285,7 +285,12 @@ public class JdbcSqlConnector implements SqlConnector {
             @Nullable Expression<Boolean> predicate,
             @Nonnull List<Expression<?>> projection,
             @Nullable FunctionEx<ExpressionEvalContext,
-                    EventTimePolicy<JetSqlRow>> eventTimePolicyProvider) {
+                    EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
+    ) {
+        if (eventTimePolicyProvider != null) {
+            throw QueryException.error("Ordering functions are not supported on top of " + TYPE_NAME + " mappings");
+        }
+
         JdbcTable table = (JdbcTable) table0;
 
         SelectQueryBuilder builder = new SelectQueryBuilder(hzTable);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/WatermarkPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/WatermarkPhysicalRule.java
@@ -48,6 +48,6 @@ final class WatermarkPhysicalRule extends RelOptRule implements TransformationRu
                         rel.getCluster(),
                         toPhysicalConvention(rel.getTraitSet()),
                         rel.getRowType(),
-                        "Ordering function cannot be applied to input table"));
+                        "Multiple ordering functions are not supported"));
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/WatermarkPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/WatermarkPhysicalRule.java
@@ -48,6 +48,6 @@ final class WatermarkPhysicalRule extends RelOptRule implements TransformationRu
                         rel.getCluster(),
                         toPhysicalConvention(rel.getTraitSet()),
                         rel.getRowType(),
-                        "Multiple ordering functions are not supported"));
+                        "IMPOSE_ORDER call is not supported in this configuration"));
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/HazelcastSqlValidator.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/HazelcastSqlValidator.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.sql.impl.validate;
 
-import com.hazelcast.jet.sql.impl.aggregate.function.ImposeOrderFunction;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.jet.sql.impl.connector.virtual.ViewTable;
 import com.hazelcast.jet.sql.impl.parse.SqlCreateMapping;
@@ -53,7 +52,6 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlUpdate;
 import org.apache.calcite.sql.SqlUtil;
@@ -233,34 +231,6 @@ public class HazelcastSqlValidator extends SqlValidatorImplBridge {
         }
 
         super.addToSelectList(list, aliases, fieldList, exp, scope, includeSystemVars);
-    }
-
-    @Override
-    protected void validateFrom(SqlNode node, RelDataType targetRowType, SqlValidatorScope scope) {
-        super.validateFrom(node, targetRowType, scope);
-
-        if (countOrderingFunctions(node) > 1) {
-            throw newValidationError(node, RESOURCE.multipleOrderingFunctionsNotSupported());
-        }
-    }
-
-    private static int countOrderingFunctions(SqlNode node) {
-        class OrderingFunctionCounter extends SqlBasicVisitor<Void> {
-            int count;
-
-            @Override
-            public Void visit(SqlCall call) {
-                SqlOperator operator = call.getOperator();
-                if (operator instanceof ImposeOrderFunction) {
-                    count++;
-                }
-                return super.visit(call);
-            }
-        }
-
-        OrderingFunctionCounter counter = new OrderingFunctionCounter();
-        node.accept(counter);
-        return counter.count;
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/ValidatorResource.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/ValidatorResource.java
@@ -34,9 +34,6 @@ public interface ValidatorResource {
     @BaseMessage("Unknown argument name ''{0}''")
     ExInst<SqlValidatorException> unknownArgumentName(String name);
 
-    @BaseMessage("Multiple ordering functions are not supported")
-    ExInst<SqlValidatorException> multipleOrderingFunctionsNotSupported();
-
     @BaseMessage("You must specify single ordering column")
     ExInst<SqlValidatorException> mustUseSingleOrderingColumn();
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/SqlStreamToStreamJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/SqlStreamToStreamJoinTest.java
@@ -574,4 +574,22 @@ public class SqlStreamToStreamJoinTest extends SqlTestSupport {
                         "ON s1.a=s2.a",
                 singletonList(new Row(timestampTz(42L), timestampTz(42L))));
     }
+
+    @Test
+    public void test_joinWithUsingClause() {
+        TestStreamSqlConnector.create(
+                sqlService,
+                "stream1",
+                singletonList("a"),
+                singletonList(TIMESTAMP_WITH_TIME_ZONE),
+                row(timestampTz(42L)));
+
+        assertRowsEventuallyInAnyOrder(
+                "SELECT * FROM " +
+                        "(SELECT * FROM TABLE(IMPOSE_ORDER(TABLE stream1, DESCRIPTOR(a), INTERVAL '1' SECONDS))) s1 " +
+                        "INNER JOIN " +
+                        "(SELECT * FROM TABLE(IMPOSE_ORDER(TABLE stream1, DESCRIPTOR(a), INTERVAL '1' SECONDS))) s2 " +
+                        " USING(a)",
+                singletonList(new Row(timestampTz(42L))));
+    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/SqlStreamToStreamJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/SqlStreamToStreamJoinTest.java
@@ -556,4 +556,22 @@ public class SqlStreamToStreamJoinTest extends SqlTestSupport {
                 "SELECT * FROM s s1 JOIN s s2 ON s1.a=s2.a",
                 singletonList(new Row(timestampTz(42L), timestampTz(42L))));
     }
+
+    @Test
+    public void test_joinWithoutViews() {
+        TestStreamSqlConnector.create(
+                sqlService,
+                "stream1",
+                singletonList("a"),
+                singletonList(TIMESTAMP_WITH_TIME_ZONE),
+                row(timestampTz(42L)));
+
+        assertRowsEventuallyInAnyOrder(
+                "SELECT * FROM " +
+                        "(SELECT * FROM TABLE(IMPOSE_ORDER(TABLE stream1, DESCRIPTOR(a), INTERVAL '1' SECONDS))) s1 " +
+                        "INNER JOIN " +
+                        "(SELECT * FROM TABLE(IMPOSE_ORDER(TABLE stream1, DESCRIPTOR(a), INTERVAL '1' SECONDS))) s2 " +
+                        "ON s1.a=s2.a",
+                singletonList(new Row(timestampTz(42L), timestampTz(42L))));
+    }
 }


### PR DESCRIPTION
A correct, but unfinished checking for non-executable `IMPOSE_ORDER` usage was in already place, introduced with the conversion of unused `WatermarkPhysicalRule` to `MustNotExecutePhysicalRel`. This PR just turns off the incorrect check on the AST level, and adds earlier throwing of an exception by the new `ExecutionStopperFinder` visitor, which finds `ShouldNotExecuteRel` instances in the optimized plan to throw exceptions before the DAG construction phase. 