### PR TITLE
Add missing wan expiry for offload case

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/ContainsKeyOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/ContainsKeyOpSteps.java
@@ -29,6 +29,7 @@ public enum ContainsKeyOpSteps implements Step<State> {
         public void runStep(State state) {
             RecordStore recordStore = state.getRecordStore();
             Record record = recordStore.getRecordOrNull(state.getKey());
+
             if (record != null) {
                 state.setOldValue(record.getValue());
                 recordStore.accessRecord(state.getKey(), record, state.getNow());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/MergeOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/MergeOpSteps.java
@@ -175,18 +175,19 @@ public enum MergeOpSteps implements Step<State> {
                 if (oldValue == null && newValue != null
                         || oldValue != null && newValue != null) {
 
+                    SplitBrainMergeTypes.MapMergeTypes mergingEntry
+                            = (SplitBrainMergeTypes.MapMergeTypes) outcomes.get(i + 3);
                     // if same values, merge expiry and continue with next entry
-                    // TODO add expiry merge
                     if (recordStore.getValueComparator().isEqual(newValue, oldValue, serializationService)) {
                         Record record = recordStore.getRecord((Data) key);
-                        Object mergingEntry = outcomes.get(i + 3);
-                        recordStore.mergeRecordExpiration((Data) key, record,
-                                (SplitBrainMergeTypes.MapMergeTypes) mergingEntry, state.getNow());
+                        recordStore.mergeRecordExpiration((Data) key, record, mergingEntry, state.getNow());
                         continue;
                     }
 
                     // put or update
                     PutOpSteps.ON_STORE.runStep(perKeyState);
+                    Record record = recordStore.getRecord((Data) key);
+                    recordStore.mergeRecordExpiration((Data) key, record, mergingEntry, state.getNow());
                 } else if (oldValue != null && newValue == null) {
                     // remove
                     DeleteOpSteps.ON_DELETE.runStep(perKeyState);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
@@ -28,6 +28,8 @@ import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.impl.recordstore.StaticParams;
 
+import static com.hazelcast.map.impl.record.Record.UNSET;
+
 public enum PutOpSteps implements Step<State> {
 
     READ() {
@@ -171,7 +173,7 @@ public enum PutOpSteps implements Step<State> {
             if (record == null) {
                 record = recordStore.createRecord(state.getKey(), state.getNewValue(), state.getNow());
                 recordStore.putMemory(record, state.getKey(), state.getOldValue(),
-                        state.getTtl(), state.getMaxIdle(), state.getExpiryTime(),
+                        state.getTtl(), state.getMaxIdle(), UNSET,
                         state.getNow(), EntryEventType.ADDED, state.getStaticParams().isBackup());
             } else {
                 // To heap copy and state object update are
@@ -180,7 +182,7 @@ public enum PutOpSteps implements Step<State> {
                         ? record.getValue() : mapServiceContext.toData(record.getValue()));
                 recordStore.updateRecord0(record, state.getNow(), state.getStaticParams().isCountAsAccess());
                 recordStore.updateMemory(record, state.getKey(), state.getOldValue(), state.getNewValue(),
-                        state.isChangeExpiryOnUpdate(), state.getTtl(), state.getMaxIdle(), state.getExpiryTime(),
+                        state.isChangeExpiryOnUpdate(), state.getTtl(), state.getMaxIdle(), UNSET,
                         state.getNow(), state.getStaticParams().isBackup());
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/State.java
@@ -60,7 +60,6 @@ public class State {
     private long ttl = UNSET;
     private long maxIdle = UNSET;
     private long version;
-    private long expiryTime;
     private long now = Clock.currentTimeMillis();
     private Data key;
     private Address callerAddress;
@@ -78,6 +77,7 @@ public class State {
     private volatile boolean triggerMapLoader;
     private volatile boolean shouldLoad;
     private volatile boolean changeExpiryOnUpdate = true;
+    private volatile boolean entryProcessorOffload;
     private volatile Object oldValue;
     private volatile Object newValue;
     private volatile Object result;
@@ -86,7 +86,6 @@ public class State {
     private volatile Collection<Data> keys;
     private volatile ArrayList<Record> records;
     private volatile EntryProcessor entryProcessor;
-    private volatile boolean entryProcessorOffload;
     private volatile EntryOperator operator;
     private volatile List<State> toStore;
     private volatile List<State> toRemove;
@@ -115,7 +114,6 @@ public class State {
                 .setMaxIdle(state.getMaxIdle())
                 .setChangeExpiryOnUpdate(state.isChangeExpiryOnUpdate())
                 .setVersion(state.getVersion())
-                .setExpiryTime(state.getExpiryTime())
                 .setNow(state.getNow())
                 .setStaticPutParams(state.getStaticParams())
                 .setOwnerUuid(state.getOwnerUuid())
@@ -174,11 +172,6 @@ public class State {
         return this;
     }
 
-    public State ownerUuid(UUID ownerUuid) {
-        this.ownerUuid = ownerUuid;
-        return this;
-    }
-
     public State setTtl(long ttl) {
         this.ttl = ttl;
         return this;
@@ -186,11 +179,6 @@ public class State {
 
     public State setMaxIdle(long maxIdle) {
         this.maxIdle = maxIdle;
-        return this;
-    }
-
-    public State setExpiryTime(long expiryTime) {
-        this.expiryTime = expiryTime;
         return this;
     }
 
@@ -258,10 +246,6 @@ public class State {
 
     public long getVersion() {
         return version;
-    }
-
-    public long getExpiryTime() {
-        return expiryTime;
     }
 
     public long getNow() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/expiry/ExpiryMetadata.java
@@ -109,6 +109,16 @@ public interface ExpiryMetadata {
         public ExpiryMetadata setRawLastUpdateTime(int lastUpdateTime) {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public String toString() {
+            return "NULL{"
+                    + "ttl=" + getTtl()
+                    + ", maxIdle=" + getMaxIdle()
+                    + ", expirationTime=" + getExpirationTime()
+                    + ", lastUpdateTime=" + getLastUpdateTime()
+                    + '}';
+        }
     };
 
     default boolean hasExpiry() {


### PR DESCRIPTION
follow up of PR https://github.com/hazelcast/hazelcast/pull/22294 

This PR fixes the issue for offloaded execution paths. It was missed in #22294.
We have a [failing test](http://jenkins.hazelcast.com/view/force-offload-map/job/force-offload-Hazelcast-EE-master-OracleJDK8-clone/lastCompletedBuild/testReport/com.hazelcast.wan.map/WanBatchPublisherMapTest/map_expiry_info_replicated_from_source_to_target_when_set_via_map_config_inMemoryFormat_BINARY__maxConcurrentInvocations__1_/) for the issue which runs periodically and it is passing with this fix.