### PR TITLE
Fix member leave test - wait for job deployment [5.2.z]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorTest.java
@@ -21,8 +21,6 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.jet.sql.impl.connector.test.TestStreamSqlConnector;
 import com.hazelcast.sql.HazelcastSqlException;
-import com.hazelcast.sql.SqlResult;
-import com.hazelcast.sql.SqlRow;
 import com.hazelcast.sql.SqlService;
 import com.hazelcast.sql.SqlStatement;
 import com.hazelcast.sql.impl.SqlErrorCode;
@@ -33,14 +31,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.Semaphore;
-
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.INTEGER;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.TIMESTAMP_WITH_TIME_ZONE;
 import static com.hazelcast.sql.impl.type.QueryDataTypeFamily.VARCHAR;
 import static java.util.Arrays.asList;
 import static junit.framework.TestCase.assertEquals;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Test for different error conditions.
@@ -69,39 +64,28 @@ public class SqlErrorTest extends SqlErrorAbstractTest {
                 row(timestampTz(20), null, null)
         );
 
-        Semaphore semaphore = new Semaphore(0);
         Thread shutdownThread = new Thread(() -> {
-            try {
-                semaphore.acquire(); // wait until at least one row is received
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
+            // Waiting for a deployment of the job on both members.
+            assertTrueEventually(() -> {
+                assertEquals(1, getExecutionContextCount(instance1));
+                assertEquals(1, getExecutionContextCount(instance2));
+            });
             instance2.shutdown();
         });
         shutdownThread.start();
 
         // Start query
-        assertThatThrownBy(() -> {
-            // The SQL here needs to create non-trivial DAG. It cannot create simple ExpectNothingP ProcessorTasklet on
-            // second node in cluster.
-            String sql = "SELECT window_start/*, window_end*/ FROM " +
-                    "TABLE(HOP(" +
-                    "  (SELECT * FROM TABLE(IMPOSE_ORDER(TABLE " + name + ", DESCRIPTOR(ts), INTERVAL '0.002' SECOND)))" +
-                    "  , DESCRIPTOR(ts)" +
-                    "  , INTERVAL '0.004' SECOND" +
-                    "  , INTERVAL '0.002' SECOND" +
-                    ")) " +
-                    "GROUP BY 1/*, 2*/";
-
-            try (SqlResult res = instance1.getSql().execute(sql)) {
-                for (SqlRow ignore : res) {
-                    semaphore.release();
-                }
-            }
-        })
-                .isInstanceOf(HazelcastSqlException.class)
-                .hasRootCauseInstanceOf(MemberLeftException.class);
-
+        SqlStatement streamingQuery = new SqlStatement("SELECT window_start/*, window_end*/ FROM " +
+                "TABLE(HOP(" +
+                "  (SELECT * FROM TABLE(IMPOSE_ORDER(TABLE " + name + ", DESCRIPTOR(ts), INTERVAL '0.002' SECOND)))" +
+                "  , DESCRIPTOR(ts)" +
+                "  , INTERVAL '0.004' SECOND" +
+                "  , INTERVAL '0.002' SECOND" +
+                ")) " +
+                "GROUP BY 1/*, 2*/");
+        HazelcastSqlException error = assertSqlException(instance1, streamingQuery);
+        shutdownThread.join();
+        assertInstanceOf(MemberLeftException.class, findRootCause(error));
         shutdownThread.join();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -497,6 +497,13 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
     }
 
     /**
+     * Returns the count of {@link ExecutionContext} that are running on given {@code instance}.
+     */
+    public static int getExecutionContextCount(HazelcastInstance instance) {
+        return getJetServiceBackend(instance).getJobExecutionService().getExecutionContexts().size();
+    }
+
+    /**
      * Asserts that the {@code job} is already visible by {@linkplain JetService#getJob} methods.
      * @param client Hazelcast Instance used to query the cluster
      * @param jobToCheck job to be checked for visibility


### PR DESCRIPTION
Backport https://github.com/hazelcast/hazelcast/pull/22476

The test worked like that:

1. execute sql query on ```instance1```
2. wait for receiving any row
3. shutdown ```instance2``` in separate thread
4. expect query to fail with ```MemberLeftException```

The fact that we received a row doesn't mean that the job is already deployed on ```instance2```. If we shutdown that instance before that member starts the job we get ```HazelcastInstanceNotActiveException```, not the ```MemberLeftException```.

I changed the second step, we do not wait for any row, but we wait for job to be executing on both members before performing shutdown.

Fixes https://github.com/hazelcast/hazelcast/issues/20501

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
