### PR TITLE
[CN-568] [CN-525] Get AZ from metadata endpoint for ECS (#22473)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsClientConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsClientConfigurator.java
@@ -75,7 +75,7 @@ final class AwsClientConfigurator {
         }
 
         if (environment.isRunningOnEcs()) {
-            return environment.getAwsRegionOnEcs();
+            return regionFrom(metadataApi.availabilityZoneEcs());
         }
 
         return regionFrom(metadataApi.availabilityZoneEc2());
@@ -141,9 +141,9 @@ final class AwsClientConfigurator {
             return awsConfig.getCluster();
         }
         if (environment.isRunningOnEcs()) {
-            String clusterArn = metadataApi.metadataEcs().getClusterArn();
-            LOGGER.info("No ECS cluster defined, using current cluster: " + clusterArn);
-            return clusterArn;
+            String cluster = metadataApi.clusterEcs();
+            LOGGER.info("No ECS cluster defined, using current cluster: " + cluster);
+            return cluster;
         }
         throw new InvalidConfigurationException("You must define 'cluster' property if not running inside ECS cluster");
     }

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEcsClient.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.aws;
 
-import com.hazelcast.aws.AwsEcsApi.Task;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.discovery.integration.DiscoveryMode;
@@ -26,7 +25,6 @@ import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
 
 class AwsEcsClient implements AwsClient {
     private static final ILogger LOGGER = Logger.getLogger(AwsClient.class);
@@ -67,12 +65,6 @@ class AwsEcsClient implements AwsClient {
 
     @Override
     public String getAvailabilityZone() {
-        String taskArn = awsMetadataApi.metadataEcs().getTaskArn();
-        AwsCredentials credentials = awsCredentialsProvider.credentials();
-        List<Task> tasks = awsEcsApi.describeTasks(cluster, singletonList(taskArn), credentials);
-        return tasks.stream()
-                .map(Task::getAvailabilityZone)
-                .findFirst()
-                .orElse("unknown");
+        return  awsMetadataApi.availabilityZoneEcs();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsMetadataApi.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsMetadataApi.java
@@ -72,12 +72,20 @@ class AwsMetadataApi {
         return createRestClient(uri, awsConfig).get().getBody();
     }
 
+    String availabilityZoneEcs() {
+        return getTaskMetadata().get("AvailabilityZone").asString();
+    }
+
     Optional<String> placementGroupEc2() {
         return getOptionalMetadata(ec2MetadataEndpoint.concat("/placement/group-name/"), "placement group");
     }
 
     Optional<String> placementPartitionNumberEc2() {
         return getOptionalMetadata(ec2MetadataEndpoint.concat("/placement/partition-number/"), "partition number");
+    }
+
+    String clusterEcs() {
+        return getTaskMetadata().get("Cluster").asString();
     }
 
     /**
@@ -112,6 +120,12 @@ class AwsMetadataApi {
         }
     }
 
+    private JsonObject getTaskMetadata() {
+        String uri = ecsTaskMetadataEndpoint.concat("/task");
+        String response = createRestClient(uri, awsConfig).get().getBody();
+        return Json.parse(response).asObject();
+    }
+
     String defaultIamRoleEc2() {
         String uri = ec2MetadataEndpoint.concat(SECURITY_CREDENTIALS_URI);
         return createRestClient(uri, awsConfig).get().getBody();
@@ -135,36 +149,5 @@ class AwsMetadataApi {
             .setSecretKey(role.getString("SecretAccessKey", null))
             .setToken(role.getString("Token", null))
             .build();
-    }
-
-    EcsMetadata metadataEcs() {
-        String response = createRestClient(ecsTaskMetadataEndpoint, awsConfig).get().getBody();
-        return parseEcsMetadata(response);
-    }
-
-    private EcsMetadata parseEcsMetadata(String response) {
-        JsonObject metadata = Json.parse(response).asObject();
-        JsonObject labels = metadata.get("Labels").asObject();
-        String taskArn = labels.get("com.amazonaws.ecs.task-arn").asString();
-        String clusterArn = labels.get("com.amazonaws.ecs.cluster").asString();
-        return new EcsMetadata(taskArn, clusterArn);
-    }
-
-    static class EcsMetadata {
-        private final String taskArn;
-        private final String clusterArn;
-
-        EcsMetadata(String taskArn, String clusterArn) {
-            this.taskArn = taskArn;
-            this.clusterArn = clusterArn;
-        }
-
-        String getTaskArn() {
-            return taskArn;
-        }
-
-        String getClusterArn() {
-            return clusterArn;
-        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aws/Environment.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/Environment.java
@@ -22,12 +22,7 @@ import com.hazelcast.internal.util.StringUtil;
  * This class is introduced to lookup system parameters.
  */
 class Environment {
-    private static final String AWS_REGION_ON_ECS = System.getenv("AWS_REGION");
     private static final boolean IS_RUNNING_ON_ECS = isRunningOnEcsEnvironment();
-
-    String getAwsRegionOnEcs() {
-        return AWS_REGION_ON_ECS;
-    }
 
     boolean isRunningOnEcs() {
         return IS_RUNNING_ON_ECS;

--- a/hazelcast/src/main/java/com/hazelcast/aws/RegionValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/RegionValidator.java
@@ -31,6 +31,9 @@ final class RegionValidator {
     }
 
     static void validateRegion(String region) {
+        if (region == null) {
+            throw new InvalidConfigurationException("The provided region is null.");
+        }
         if (!AWS_REGION_PATTERN.matcher(region).matches()) {
             String message = String.format("The provided region %s is not a valid AWS region.", region);
             throw new InvalidConfigurationException(message);

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsClientConfiguratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsClientConfiguratorTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.aws;
 
-import com.hazelcast.aws.AwsMetadataApi.EcsMetadata;
 import com.hazelcast.config.InvalidConfigurationException;
 import org.junit.Test;
 
@@ -47,23 +46,6 @@ public class AwsClientConfiguratorTest {
     }
 
     @Test
-    public void resolveRegionEcsConfig() {
-        // given
-        String region = "us-east-1";
-        AwsConfig awsConfig = AwsConfig.builder().build();
-        AwsMetadataApi awsMetadataApi = mock(AwsMetadataApi.class);
-        Environment environment = mock(Environment.class);
-        given(environment.getAwsRegionOnEcs()).willReturn(region);
-        given(environment.isRunningOnEcs()).willReturn(true);
-
-        // when
-        String result = resolveRegion(awsConfig, awsMetadataApi, environment);
-
-        // then
-        assertEquals(region, result);
-    }
-
-    @Test
     public void resolveRegionEc2Metadata() {
         // given
         AwsConfig awsConfig = AwsConfig.builder().build();
@@ -74,6 +56,21 @@ public class AwsClientConfiguratorTest {
         // when
         String result = resolveRegion(awsConfig, awsMetadataApi, environment);
 
+        // then
+        assertEquals("us-east-1", result);
+    }
+
+    @Test
+    public void resolveRegionEcsMetadata() {
+        // given
+        AwsConfig awsConfig = AwsConfig.builder().build();
+        AwsMetadataApi awsMetadataApi = mock(AwsMetadataApi.class);
+        Environment environment = mock(Environment.class);
+        given(environment.isRunningOnEcs()).willReturn(true);
+        given(awsMetadataApi.availabilityZoneEcs()).willReturn("us-east-1a");
+
+        // when
+        String result = resolveRegion(awsConfig, awsMetadataApi, environment);
         // then
         assertEquals("us-east-1", result);
     }
@@ -134,7 +131,7 @@ public class AwsClientConfiguratorTest {
         String cluster = "service-name";
         AwsConfig config = AwsConfig.builder().build();
         AwsMetadataApi metadataApi = mock(AwsMetadataApi.class);
-        given(metadataApi.metadataEcs()).willReturn(new EcsMetadata(null, cluster));
+        given(metadataApi.clusterEcs()).willReturn(cluster);
         Environment environment = mock(Environment.class);
         given(environment.isRunningOnEcs()).willReturn(true);
 

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
@@ -16,33 +16,29 @@
 
 package com.hazelcast.aws;
 
-import com.hazelcast.aws.AwsEcsApi.Task;
-import com.hazelcast.aws.AwsMetadataApi.EcsMetadata;
 import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AwsEcsClientTest {
-    private static final String TASK_ARN = "task-arn";
     private static final String CLUSTER = "cluster-arn";
     private static final AwsCredentials CREDENTIALS = AwsCredentials.builder()
         .setAccessKey("access-key")
@@ -66,15 +62,11 @@ public class AwsEcsClientTest {
 
     @Before
     public void setUp() {
-        EcsMetadata ecsMetadata = mock(EcsMetadata.class);
+        given(awsMetadataApi.clusterEcs()).willReturn(CLUSTER);
         AwsConfig awsConfig = AwsConfig.builder()
                 .setDiscoveryMode(DiscoveryMode.Member)
                 .build();
-        given(ecsMetadata.getTaskArn()).willReturn(TASK_ARN);
-        given(ecsMetadata.getClusterArn()).willReturn(CLUSTER);
-        given(awsMetadataApi.metadataEcs()).willReturn(ecsMetadata);
         given(awsCredentialsProvider.credentials()).willReturn(CREDENTIALS);
-
         awsEcsClient = new AwsEcsClient(CLUSTER, awsConfig, awsEcsApi, awsEc2Api, awsMetadataApi, awsCredentialsProvider);
     }
 
@@ -123,27 +115,14 @@ public class AwsEcsClientTest {
     @Test
     public void getAvailabilityZone() {
         // given
-        String availabilityZone = "us-east-1";
-        given(awsEcsApi.describeTasks(CLUSTER, singletonList(TASK_ARN), CREDENTIALS))
-            .willReturn(singletonList(new Task(null, availabilityZone)));
+        String expectedResult = "us-east-1a";
+        given(awsMetadataApi.availabilityZoneEcs()).willReturn(expectedResult);
 
         // when
         String result = awsEcsClient.getAvailabilityZone();
 
         // then
-        assertEquals(availabilityZone, result);
-    }
-
-    @Test
-    public void getAvailabilityZoneUnknown() {
-        // given
-        given(awsEcsApi.describeTasks(CLUSTER, singletonList(TASK_ARN), CREDENTIALS)).willReturn(emptyList());
-
-        // when
-        String result = awsEcsClient.getAvailabilityZone();
-
-        // then
-        assertEquals("unknown", result);
+        assertEquals(expectedResult, result);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsMetadataApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsMetadataApiTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.aws;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.hazelcast.aws.AwsMetadataApi.EcsMetadata;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -68,6 +67,25 @@ public class AwsMetadataApiTest {
 
         // then
         assertEquals(availabilityZone, result);
+    }
+
+    @Test
+    public void availabilityZoneEcs() {
+        // given
+        //language=JSON
+        String response = "{\n"
+                + "  \"Cluster\" : \"hz-cluster\",\n"
+                + "  \"AvailabilityZone\": \"ca-central-1a\"\n"
+                + "}";
+
+        stubFor(get(urlEqualTo("/task"))
+                .willReturn(aResponse().withStatus(200).withBody(response)));
+
+        // when
+        String result = awsMetadataApi.availabilityZoneEcs();
+
+        // then
+        assertEquals("ca-central-1a", result);
     }
 
     @Test
@@ -133,6 +151,26 @@ public class AwsMetadataApiTest {
         verify(moreThan(RETRY_COUNT), getRequestedFor(urlEqualTo(GROUP_NAME_URL)));
     }
 
+
+    @Test
+    public void clusterEcs() {
+        // given
+        //language=JSON
+        String response = "{\n"
+                + "  \"Cluster\" : \"hz-cluster\",\n"
+                + "  \"AvailabilityZone\": \"ca-central-1a\"\n"
+                + "}";
+
+        stubFor(get(urlEqualTo("/task"))
+                .willReturn(aResponse().withStatus(200).withBody(response)));
+
+        // when
+        String result = awsMetadataApi.clusterEcs();
+
+        // then
+        assertEquals("hz-cluster", result);
+    }
+
     @Test
     public void defaultIamRoleEc2() {
         // given
@@ -190,38 +228,6 @@ public class AwsMetadataApiTest {
         assertEquals("Access1234", result.getAccessKey());
         assertEquals("Secret1234", result.getSecretKey());
         assertEquals("Token1234", result.getToken());
-    }
-
-    @Test
-    public void metadataEcs() {
-        // given
-        //language=JSON
-        String response = "{\n"
-            + "  \"Name\": \"container-name\",\n"
-            + "  \"Labels\": {\n"
-            + "    \"com.amazonaws.ecs.cluster\": \"arn:aws:ecs:eu-central-1:665466731577:cluster/default\",\n"
-            + "    \"com.amazonaws.ecs.container-name\": \"container-name\",\n"
-            + "    \"com.amazonaws.ecs.task-arn\": \"arn:aws:ecs:eu-central-1:665466731577:task/default/0dcf990c3ef3436c84e0c7430d14a3d4\",\n"
-            + "    \"com.amazonaws.ecs.task-definition-family\": \"family-name\"\n"
-            + "  },\n"
-            + "  \"Networks\": [\n"
-            + "    {\n"
-            + "      \"NetworkMode\": \"awsvpc\",\n"
-            + "      \"IPv4Addresses\": [\n"
-            + "        \"10.0.1.174\"\n"
-            + "      ]\n"
-            + "    }\n"
-            + "  ]\n"
-            + "}";
-        stubFor(get("/").willReturn(aResponse().withStatus(200).withBody(response)));
-
-        // when
-        EcsMetadata result = awsMetadataApi.metadataEcs();
-
-        // then
-        assertEquals("arn:aws:ecs:eu-central-1:665466731577:task/default/0dcf990c3ef3436c84e0c7430d14a3d4",
-            result.getTaskArn());
-        assertEquals("arn:aws:ecs:eu-central-1:665466731577:cluster/default", result.getClusterArn());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/aws/RegionValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/RegionValidatorTest.java
@@ -57,4 +57,16 @@ public class RegionValidatorTest {
         assertEquals(expectedMessage, thrownEx.getMessage());
     }
 
+    @Test
+    public void validateNullRegion() {
+        // given
+        String expectedMessage = "The provided region is null.";
+
+        // when
+        Runnable validateRegion = () -> RegionValidator.validateRegion(null);
+
+        //then
+        InvalidConfigurationException thrownEx = assertThrows(InvalidConfigurationException.class, validateRegion);
+        assertEquals(expectedMessage, thrownEx.getMessage());
+    }
 }


### PR DESCRIPTION
Send requests to the private metadata API to fetch AZ of the task instead of AWS ECS API.

Backport of: https://github.com/hazelcast/hazelcast/pull/22411

Checklist: https://github.com/hazelcast/hazelcast/pull/22473

- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label Add to `Release Notes` or `Not Release Notes` content set
- [x] Request reviewers, if possible
- [x] Send backports/forwardports if a fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc