### PR TITLE
Wait for RUNNING jobs to finish before next test [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -129,6 +129,7 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
         }
         for (HazelcastInstance instance : instances) {
             assertTrueEventually(() -> {
+                // Let's wait for all unprocessed operations (like destroying distributed object) to complete
                 assertEquals(0, getNodeEngineImpl(instance).getEventService().getEventQueueSize());
             });
         }


### PR DESCRIPTION
Backport of: https://github.com/hazelcast/hazelcast/pull/22448.

Fixes https://github.com/hazelcast/hazelcast/issues/22037, https://github.com/hazelcast/hazelcast/issues/18644, may also fix https://github.com/hazelcast/hazelcast/issues/22215.

Root cause: we execute ```ditchJob()``` for all jobs in method annotated with ```@After```. The ```ditchJob()``` doesn't wait for changing the status of the job, which is done asynchronously in separate thread. There are some tests that assumes that after submitting a job that job is the only one with ```RUNNING``` status. To make that assumption valid we wait for the job to change status before starting next test.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
