### PR TITLE
No offload for WB store ops

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/ClearOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/ClearOpSteps.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
-public enum ClearOpSteps implements Step<State> {
+public enum ClearOpSteps implements IMapOpStep {
 
     CLEAR_MEMORY() {
         @Override
@@ -69,7 +69,7 @@ public enum ClearOpSteps implements Step<State> {
 
     CLEAR_MAP_STORE() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/ContainsKeyOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/ContainsKeyOpSteps.java
@@ -22,7 +22,7 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 
-public enum ContainsKeyOpSteps implements Step<State> {
+public enum ContainsKeyOpSteps implements IMapOpStep {
 
     READ() {
         @Override
@@ -45,7 +45,7 @@ public enum ContainsKeyOpSteps implements Step<State> {
 
     LOAD() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isLoadStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/DeleteOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/DeleteOpSteps.java
@@ -24,7 +24,7 @@ import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 
-public enum DeleteOpSteps implements Step<State> {
+public enum DeleteOpSteps implements IMapOpStep {
 
     READ() {
         @Override
@@ -54,7 +54,7 @@ public enum DeleteOpSteps implements Step<State> {
 
     DELETE() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/EntryOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/EntryOpSteps.java
@@ -253,6 +253,8 @@ public enum EntryOpSteps implements IMapOpStep {
 
         @Override
         public void runStep(State state) {
+            assertWBStoreRunsOnPartitionThread(state);
+
             PutOpSteps.STORE.runStep(state);
         }
 
@@ -282,6 +284,8 @@ public enum EntryOpSteps implements IMapOpStep {
 
         @Override
         public void runStep(State state) {
+            assertWBStoreRunsOnPartitionThread(state);
+
             DeleteOpSteps.DELETE.runStep(state);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/EntryOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/EntryOpSteps.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.impl.executionservice.impl.StatsAwareRunnable;
 
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
 
-public enum EntryOpSteps implements Step<State> {
+public enum EntryOpSteps implements IMapOpStep {
 
     EP_START() {
         @Override
@@ -67,7 +67,7 @@ public enum EntryOpSteps implements Step<State> {
 
     LOAD() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isLoadStep() {
             return true;
         }
 
@@ -91,7 +91,7 @@ public enum EntryOpSteps implements Step<State> {
 
     RUN_OFFLOADED_ENTRY_PROCESSOR() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 
@@ -247,7 +247,7 @@ public enum EntryOpSteps implements Step<State> {
 
     STORE() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 
@@ -276,7 +276,7 @@ public enum EntryOpSteps implements Step<State> {
 
     DELETE() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/GetAllOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/GetAllOpSteps.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public enum GetAllOpSteps implements Step<State> {
+public enum GetAllOpSteps implements IMapOpStep {
 
     READ() {
         @Override
@@ -51,7 +51,7 @@ public enum GetAllOpSteps implements Step<State> {
 
     LOAD_ALL() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isLoadStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/GetOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/GetOpSteps.java
@@ -26,7 +26,7 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 
-public enum GetOpSteps implements Step<State> {
+public enum GetOpSteps implements IMapOpStep {
 
     READ() {
         @Override
@@ -47,7 +47,7 @@ public enum GetOpSteps implements Step<State> {
 
     LOAD() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isLoadStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/IMapOpStep.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/IMapOpStep.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation.steps;
 
+import com.hazelcast.internal.util.ThreadUtil;
 import com.hazelcast.map.impl.mapstore.writebehind.WriteBehindStore;
 import com.hazelcast.map.impl.operation.steps.engine.State;
 import com.hazelcast.map.impl.operation.steps.engine.Step;
@@ -59,6 +60,12 @@ public interface IMapOpStep extends Step<State> {
     default boolean isWriteBehind(State state) {
         return state.getRecordStore().getMapDataStore()
                 instanceof WriteBehindStore;
+    }
+
+    default void assertWBStoreRunsOnPartitionThread(State state) {
+        if (isStoreStep() && isWriteBehind(state)) {
+            assert ThreadUtil.isRunningOnPartitionThread();
+        }
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/IMapOpStep.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/IMapOpStep.java
@@ -63,9 +63,8 @@ public interface IMapOpStep extends Step<State> {
     }
 
     default void assertWBStoreRunsOnPartitionThread(State state) {
-        if (isStoreStep() && isWriteBehind(state)) {
-            assert ThreadUtil.isRunningOnPartitionThread();
-        }
+        assert isStoreStep() && isWriteBehind(state)
+                ? ThreadUtil.isRunningOnPartitionThread() : true;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/IMapOpStep.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/IMapOpStep.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation.steps;
+
+import com.hazelcast.map.impl.mapstore.writebehind.WriteBehindStore;
+import com.hazelcast.map.impl.operation.steps.engine.State;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
+
+import static com.hazelcast.spi.impl.executionservice.ExecutionService.MAP_STORE_OFFLOADABLE_EXECUTOR;
+
+/**
+ * {@link Step} specialized for {@link
+ * com.hazelcast.map.IMap} operations.
+ */
+public interface IMapOpStep extends Step<State> {
+
+    /**
+     * Decides when to offload based on configured map-store type.
+     * <p>
+     * Reasoning: Blindly offloading every step
+     * may be less performant in all cases.
+     * <ul>
+     *     <li>Offloads all load and store steps
+     *     when write-through map-store</li>
+     *     <li>Offloads only load steps when write-behind map-store.
+     *     <p>
+     *     Since store steps in this case, have no-blocking behavior.
+     *     <p>
+     *     This is more performance friendly compared to offloading.
+     *     </li>
+     * </ul>
+     */
+    default boolean isOffloadStep(State state) {
+        if (isLoadStep()) {
+            return true;
+        }
+
+        if (isStoreStep()) {
+            return !isWriteBehind(state);
+        }
+
+        return false;
+    }
+
+    default boolean isWriteBehind(State state) {
+        return state.getRecordStore().getMapDataStore()
+                instanceof WriteBehindStore;
+    }
+
+    /**
+     * @return {@code true} when this step is loading
+     * data via MapLoader, otherwise {@code false}
+     */
+    default boolean isLoadStep() {
+        return false;
+    }
+
+    /**
+     * @return {@code true} when this step is storing
+     * data via MapStore, otherwise {@code false}
+     */
+    default boolean isStoreStep() {
+        return false;
+    }
+
+    /**
+     * @return name of the executor to execute this map operation step
+     */
+    default String getExecutorName(State state) {
+        return MAP_STORE_OFFLOADABLE_EXECUTOR;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/MergeOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/MergeOpSteps.java
@@ -39,7 +39,7 @@ import java.util.Queue;
 import static com.hazelcast.core.EntryEventType.MERGED;
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 
-public enum MergeOpSteps implements Step<State> {
+public enum MergeOpSteps implements IMapOpStep {
 
     READ() {
         @Override
@@ -102,7 +102,7 @@ public enum MergeOpSteps implements Step<State> {
 
     STORE_OR_DELETE() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/MultipleEntryOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/MultipleEntryOpSteps.java
@@ -37,7 +37,7 @@ import java.util.Map;
 
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
 
-public enum MultipleEntryOpSteps implements Step<State> {
+public enum MultipleEntryOpSteps implements IMapOpStep {
 
     FIND_KEYS_TO_LOAD() {
         @Override
@@ -71,7 +71,7 @@ public enum MultipleEntryOpSteps implements Step<State> {
 
     LOAD_ALL() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isLoadStep() {
             return true;
         }
 
@@ -175,7 +175,7 @@ public enum MultipleEntryOpSteps implements Step<State> {
 
     STORE_OR_DELETE() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PartitionWideOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PartitionWideOpSteps.java
@@ -39,7 +39,7 @@ import java.util.List;
 import static com.hazelcast.internal.util.ToHeapDataConverter.toHeapData;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
 
-public enum PartitionWideOpSteps implements Step<State> {
+public enum PartitionWideOpSteps implements IMapOpStep {
 
     PROCESS() {
         @Override
@@ -164,7 +164,7 @@ public enum PartitionWideOpSteps implements Step<State> {
 
     STORE_OR_DELETE() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutAllOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutAllOpSteps.java
@@ -41,7 +41,7 @@ import static com.hazelcast.core.EntryEventType.ADDED;
 import static com.hazelcast.core.EntryEventType.UPDATED;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 
-public enum PutAllOpSteps implements Step<State> {
+public enum PutAllOpSteps implements IMapOpStep {
 
     READ() {
         @Override
@@ -71,22 +71,38 @@ public enum PutAllOpSteps implements Step<State> {
 
         @Override
         public Step nextStep(State state) {
-            return PutAllOpSteps.LOAD_ALL_STORE_ALL;
+            if (!CollectionUtil.isEmpty(state.getKeysToLoad())) {
+                return PutAllOpSteps.LOAD_ALL;
+            }
+            return PutAllOpSteps.STORE_ALL;
         }
     },
 
-    LOAD_ALL_STORE_ALL() {
+    LOAD_ALL() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isLoadStep() {
             return true;
         }
 
         @Override
         public void runStep(State state) {
-            if (!CollectionUtil.isEmpty(state.getKeysToLoad())) {
-                MultipleEntryOpSteps.LOAD_ALL.runStep(state);
-            }
+            MultipleEntryOpSteps.LOAD_ALL.runStep(state);
+        }
 
+        @Override
+        public Step nextStep(State state) {
+            return STORE_ALL;
+        }
+    },
+
+    STORE_ALL() {
+        @Override
+        public boolean isStoreStep() {
+            return true;
+        }
+
+        @Override
+        public void runStep(State state) {
             DefaultRecordStore recordStore = ((DefaultRecordStore) state.getRecordStore());
             long expirationTime = recordStore.getExpirySystem().calculateExpirationTime(state.getTtl(),
                     state.getMaxIdle(), state.getNow(), state.getNow());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
@@ -30,7 +30,7 @@ import com.hazelcast.map.impl.recordstore.StaticParams;
 
 import static com.hazelcast.map.impl.record.Record.UNSET;
 
-public enum PutOpSteps implements Step<State> {
+public enum PutOpSteps implements IMapOpStep {
 
     READ() {
         @Override
@@ -51,7 +51,7 @@ public enum PutOpSteps implements Step<State> {
 
     LOAD() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isLoadStep() {
             return true;
         }
 
@@ -77,6 +77,7 @@ public enum PutOpSteps implements Step<State> {
     },
 
     PROCESS() {
+        @SuppressWarnings("checkstyle:cyclomaticcomplexity")
         @Override
         public void runStep(State state) {
             StaticParams staticParams = state.getStaticParams();
@@ -87,45 +88,47 @@ public enum PutOpSteps implements Step<State> {
             MapContainer mapContainer = recordStore.getMapContainer();
             MapServiceContext mapServiceContext = mapContainer.getMapServiceContext();
 
-            if (staticParams.isPutIfAbsent()) {
-                Record record = recordStore.getRecord(state.getKey());
-                if (record == null && state.getOldValue() != null) {
-                    record = ((DefaultRecordStore) recordStore).onLoadRecord(state.getKey(),
-                            state.getOldValue(), false, state.getCallerAddress());
-                }
+            if (!staticParams.isPutVanilla()) {
+                if (staticParams.isPutIfAbsent()) {
+                    Record record = recordStore.getRecord(state.getKey());
+                    if (record == null && state.getOldValue() != null) {
+                        record = ((DefaultRecordStore) recordStore).onLoadRecord(state.getKey(),
+                                state.getOldValue(), false, state.getCallerAddress());
+                    }
 
-                if (record != null) {
+                    if (record != null) {
+                        state.setOldValue(record.getValue());
+                        state.setStopExecution(true);
+                        return;
+                    }
+                } else if (staticParams.isPutIfExists()) {
+                    Record record = recordStore.getRecord(state.getKey());
+                    if (record == null && state.getOldValue() != null) {
+                        record = ((DefaultRecordStore) recordStore).onLoadRecord(state.getKey(),
+                                state.getOldValue(), false, state.getCallerAddress());
+                    }
+
+                    if (record == null) {
+                        state.setOldValue(null);
+                        state.setStopExecution(true);
+                        state.setResult(false);
+                        return;
+                    }
+
+                    newValue = staticParams.isSetTtl() ? record.getValue() : newValue;
+                    state.setNewValue(newValue);
                     state.setOldValue(record.getValue());
-                    state.setStopExecution(true);
-                    return;
-                }
-            } else if (staticParams.isPutIfExists()) {
-                Record record = recordStore.getRecord(state.getKey());
-                if (record == null && state.getOldValue() != null) {
-                    record = ((DefaultRecordStore) recordStore).onLoadRecord(state.getKey(),
-                            state.getOldValue(), false, state.getCallerAddress());
-                }
 
-                if (record == null) {
-                    state.setOldValue(null);
-                    state.setStopExecution(true);
-                    state.setResult(false);
-                    return;
+                    if (staticParams.isPutIfEqual()
+                            && !((DefaultRecordStore) recordStore).getValueComparator()
+                            .isEqual(state.getExpect(), state.getOldValue(),
+                                    mapServiceContext.getNodeEngine().getSerializationService())) {
+                        state.setResult(false);
+                        state.setStopExecution(true);
+                        state.setOldValue(null);
+                        return;
+                    }
                 }
-
-                newValue = staticParams.isSetTtl() ? record.getValue() : newValue;
-                state.setNewValue(newValue);
-                state.setOldValue(record.getValue());
-            }
-
-            if (staticParams.isPutIfEqual()
-                    && !((DefaultRecordStore) recordStore).getValueComparator()
-                    .isEqual(state.getExpect(), state.getOldValue(),
-                            mapServiceContext.getNodeEngine().getSerializationService())) {
-                state.setResult(false);
-                state.setStopExecution(true);
-                state.setOldValue(null);
-                return;
             }
 
             // Intercept put on owner partition.
@@ -145,7 +148,7 @@ public enum PutOpSteps implements Step<State> {
 
     STORE() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
@@ -154,6 +154,8 @@ public enum PutOpSteps implements IMapOpStep {
 
         @Override
         public void runStep(State state) {
+            assertWBStoreRunsOnPartitionThread(state);
+
             Object newValue = ((DefaultRecordStore) state.getRecordStore()).putIntoMapStore0(state.getKey(),
                     state.getNewValue(), state.getTtl(), state.getMaxIdle(), state.getNow(), state.getTxnId());
             state.setNewValue(newValue);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/RemoveIfSameOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/RemoveIfSameOpSteps.java
@@ -26,7 +26,7 @@ import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 
-public enum RemoveIfSameOpSteps implements Step<State> {
+public enum RemoveIfSameOpSteps implements IMapOpStep {
 
     READ() {
         @Override
@@ -43,7 +43,7 @@ public enum RemoveIfSameOpSteps implements Step<State> {
 
     LOAD() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isLoadStep() {
             return true;
         }
 
@@ -94,7 +94,7 @@ public enum RemoveIfSameOpSteps implements Step<State> {
 
     DELETE() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/RemoveOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/RemoveOpSteps.java
@@ -24,7 +24,7 @@ import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 
-public enum RemoveOpSteps implements Step<State> {
+public enum RemoveOpSteps implements IMapOpStep {
 
     READ() {
         @Override
@@ -55,7 +55,7 @@ public enum RemoveOpSteps implements Step<State> {
 
     LOAD() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isLoadStep() {
             return true;
         }
 
@@ -76,7 +76,7 @@ public enum RemoveOpSteps implements Step<State> {
 
     DELETE() {
         @Override
-        public boolean isOffloadStep() {
+        public boolean isStoreStep() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnDeleteOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnDeleteOpSteps.java
@@ -25,7 +25,7 @@ import com.hazelcast.map.impl.recordstore.RecordStore;
 
 import java.util.UUID;
 
-public enum TxnDeleteOpSteps implements Step<State> {
+public enum TxnDeleteOpSteps implements IMapOpStep {
 
     READ() {
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnLockAndGetOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnLockAndGetOpSteps.java
@@ -24,7 +24,7 @@ import com.hazelcast.transaction.TransactionException;
 
 import java.util.UUID;
 
-public enum TxnLockAndGetOpSteps implements Step<State> {
+public enum TxnLockAndGetOpSteps implements IMapOpStep {
 
     READ() {
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnSetOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnSetOpSteps.java
@@ -25,7 +25,7 @@ import com.hazelcast.map.impl.recordstore.RecordStore;
 
 import java.util.UUID;
 
-public enum TxnSetOpSteps implements Step<State> {
+public enum TxnSetOpSteps implements IMapOpStep {
 
     READ() {
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/UtilSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/UtilSteps.java
@@ -23,7 +23,7 @@ import com.hazelcast.map.impl.operation.steps.engine.StepResponseUtil;
 import com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
-public enum UtilSteps implements Step<State> {
+public enum UtilSteps implements IMapOpStep {
 
     SEND_RESPONSE() {
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/Step.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/Step.java
@@ -18,8 +18,6 @@ package com.hazelcast.map.impl.operation.steps.engine;
 
 import javax.annotation.Nullable;
 
-import static com.hazelcast.spi.impl.executionservice.ExecutionService.MAP_STORE_OFFLOADABLE_EXECUTOR;
-
 /**
  * Represents an isolated step of an operation. e.g.
  * {@link  com.hazelcast.map.impl.operation.PutOperation}
@@ -52,15 +50,17 @@ public interface Step<S> {
      * com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread}
      * otherwise {@code false}
      */
-    default boolean isOffloadStep() {
+    default boolean isOffloadStep(S state) {
         return false;
     }
 
     /**
+     * Used when this step is an
+     * offload-step, otherwise not used.
+     *
      * @param state the state object
-     * @return name of the executor to run this step
+     * @return name of the executor to run
+     * this step(valid if this step is an offload-step)
      */
-    default String getExecutorName(S state) {
-        return MAP_STORE_OFFLOADABLE_EXECUTOR;
-    }
+    String getExecutorName(S state);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplier.java
@@ -83,7 +83,7 @@ public class StepSupplier implements Supplier<Runnable> {
 
         // 1. If step needs to be offloaded,
         // return step wrapped as a runnable.
-        if (step.isOffloadStep()) {
+        if (step.isOffloadStep(state)) {
             return new ExecutorNameAwareRunnable() {
                 @Override
                 public String getExecutorName() {


### PR DESCRIPTION
Seen during investigations of https://github.com/hazelcast/hazelcast/issues/22601

**Issue:**
Stores are not blocking when write-behind is in use therefore they don't need any offload. (Loads are different and even write-behind is in use they are blocking so offload is needed for them). This offload, handing map-store api to a different thread, creates a perf penalty in write behind case.

**Fix:**
This PR creates two sub-types for offloadable Step, as load and store types, only `load` types are offloaded when write-behind is enabled and `store` types are processed by partition threads.