### PR TITLE
Fix MemberReconnectionStressTest  [HZ-1617]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -409,16 +409,22 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
 
         // Let's wait for the job to be not RUNNING on all the members.
         assertTrueEventually(() -> {
-            //If a member throws exception ignore it
+
             try {
                 assertNotEquals(RUNNING, job.getStatus());
-                for (HazelcastInstance instance : instances) {
+            } catch (Exception e) {
+                SUPPORT_LOGGER.severe("Failure to read job status on coordinator: ", e);
+            }
+
+            for (HazelcastInstance instance : instances) {
+                try {
                     Job instanceJob = instance.getJet().getJob(job.getId());
                     if (instanceJob != null) {
                         assertNotEquals(RUNNING, instanceJob.getStatus());
                     }
+                } catch (Exception e) {
+                    SUPPORT_LOGGER.severe("Failure to read job status on member: ", e);
                 }
-            } catch (Exception ignored) {
             }
         });
     }

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -405,7 +405,7 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
      */
     public static void ditchJob(@Nonnull Job job, @Nonnull HazelcastInstance... instances) {
         boolean result = ditchJob0(job, instances);
-        //If job could not be ditched, no need to continue
+        // If job could not be ditched, no need to continue
         if (!result) {
             return;
         }

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -41,15 +40,8 @@ import static org.junit.Assert.fail;
 @Category({NightlyTest.class})
 public class MemberReconnectionStressTest extends JetTestSupport {
 
-    private final AtomicBoolean terminated = new AtomicBoolean();
-
-    @After
-    public void after() {
-        terminated.set(true);
-    }
-
     @Test
-    public void test() {
+    public void test() throws InterruptedException {
         /*
         The test will start 2 thread:
         - one will submit short batch jobs, serially, after joining the previous job
@@ -70,6 +62,8 @@ public class MemberReconnectionStressTest extends JetTestSupport {
         HazelcastInstance inst1 = createHazelcastInstance(config);
         HazelcastInstance inst2 = createHazelcastInstance(config);
         logger.info("Instances started");
+
+        final AtomicBoolean terminated = new AtomicBoolean();
 
         Thread connectionThread = new Thread(() -> {
             while (!terminated.get()) {
@@ -121,13 +115,10 @@ public class MemberReconnectionStressTest extends JetTestSupport {
             sleepMillis(100);
         }
         //Test finished, close the threads
-        try {
-            terminated.set(true);
+        terminated.set(true);
 
-            connectionThread.join();
-            newJobThread.join();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        connectionThread.join();
+        newJobThread.join();
+
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
@@ -87,6 +87,7 @@ public class MemberReconnectionStressTest extends JetTestSupport {
 
         AtomicInteger jobCount = new AtomicInteger();
         Thread newJobThread = new Thread(() -> {
+            // Continuously submit a new job and wait for it to complete
             while (!terminated.get()) {
                 try {
                     inst1.getJet().newJob(dag).getFuture().join();


### PR DESCRIPTION
- The test was creating two threads but was not stopping them at the end.
- When the test is closed, the test fixture was trying to wait for the result of jobs that did not exist

Fixes #22649

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
