### PR TITLE
Java 19 test fixes

### DIFF
--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
@@ -45,7 +45,8 @@ public final class ArchUnitRules {
             .and().implement(Serializable.class)
             .and().doNotImplement("com.hazelcast.nio.serialization.DataSerializable")
             .and().areNotAnonymousClasses()
-            .should(haveValidSerialVersionUid());
+            .should(haveValidSerialVersionUid())
+            .allowEmptyShould(true);
 
     private ArchUnitRules() {
     }

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.test.archunit;
 
-import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaModifier;
@@ -26,6 +25,7 @@ import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 import static com.hazelcast.test.archunit.ArchUnitRules.SerialVersionUidFieldCondition.haveValidSerialVersionUid;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.beFinal;

--- a/hazelcast-archunit-rules/src/test/java/com/hazelcast/test/archunit/ArchUnitRulesTest.java
+++ b/hazelcast-archunit-rules/src/test/java/com/hazelcast/test/archunit/ArchUnitRulesTest.java
@@ -18,13 +18,28 @@ package com.hazelcast.test.archunit;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
+
+import static org.junit.Assume.assumeThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.ONLY_INCLUDE_TESTS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 
 public class ArchUnitRulesTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        assumeThat("Skipping as ASM shaded within ArchUnit 1.0.0 doesn't support Java 20", getCurrentJavaVersion(),
+                is(lessThan(20)));
+    }
+
     @Test
     public void should_fail_with_non_compliant_class() {
         JavaClasses classes = new ClassFileImporter()
@@ -45,5 +60,19 @@ public class ArchUnitRulesTest {
         assertThat(classes).isNotEmpty();
 
         ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
+    }
+
+    private static int getCurrentJavaVersion() {
+        Class runtimeClass = Runtime.class;
+
+        try {
+            Class versionClass = Class.forName("java.lang.Runtime$Version");
+            Method versionMethod = runtimeClass.getDeclaredMethod("version");
+            Object versionObj = versionMethod.invoke(Runtime.getRuntime());
+            Method majorMethod = versionClass.getDeclaredMethod("major");
+            return (int) majorMethod.invoke(versionObj);
+        } catch (Exception e) {
+            return 8;
+        }
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/HazelcastJsonUpsertTargetTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/HazelcastJsonUpsertTargetTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.sql.impl.inject;
 
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.util.JavaVersion;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -30,6 +31,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 
+import static com.hazelcast.internal.util.JavaVersion.JAVA_19;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -73,29 +75,51 @@ public class HazelcastJsonUpsertTargetTest {
         timestampInjector.set(LocalDateTime.of(2020, 9, 9, 12, 23, 34, 100_000_000));
         timestampTzInjector.set(OffsetDateTime.of(2020, 9, 9, 12, 23, 34, 200_000_000, UTC));
         Object hazelcastJson = target.conclude();
-
-        assertThat(hazelcastJson).isEqualTo(new HazelcastJsonValue("{"
-                + "\"null\":null"
-                + ",\"object\":{}"
-                + ",\"string\":\"string\""
-                + ",\"boolean\":true"
-                + ",\"byte\":127"
-                + ",\"short\":32767"
-                + ",\"int\":2147483647"
-                + ",\"long\":9223372036854775807"
-                + ",\"float\":1.23456794E9"
-                + ",\"double\":1.234512345678901E14"
-                + ",\"decimal\":\"9223372036854775.123\""
-                + ",\"time\":\"12:23:34\""
-                + ",\"date\":\"2020-09-09\""
-                + ",\"timestamp\":\"2020-09-09T12:23:34.100\""
-                + ",\"timestampTz\":\"2020-09-09T12:23:34.200Z\""
-                + "}"
-        ));
+        String expectedJson;
+        if (JavaVersion.isAtLeast(JAVA_19)) {
+            // old, old, old JDK bug fixed now https://bugs.openjdk.org/browse/JDK-4511638
+            expectedJson = "{"
+                    + "\"null\":null"
+                    + ",\"object\":{}"
+                    + ",\"string\":\"string\""
+                    + ",\"boolean\":true"
+                    + ",\"byte\":127"
+                    + ",\"short\":32767"
+                    + ",\"int\":2147483647"
+                    + ",\"long\":9223372036854775807"
+                    + ",\"float\":1.234568E9"
+                    + ",\"double\":1.234512345678901E14"
+                    + ",\"decimal\":\"9223372036854775.123\""
+                    + ",\"time\":\"12:23:34\""
+                    + ",\"date\":\"2020-09-09\""
+                    + ",\"timestamp\":\"2020-09-09T12:23:34.100\""
+                    + ",\"timestampTz\":\"2020-09-09T12:23:34.200Z\""
+                    + "}";
+        } else {
+            expectedJson = "{"
+                    + "\"null\":null"
+                    + ",\"object\":{}"
+                    + ",\"string\":\"string\""
+                    + ",\"boolean\":true"
+                    + ",\"byte\":127"
+                    + ",\"short\":32767"
+                    + ",\"int\":2147483647"
+                    + ",\"long\":9223372036854775807"
+                    + ",\"float\":1.23456794E9"
+                    + ",\"double\":1.234512345678901E14"
+                    + ",\"decimal\":\"9223372036854775.123\""
+                    + ",\"time\":\"12:23:34\""
+                    + ",\"date\":\"2020-09-09\""
+                    + ",\"timestamp\":\"2020-09-09T12:23:34.100\""
+                    + ",\"timestampTz\":\"2020-09-09T12:23:34.200Z\""
+                    + "}";
+        }
+        assertThat(hazelcastJson).isEqualTo(new HazelcastJsonValue(expectedJson));
     }
 
     @SuppressWarnings("unused")
     private Object[] values() {
+        String expectedFloat = JavaVersion.isAtLeast(JAVA_19) ? "1.234568E9" : "1.23456794E9";
         return new Object[]{
                 new Object[]{null, "null"},
                 new Object[]{new JsonObject(), "{}"},
@@ -105,7 +129,7 @@ public class HazelcastJsonUpsertTargetTest {
                 new Object[]{(short) 32767, "32767"},
                 new Object[]{2147483647, "2147483647"},
                 new Object[]{9223372036854775807L, "9223372036854775807"},
-                new Object[]{1234567890.1F, "1.23456794E9"},
+                new Object[]{1234567890.1F, expectedFloat},
                 new Object[]{123451234567890.1D, "1.234512345678901E14"},
                 new Object[]{new BigDecimal("9223372036854775.123"), "\"9223372036854775.123\""},
                 new Object[]{LocalTime.of(12, 23, 34), "\"12:23:34\""},

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/JsonUpsertTargetTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/JsonUpsertTargetTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.sql.impl.inject;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.hazelcast.internal.util.JavaVersion;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -30,6 +31,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 
+import static com.hazelcast.internal.util.JavaVersion.JAVA_19;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,28 +77,51 @@ public class JsonUpsertTargetTest {
         timestampTzInjector.set(OffsetDateTime.of(2020, 9, 9, 12, 23, 34, 200_000_000, UTC));
         Object json = target.conclude();
 
-        assertThat(new String((byte[]) json)).isEqualTo("{"
-                + "\"null\":null"
-                + ",\"object\":{}"
-                + ",\"string\":\"string\""
-                + ",\"boolean\":true"
-                + ",\"byte\":127"
-                + ",\"short\":32767"
-                + ",\"int\":2147483647"
-                + ",\"long\":9223372036854775807"
-                + ",\"float\":1.23456794E9"
-                + ",\"double\":1.234512345678901E14"
-                + ",\"decimal\":\"9223372036854775.123\""
-                + ",\"time\":\"12:23:34\""
-                + ",\"date\":\"2020-09-09\""
-                + ",\"timestamp\":\"2020-09-09T12:23:34.100\""
-                + ",\"timestampTz\":\"2020-09-09T12:23:34.200Z\""
-                + "}"
-        );
+        String expectedJson;
+        if (JavaVersion.isAtLeast(JAVA_19)) {
+            // old, old, old JDK bug fixed now https://bugs.openjdk.org/browse/JDK-4511638
+            expectedJson = "{"
+                    + "\"null\":null"
+                    + ",\"object\":{}"
+                    + ",\"string\":\"string\""
+                    + ",\"boolean\":true"
+                    + ",\"byte\":127"
+                    + ",\"short\":32767"
+                    + ",\"int\":2147483647"
+                    + ",\"long\":9223372036854775807"
+                    + ",\"float\":1.234568E9"
+                    + ",\"double\":1.234512345678901E14"
+                    + ",\"decimal\":\"9223372036854775.123\""
+                    + ",\"time\":\"12:23:34\""
+                    + ",\"date\":\"2020-09-09\""
+                    + ",\"timestamp\":\"2020-09-09T12:23:34.100\""
+                    + ",\"timestampTz\":\"2020-09-09T12:23:34.200Z\""
+                    + "}";
+        } else {
+            expectedJson = "{"
+                    + "\"null\":null"
+                    + ",\"object\":{}"
+                    + ",\"string\":\"string\""
+                    + ",\"boolean\":true"
+                    + ",\"byte\":127"
+                    + ",\"short\":32767"
+                    + ",\"int\":2147483647"
+                    + ",\"long\":9223372036854775807"
+                    + ",\"float\":1.23456794E9"
+                    + ",\"double\":1.234512345678901E14"
+                    + ",\"decimal\":\"9223372036854775.123\""
+                    + ",\"time\":\"12:23:34\""
+                    + ",\"date\":\"2020-09-09\""
+                    + ",\"timestamp\":\"2020-09-09T12:23:34.100\""
+                    + ",\"timestampTz\":\"2020-09-09T12:23:34.200Z\""
+                    + "}";
+        }
+        assertThat(new String((byte[]) json)).isEqualTo(expectedJson);
     }
 
     @SuppressWarnings("unused")
     private Object[] values() {
+        String expectedFloat = JavaVersion.isAtLeast(JAVA_19) ? "1.234568E9" : "1.23456794E9";
         return new Object[]{
                 new Object[]{null, "null"},
                 new Object[]{new ObjectNode(JsonNodeFactory.instance), "{}"},
@@ -106,7 +131,7 @@ public class JsonUpsertTargetTest {
                 new Object[]{(short) 32767, "32767"},
                 new Object[]{2147483647, "2147483647"},
                 new Object[]{9223372036854775807L, "9223372036854775807"},
-                new Object[]{1234567890.1F, "1.23456794E9"},
+                new Object[]{1234567890.1F, expectedFloat},
                 new Object[]{123451234567890.1D, "1.234512345678901E14"},
                 new Object[]{new BigDecimal("9223372036854775.123"), "\"9223372036854775.123\""},
                 new Object[]{LocalTime.of(12, 23, 34), "\"12:23:34\""},

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
@@ -45,7 +45,10 @@ public enum JavaVersion implements JavaMajorVersion {
     JAVA_14(14),
     JAVA_15(15),
     JAVA_16(16),
-    JAVA_17(17)
+    JAVA_17(17),
+    JAVA_18(18),
+    JAVA_19(19),
+    JAVA_20(20)
     ;
 
     public static final JavaMajorVersion CURRENT_VERSION = detectCurrentVersion();

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationIssueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationIssueTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -40,6 +41,8 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
+
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -50,6 +53,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InvalidClassException;
 import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
@@ -69,6 +73,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -562,12 +567,13 @@ public class SerializationIssueTest extends HazelcastTestSupport {
         Object ocd
                 = Proxy.newProxyInstance(current, new Class[]{IPrivateObjectB.class, IPrivateObjectC.class}, DummyInvocationHandler.INSTANCE);
         Data data = ss.toData(ocd);
-        try {
-            ss.toObject(data);
-            Assert.fail("the object should not be deserializable");
-        } catch (IllegalAccessError expected) {
-            // expected
-        }
+        // when
+        Throwable thrown = Assertions.catchThrowable(() -> ss.toObject(data));
+        // https://bugs.openjdk.org/browse/JDK-8280642
+        assertThat(thrown).satisfiesAnyOf(
+                t -> assertThat(t).isInstanceOf(IllegalAccessError.class),
+                t -> assertThat(t).isInstanceOf(HazelcastSerializationException.class).hasCauseInstanceOf(InvalidClassException.class)
+        );
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
         <testcontainers.version>1.17.3</testcontainers.version>
-        <archunit.version>0.22.0</archunit.version>
+        <archunit.version>1.0.0</archunit.version>
         <errorprone.version>2.15.0</errorprone.version>
         <awaitility.version>4.1.1</awaitility.version>
         <hikari.version>4.0.3</hikari.version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
         <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
         <testcontainers.version>1.17.3</testcontainers.version>
+        <!--  When updating archunit.version, check/remove Java version assumptions in ArchUnitRulesTest.java -->
         <archunit.version>1.0.0</archunit.version>
         <errorprone.version>2.15.0</errorprone.version>
         <awaitility.version>4.1.1</awaitility.version>


### PR DESCRIPTION
This PR updates Hazelcast tests to run properly with Java 19.
There were some bugfixes introduced in JDK 19 which slightly change the behavior and we have to reflect it in tests:
* https://bugs.openjdk.org/browse/JDK-4511638
* https://bugs.openjdk.org/browse/JDK-8280642

Among these code changes, it is also necessary to enable Java 19 support in bytebuddy library. The lib is used for testing Config equality for instance.

```bash
mvn ...  -DextraVmArgs="-Dnet.bytebuddy.experimental=true"
```