### PR TITLE
[CN-543] Fix EC2 API DescribeNetworkInterfaces filter (#22488)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Api.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Api.java
@@ -22,6 +22,7 @@ import com.hazelcast.logging.Logger;
 import org.w3c.dom.Node;
 
 import java.time.Clock;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -167,6 +168,9 @@ class AwsEc2Api {
      * to make external smart clients able to work properly when possible.
      */
     Map<String, String> describeNetworkInterfaces(List<String> privateAddresses, AwsCredentials credentials) {
+        if (privateAddresses.isEmpty()) {
+            return Collections.emptyMap();
+        }
         try {
             Map<String, String> attributes = createAttributesDescribeNetworkInterfaces(privateAddresses);
             Map<String, String> headers = createHeaders(attributes, credentials);

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsCredentialsProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsCredentialsProviderTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.InvalidConfigurationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyTest.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
@@ -22,20 +22,24 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -43,7 +47,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AwsEc2ApiTest {
@@ -329,8 +333,24 @@ public class AwsEc2ApiTest {
 
         // then
         assertEquals(2, result.size());
+        assertTrue(result.containsKey("10.0.1.207"));
         assertNull(result.get("10.0.1.207"));
+        assertTrue(result.containsKey("10.0.1.82"));
         assertNull(result.get("10.0.1.82"));
+    }
+
+    @Test
+    public void describeNetworkInterfacesEmptyPrivateAddressList() {
+        // given
+        List<String> privateAddresses = Collections.emptyList();
+
+        // when
+        Map<String, String> result = awsEc2Api.describeNetworkInterfaces(privateAddresses, CREDENTIALS);
+
+        // then
+        assertEquals(0, result.size());
+
+        verify(exactly(0), getRequestedFor(urlEqualTo("/?Action=DescribeNetworkInterfaces&Version=2016-11-15")));
     }
 
     @Test
@@ -339,7 +359,7 @@ public class AwsEc2ApiTest {
         int errorCode = 401;
         String errorMessage = "Error message retrieved from AWS";
         stubFor(get(urlMatching("/.*"))
-            .willReturn(aResponse().withStatus(errorCode).withBody(errorMessage)));
+                .willReturn(aResponse().withStatus(errorCode).withBody(errorMessage)));
 
         // when
         Exception exception = assertThrows(Exception.class, () -> awsEc2Api.describeInstances(CREDENTIALS));

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ClientTest.java
@@ -20,7 +20,9 @@ import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
@@ -36,6 +38,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+@RunWith(MockitoJUnitRunner.class)
 public class AwsEc2ClientTest {
     @Mock
     private AwsEc2Api awsEc2Api;

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsApiTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AwsEcsApiTest {


### PR DESCRIPTION
Check filter of (private ip list) DescribeNetworkInterfaces request before sending. Otherwise, it will return the network interfaces of all EC2 instances when the filter is empty.

Checklist:

- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label Add to `Release Notes` or `Not Release Notes` content set
- [x] Request reviewers, if possible
- [x] Send backports/forwardports if a fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc