### PR TITLE
Fix DelegatingScheduledFutureStripperTest.getDelay test [HZ-1692]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/DelegatingScheduledFutureStripperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/DelegatingScheduledFutureStripperTest.java
@@ -40,7 +40,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -80,13 +79,15 @@ public class DelegatingScheduledFutureStripperTest {
 
     @Test
     public void getDelay() {
-        ScheduledFuture<Integer> future = new DelegatingScheduledFutureStripper<Integer>(
+        ScheduledFuture<Integer> future = new DelegatingScheduledFutureStripper<>(
                 scheduler.schedule(new SimpleCallableTestTask(), 0, TimeUnit.SECONDS));
-        assertEquals(0, future.getDelay(TimeUnit.SECONDS));
+        //getDelay returns the remaining delay; zero or negative values indicate that the delay has already elapsed
+        //If JVM pauses for GC we may get a negative value
+        assertTrue(future.getDelay(TimeUnit.SECONDS) <= 0);
 
-        future = new DelegatingScheduledFutureStripper<Integer>(
+        future = new DelegatingScheduledFutureStripper<>(
                 scheduler.schedule(new SimpleCallableTestTask(), 10, TimeUnit.SECONDS));
-        assertEquals(10, future.getDelay(TimeUnit.SECONDS), 1);
+        assertTrue(future.getDelay(TimeUnit.SECONDS) <= 10);
     }
 
     @Test
@@ -97,7 +98,7 @@ public class DelegatingScheduledFutureStripperTest {
 
         new DelegatingScheduledFutureStripper<Object>(outer).cancel(true);
 
-        verify(inner).cancel(eq(true));
+        verify(inner).cancel(true);
     }
 
     @Test
@@ -205,9 +206,4 @@ public class DelegatingScheduledFutureStripperTest {
         }
     }
 
-    private static class SimpleRunnableTestTask implements Runnable {
-        @Override
-        public void run() {
-        }
-    }
 }


### PR DESCRIPTION
- The test was failing because sometimes JVM was pausing for GC and getDelay() was returning a negative value. Changed the test to check for '<= delay'



Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
