### PR TITLE
[CN-543] Fix EC2 API DescribeNetworkInterfaces filter (#22488)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Api.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsEc2Api.java
@@ -22,6 +22,7 @@ import com.hazelcast.logging.Logger;
 import org.w3c.dom.Node;
 
 import java.time.Clock;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,6 +157,9 @@ class AwsEc2Api {
      * EC2 Describe Network Interfaces</a>
      */
     Map<String, String> describeNetworkInterfaces(List<String> privateAddresses, AwsCredentials credentials) {
+        if (privateAddresses.isEmpty()) {
+            return Collections.emptyMap();
+        }
         Map<String, String> attributes = createAttributesDescribeNetworkInterfaces(privateAddresses);
         Map<String, String> headers = createHeaders(attributes, credentials);
         String response = callAwsService(attributes, headers);

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsCredentialsProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsCredentialsProviderTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.InvalidConfigurationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsDiscoveryStrategyTest.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
@@ -33,10 +33,13 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -293,45 +296,13 @@ public class AwsEc2ApiTest {
         // given
         List<String> privateAddresses = Collections.emptyList();
 
-        String requestUrl = "/?Action=DescribeNetworkInterfaces"
-                + "&Filter.1.Name=addresses.private-ip-address"
-                + "&Filter.1.Value.1=10.0.1.207"
-                + "&Filter.1.Value.2=10.0.1.82"
-                + "&Version=2016-11-15";
-
-        //language=XML
-        String response = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                + "<DescribeNetworkInterfacesResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\">\n"
-                + "    <requestId>21bc9f93-2196-4107-87a3-9e5b2b3f29d9</requestId>\n"
-                + "    <networkInterfaceSet>\n"
-                + "        <item>\n"
-                + "            <availabilityZone>eu-central-1a</availabilityZone>\n"
-                + "            <privateIpAddress>10.0.1.207</privateIpAddress>\n"
-                + "            <association>\n"
-                + "                <publicIp>54.93.217.194</publicIp>\n"
-                + "            </association>\n"
-                + "        </item>\n"
-                + "        <item>\n"
-                + "            <availabilityZone>eu-central-1a</availabilityZone>\n"
-                + "            <privateIpAddress>10.0.1.82</privateIpAddress>\n"
-                + "            <association>\n"
-                + "                <publicIp>35.156.192.128</publicIp>\n"
-                + "            </association>\n"
-                + "        </item>\n"
-                + "    </networkInterfaceSet>\n"
-                + "</DescribeNetworkInterfacesResponse>";
-
-        stubFor(get(urlEqualTo(requestUrl))
-                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
-                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
-                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
-                .willReturn(aResponse().withStatus(200).withBody(response)));
-
         // when
         Map<String, String> result = awsEc2Api.describeNetworkInterfaces(privateAddresses, CREDENTIALS);
 
         // then
         assertEquals(0, result.size());
+
+        verify(exactly(0), getRequestedFor(urlEqualTo("/?Action=DescribeNetworkInterfaces&Version=2016-11-15")));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
@@ -27,6 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -281,8 +282,56 @@ public class AwsEc2ApiTest {
 
         // then
         assertEquals(2, result.size());
+        assertTrue(result.containsKey("10.0.1.207"));
         assertNull(result.get("10.0.1.207"));
+        assertTrue(result.containsKey("10.0.1.82"));
         assertNull(result.get("10.0.1.82"));
+    }
+
+    @Test
+    public void describeNetworkInterfacesEmptyPrivateAddressList() {
+        // given
+        List<String> privateAddresses = Collections.emptyList();
+
+        String requestUrl = "/?Action=DescribeNetworkInterfaces"
+                + "&Filter.1.Name=addresses.private-ip-address"
+                + "&Filter.1.Value.1=10.0.1.207"
+                + "&Filter.1.Value.2=10.0.1.82"
+                + "&Version=2016-11-15";
+
+        //language=XML
+        String response = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<DescribeNetworkInterfacesResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\">\n"
+                + "    <requestId>21bc9f93-2196-4107-87a3-9e5b2b3f29d9</requestId>\n"
+                + "    <networkInterfaceSet>\n"
+                + "        <item>\n"
+                + "            <availabilityZone>eu-central-1a</availabilityZone>\n"
+                + "            <privateIpAddress>10.0.1.207</privateIpAddress>\n"
+                + "            <association>\n"
+                + "                <publicIp>54.93.217.194</publicIp>\n"
+                + "            </association>\n"
+                + "        </item>\n"
+                + "        <item>\n"
+                + "            <availabilityZone>eu-central-1a</availabilityZone>\n"
+                + "            <privateIpAddress>10.0.1.82</privateIpAddress>\n"
+                + "            <association>\n"
+                + "                <publicIp>35.156.192.128</publicIp>\n"
+                + "            </association>\n"
+                + "        </item>\n"
+                + "    </networkInterfaceSet>\n"
+                + "</DescribeNetworkInterfacesResponse>";
+
+        stubFor(get(urlEqualTo(requestUrl))
+                .withHeader("X-Amz-Date", equalTo("20200403T102518Z"))
+                .withHeader("Authorization", equalTo(AUTHORIZATION_HEADER))
+                .withHeader("X-Amz-Security-Token", equalTo(TOKEN))
+                .willReturn(aResponse().withStatus(200).withBody(response)));
+
+        // when
+        Map<String, String> result = awsEc2Api.describeNetworkInterfaces(privateAddresses, CREDENTIALS);
+
+        // then
+        assertEquals(0, result.size());
     }
 
     @Test
@@ -291,7 +340,7 @@ public class AwsEc2ApiTest {
         int errorCode = 401;
         String errorMessage = "Error message retrieved from AWS";
         stubFor(get(urlMatching("/.*"))
-            .willReturn(aResponse().withStatus(errorCode).withBody(errorMessage)));
+                .willReturn(aResponse().withStatus(errorCode).withBody(errorMessage)));
 
         // when
         Exception exception = assertThrows(Exception.class, () -> awsEc2Api.describeInstances(CREDENTIALS));

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ApiTest.java
@@ -22,7 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AwsEc2ApiTest {

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEc2ClientTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Map;
 import java.util.Optional;

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsApiTest.java
@@ -23,7 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AwsEcsApiTest {

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsEcsClientTest.java
@@ -21,7 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Check filter of (private ip list) DescribeNetworkInterfaces request before sending. Otherwise, it will return the network interfaces of all EC2 instances when the filter is empty.

Checklist:

- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label Add to `Release Notes` or `Not Release Notes` content set
- [x] Request reviewers, if possible
- [x] Send backports/forwardports if a fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc