### PR TITLE
Add sleep to give nodes time to finish joining operations [HZ-1685]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioChannelMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioChannelMemoryLeakTest.java
@@ -77,6 +77,8 @@ public class NioChannelMemoryLeakTest extends HazelcastTestSupport {
         assertClusterSizeEventually(3, instance1, instance2, instance3);
 
         for (int i = 0; i < 5; i++) {
+            sleepSeconds(1);
+
             closeConnectionBetween(instance1, instance3);
             closeConnectionBetween(instance2, instance3);
             assertClusterSizeEventually(2, instance1, instance2);


### PR DESCRIPTION
**Test failure analyses** 
It seems that due to immediate closing connections with `instance3` in a test, not all `JoinRequest`/`JoinMessage` messages have time to reach other members. 
When `instance3` joined back to the cluster and changed its UUID, those messages finally reach other nodes but with the outdated `instance3` UUID. After this, the outdated `JoinMessage` is considered as a new join request, which leads to the connection closing and splitting of the cluster. We can assert this because the log contains the following warning: 
`New join request has been received from an existing endpoint Member [127.0.0.1]:5703 - <<outdated UUID>>. Removing old member and processing join request...`

Adding a delay in the test should fix the test failure, but the potential problem with outdated `JoinRequest`/`JoinMessage` messages is left.

Fixes #21697 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
