### PR TITLE
Test the Relational DB OOTB connector [HZ-1294]

### DIFF
--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
@@ -30,10 +30,15 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -593,6 +598,35 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
 
         GenericRecord record = mapStore.load(0);
         assertThat(record).isNotNull();
+    }
+
+    @Test
+    @Ignore("https://github.com/hazelcast/hazelcast/issues/22527")
+    public void givenColumnPropSubset_whenStore_thenTableContainsRow() throws SQLException {
+        createTable(mapName, "id INT PRIMARY KEY", "name VARCHAR(100)", "other VARCHAR(100) DEFAULT 'def'");
+        try (Connection conn = DriverManager.getConnection(dbConnectionUrl);
+             Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute("INSERT INTO " + mapName + " (id, name) VALUES(0, 'name-0')");
+        }
+
+        Properties properties = new Properties();
+        properties.setProperty(EXTERNAL_REF_ID_PROPERTY, TEST_DATABASE_REF);
+
+        properties.setProperty("columns", "id,name");
+        GenericMapStore<Integer> mapStore = createMapStore(properties, hz);
+
+        GenericRecord person = GenericRecordBuilder.compact(mapName)
+                .setInt32("id", 1)
+                .setString("name", "name-1")
+                .build();
+        mapStore.store(1, person);
+
+
+        assertJdbcRowsAnyOrder(mapName,
+                new Row(0, "name-0"),
+                new Row(1, "name-1")
+        );
     }
 
     private <K> GenericMapStore<K> createMapStore() {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DatabaseRule.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DatabaseRule.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.jdbc;
+
+import com.hazelcast.test.jdbc.TestDatabaseProvider;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class DatabaseRule implements TestRule {
+
+    private TestDatabaseProvider databaseProvider;
+    private String dbConnectionUrl;
+
+    public String getDbConnectionUrl() {
+        return dbConnectionUrl;
+    }
+
+    public DatabaseRule(TestDatabaseProvider databaseProvider) {
+        this.databaseProvider = databaseProvider;
+        dbConnectionUrl = databaseProvider.createDatabase(DatabaseRule.class.getName());
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    statement.evaluate();
+                } finally {
+                    if (dbConnectionUrl != null) {
+                        databaseProvider.shutdown();
+                        databaseProvider = null;
+                        dbConnectionUrl = null;
+                    }
+                }
+            }
+        };
+    }
+
+    public void createTable(String tableName, String... columns) throws SQLException {
+        executeJdbc("CREATE TABLE " + tableName + " (" + String.join(", ", columns) + ")");
+    }
+
+    public void executeJdbc(String sql) throws SQLException {
+
+        try (Connection conn = DriverManager.getConnection(dbConnectionUrl);
+             java.sql.Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute(sql);
+        }
+    }
+
+    public void insertItems(String tableName, int count) throws SQLException {
+        for (int i = 0; i < count; i++) {
+            executeJdbc(String.format("INSERT INTO " + tableName + " VALUES(%d, 'name-%d')", i, i));
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
@@ -17,17 +17,43 @@
 package com.hazelcast.jet.sql.impl.connector.jdbc;
 
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.sql.SQLException;
+
 import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_EXTERNAL_DATASTORE_REF;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.util.Lists.newArrayList;
 
 public class JdbcJoinTest extends JdbcSqlTestSupport {
+
+    private static final int ITEM_COUNT = 5;
+
+    private String tableName;
 
     @BeforeClass
     public static void beforeClass() {
         initialize(new H2DatabaseProvider());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        tableName = randomTableName();
+        createTable(tableName);
+        insertItems(tableName, ITEM_COUNT);
+
+        execute(
+                "CREATE MAPPING " + tableName + " ("
+                        + " id INT, "
+                        + " name VARCHAR "
+                        + ") "
+                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "OPTIONS ( "
+                        + " '" + OPTION_EXTERNAL_DATASTORE_REF + "'='" + TEST_DATABASE_REF + "'"
+                        + ")"
+        );
     }
 
     @Test
@@ -52,5 +78,141 @@ public class JdbcJoinTest extends JdbcSqlTestSupport {
                         "TABLE(GENERATE_STREAM(2)) t " +
                         "JOIN " + tableName + " n ON n.id = t.v;")
         ).hasMessageContaining("JDBC connector doesn't support stream-to-batch JOIN");
+    }
+
+    @Test
+    public void joinWithOtherJdbc() throws SQLException {
+
+        String otherTableName = randomTableName();
+        createTable(otherTableName);
+        insertItems(otherTableName, ITEM_COUNT);
+
+        execute(
+                "CREATE MAPPING " + otherTableName + " ("
+                        + " id INT, "
+                        + " name VARCHAR "
+                        + ") "
+                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "OPTIONS ( "
+                        + " '" + OPTION_EXTERNAL_DATASTORE_REF + "'='" + TEST_DATABASE_REF + "'"
+                        + ")"
+        );
+
+        assertRowsAnyOrder(
+                "SELECT t1.id, t2.name " +
+                        "FROM " + tableName + " t1 " +
+                        "JOIN " + otherTableName + " t2 " +
+                        "   ON t1.id = t2.id",
+                newArrayList(
+                        new Row(0, "name-0"),
+                        new Row(1, "name-1"),
+                        new Row(2, "name-2"),
+                        new Row(3, "name-3"),
+                        new Row(4, "name-4")
+                )
+        );
+    }
+
+    @Test
+    public void leftJoinWithOtherJdbc() throws SQLException {
+
+        String otherTableName = randomTableName();
+        createTable(otherTableName);
+        insertItems(otherTableName, 3);
+
+        execute(
+                "CREATE MAPPING " + otherTableName + " ("
+                        + " id INT, "
+                        + " name VARCHAR "
+                        + ") "
+                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "OPTIONS ( "
+                        + " '" + OPTION_EXTERNAL_DATASTORE_REF + "'='" + TEST_DATABASE_REF + "'"
+                        + ")"
+        );
+
+        assertRowsAnyOrder(
+                "SELECT t1.id, t2.name " +
+                        "FROM " + tableName + " t1 " +
+                        "LEFT JOIN " + otherTableName + " t2 " +
+                        "   ON t1.id = t2.id",
+                newArrayList(
+                        new Row(0, "name-0"),
+                        new Row(1, "name-1"),
+                        new Row(2, "name-2"),
+                        new Row(3, null),
+                        new Row(4, null)
+                )
+        );
+    }
+
+    @Test
+    public void rightJoinWithOtherJdbc() throws SQLException {
+
+        String otherTableName = randomTableName();
+        createTable(otherTableName);
+        insertItems(otherTableName, 7);
+
+        execute(
+                "CREATE MAPPING " + otherTableName + " ("
+                        + " id INT, "
+                        + " name VARCHAR "
+                        + ") "
+                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "OPTIONS ( "
+                        + " '" + OPTION_EXTERNAL_DATASTORE_REF + "'='" + TEST_DATABASE_REF + "'"
+                        + ")"
+        );
+
+        assertRowsAnyOrder(
+                "SELECT t1.id, t2.name " +
+                        "FROM " + tableName + " t1 " +
+                        "RIGHT JOIN " + otherTableName + " t2 " +
+                        "   ON t1.id = t2.id",
+                newArrayList(
+                        new Row(0, "name-0"),
+                        new Row(1, "name-1"),
+                        new Row(2, "name-2"),
+                        new Row(3, "name-3"),
+                        new Row(4, "name-4"),
+                        new Row(null, "name-5"),
+                        new Row(null, "name-6")
+                )
+        );
+    }
+
+    @Test
+    public void joinWithIMap() {
+
+        String mapName = "my_map";
+        execute(
+                "CREATE MAPPING " + mapName + " ( " +
+                        "__key INT, " +
+                        "id INT, " +
+                        "name VARCHAR ) " +
+                        "TYPE IMap " +
+                        "OPTIONS (" +
+                        "    'keyFormat' = 'int'," +
+                        "    'valueFormat' = 'compact',\n" +
+                        "    'valueCompactTypeName' = 'person'" +
+                        ")"
+        );
+
+        execute("INSERT INTO " + mapName + "(__key, id, name)" +
+                " SELECT v,v,'name-' || v FROM TABLE(generate_series(0,4))");
+
+        assertRowsAnyOrder(
+                "SELECT t1.id, t2.name " +
+                        "FROM " + tableName + " t1 " +
+                        "JOIN " + mapName + " t2 " +
+                        "   ON t1.id = t2.id",
+                newArrayList(
+                        new Row(0, "name-0"),
+                        new Row(1, "name-1"),
+                        new Row(2, "name-2"),
+                        new Row(3, "name-3"),
+                        new Row(4, "name-4")
+                )
+        );
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnectorBounceTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnectorBounceTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.jdbc;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ExternalDataStoreConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.datastore.JdbcDataStoreFactory;
+import com.hazelcast.jet.sql.SqlTestSupport;
+import com.hazelcast.sql.SqlResult;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
+import com.hazelcast.test.jdbc.H2DatabaseProvider;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static com.hazelcast.jet.sql.SqlTestSupport.assertRowsAnyOrder;
+import static com.hazelcast.jet.sql.SqlTestSupport.randomName;
+import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_EXTERNAL_DATASTORE_REF;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.util.Lists.newArrayList;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class JdbcSqlConnectorBounceTest {
+
+    private static final int ITEM_COUNT = 5;
+    private static final int CONCURRENCY = 10;
+    private static final String TEST_DATABASE_REF = "test-database-ref";
+
+    private String tableName;
+
+    private final DatabaseRule dbRule = new DatabaseRule(new H2DatabaseProvider());
+    private final BounceMemberRule bounceMemberRule =
+            BounceMemberRule.with(getConfig(dbRule.getDbConnectionUrl()))
+                .clusterSize(4)
+                .driverCount(4)
+                .driverType(BounceTestConfiguration.DriverType.CLIENT)
+                .build();
+
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(dbRule).around(bounceMemberRule);
+
+    private Config getConfig(String jdbcUrl) {
+        Properties properties = new Properties();
+        properties.setProperty("jdbcUrl", jdbcUrl);
+        return smallInstanceConfig().addExternalDataStoreConfig(
+                new ExternalDataStoreConfig(TEST_DATABASE_REF)
+                        .setClassName(JdbcDataStoreFactory.class.getName())
+                        .setProperties(properties)
+        );
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        tableName = "table_" + randomName();
+        dbRule.createTable(tableName, "id INT PRIMARY KEY", "name VARCHAR(100)");
+        dbRule.insertItems(tableName, ITEM_COUNT);
+
+        execute(
+                "CREATE MAPPING " + tableName + " ("
+                        + " id INT, "
+                        + " name VARCHAR "
+                        + ") "
+                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "OPTIONS ( "
+                        + " '" + OPTION_EXTERNAL_DATASTORE_REF + "'='" + TEST_DATABASE_REF + "'"
+                        + ")"
+        );
+    }
+
+    @Test
+    public void testQuery() {
+
+        QueryRunnable[] testTasks = new QueryRunnable[CONCURRENCY];
+        for (int i = 0; i < CONCURRENCY; i++) {
+            testTasks[i] = new QueryRunnable(bounceMemberRule.getNextTestDriver());
+        }
+        bounceMemberRule.testRepeatedly(testTasks, MINUTES.toSeconds(1));
+    }
+
+    private void execute(String sql, Object... arguments) {
+        try (SqlResult ignored = bounceMemberRule
+                .getSteadyMember()
+                .getSql()
+                .execute(sql, arguments)
+        ) {
+            // empty try-with-resources
+        }
+    }
+
+    public class QueryRunnable implements Runnable {
+
+        private final HazelcastInstance hazelcastInstance;
+
+        public QueryRunnable(HazelcastInstance hazelcastInstance) {
+            this.hazelcastInstance = hazelcastInstance;
+        }
+
+        @Override
+        public void run() {
+            assertRowsAnyOrder(
+                    hazelcastInstance,
+                    "SELECT * FROM " + tableName,
+                    newArrayList(
+                            new SqlTestSupport.Row(0, "name-0"),
+                            new SqlTestSupport.Row(1, "name-1"),
+                            new SqlTestSupport.Row(2, "name-2"),
+                            new SqlTestSupport.Row(3, "name-3"),
+                            new SqlTestSupport.Row(4, "name-4")
+                    )
+            );
+        }
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnectorStabilityTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnectorStabilityTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.jdbc;
+
+import com.hazelcast.sql.HazelcastSqlException;
+import com.hazelcast.test.jdbc.H2DatabaseProvider;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static com.hazelcast.function.ConsumerEx.noop;
+import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_EXTERNAL_DATASTORE_REF;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.util.Lists.newArrayList;
+
+public class JdbcSqlConnectorStabilityTest extends JdbcSqlTestSupport {
+
+    private static final int ITEM_COUNT = 5;
+
+    private String tableName;
+
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(new H2DatabaseProvider());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        tableName = randomTableName();
+        createTable(tableName);
+        insertItems(tableName, ITEM_COUNT);
+
+        execute(
+                "CREATE MAPPING " + tableName + " ("
+                        + " id INT, "
+                        + " name VARCHAR "
+                        + ") "
+                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "OPTIONS ( "
+                        + " '" + OPTION_EXTERNAL_DATASTORE_REF + "'='" + TEST_DATABASE_REF + "'"
+                        + ")"
+        );
+    }
+
+    @Test
+    public void dataStoreDownShouldTimeout() {
+
+        assertRowsAnyOrder(
+                "SELECT * FROM " + tableName,
+                newArrayList(
+                        new Row(0, "name-0"),
+                        new Row(1, "name-1"),
+                        new Row(2, "name-2"),
+                        new Row(3, "name-3"),
+                        new Row(4, "name-4")
+                )
+        );
+
+        databaseProvider.shutdown();
+
+        assertThatThrownBy(() -> {
+            instance()
+                    .getSql()
+                    .execute("SELECT * FROM " + tableName)
+                    .forEach(noop());
+        }).isInstanceOf(HazelcastSqlException.class);
+    }
+
+    @Test
+    @Ignore("https://github.com/hazelcast/hazelcast/issues/22651")
+    public void dataStoreDownShouldNotAffectUnrelatedQueries() {
+
+        assertRowsAnyOrder(
+                "SELECT * FROM " + tableName,
+                newArrayList(
+                        new Row(0, "name-0"),
+                        new Row(1, "name-1"),
+                        new Row(2, "name-2"),
+                        new Row(3, "name-3"),
+                        new Row(4, "name-4")
+                )
+        );
+
+        databaseProvider.shutdown();
+
+        assertRowsAnyOrder(
+                "SELECT * FROM TABLE(generate_series(0, 4))",
+                newArrayList(
+                        new Row(0),
+                        new Row(1),
+                        new Row(2),
+                        new Row(3),
+                        new Row(4)
+                )
+        );
+    }
+
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLAllTypesInsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLAllTypesInsertJdbcSqlConnectorTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.AllTypesInsertJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -26,7 +25,7 @@ import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class MySQLAllTypesInsertJdbcSqlConnectorTest extends AllTypesInsertJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLAllTypesSelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLAllTypesSelectJdbcSqlConnectorTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.AllTypesSelectJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -26,7 +25,7 @@ import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class MySQLAllTypesSelectJdbcSqlConnectorTest extends AllTypesSelectJdbcSqlConnectorTest {
 
     /*

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLDeleteJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLDeleteJdbcSqlConnectorTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.DeleteJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class MySQLDeleteJdbcSqlConnectorTest extends DeleteJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLInsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLInsertJdbcSqlConnectorTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.InsertJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class MySQLInsertJdbcSqlConnectorTest extends InsertJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLJdbcJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLJdbcJoinTest.java
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
+package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
-import com.hazelcast.jet.sql.impl.connector.jdbc.MappingJdbcSqlConnectorTest;
+import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcJoinTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
+import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 @Category(NightlyTest.class)
-public class PostgresMappingJdbcSqlConnectorTest extends MappingJdbcSqlConnectorTest {
+public class MySQLJdbcJoinTest extends JdbcJoinTest {
 
     @BeforeClass
     public static void beforeClass() {
-        initialize(new PostgresDatabaseProvider());
+        initialize(new MySQLDatabaseProvider());
     }
-
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLJdbcSqlConnectorStabilityTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLJdbcSqlConnectorStabilityTest.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
+package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
-import com.hazelcast.jet.sql.impl.connector.jdbc.MappingJdbcSqlConnectorTest;
+import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnectorStabilityTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
+import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
+
 @Category(NightlyTest.class)
-public class PostgresMappingJdbcSqlConnectorTest extends MappingJdbcSqlConnectorTest {
+public class MySQLJdbcSqlConnectorStabilityTest extends JdbcSqlConnectorStabilityTest {
 
     @BeforeClass
     public static void beforeClass() {
-        initialize(new PostgresDatabaseProvider());
+        initialize(new MySQLDatabaseProvider());
     }
-
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLMappingJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLMappingJdbcSqlConnectorTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.MappingJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class MySQLMappingJdbcSqlConnectorTest extends MappingJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLSelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLSelectJdbcSqlConnectorTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.SelectJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class MySQLSelectJdbcSqlConnectorTest extends SelectJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLUpdateJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLUpdateJdbcSqlConnectorTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.UpdateJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class MySQLUpdateJdbcSqlConnectorTest extends UpdateJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresAllTypesInsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresAllTypesInsertJdbcSqlConnectorTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.AllTypesInsertJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -26,7 +25,7 @@ import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class PostgresAllTypesInsertJdbcSqlConnectorTest extends AllTypesInsertJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresAllTypesSelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresAllTypesSelectJdbcSqlConnectorTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.AllTypesSelectJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -26,7 +25,7 @@ import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class PostgresAllTypesSelectJdbcSqlConnectorTest extends AllTypesSelectJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresDeleteJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresDeleteJdbcSqlConnectorTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.DeleteJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class PostgresDeleteJdbcSqlConnectorTest extends DeleteJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresInsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresInsertJdbcSqlConnectorTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.InsertJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class PostgresInsertJdbcSqlConnectorTest extends InsertJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresJdbcJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresJdbcJoinTest.java
@@ -16,18 +16,17 @@
 
 package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
-import com.hazelcast.jet.sql.impl.connector.jdbc.MappingJdbcSqlConnectorTest;
+import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcJoinTest;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 @Category(NightlyTest.class)
-public class PostgresMappingJdbcSqlConnectorTest extends MappingJdbcSqlConnectorTest {
+public class PostgresJdbcJoinTest extends JdbcJoinTest {
 
     @BeforeClass
     public static void beforeClass() {
         initialize(new PostgresDatabaseProvider());
     }
-
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresJdbcSqlConnectorStabilityTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresJdbcSqlConnectorStabilityTest.java
@@ -16,18 +16,17 @@
 
 package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
-import com.hazelcast.jet.sql.impl.connector.jdbc.MappingJdbcSqlConnectorTest;
+import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnectorStabilityTest;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 @Category(NightlyTest.class)
-public class PostgresMappingJdbcSqlConnectorTest extends MappingJdbcSqlConnectorTest {
+public class PostgresJdbcSqlConnectorStabilityTest extends JdbcSqlConnectorStabilityTest {
 
     @BeforeClass
     public static void beforeClass() {
         initialize(new PostgresDatabaseProvider());
     }
-
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresSelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresSelectJdbcSqlConnectorTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.SelectJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class PostgresSelectJdbcSqlConnectorTest extends SelectJdbcSqlConnectorTest {
 
     @BeforeClass

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresUpdateJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresUpdateJdbcSqlConnectorTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.UpdateJdbcSqlConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class PostgresUpdateJdbcSqlConnectorTest extends UpdateJdbcSqlConnectorTest {
 
     @BeforeClass


### PR DESCRIPTION
This includes various test scenarios for the JDBC OOTB Connector (JDBC 
Mapping and `GenericMapStore`) such as:

- Test for various `IMap` methods that weren't already covered in
`GenericMapStoreIntegrationTest`
- Test behavior when underlying datastore is down/disconnected
- Verify JDBC mapping for use in SQL joins
- Check that client queries to JDBC return proper results even when
bouncing cluster members



