### PR TITLE
Handle RejectedExecutionException for StepRunner

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/UtilSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/UtilSteps.java
@@ -16,17 +16,12 @@
 
 package com.hazelcast.map.impl.operation.steps;
 
-import com.hazelcast.core.HazelcastInstanceNotActiveException;
-import com.hazelcast.instance.impl.Node;
-import com.hazelcast.instance.impl.NodeState;
-import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.steps.engine.State;
 import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.operation.steps.engine.StepResponseUtil;
-import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
 public enum UtilSteps implements Step<State> {
 
@@ -50,48 +45,10 @@ public enum UtilSteps implements Step<State> {
         @Override
         public void runStep(State state) {
             try {
-                handleOperationError(state);
+                OperationRunnerImpl operationRunner = getPartitionOperationRunner(state);
+                operationRunner.handleOperationError(state.getOperation(), state.getThrowable());
             } finally {
                 state.setThrowable(null);
-            }
-        }
-
-        public void handleOperationError(State state) {
-            MapOperation operation = state.getOperation();
-            Throwable e = state.getThrowable();
-
-            if (e instanceof OutOfMemoryError) {
-                OutOfMemoryErrorDispatcher.onOutOfMemory((OutOfMemoryError) e);
-            }
-            try {
-                operation.onExecutionFailure(e);
-            } catch (Throwable t) {
-                operation.getNodeEngine().getLogger(operation.getClass())
-                        .warning("While calling 'operation.onFailure(e)'... op: "
-                                + operation + ", error: " + e, t);
-            }
-
-            operation.logError(e);
-
-            // A response is sent regardless of the
-            // Operation.returnsResponse method because some operations do
-            // want to send back a response, but they didn't want to send it
-            // yet but they ran into some kind of error. If on the receiving
-            // side no invocation is waiting, the response is ignored.
-            sendResponseAfterOperationError(operation, e);
-        }
-
-        private void sendResponseAfterOperationError(Operation operation, Throwable e) {
-            try {
-                Node node = ((NodeEngineImpl) operation.getNodeEngine()).getNode();
-                if (node.getState() != NodeState.SHUT_DOWN) {
-                    operation.sendResponse(e);
-                } else if (operation.executedLocally()) {
-                    operation.sendResponse(new HazelcastInstanceNotActiveException());
-                }
-            } catch (Throwable t) {
-                ILogger logger = operation.getNodeEngine().getLogger(operation.getClass());
-                logger.warning("While sending op error... op: " + operation + ", error: " + e, t);
             }
         }
 
@@ -99,5 +56,12 @@ public enum UtilSteps implements Step<State> {
         public Step nextStep(State state) {
             return null;
         }
+    };
+
+    public static OperationRunnerImpl getPartitionOperationRunner(State state) {
+        MapOperation operation = state.getOperation();
+        return (OperationRunnerImpl) ((OperationServiceImpl) operation.getNodeEngine()
+                .getOperationService()).getOperationExecutor()
+                .getPartitionOperationRunners()[state.getPartitionId()];
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/Step.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/Step.java
@@ -58,7 +58,7 @@ public interface Step<S> {
 
     /**
      * @param state the state object
-     * @return name of executor to run
+     * @return name of the executor to run this step
      */
     default String getExecutorName(S state) {
         return MAP_STORE_OFFLOADABLE_EXECUTOR;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -412,7 +412,7 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
         return (op instanceof ReadonlyOperation && staleReadOnMigrationEnabled) || isMigrationOperation(op);
     }
 
-    private void handleOperationError(Operation operation, Throwable e) {
+    public void handleOperationError(Operation operation, Throwable e) {
         if (e instanceof OutOfMemoryError) {
             OutOfMemoryErrorDispatcher.onOutOfMemory((OutOfMemoryError) e);
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplierTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplierTest.java
@@ -16,13 +16,19 @@
 package com.hazelcast.map.impl.operation.steps.engine;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.ExecutorConfig;
+import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.internal.util.FutureUtil;
+import com.hazelcast.map.IMap;
+import com.hazelcast.map.MapStoreAdapter;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.SetOperation;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.OperationAccessor;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.test.Accessors;
@@ -34,6 +40,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -44,9 +53,14 @@ import static org.junit.Assert.fail;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class StepSupplierTest extends HazelcastTestSupport {
 
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfig();
+    }
+
     @Test
     public void step_supplier_finishes() throws Exception {
-        HazelcastInstance node = createHazelcastInstance();
+        HazelcastInstance node = createHazelcastInstance(getConfig());
         Data data = Accessors.getSerializationService(node).toData("data");
         MapOperation operation = new SetOperation("map", data, data);
         operation.setNodeEngine(Accessors.getNodeEngineImpl(node));
@@ -66,7 +80,7 @@ public class StepSupplierTest extends HazelcastTestSupport {
 
     @Test
     public void step_supplier_get_returns_same_step() throws Exception {
-        HazelcastInstance node = createHazelcastInstance();
+        HazelcastInstance node = createHazelcastInstance(getConfig());
         Data data = Accessors.getSerializationService(node).toData("data");
         MapOperation operation = new SetOperation("map", data, data);
         operation.setNodeEngine(Accessors.getNodeEngineImpl(node));
@@ -82,7 +96,7 @@ public class StepSupplierTest extends HazelcastTestSupport {
     @Test
     public void step_supplier_ends_with_call_timeout_response_when_operation_timed_out() {
         // create node with force offload
-        Config config = smallInstanceConfig();
+        Config config = getConfig();
         config.setProperty(MapServiceContext.FORCE_OFFLOAD_ALL_OPERATIONS.getName(), "true");
         HazelcastInstance node = createHazelcastInstance(config);
 
@@ -117,5 +131,34 @@ public class StepSupplierTest extends HazelcastTestSupport {
         // wait operation end
         assertOpenEventually(latch);
         assertInstanceOf(CallTimeoutResponse.class, expectedResponse.get());
+    }
+
+    @Test
+    public void step_supplier_handles_rejected_execution_exception_then_operations_finish() {
+        Config config = getConfig();
+        // configure offloadable executor to throw
+        // RejectedExecutionException quickly
+        ExecutorConfig executorConfig
+                = config.getExecutorConfig(ExecutionService.MAP_STORE_OFFLOADABLE_EXECUTOR);
+        executorConfig.setPoolSize(1).setQueueCapacity(1);
+
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig
+                .setEnabled(true)
+                .setImplementation(new MapStoreAdapter<String, String>());
+
+        String mapName = "default";
+        config.getMapConfig(mapName)
+                .setMapStoreConfig(mapStoreConfig);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        IMap<String, String> map = instance.getMap(mapName);
+
+        List<CompletableFuture> futures = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            futures.add(map.setAsync("key-" + i, String.valueOf(i)).toCompletableFuture());
+        }
+
+        FutureUtil.waitUntilAllResponded(futures);
     }
 }


### PR DESCRIPTION
I have seen these issues during https://github.com/hazelcast/hazelcast/issues/22601 investigation.

**Issues:**
1.  If offload executor rejects task, all queued ops are stuck.
2.  If first step is an offload step, offloading does not happen. This is a potential future issue, 
   currently it cannot be happen.

**Modifications:**
1.  Handle possible `RejectedExecutionException` case while offloading to executor.
2.  Allow offload when `currentExecutorName` is `null`. 