### PR TITLE
Force higher version of JNA for M1 compatibility

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -739,6 +739,7 @@
             <scope>test</scope>
         </dependency>
         <!-- Force higher version, compatible with M1 -->
+        <!-- Otherwise Docker for Java (used by TestContainers) is not able to load all JNA files for aarch64 -->
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -738,6 +738,13 @@
             <version>${postgresql.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Force higher version, compatible with M1 -->
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>${jna.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,8 @@
         <mockito.version>3.6.0</mockito.version>
         <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
-        <testcontainers.version>1.17.3</testcontainers.version>
+        <testcontainers.version>1.17.5</testcontainers.version>
+        <jna.version>5.12.1</jna.version>
         <archunit.version>0.22.0</archunit.version>
         <errorprone.version>2.15.0</errorprone.version>
         <awaitility.version>4.1.1</awaitility.version>


### PR DESCRIPTION
Same change was done in EE repository

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
