### PR TITLE
Fix JobTimeoutTest.when_jobIsResumedAndExceedsTimeout_jobIsCancelled [HZ-1707]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobTimeoutTest.java
@@ -106,10 +106,10 @@ public class JobTimeoutTest extends JetTestSupport {
         final JobConfig jobConfig = new JobConfig().setTimeoutMillis(1000L);
         final Job job = hz.getJet().newJob(dag, jobConfig);
 
-        assertJobStatusEventually(job, JobStatus.RUNNING, 1);
+        assertJobStatusEventually(job, JobStatus.RUNNING);
         job.suspend();
 
-        assertJobStatusEventually(job, JobStatus.SUSPENDED, 1);
+        assertJobStatusEventually(job, JobStatus.SUSPENDED);
 
         assertThrows(CancellationException.class, job::join);
         assertEquals(JobStatus.FAILED, job.getStatus());

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobTimeoutTest.java
@@ -88,10 +88,10 @@ public class JobTimeoutTest extends JetTestSupport {
         final JobConfig jobConfig = new JobConfig().setTimeoutMillis(1000L);
         final Job job = hz.getJet().newJob(dag, jobConfig);
 
-        assertJobStatusEventually(job, JobStatus.RUNNING, 1);
+        assertJobStatusEventually(job, JobStatus.RUNNING);
         job.suspend();
 
-        assertJobStatusEventually(job, JobStatus.SUSPENDED, 1);
+        assertJobStatusEventually(job, JobStatus.SUSPENDED);
         job.resume();
 
         assertThrows(CancellationException.class, job::join);


### PR DESCRIPTION
The test was probably failing because of the timeout value used in assertJobStatusEventually() method. The timeout value was 1 second, which is too small. Changed the test to not use timeout for assertJobStatusEventually() method

Fixes #22648

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
