### PR TITLE
Add eventually waiting for the 'MemberLeftException' exception [HZ-1708]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
@@ -43,6 +43,7 @@ import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionOptions.TransactionType;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -424,8 +425,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
         changeClusterStateEventually(hz2, state);
         hz1.shutdown();
 
-        expectedException.expect(MemberLeftException.class);
-        future.get();
+        assertTrueEventually(() -> Assert.assertThrows(MemberLeftException.class, future::get));
     }
 
     @Test


### PR DESCRIPTION
It seems that the instance shutdown process hasn't been completed before the assertion, and returns the wrong type of exception:
`java.lang.IllegalStateException: Cluster is in PASSIVE state! Operation: com.hazelcast.partition.IndeterminateOperationStateExceptionTest$SilentOperation{serviceName='null', identityHash=-476619532, partitionId=-1, replicaIndex=0, callId=3, invocationTime=1641177075445 (2022-01-03 02:31:15.445), waitTimeout=-1, callTimeout=60000, tenantControl=com.hazelcast.spi.impl.tenantcontrol.NoopTenantControl@0}`
Adding eventually waiting for the `MemberLeftException` should be a fix.

Fixes #20297

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
