### PR TITLE
Move JNA version change to dependency management, instead of providing normal dependency

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -738,14 +738,6 @@
             <version>${postgresql.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- Force higher version, compatible with M1 -->
-        <!-- Otherwise Docker for Java (used by TestContainers) is not able to load all JNA files for aarch64 -->
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1842,6 +1842,13 @@
               <artifactId>proto-google-iam-v1</artifactId>
               <version>1.1.7</version>
             </dependency>
+            <!-- Force higher version, compatible with M1 -->
+            <!-- Otherwise Docker for Java (used by TestContainers) is not able to load all JNA files for aarch64 -->
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>${jna.version}</version>
+            </dependency>
             <!--
             The following are test dependencies, they are not in the final distribution.
             We put them there for the dependency convergence task to succeed.


### PR DESCRIPTION
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
