### PR TITLE
Improve isTechnicalCancellationException check [HZ-1698]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/LogExceptionSqlTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/LogExceptionSqlTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.sql;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
@@ -70,7 +71,7 @@ public class LogExceptionSqlTest extends SimpleTestInClusterSupport {
         assertNoJobsLeftEventually(instance());
 
         // then
-        List<Throwable> exceptions = recorder.exceptionsOfTypes(ResultLimitReachedException.class);
+        List<Throwable> exceptions = recorder.exceptionsOfTypes(ResultLimitReachedException.class, JetException.class);
         assertThat(exceptions).isEmpty();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -236,8 +236,12 @@ public final class ExceptionUtil {
         return peeledFailure instanceof JobTerminateRequestedException
                 || peeledFailure instanceof ResultLimitReachedException
                 || peeledFailure instanceof TerminatedWithSnapshotException
-                ||
-                (peeledFailure != peeledFailure.getCause()
-                        && isTechnicalCancellationException(peeledFailure.getCause()));
+                || checkCause(peeledFailure);
+    }
+
+    private static boolean checkCause(Throwable peeledFailure) {
+        return peeledFailure.getCause() != null
+                && peeledFailure != peeledFailure.getCause()
+                && isTechnicalCancellationException(peeledFailure.getCause());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -235,6 +235,9 @@ public final class ExceptionUtil {
         Throwable peeledFailure = peel(t);
         return peeledFailure instanceof JobTerminateRequestedException
                 || peeledFailure instanceof ResultLimitReachedException
-                || peeledFailure instanceof TerminatedWithSnapshotException;
+                || peeledFailure instanceof TerminatedWithSnapshotException
+                ||
+                (peeledFailure != peeledFailure.getCause()
+                        && isTechnicalCancellationException(peeledFailure.getCause()));
     }
 }


### PR DESCRIPTION
Follow up to #22275.

SQL query with limit still printed ResultLimitReachedException wrapped in JetException as cause at error level. It wasn't discovered due to an incorrect assertion in LogExceptionSqlTest.

Fixes #22650

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases

Backport to 5.2.z