### PR TITLE
Make `MapIndexScanP` non-cooperative [HZ-1703]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import java.util.PrimitiveIterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.impl.util.Util.getNodeEngine;
@@ -149,9 +150,22 @@ final class MapIndexScanP extends AbstractProcessor {
         return isIndexSorted ? runSortedIndex() : runHashIndex();
     }
 
+    /**
+     * Processor uses operation runner, which may hold locks
+     * for {@link java.util.concurrent.ConcurrentHashMap#computeIfAbsent(Object, Function)}.
+     * <p>
+     * See more : {@link com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl#run(Operation, long)}
+     *
+     * @return false
+     */
+    @Override
+    public boolean isCooperative() {
+        return false;
+    }
+
     @Override
     public boolean closeIsCooperative() {
-        return true;
+        return false;
     }
 
     private boolean runSortedIndex() {


### PR DESCRIPTION
`MapIndexScanP` uses operation to fetch index data from imap partitions.  Unfortunately for us, `OperationRunnerImpl` use concurrent hash map, which may hold lock in `computeIfAbsent` method. It makes counterproductive to have `MapIndexScanP` cooperative, and that patch make it non-cooperative.