### PR TITLE
Update comments with closeIsCooperative method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -55,6 +55,7 @@ import javax.annotation.Nonnull;
  * <ul>
  *     <li>{@link #isCooperative()}
  *     <li>{@link #init(Outbox, Context)}
+ *     <li>{@link #closeIsCooperative()}
  *     <li>{@link #close()}
  * </ul>
  *
@@ -87,12 +88,13 @@ import javax.annotation.Nonnull;
  *
  * <h3>How the methods are called</h3>
  * <p>
- * Besides {@link #init}, {@link #close} and {@link #isCooperative} the methods
- * are called in a tight loop with a possibly short back-off if the method does
- * no work. "No work" is defined as adding nothing to outbox and taking nothing
- * from inbox. If you do heavy work on each call (such as querying a remote
- * service), you can do additional back-off: use {@code sleep} in a
- * non-cooperative processor or do nothing if sufficient time didn't elapse.
+ * Besides {@link #init}, {@link #close}, {@link #isCooperative} and {@link
+ * #closeIsCooperative()} the methods are called in a tight loop with a possibly
+ * short back-off if the method does no work. "No work" is defined as adding
+ * nothing to outbox and taking nothing from inbox. If you do heavy work on each
+ * call (such as querying a remote service), you can do additional back-off: use
+ * {@code sleep} in a non-cooperative processor or do nothing if sufficient time
+ * didn't elapse.
  *
  * @since Jet 3.0
  */

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -88,13 +88,13 @@ import javax.annotation.Nonnull;
  *
  * <h3>How the methods are called</h3>
  * <p>
- * Besides {@link #init}, {@link #close}, {@link #isCooperative} and {@link
- * #closeIsCooperative()} the methods are called in a tight loop with a possibly
- * short back-off if the method does no work. "No work" is defined as adding
- * nothing to outbox and taking nothing from inbox. If you do heavy work on each
- * call (such as querying a remote service), you can do additional back-off: use
- * {@code sleep} in a non-cooperative processor or do nothing if sufficient time
- * didn't elapse.
+ * Except for {@link #init}, {@link #close}, {@link #isCooperative} and {@link
+ * #closeIsCooperative()}, the methods are called in a tight loop with a
+ * possibly short back-off if the method does no work. "No work" is defined as
+ * adding nothing to outbox and taking nothing from inbox. If you do heavy work
+ * on each call (such as querying a remote service), you can do additional
+ * back-off: use {@code sleep} in a non-cooperative processor or do nothing if
+ * sufficient time didn't elapse.
  *
  * @since Jet 3.0
  */


### PR DESCRIPTION
Added missing `closeIsCooperative` references in comments.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
