### PR TITLE
Avoid logging errors for metricsJournal reads with a wrong sequence [MC-1177][5.1.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
@@ -193,6 +193,10 @@ public class MetricsService implements ManagedService, LiveOperationsTracker {
             if (!slice.isEmpty()) {
                 future.complete(slice);
             }
+        } catch (ConcurrentArrayRingbuffer.SequenceOutOfBoundsException e) {
+            logger.fine("Error reading from metrics journal, sequence: " + sequence + "."
+                    + " In case of persistence-enabled member restart, this error is handled by MC gracefully.", e);
+            future.completeExceptionally(e);
         } catch (Exception e) {
             logger.severe("Error reading from metrics journal, sequence: " + sequence, e);
             future.completeExceptionally(e);

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ConcurrentArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/managementcenter/ConcurrentArrayRingbuffer.java
@@ -103,14 +103,14 @@ public class ConcurrentArrayRingbuffer<E> {
 
     private void checkSequence(long sequence) {
         if (sequence >= tail) {
-            throw new IllegalArgumentException("sequence:" + sequence
+            throw new SequenceOutOfBoundsException("sequence:" + sequence
                     + " is too large. The current tail is:" + tail);
         }
 
         if (sequence < head) {
-            throw new IllegalArgumentException("sequence:" + sequence
-                    + " is too small. The current headSequence is:" + head
-                    + " tailSequence is:" + tail);
+            throw new SequenceOutOfBoundsException("sequence:" + sequence
+                    + " is too small. The current head is:" + head
+                    + " tail is:" + tail);
         }
     }
 
@@ -148,6 +148,13 @@ public class ConcurrentArrayRingbuffer<E> {
          */
         public long nextSequence() {
             return nextSequence;
+        }
+    }
+
+    public static class SequenceOutOfBoundsException extends RuntimeException {
+
+        public SequenceOutOfBoundsException(String message) {
+            super(message);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ConcurrentArrayRingbufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ConcurrentArrayRingbufferTest.java
@@ -68,13 +68,13 @@ public class ConcurrentArrayRingbufferTest {
 
     @Test
     public void when_sequenceTooHigh_then_fail() {
-        exception.expect(IllegalArgumentException.class);
+        exception.expect(ConcurrentArrayRingbuffer.SequenceOutOfBoundsException.class);
         rb.get(0);
     }
 
     @Test
     public void when_sequenceTooLow_then_fail() {
-        exception.expect(IllegalArgumentException.class);
+        exception.expect(ConcurrentArrayRingbuffer.SequenceOutOfBoundsException.class);
         rb.get(-1);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsServiceTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
+import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer;
 import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer.RingbufferSlice;
 import com.hazelcast.internal.metrics.managementcenter.MetricsResultSet;
 import com.hazelcast.logging.ILogger;
@@ -38,8 +39,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.JmxLeakHelper;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.core.Is;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,6 +58,7 @@ import static com.hazelcast.internal.metrics.MetricTarget.MANAGEMENT_CENTER;
 import static com.hazelcast.internal.metrics.ProbeUnit.COUNT;
 import static com.hazelcast.internal.metrics.impl.DefaultMetricDescriptorSupplier.DEFAULT_DESCRIPTOR_SUPPLIER;
 import static com.hazelcast.internal.metrics.impl.MetricsCompressor.extractMetrics;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -306,11 +306,10 @@ public class MetricsServiceTest extends HazelcastTestSupport {
         long futureSequence = 42;
         long headSequence = 0;
 
-        expectedException.expect(ExecutionException.class);
-        expectedException.expectCause(Is.is(CoreMatchers.instanceOf(IllegalArgumentException.class)));
-        expectedException.expectMessage(Long.toString(futureSequence));
-        expectedException.expectMessage(Long.toString(headSequence));
-        readMetrics(metricsService, futureSequence, metricConsumerMock);
+        assertThatExceptionOfType(ExecutionException.class)
+                .isThrownBy(() -> readMetrics(metricsService, futureSequence, metricConsumerMock))
+                .withCauseExactlyInstanceOf(ConcurrentArrayRingbuffer.SequenceOutOfBoundsException.class)
+                .withMessageContainingAll(Long.toString(futureSequence), Long.toString(headSequence));
     }
 
     @Test


### PR DESCRIPTION
Logs like:
```
Error reading from metrics journal, sequence: 716
java.lang.IllegalArgumentException: sequence:716 is too large. The current tail is:23
```
may occur when member was restarted and `metricsJournal` was recreated, but MC tries to get metrics from the latest known sequence.
This case is gracefully handled on MC side, so MC retries reading metrics with a sequence = 0.

Backport of: https://github.com/hazelcast/hazelcast/pull/22698

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases