### PR TITLE
Fix ClientScheduledExecutorServiceSlowTest.schedule_withLongSleepingCallable_blockingOnGet  [API-1658]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceSlowTest.java
@@ -68,14 +68,19 @@ public class ScheduledExecutorServiceSlowTest extends ScheduledExecutorServiceTe
         IScheduledFuture<Double> future = executorService.schedule(
                 new ICountdownLatchCallableTask(initCountLatch.getName(), waitCountLatch.getName(), doneCountLatch.getName()), delay, SECONDS);
 
-        assertOpenEventually(initCountLatch);
-
         int sleepPeriod = 10000;
         long start = System.currentTimeMillis();
-        new Thread(() -> {
+        Thread thread = new Thread(() -> {
+            //This is to make sure that the executorService has scheduled the task
+            //and waiting for waitCountLatch
+            assertOpenEventually(initCountLatch);
+
             sleepAtLeastMillis(sleepPeriod);
             waitCountLatch.countDown();
-        }).start();
+        });
+        thread.start();
+        //Make sure the thread has run
+        thread.join();
 
         double result = future.get();
 

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceSlowTest.java
@@ -68,23 +68,18 @@ public class ScheduledExecutorServiceSlowTest extends ScheduledExecutorServiceTe
         IScheduledFuture<Double> future = executorService.schedule(
                 new ICountdownLatchCallableTask(initCountLatch.getName(), waitCountLatch.getName(), doneCountLatch.getName()), delay, SECONDS);
 
-        int sleepPeriod = 10000;
-        long start = System.currentTimeMillis();
-        Thread thread = new Thread(() -> {
-            //This is to make sure that the executorService has scheduled the task
-            //and waiting for waitCountLatch
-            assertOpenEventually(initCountLatch);
+        assertOpenEventually(initCountLatch);
 
+        int sleepPeriod = 10000;
+        long start = System.nanoTime();
+        new Thread(() -> {
             sleepAtLeastMillis(sleepPeriod);
             waitCountLatch.countDown();
-        });
-        thread.start();
-        //Make sure the thread has run
-        thread.join();
+        }).start();
 
         double result = future.get();
 
-        assertTrue(System.currentTimeMillis() - start > sleepPeriod);
+        assertTrue(System.nanoTime() - start > sleepPeriod);
         assertTrue(doneCountLatch.await(0, SECONDS));
         assertEquals(expectedResult, result, 0);
         assertTrue(future.isDone());

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceSlowTest.java
@@ -70,16 +70,20 @@ public class ScheduledExecutorServiceSlowTest extends ScheduledExecutorServiceTe
 
         assertOpenEventually(initCountLatch);
 
-        int sleepPeriod = 10000;
+        long sleepPeriod = 10;
+        long sleepPeriodInMillis = SECONDS.toMillis(sleepPeriod);
+        long sleepPeriodInNanos = SECONDS.toNanos(sleepPeriod);
+
         long start = System.nanoTime();
         new Thread(() -> {
-            sleepAtLeastMillis(sleepPeriod);
+
+            sleepAtLeastMillis(sleepPeriodInMillis);
             waitCountLatch.countDown();
         }).start();
 
         double result = future.get();
 
-        assertTrue(System.nanoTime() - start > sleepPeriod);
+        assertTrue(System.nanoTime() - start > sleepPeriodInNanos);
         assertTrue(doneCountLatch.await(0, SECONDS));
         assertEquals(expectedResult, result, 0);
         assertTrue(future.isDone());


### PR DESCRIPTION
System.currentTimeMillis() is replaced with System.nanoTime() to use the same clock within the test


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

closes #22068