### PR TITLE
Make cluster tests less flaky [HZ-1714]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.impl.JetServiceBackend;
@@ -41,6 +42,7 @@ import java.util.stream.Collectors;
 import static com.hazelcast.jet.Util.idToString;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -58,6 +60,8 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
     private static HazelcastInstance client;
 
     protected static void initialize(int memberCount, @Nullable Config config) {
+        assertNoRunningInstances();
+
         assert factory == null : "already initialized";
         factory = new TestHazelcastFactory();
         instances = new HazelcastInstance[memberCount];
@@ -190,5 +194,9 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
      */
     protected static HazelcastInstance client() {
         return client;
+    }
+
+    private static void assertNoRunningInstances() {
+        assertThat(Hazelcast.getAllHazelcastInstances()).as("There should be no running instances").isEmpty();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/AfterClassesStatement.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AfterClassesStatement.java
@@ -19,6 +19,7 @@ package com.hazelcast.test;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import org.junit.runners.model.Statement;
 
 import java.util.Collection;
@@ -42,7 +43,7 @@ class AfterClassesStatement extends Statement {
         Set<HazelcastInstance> instances = Hazelcast.getAllHazelcastInstances();
         if (!instances.isEmpty()) {
             String message = "Instances haven't been shut down: " + instances;
-            Hazelcast.shutdownAll();
+            HazelcastInstanceFactory.terminateAll();
             throw new IllegalStateException(message);
         }
         Collection<HazelcastInstance> clientInstances = HazelcastClient.getAllHazelcastClients();


### PR DESCRIPTION
It could be that one failing cluster test can results with failures of other consequent tests. 

- Added assertions that there no running instances during the initialisation of the new test cluster
- Terminate all running instances after test class instead of shutting them down

A failure of `com.hazelcast.jet.core.MemberReconnectionStressTest` could break the next tests (https://jenkins.hazelcast.com/view/Official%20Builds/job/Hazelcast-master-OracleJDK8-nightly/921/consoleText
):

```
[ERROR] com.hazelcast.jet.core.MemberReconnectionStressTest  Time elapsed: 180.361 s  <<< ERROR!
java.lang.IllegalStateException: Instances haven't been shut down: [HazelcastInstance{name='objective_greider', node=[127.0.0.1]:5702}, HazelcastInstance{name='relaxed_greider', node=[127.0.0.1]:5701}]
	at com.hazelcast.test.AfterClassesStatement.evaluate(AfterClassesStatement.java:46)
	at com.hazelcast.test.OverridePropertyRule$1.evaluate(OverridePropertyRule.java:66)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)
```

Later during the initialisation of the new cluster in the next test (at the very beginning) we see:
```
[ERROR] test_supplied_closeable_datasource_is_NOT_closed(com.hazelcast.jet.impl.connector.WriteJdbcPTest)  Time elapsed: 0.592 s  <<< ERROR!
com.hazelcast.core.HazelcastInstanceNotActiveException: Hazelcast instance is not active!
	at com.hazelcast.instance.impl.HazelcastInstanceProxy.getOriginal(HazelcastInstanceProxy.java:322)
	at com.hazelcast.instance.impl.HazelcastInstanceProxy.getJet(HazelcastInstanceProxy.java:306)
	at com.hazelcast.jet.impl.connector.WriteJdbcPTest.test_supplied_closeable_datasource_is_NOT_closed(WriteJdbcPTest.java:149)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:115)
	at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:107)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)
```




Fixes https://github.com/hazelcast/hazelcast/issues/22670