### PR TITLE
Init cached partitions [HZ-1715]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -199,7 +199,10 @@ class MapMigrationAwareService
             // has been already started this call will do nothing
             recordStore.startLoading();
         }
-        mapServiceContext.nullifyOwnedPartitions();
+
+        if (event.getCurrentReplicaIndex() == 0 || event.getNewReplicaIndex() == 0) {
+            mapServiceContext.refreshCachedOwnedPartitions();
+        }
 
         removeOrRegenerateNearCacheUuid(event);
 
@@ -259,7 +262,9 @@ class MapMigrationAwareService
             partitionContainer.cleanUpOnMigration(event.getCurrentReplicaIndex());
         }
 
-        mapServiceContext.nullifyOwnedPartitions();
+        if (event.getCurrentReplicaIndex() == 0 || event.getNewReplicaIndex() == 0) {
+            mapServiceContext.refreshCachedOwnedPartitions();
+        }
     }
 
     private void clearNonGlobalIndexes(PartitionMigrationEvent event) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -155,9 +155,9 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport,
      * Returns cached collection of owned partitions,
      * When it is null, reloads and caches it again.
      */
-    PartitionIdSet getOrInitCachedMemberPartitions();
+    PartitionIdSet getCachedOwnedPartitions();
 
-    void nullifyOwnedPartitions();
+    void refreshCachedOwnedPartitions();
 
     ExpirationManager getExpirationManager();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -90,6 +90,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
@@ -143,6 +144,7 @@ class MapServiceContextImpl implements MapServiceContext {
     private final ConcurrentMap<String, MapContainer> mapContainers = new ConcurrentHashMap<>();
     private final ExecutorStats offloadedExecutorStats = new ExecutorStats();
     private final EventListenerCounter eventListenerCounter = new EventListenerCounter();
+    private final AtomicReference<PartitionIdSet> cachedOwnedPartitions = new AtomicReference<>();
 
     /**
      * @see {@link MapKeyLoader#DEFAULT_LOADED_KEY_LIMIT_PER_NODE}
@@ -151,8 +153,6 @@ class MapServiceContextImpl implements MapServiceContext {
     private final boolean forceOffloadEnabled;
 
     private MapService mapService;
-
-    private volatile PartitionIdSet ownedPartitions;
 
     @SuppressWarnings("checkstyle:executablestatementcount")
     MapServiceContextImpl(NodeEngine nodeEngine) {
@@ -504,28 +504,30 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     @Override
-    public PartitionIdSet getOrInitCachedMemberPartitions() {
-        PartitionIdSet ownedPartitionIdSet = ownedPartitions;
-        if (ownedPartitionIdSet != null) {
-            return ownedPartitionIdSet;
+    public PartitionIdSet getCachedOwnedPartitions() {
+        PartitionIdSet ownedSet = cachedOwnedPartitions.get();
+        if (ownedSet == null) {
+            refreshCachedOwnedPartitions();
+            ownedSet = cachedOwnedPartitions.get();
         }
-
-        synchronized (this) {
-            ownedPartitionIdSet = ownedPartitions;
-            if (ownedPartitionIdSet != null) {
-                return ownedPartitionIdSet;
-            }
-            IPartitionService partitionService = nodeEngine.getPartitionService();
-            Collection<Integer> partitions = partitionService.getMemberPartitions(nodeEngine.getThisAddress());
-            ownedPartitionIdSet = immutablePartitionIdSet(partitionService.getPartitionCount(), partitions);
-            ownedPartitions = ownedPartitionIdSet;
-        }
-        return ownedPartitionIdSet;
+        return ownedSet;
     }
 
+    private PartitionIdSet getOwnedMemberPartitions() {
+        IPartitionService partitionService = nodeEngine.getPartitionService();
+        Collection<Integer> partitions = partitionService.getMemberPartitions(nodeEngine.getThisAddress());
+        return immutablePartitionIdSet(partitionService.getPartitionCount(), partitions);
+    }
+
+    @SuppressWarnings("checkstyle:multiplevariabledeclarations")
     @Override
-    public void nullifyOwnedPartitions() {
-        ownedPartitions = null;
+    // can be called concurrently
+    public void refreshCachedOwnedPartitions() {
+        PartitionIdSet expectedSet, newSet;
+        do {
+            expectedSet = cachedOwnedPartitions.get();
+            newSet = getOwnedMemberPartitions();
+        } while (!cachedOwnedPartitions.compareAndSet(expectedSet, newSet));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -16,30 +16,6 @@
 
 package com.hazelcast.map.impl.proxy;
 
-import static com.hazelcast.core.EntryEventType.CLEAR_ALL;
-import static com.hazelcast.internal.util.CollectionUtil.asIntegerList;
-import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
-import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
-import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterSerial;
-import static com.hazelcast.internal.util.IterableUtil.nullToEmpty;
-import static com.hazelcast.internal.util.MapUtil.createHashMap;
-import static com.hazelcast.internal.util.MapUtil.toIntSize;
-import static com.hazelcast.internal.util.Preconditions.checkFalse;
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
-import static com.hazelcast.internal.util.SetUtil.createHashSet;
-import static com.hazelcast.internal.util.ThreadUtil.getThreadId;
-import static com.hazelcast.internal.util.TimeUtil.timeInMsOrOneIfResultIsZero;
-import static com.hazelcast.map.impl.EntryRemovingProcessor.ENTRY_REMOVING_PROCESSOR;
-import static com.hazelcast.map.impl.MapOperationStatsUpdater.incrementOperationStats;
-import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
-import static com.hazelcast.map.impl.query.Target.createPartitionTarget;
-import static com.hazelcast.query.Predicates.alwaysFalse;
-import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
-import static java.lang.Math.ceil;
-import static java.lang.Math.log10;
-import static java.lang.Math.min;
-import static java.util.Collections.singletonMap;
-
 import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.EntryListenerConfig;
@@ -117,6 +93,9 @@ import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.impl.operationservice.impl.InvocationFuture;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -135,8 +114,30 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import static com.hazelcast.core.EntryEventType.CLEAR_ALL;
+import static com.hazelcast.internal.util.CollectionUtil.asIntegerList;
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
+import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterSerial;
+import static com.hazelcast.internal.util.IterableUtil.nullToEmpty;
+import static com.hazelcast.internal.util.MapUtil.createHashMap;
+import static com.hazelcast.internal.util.MapUtil.toIntSize;
+import static com.hazelcast.internal.util.Preconditions.checkFalse;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.internal.util.SetUtil.createHashSet;
+import static com.hazelcast.internal.util.ThreadUtil.getThreadId;
+import static com.hazelcast.internal.util.TimeUtil.timeInMsOrOneIfResultIsZero;
+import static com.hazelcast.map.impl.EntryRemovingProcessor.ENTRY_REMOVING_PROCESSOR;
+import static com.hazelcast.map.impl.MapOperationStatsUpdater.incrementOperationStats;
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.map.impl.query.Target.createPartitionTarget;
+import static com.hazelcast.query.Predicates.alwaysFalse;
+import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
+import static java.lang.Math.ceil;
+import static java.lang.Math.log10;
+import static java.lang.Math.min;
+import static java.util.Collections.singletonMap;
 
 abstract class MapProxySupport<K, V>
         extends AbstractDistributedObject<MapService>
@@ -1357,7 +1358,7 @@ abstract class MapProxySupport<K, V>
         try {
             AddIndexOperation addIndexOperation = new AddIndexOperation(name, indexConfig0);
             if (localOnly) {
-                PartitionIdSet ownedPartitions = mapServiceContext.getOrInitCachedMemberPartitions();
+                PartitionIdSet ownedPartitions = mapServiceContext.getCachedOwnedPartitions();
                 operationService.invokeOnPartitions(SERVICE_NAME,
                         new BinaryOperationFactory(addIndexOperation, getNodeEngine()), ownedPartitions);
             } else {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultSizeLimiter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultSizeLimiter.java
@@ -122,7 +122,7 @@ public class QueryResultSizeLimiter {
         }
 
         // limit number of local partitions to check to keep runtime constant
-        PartitionIdSet localPartitions = mapServiceContext.getOrInitCachedMemberPartitions();
+        PartitionIdSet localPartitions = mapServiceContext.getCachedOwnedPartitions();
         int partitionsToCheck = min(localPartitions.size(), maxLocalPartitionsLimitForPreCheck);
         if (partitionsToCheck == 0) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -122,26 +122,26 @@ public class QueryRunner {
      */
     public Result runIndexOrPartitionScanQueryOnOwnedPartitions(Query query, boolean doPartitionScan) {
         int migrationStamp = getMigrationStamp();
-        PartitionIdSet initialPartitions = mapServiceContext.getOrInitCachedMemberPartitions();
+        PartitionIdSet ownedPartitions = mapServiceContext.getCachedOwnedPartitions();
         PartitionIdSet actualPartitions = query.getPartitionIdSet() != null
-                ? initialPartitions.intersectCopy(query.getPartitionIdSet())
-                : initialPartitions;
+                ? ownedPartitions.intersectCopy(query.getPartitionIdSet())
+                : ownedPartitions;
 
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
 
         // to optimize the query we need to get any index instance
         Indexes indexes = mapContainer.getIndexes();
         if (indexes == null) {
-            indexes = mapContainer.getIndexes(initialPartitions.iterator().next());
+            indexes = mapContainer.getIndexes(ownedPartitions.iterator().next());
         }
         // first we optimize the query
         Predicate predicate = queryOptimizer.optimize(query.getPredicate(), indexes);
 
         // then we try to run using an index, but if that doesn't work, we'll try a full table scan
         Iterable<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer,
-                migrationStamp, initialPartitions.size());
+                migrationStamp, ownedPartitions.size());
 
-        if (entries != null && !initialPartitions.equals(actualPartitions)) {
+        if (entries != null && !ownedPartitions.equals(actualPartitions)) {
             assert indexes.isGlobal();
             // if the query runs on a subset of partitions, filter the results from a global index
             entries = IterableUtil.filter(entries,
@@ -188,28 +188,28 @@ public class QueryRunner {
      */
     public Result runIndexQueryOnOwnedPartitions(Query query) {
         int migrationStamp = getMigrationStamp();
-        PartitionIdSet initialPartitions = mapServiceContext.getOrInitCachedMemberPartitions();
+        PartitionIdSet ownedPartitions = mapServiceContext.getCachedOwnedPartitions();
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
 
         // to optimize the query we need to get any index instance
         Indexes indexes = mapContainer.getIndexes();
         if (indexes == null) {
-            indexes = mapContainer.getIndexes(initialPartitions.iterator().next());
+            indexes = mapContainer.getIndexes(ownedPartitions.iterator().next());
         }
         // first we optimize the query
         Predicate predicate = queryOptimizer.optimize(query.getPredicate(), indexes);
 
         // then we try to run using an index
         Iterable<QueryableEntry> entries = runUsingGlobalIndexSafely(predicate, mapContainer,
-                migrationStamp, initialPartitions.size());
+                migrationStamp, ownedPartitions.size());
 
         Result result;
         if (entries == null) {
             // failed with index query because of ongoing migrations
-            result = populateEmptyResult(query, initialPartitions);
+            result = populateEmptyResult(query, ownedPartitions);
         } else {
             // success
-            result = populateNonEmptyResult(query, entries, initialPartitions);
+            result = populateNonEmptyResult(query, entries, ownedPartitions);
         }
 
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/MapTableUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/schema/map/MapTableUtils.java
@@ -51,10 +51,10 @@ public final class MapTableUtils {
     public static long estimatePartitionedMapRowCount(NodeEngine nodeEngine, MapServiceContext context, String mapName) {
         long entryCount = 0L;
 
-        PartitionIdSet ownerPartitions = context.getOrInitCachedMemberPartitions();
+        PartitionIdSet ownedPartitions = context.getCachedOwnedPartitions();
 
         for (PartitionContainer partitionContainer : context.getPartitionContainers()) {
-            if (!ownerPartitions.contains(partitionContainer.getPartitionId())) {
+            if (!ownedPartitions.contains(partitionContainer.getPartitionId())) {
                 continue;
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregationMemberBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregationMemberBounceTest.java
@@ -61,7 +61,6 @@ public class AggregationMemberBounceTest extends HazelcastTestSupport {
 
     @Test
     public void aggregationReturnsCorrectResultWhenBouncing() {
-
         Runnable[] runnables = new Runnable[DRIVER_COUNT];
         for (int i = 0; i < DRIVER_COUNT; i++) {
             HazelcastInstance driver = bounceMemberRule.getNextTestDriver();

--- a/hazelcast/src/test/java/com/hazelcast/json/MapIndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapIndexJsonTest.java
@@ -272,7 +272,7 @@ public class MapIndexJsonTest extends HazelcastTestSupport {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
 
         List<Index> result = new ArrayList<>();
-        for (int partitionId : mapServiceContext.getOrInitCachedMemberPartitions()) {
+        for (int partitionId : mapServiceContext.getCachedOwnedPartitions()) {
             Indexes indexes = mapContainer.getIndexes(partitionId);
             result.add(indexes.getIndex(attribute));
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
@@ -57,7 +57,7 @@ public class RecordStoreTest extends HazelcastTestSupport {
     private void clearIndexes(IMap<Object, Object> map) {
         MapServiceContext mapServiceContext = getMapServiceContext((MapProxyImpl) map);
         MapContainer mapContainer = mapServiceContext.getMapContainer(map.getName());
-        for (int partitionId : mapServiceContext.getOrInitCachedMemberPartitions()) {
+        for (int partitionId : mapServiceContext.getCachedOwnedPartitions()) {
             mapContainer.getIndexes(partitionId).destroyIndexes();
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultSizeLimiterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultSizeLimiterTest.java
@@ -253,7 +253,7 @@ public class QueryResultSizeLimiterTest {
         MapServiceContext mapServiceContext = mock(MapServiceContext.class);
         when(mapServiceContext.getNodeEngine()).thenReturn(nodeEngine);
         when(mapServiceContext.getRecordStore(anyInt(), anyString())).thenReturn(recordStore);
-        when(mapServiceContext.getOrInitCachedMemberPartitions()).thenReturn(new PartitionIdSet(PARTITION_COUNT, localPartitions.keySet()));
+        when(mapServiceContext.getCachedOwnedPartitions()).thenReturn(new PartitionIdSet(PARTITION_COUNT, localPartitions.keySet()));
 
         limiter = new QueryResultSizeLimiter(mapServiceContext, Logger.getLogger(QueryResultSizeLimiterTest.class));
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
@@ -100,7 +100,7 @@ public class QueryRunnerTest extends HazelcastTestSupport {
 
         assertEquals(1, result.getRows().size());
         assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
-        assertArrayEquals(result.getPartitionIds().toArray(), mapService.getMapServiceContext().getOrInitCachedMemberPartitions().toArray());
+        assertArrayEquals(result.getPartitionIds().toArray(), mapService.getMapServiceContext().getCachedOwnedPartitions().toArray());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
@@ -225,7 +225,7 @@ public class IndexIntegrationTest extends HazelcastTestSupport {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
 
         List<Index> result = new ArrayList<>();
-        for (int partitionId : mapServiceContext.getOrInitCachedMemberPartitions()) {
+        for (int partitionId : mapServiceContext.getCachedOwnedPartitions()) {
             Indexes indexes = mapContainer.getIndexes(partitionId);
 
             for (InternalIndex index : indexes.getIndexes()) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
@@ -205,7 +205,7 @@ public class JsonIndexIntegrationTest extends HazelcastTestSupport {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
 
         List<Index> result = new ArrayList<Index>();
-        for (int partitionId : mapServiceContext.getOrInitCachedMemberPartitions()) {
+        for (int partitionId : mapServiceContext.getCachedOwnedPartitions()) {
             Indexes indexes = mapContainer.getIndexes(partitionId);
 
             for (InternalIndex index : indexes.getIndexes()) {


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/21758

Test is not failing even after many runs with the fix in this PR.

**Modifications:**

- Refresh cached owned partitions by taking concurrent refreshing possibility into account. 
   Otherwise cached owned partitions can have missing partitions.
- Method renaming

- [ ] backport 5.2, 5.1, 5.0