### PR TITLE
Correct Javadoc on CacheConfiguration.setManagementEnabled(boolean) [HZ-1716]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -246,7 +246,7 @@ public abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K,
      * <p>
      * Management may be enabled or disabled at runtime via {@link javax.cache.CacheManager#enableManagement(String, boolean)}.
      *
-     * @param enabled {@code true} to enable statistics, {@code false} to disable
+     * @param enabled {@code true} to enable management, {@code false} to disable
      * @return the {@link CacheConfig}
      */
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfiguration.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfiguration.java
@@ -145,7 +145,7 @@ public interface CacheConfiguration<K, V>
      * Management may be enabled or disabled at runtime via
      * {@link javax.cache.CacheManager#enableManagement(String, boolean)}.
      *
-     * @param enabled {@code true} to enable statistics, {@code false} to disable
+     * @param enabled {@code true} to enable management, {@code false} to disable
      * @return the {@link com.hazelcast.config.CacheConfiguration} to permit fluent-style method calls
      */
     CacheConfiguration<K, V> setManagementEnabled(boolean enabled);


### PR DESCRIPTION
Replaced "statistics" with "management"

Fixes #22574

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

