### PR TITLE
Fix LogExceptionSqlTest prints exception [5.2.z]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/LogExceptionSqlTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/LogExceptionSqlTest.java
@@ -68,7 +68,7 @@ public class LogExceptionSqlTest extends SimpleTestInClusterSupport {
         }
 
         // result is closed before the job is cleaned on member side, so wait here
-        assertNoJobsLeftEventually(instance());
+        assertNoLightJobsLeftEventually(instance());
 
         // then
         List<Throwable> exceptions = recorder.exceptionsOfTypes(ResultLimitReachedException.class, JetException.class);

--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -83,13 +83,13 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
         client = factory.newHazelcastClient(clientConfig);
     }
 
-    protected void assertNoJobsLeftEventually(HazelcastInstance instance) {
+    protected void assertNoLightJobsLeftEventually(HazelcastInstance instance) {
         assertTrueEventually(() -> {
             List<Job> runningJobs = instance.getJet().getJobs().stream()
-                                            .filter(j -> !j.getFuture().isDone() && !j.getStatus().isTerminal())
-                                            .collect(toList());
+                    .filter(Job::isLightJob)
+                    .collect(toList());
             int size = runningJobs.size();
-            assertEquals("at this point no running jobs were expected, but got: " + runningJobs, 0, size);
+            assertEquals("at this point no running light jobs were expected, but got: " + runningJobs, 0, size);
         });
     }
 


### PR DESCRIPTION
Backport of: https://github.com/hazelcast/hazelcast/pull/22735

Fixes: https://github.com/hazelcast/hazelcast/issues/22729

Between ```getJobs()``` and ```getFuture()``` the job may be removed. That results in printing ```JobNotFoundException``` which fails the test.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases

(cherry picked from commit 0a88304329138340e91a1affa0f8ada9fc43ede0)