### PR TITLE
Fix JSON/VARCHAR comparison in SQL [HZ-1706] #22671

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeCoercion.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeCoercion.java
@@ -210,10 +210,10 @@ public final class HazelcastTypeCoercion extends TypeCoercionImpl {
                 || sourceAndTargetAreTemporalAndSourceCanBeConvertedToTarget(targetHzType, sourceHzType)
                 || targetIsTemporalAndSourceIsVarcharLiteral(targetHzType, sourceHzType, rowElement)
                 || sourceHzType.getTypeFamily() == QueryDataTypeFamily.NULL
-                || sourceHzType.getTypeFamily() == QueryDataTypeFamily.VARCHAR
-                        && targetHzType.getTypeFamily() == QueryDataTypeFamily.JSON
-                || sourceHzType.getTypeFamily() == QueryDataTypeFamily.JSON
-                        && targetHzType.getTypeFamily() == QueryDataTypeFamily.VARCHAR;
+                || (sourceHzType.getTypeFamily() == QueryDataTypeFamily.VARCHAR
+                        && targetHzType.getTypeFamily() == QueryDataTypeFamily.JSON)
+                || (sourceHzType.getTypeFamily() == QueryDataTypeFamily.JSON
+                        && targetHzType.getTypeFamily() == QueryDataTypeFamily.VARCHAR);
 
         if (!valid) {
             // Types cannot be converted to each other, fail to coerce

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeCoercion.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/types/HazelcastTypeCoercion.java
@@ -211,7 +211,9 @@ public final class HazelcastTypeCoercion extends TypeCoercionImpl {
                 || targetIsTemporalAndSourceIsVarcharLiteral(targetHzType, sourceHzType, rowElement)
                 || sourceHzType.getTypeFamily() == QueryDataTypeFamily.NULL
                 || sourceHzType.getTypeFamily() == QueryDataTypeFamily.VARCHAR
-                        && targetHzType.getTypeFamily() == QueryDataTypeFamily.JSON;
+                        && targetHzType.getTypeFamily() == QueryDataTypeFamily.JSON
+                || sourceHzType.getTypeFamily() == QueryDataTypeFamily.JSON
+                        && targetHzType.getTypeFamily() == QueryDataTypeFamily.VARCHAR;
 
         if (!valid) {
             // Types cannot be converted to each other, fail to coerce

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlJsonTypeTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlJsonTypeTest.java
@@ -18,12 +18,12 @@ package com.hazelcast.jet.sql;
 
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.sql.HazelcastSqlException;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
-@Category(SlowTest.class)
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class SqlJsonTypeTest extends SqlJsonTestSupport {
     @BeforeClass
     public static void beforeClass() {
@@ -116,6 +116,95 @@ public class SqlJsonTypeTest extends SqlJsonTestSupport {
                         2L, json("[4,5,6]"),
                         3L, json("[7,8,9]")
                 ));
+    }
+
+
+    @Test
+    // test for https://github.com/hazelcast/hazelcast/issues/22671
+    public void test_jsonEqualComparedAsVarchar() {
+        // for the `=` operator, we convert JSON operands to VARCHAR
+        assertRowsAnyOrder("SELECT " +
+                        // json-json not equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) = CAST('{\"f2\":43, \"f1\":42}' AS JSON)," +
+                        // json-json equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) = CAST('{\"f1\":42, \"f2\":43}' AS JSON)," +
+                        // json-varchar not equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) = '{\"f2\":43, \"f1\":42}'," +
+                        "'{\"f1\":42, \"f2\":43}' = CAST('{\"f2\":43, \"f1\":42}' AS JSON)," +
+                        // json-varchar equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) = '{\"f1\":42, \"f2\":43}'," +
+                        "'{\"f1\":42, \"f2\":43}' = CAST('{\"f1\":42, \"f2\":43}' AS JSON)",
+                rows(6, false, true, false, false, true, true));
+    }
+
+    @Test
+    // test for https://github.com/hazelcast/hazelcast/issues/22671
+    public void test_jsonNotEqualComparedAsVarchar() {
+        // for the `!=` operator, we convert JSON operands to VARCHAR
+        assertRowsAnyOrder("SELECT " +
+                        // json-json not equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) != CAST('{\"f2\":43, \"f1\":42}' AS JSON)," +
+                        // json-json equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) != CAST('{\"f1\":42, \"f2\":43}' AS JSON)," +
+                        // json-varchar not equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) != '{\"f2\":43, \"f1\":42}'," +
+                        "'{\"f1\":42, \"f2\":43}' != CAST('{\"f2\":43, \"f1\":42}' AS JSON)," +
+                        // json-varchar equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) != '{\"f1\":42, \"f2\":43}'," +
+                        "'{\"f1\":42, \"f2\":43}' != CAST('{\"f1\":42, \"f2\":43}' AS JSON)",
+                rows(6, true, false, true, true, false, false));
+    }
+
+    @Test
+    // test for https://github.com/hazelcast/hazelcast/issues/22671
+    public void test_jsonLessComparedAsVarchar() {
+        // for the `<` operator, we convert JSON operands to VARCHAR
+        // other relative comparison operators should behave the same
+        assertRowsAnyOrder("SELECT " +
+                        // json-json not equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) < CAST('{\"f2\":43, \"f1\":42}' AS JSON)," +
+                        // json-json equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) < CAST('{\"f1\":42, \"f2\":43}' AS JSON)," +
+                        // json-varchar not equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) < '{\"f2\":43, \"f1\":42}'," +
+                        "'{\"f1\":42, \"f2\":43}' < CAST('{\"f2\":43, \"f1\":42}' AS JSON)," +
+                        // json-varchar equal
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) < '{\"f1\":42, \"f2\":43}'," +
+                        "'{\"f1\":42, \"f2\":43}' < CAST('{\"f1\":42, \"f2\":43}' AS JSON)",
+                rows(6, true, false, true, true, false, false));
+    }
+
+    @Test
+    public void test_jsonLengthNotSupported() {
+        assertThatThrownBy(() -> execute("SELECT " +
+                        "LENGTH(CAST('{\"f1\":42, \"f2\":43}' AS JSON))"))
+                .isInstanceOf(HazelcastSqlException.class)
+                .hasMessageEndingWith("Cannot apply 'LENGTH' function to [JSON] (consider adding an explicit CAST)");
+    }
+
+    @Test
+    public void test_jsonSubstringNotSupported() {
+        assertThatThrownBy(() -> execute("SELECT " +
+                "SUBSTRING(CAST('{\"f1\":42, \"f2\":43}' AS JSON) FROM 1 FOR 5)"))
+                .isInstanceOf(HazelcastSqlException.class)
+                .hasMessageEndingWith("Cannot apply 'SUBSTRING' function to [JSON, INTEGER, INTEGER] (consider adding an explicit CAST)");
+    }
+
+    @Test
+    public void test_jsonConcat() {
+        // concat has more permissive conversions than other functions
+        assertRowsAnyOrder("SELECT " +
+                "CAST('{\"f1\":42, \"f2\":43}' AS JSON) || CAST('suffix' AS VARCHAR)",
+                rows(1, "{\"f1\":42, \"f2\":43}suffix"));
+
+        assertRowsAnyOrder("SELECT " +
+                        "CAST('{\"f1\":42, \"f2\":43}' AS VARCHAR) || CAST('suffix' AS JSON)",
+                rows(1, "{\"f1\":42, \"f2\":43}suffix"));
+
+        assertRowsAnyOrder("SELECT " +
+                        "CAST('{\"f1\":42, \"f2\":43}' AS JSON) || CAST('suffix' AS JSON)",
+                rows(1, "{\"f1\":42, \"f2\":43}suffix"));
+
     }
 
     public void execute(final String sql, final Object ...arguments) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/validate/RowAssignmentTypeCoercionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/validate/RowAssignmentTypeCoercionTest.java
@@ -900,9 +900,8 @@ public class RowAssignmentTypeCoercionTest extends SqlTestSupport {
                         .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of JSON type, but OBJECT was found"),
 
                 // JSON
-                TestParams.failingCase(2501, JSON, VARCHAR, "CAST('\"foo\"' AS JSON)", new HazelcastJsonValue("\"foo\""))
-                        .withExpectedLiteralFailureRegex("Cannot assign to target field 'field1' of type VARCHAR from source field '.+' of type JSON")
-                        .withExpectedColumnFailureRegex("Cannot assign to target field 'field1' of type VARCHAR from source field '.+' of type JSON")
+                TestParams.passingCase(2501, JSON, VARCHAR, "CAST('\"foo\"' AS JSON)", new HazelcastJsonValue("\"foo\""), "\"foo\"")
+                        // JSON->VARCHAR coercion is not supported for dynamic parameters
                         .withExpectedDynamicParameterFailureRegex("Parameter at position 0 must be of VARCHAR type, but JSON was found"),
                 TestParams.failingCase(2502, JSON, BOOLEAN, "CAST('true' AS JSON)", new HazelcastJsonValue("true"))
                         .withExpectedLiteralFailureRegex("Cannot assign to target field 'field1' of type BOOLEAN from source field '.+' of type JSON")


### PR DESCRIPTION
Comparison operators cast JSON argument to VARCHAR when one argument is JSON and the other one is VARCHAR.

Fixes [HZ-1706] #22671

Breaking changes (list specific methods/types/messages):
* (probably not a big deal): some invalid SQL queries will be valid now

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible


[HZ-1706]: https://hazelcast.atlassian.net/browse/HZ-1706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ