### PR TITLE
Fix doInvoke() and InvocationMonitor concurrency issues [HZ-977]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -477,7 +477,6 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
     boolean detectAndHandleLeftMember() {
         // volatile read
         if (invocationCanRetry
-                // for wan and join operations maybe something can be done in future
                 && invocationShouldHaveTargetMember()
                 // if target member is null, error is already notified
                 && targetMember != null

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -318,7 +318,7 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
         }
     }
 
-    boolean invocationShouldHaveTargetMember() {
+    private boolean invocationShouldHaveTargetMember() {
         return !(isJoinOperation(op) || isWanReplicationOperation(op));
     }
 
@@ -812,10 +812,10 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
                 + '}';
     }
 
-    private class InvocationRetryTask implements Runnable {
+    private final class InvocationRetryTask implements Runnable {
         private final boolean reset;
 
-        public InvocationRetryTask(boolean reset) {
+        private InvocationRetryTask(boolean reset) {
             this.reset = reset;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -200,16 +200,16 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
     /**
      * Shows whether invocation can retry or not. It has two purposes.
      *
-     * <p>
+     * <ul><li>
      * Control access to {@link Invocation#doInvoke(boolean)}. This method
      * can be accessed from the invoker thread or the single threaded
      * scheduler of {@link InvocationMonitor}. This variable ensures that
      * when scheduler retries, invoker thread will no longer read/write to
      * a shared non-final variable.
-     *
-     * <p>
+     * </li><li>
      * Provide a happens-before relationship between invoker thread,
      * scheduler and callers of {@link Invocation#toString()}.
+     * </li></ul>
      *
      * <p>
      * Note that after the invocation is registered, this variable must be

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -317,6 +317,7 @@ public class InvocationMonitor implements Consumer<Packet>, StaticMetricsProvide
 
             int backupTimeouts = 0;
             int normalTimeouts = 0;
+            int memberLeft = 0;
             int invocationCount = 0;
 
             for (Invocation inv : invocationRegistry) {
@@ -326,6 +327,8 @@ public class InvocationMonitor implements Consumer<Packet>, StaticMetricsProvide
                         normalTimeouts++;
                     } else if (inv.detectAndHandleBackupTimeout(backupTimeoutMillis)) {
                         backupTimeouts++;
+                    } else if (inv.detectAndHandleLeftMember()) {
+                        memberLeft++;
                     }
                 } catch (Throwable t) {
                     inspectOutOfMemoryError(t);
@@ -335,12 +338,12 @@ public class InvocationMonitor implements Consumer<Packet>, StaticMetricsProvide
 
             backupTimeoutsCount.inc(backupTimeouts);
             normalTimeoutsCount.inc(normalTimeouts);
-            log(invocationCount, backupTimeouts, normalTimeouts);
+            log(invocationCount, backupTimeouts, normalTimeouts, memberLeft);
         }
 
-        private void log(int invocationCount, int backupTimeouts, int invocationTimeouts) {
+        private void log(int invocationCount, int backupTimeouts, int invocationTimeouts, int memberLeft) {
             Level logLevel = null;
-            if (backupTimeouts > 0 || invocationTimeouts > 0) {
+            if (backupTimeouts > 0 || invocationTimeouts > 0 || memberLeft > 0) {
                 logLevel = INFO;
             } else if (logger.isFineEnabled()) {
                 logLevel = FINE;
@@ -349,7 +352,8 @@ public class InvocationMonitor implements Consumer<Packet>, StaticMetricsProvide
             if (logLevel != null) {
                 logger.log(logLevel, "Invocations:" + invocationCount
                         + " timeouts:" + invocationTimeouts
-                        + " backup-timeouts:" + backupTimeouts);
+                        + " backup-timeouts:" + backupTimeouts
+                        + " member-left: " + memberLeft);
             }
         }
     }


### PR DESCRIPTION
Previously, entry to `doInvoke()` had data race. After invoker thread 
registered the invocation, `InvocationMonitor` could retry and modify 
target again. This lead to `IllegalArgumentException("Target is this 
node! -> " + target + ", op: " + op)`. Also there is nothing 
synchronizes scheduler thread with invoker thread.

Now, volatile `invocationCanRetry` enforces scheduler thread to enter 
`doInvoke()` only when it won't cause an issue. Also, it provides a 
happens-before relationship.

This isn't enough by itself because sometimes an invocation may be 
registered after `OnMemberLeftTask` run with a missing member. If this 
happens, that invocation have to timeout. Now, we also check for some 
time for invocations whose targets left the cluster via 
`MonitorInvocationsTask`.

There are still issues I left out from this PR:

First, `InvocationMonitor` tasks and invoker threads are not 
synchronized. Reading  `invocationCanRetry` while iterating 
`invocationRegistry` should solve  this issue, but I don't know if this 
read can be optimized out by the compiler if it isn't used, so I left 
it out. Alternatively we can make all non-final variables, volatile. 
But I'm not sure about its performance effects.

Second, same thing happened for `OnMemberLeftTask` can happen for 
`OnEndpointLeftTask`. In this case, we may see an invocation timeout.
Since I don't know how to check if an endpoint left, like we do for 
members via `clusterService`, I left this out of this PR.

Fixes https://github.com/hazelcast/hazelcast/issues/1325

Passed Jenkins runs (all of them timed out after 4 hours):
https://jenkins.hazelcast.com/job/ramiz-hazelcast-os-2/5/ c425ed9
https://jenkins.hazelcast.com/job/ramiz-hazelcast-os-2/6/ 1b358be

https://jenkins.hazelcast.com/job/ramiz-hazelcast-os/13/ c425ed9 with repeat
https://jenkins.hazelcast.com/job/ramiz-hazelcast-os/14/ 1b358be with repeat 