### PR TITLE
Nice exception for stream-to-batch JOIN with JDBC batch source [HZ-1560]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/JoinLogicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/JoinLogicalRule.java
@@ -42,8 +42,7 @@ final class JoinLogicalRule extends ConverterRule {
     public RelNode convert(RelNode rel) {
         LogicalJoin join = (LogicalJoin) rel;
 
-        // We convert every RIGHT JOIN to LEFT JOIN to use already-implemented
-        // LEFT JOIN operators.
+        // We convert every RIGHT JOIN to LEFT JOIN to use already-implemented LEFT JOIN operators.
         if (OptUtils.isBounded(join) && join.getJoinType() == JoinRelType.RIGHT) {
             return JoinCommuteRule.swap(join, true);
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/JoinPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/JoinPhysicalRule.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.sql.impl.opt.physical;
 
+import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.jet.sql.impl.connector.SqlConnectorUtil;
 import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.jet.sql.impl.opt.logical.JoinLogicalRel;
@@ -93,7 +94,8 @@ public final class JoinPhysicalRule extends RelRule<RelRule.Config> {
 
         if (rightInput instanceof TableScan) {
             HazelcastTable rightHzTable = rightInput.getTable().unwrap(HazelcastTable.class);
-            if (SqlConnectorUtil.getJetSqlConnector(rightHzTable.getTarget()).isNestedLoopReaderSupported()) {
+            SqlConnector connector = SqlConnectorUtil.getJetSqlConnector(rightHzTable.getTarget());
+            if (connector.isNestedLoopReaderSupported()) {
                 RelNode rel2 = new JoinNestedLoopPhysicalRel(
                         logicalJoin.getCluster(),
                         OptUtils.toPhysicalConvention(logicalJoin.getTraitSet()),
@@ -103,7 +105,20 @@ public final class JoinPhysicalRule extends RelRule<RelRule.Config> {
                         logicalJoin.getJoinType()
                 );
                 call.transformTo(rel2);
+            } else {
+                call.transformTo(
+                        fail(logicalJoin, connector.typeName() + " connector doesn't support stream-to-batch JOIN")
+                );
             }
         }
+    }
+
+    private ShouldNotExecuteRel fail(RelNode node, String message) {
+        return new ShouldNotExecuteRel(
+                node.getCluster(),
+                node.getTraitSet().replace(PHYSICAL),
+                node.getRowType(),
+                message
+        );
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
@@ -1,0 +1,40 @@
+package com.hazelcast.jet.sql.impl.connector.jdbc;
+
+import com.hazelcast.test.jdbc.H2DatabaseProvider;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_EXTERNAL_DATASTORE_REF;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class JdbcJoinTest extends JdbcSqlTestSupport {
+
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(new H2DatabaseProvider());
+    }
+
+    @Test
+    public void test_stream2BatchJoinAsNestedLoopJoinIsNotSupported() throws Exception {
+        String tableName = randomTableName();
+        createTable(tableName);
+        insertItems(tableName, 5);
+
+        execute(
+                "CREATE MAPPING " + tableName + " ("
+                        + " id INT, "
+                        + " name VARCHAR "
+                        + ") "
+                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "OPTIONS ( "
+                        + " '" + OPTION_EXTERNAL_DATASTORE_REF + "'='" + TEST_DATABASE_REF + "'"
+                        + ")"
+        );
+
+        assertThatThrownBy(() ->
+                sqlService.execute("SELECT n.name, t.v FROM " +
+                        "TABLE(GENERATE_STREAM(2)) t " +
+                        "JOIN " + tableName + " n ON n.id = t.v;")
+        ).hasMessageContaining("JDBC connector doesn't support stream-to-batch JOIN");
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.jet.sql.impl.connector.jdbc;
 
 import com.hazelcast.test.jdbc.H2DatabaseProvider;


### PR DESCRIPTION
Right now JDBC connector doesn't support stream-to-batch JOIN with JDBC batch source. 
Trying to make it, an internal calcite exception like 'no rules cannot be applied' was produced. 
This PR adds a convenient user-friendly exception for stream-to-batch JOIN with JDBC batch source. 

Also, I plan to backport it to 5.2.x.

Closes https://github.com/hazelcast/hazelcast/issues/22421