### PR TITLE
Convert HotRestartTriggerBackupMessageTask and ShutdownClusterMessageTask to async message tasks [5.0.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerBackupMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/HotRestartTriggerBackupMessageTask.java
@@ -18,50 +18,36 @@ package com.hazelcast.client.impl.protocol.task.management;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MCTriggerHotRestartBackupCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractAsyncMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 
 import java.security.Permission;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
-import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
-import static com.hazelcast.internal.util.ExceptionUtil.peel;
-import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
-
-public class HotRestartTriggerBackupMessageTask
-        extends AbstractCallableMessageTask<Void> {
+public class HotRestartTriggerBackupMessageTask extends AbstractAsyncMessageTask<Void, Void> {
 
     private static final Permission REQUIRED_PERMISSION = new ManagementPermission("hotrestart.triggerBackup");
 
-    private final Node node;
-
     public HotRestartTriggerBackupMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
-        this.node = node;
     }
 
     @Override
-    protected Object call() throws Exception {
-        ILogger logger = nodeEngine.getLogger(getClass());
+    protected CompletableFuture<Void> processInternal() {
         ExecutionService executionService = nodeEngine.getExecutionService();
         Future<Void> future = executionService.submit(
                 ExecutionService.ASYNC_EXECUTOR,
                 () -> {
-                    node.getNodeExtension().getHotRestartService().backup();
+                    nodeEngine.getNode().getNodeExtension().getHotRestartService().backup();
                     return null;
                 });
 
-        executionService.asCompletableFuture(future).whenCompleteAsync(
-                withTryCatch(
-                        logger,
-                        (empty, error) -> sendResponse(error != null ? peel(error) : null)), CALLER_RUNS);
-
-        return null;
+        return executionService.asCompletableFuture(future);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ShutdownClusterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/management/ShutdownClusterMessageTask.java
@@ -18,22 +18,18 @@ package com.hazelcast.client.impl.protocol.task.management;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MCShutdownClusterCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractAsyncMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.security.permission.ManagementPermission;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 
 import java.security.Permission;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
-import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
-import static com.hazelcast.internal.util.ExceptionUtil.peel;
-import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
-
-public class ShutdownClusterMessageTask extends AbstractCallableMessageTask<Void> {
+public class ShutdownClusterMessageTask extends AbstractAsyncMessageTask<Void, Void> {
 
     private static final Permission REQUIRED_PERMISSION = new ManagementPermission("cluster.shutdown");
 
@@ -42,8 +38,7 @@ public class ShutdownClusterMessageTask extends AbstractCallableMessageTask<Void
     }
 
     @Override
-    protected Object call() throws Exception {
-        ILogger logger = nodeEngine.getLogger(getClass());
+    protected CompletableFuture<Void> processInternal() {
         ExecutionService executionService = nodeEngine.getExecutionService();
         Future<Void> future = executionService.submit(
                 ExecutionService.ASYNC_EXECUTOR,
@@ -52,12 +47,7 @@ public class ShutdownClusterMessageTask extends AbstractCallableMessageTask<Void
                     return null;
                 });
 
-        executionService.asCompletableFuture(future).whenCompleteAsync(
-                withTryCatch(
-                        logger,
-                        (empty, error) -> sendResponse(error != null ? peel(error) : null)), CALLER_RUNS);
-
-        return null;
+        return executionService.asCompletableFuture(future);
     }
 
     @Override


### PR DESCRIPTION
Formerly, the tasks were callable, meaning that they will send a response back to the client, once the call method completes.

There was a fundamental problem with these tasks' implementation. They were scheduling a task to be executed in the execution service, and depending on the result of it, sending a response or an exception to the client.

However, since the tasks were callable, we were actually sending a response to the client, once the call method finishes.

After the execution service completes the runnable, it was sending another response or exception, depending on the result of the call, but the client was ignoring it, because it was receiving a successful response for that correlation id before.

That's why we were not able to notify clients about the actual status of the operations. The second response, whether it is an exception or normal response, was ignored by the client.

As a solution, I converted these tasks to async tasks, which handle the proper error handling themselves and send the correct response type according to the actual result of the runnable tasks.

clean backport of #22737