### PR TITLE
Proper data structure to store DbField for JDBC

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -52,10 +52,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
@@ -156,7 +156,7 @@ public class JdbcSqlConnector implements SqlConnector {
             ResultSet rs = statement.getResultSet();
             ResultSetMetaData metaData = rs.getMetaData();
 
-            Map<String, DbField> fields = new TreeMap<>();
+            Map<String, DbField> fields = new LinkedHashMap<>();
             for (int i = 1; i <= metaData.getColumnCount(); i++) {
                 String columnName = metaData.getColumnName(i);
                 fields.put(columnName,

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/MappingJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/MappingJdbcSqlConnectorTest.java
@@ -228,7 +228,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                 + ")"
         );
 
-        // If you change TreeMap -> HashMap at JdbcSqlConnector:159, it will fail.
+        // If you change LinkedHashMap -> HashMap at JdbcSqlConnector:159, it will fail.
         assertRowsAnyOrder(
                 "SELECT * FROM " + tableName,
                 asList(new Row(0, "name-0"), new Row(1, "name-1"))


### PR DESCRIPTION
I remember that LinkedHashMap is even more suitable to store DbField, because is preserves insertion order and has O(1) complexity for key operations like put/get.