### PR TITLE
Fix tstore tests failing with low native memory [HZ-1729]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
@@ -162,6 +162,11 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
     }
 
     static MapConfig initializeSqlCatalog(MapConfig config) {
+        // TODO HZ-1743 when implemented properly align this with the chosen
+        //  approach that HZ-1743 follows
+        // disabling tiered store configuration for the __sql.catalog map to
+        // prevent unnecessarily increasing tstore's memory demand
+        config.getTieredStoreConfig().setEnabled(false);
         return config
                 .setName(SQL_CATALOG_MAP_NAME)
                 .setBackupCount(MapConfig.MAX_BACKUP_COUNT)


### PR DESCRIPTION
There are two causes making some of the tstore test failing: 
1) `__sql.catalog` can inherit tstore properties from its parent (`*` in the tests), which increases the memory demand for these tests. This is undesired, the OS part of the changes force-disables tstore for this map, making some tests passing.
2) Low resource in `TieredStoreEntryProcessorBouncingNodesTest`. The memory capacity is doubled to satisfy the tstore demand.

[HZ-1743](https://hazelcast.atlassian.net/browse/HZ-1743) is created to make a strategic fix for 1).

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/5446
5.2.z backport: https://github.com/hazelcast/hazelcast/pull/22776

Fixes #5325

- [x] Backported to `5.2.z`