### PR TITLE
Define close as cooperative for eligible Processors #18730

### DIFF
--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/main/java/com/hazelcast/connector/WriteMapP.java
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/src/main/java/com/hazelcast/connector/WriteMapP.java
@@ -111,7 +111,6 @@ final class WriteMapP<T, K, V> implements Processor {
         return toValueFn.apply(item);
     }
 
-
     @Override
     public boolean tryProcess() {
         checkFailure();
@@ -141,6 +140,11 @@ final class WriteMapP<T, K, V> implements Processor {
     @Override
     public boolean complete() {
         return ensureAllSuccessfullyWritten();
+    }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
     }
 
     private void checkFailure() {

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/sink/KinesisSinkP.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/sink/KinesisSinkP.java
@@ -125,6 +125,11 @@ public class KinesisSinkP<T> implements Processor {
     }
 
     @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
+    @Override
     public void init(@Nonnull Outbox outbox, @Nonnull Context context) {
         logger = context.logger();
         sinkCount = context.totalParallelism();

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/KinesisSourceP.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/KinesisSourceP.java
@@ -269,6 +269,11 @@ public class KinesisSourceP<T> extends AbstractProcessor implements DynamicMetri
         }
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     private static int incrementCircular(int v, int limit) {
         v++;
         if (v == limit) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
@@ -131,5 +131,10 @@ final class InfoSchemaConnector implements SqlConnector {
         public boolean complete() {
             return emitFromTraverser(traverser);
         }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return true;
+        }
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/InsertProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/InsertProcessorSupplier.java
@@ -172,5 +172,10 @@ final class InsertProcessorSupplier implements ProcessorSupplier, DataSerializab
             }
             return true;
         }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return true;
+        }
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/LateItemsDropP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/LateItemsDropP.java
@@ -82,4 +82,9 @@ public class LateItemsDropP extends AbstractProcessor {
         }
         return super.tryProcessWatermark(watermark);
     }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/SqlHashJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/SqlHashJoinP.java
@@ -147,4 +147,9 @@ public class SqlHashJoinP extends AbstractProcessor {
             rightInputColumnCount = in.readInt();
         }
     }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
@@ -466,4 +466,9 @@ public class StreamToStreamJoinP extends AbstractProcessor {
             rightInputColumnCount = in.readInt();
         }
     }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -557,9 +557,9 @@ public interface Processor {
      * <p>
      * This flag is ignored for non-cooperative processors.
      * <p>
-     * By default {@link #close()} is assumed to be non-cooperative to guarantee
+     * By default, {@link #close()} is assumed to be non-cooperative to guarantee
      * correct-by-default behavior for custom processors, even though default
-     * implementation of {@link #close()} is empty so obviously cooperative.
+     * implementation of {@link #close()} is empty, so it's cooperative.
      * Implementors are however encouraged to override this method if the
      * default, empty {@link #close()} is used in a cooperative processor to
      * avoid offloading an empty invocation to another thread.

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -556,6 +556,13 @@ public interface Processor {
      * off-loaded to another thread.
      * <p>
      * This flag is ignored for non-cooperative processors.
+     * <p>
+     * By default {@link #close()} is assumed to be non-cooperative to guarantee
+     * correct-by-default behavior for custom processors, even though default
+     * implementation of {@link #close()} is empty so obviously cooperative.
+     * Implementors are however encouraged to override this method if the
+     * default, empty {@link #close()} is used in a cooperative processor to
+     * avoid offloading an empty invocation to another thread.
      */
     default boolean closeIsCooperative() {
         return false;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/ExplodeSnapshotP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/ExplodeSnapshotP.java
@@ -98,4 +98,9 @@ public class ExplodeSnapshotP extends AbstractProcessor {
         }
         return flatMapper.tryProcess(castItem.getValue());
     }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AsyncHazelcastWriterP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AsyncHazelcastWriterP.java
@@ -93,6 +93,11 @@ public abstract class AsyncHazelcastWriterP implements Processor {
         return flush() && asyncCallsDone();
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     private boolean flush() {
         checkError();
         try {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
@@ -146,6 +146,11 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
         return false;
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     @SuppressWarnings("unchecked")
     private void initialRead() {
         readFutures = (F[]) new CompletableFuture[partitionIds.length];
@@ -280,6 +285,11 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
         }
 
         @Override
+        public boolean closeIsCooperative() {
+            return true;
+        }
+
+        @Override
         public int preferredLocalParallelism() {
             return 1;
         }
@@ -321,6 +331,11 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
                     .map(partitions ->
                             new ReadMapOrCacheP<>(readerSupplier.apply(hzInstance, serializationService), partitions))
                     .collect(toList());
+        }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return true;
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
@@ -270,6 +270,11 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         return true;
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     @SuppressWarnings("unchecked")
     private void initialRead() {
         readFutures = new CompletableFuture[partitionIds.length];

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/UpdateMapP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/UpdateMapP.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.impl.connector;
 
-
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/test/AssertionP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/test/AssertionP.java
@@ -83,6 +83,11 @@ public final class AssertionP<S, T> extends AbstractProcessor {
         return true;
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     @Nonnull
     public static <A, T> ProcessorMetaSupplier assertionP(
         @Nonnull String name,

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/ExpectNothingP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/ExpectNothingP.java
@@ -51,4 +51,9 @@ public class ExpectNothingP extends AbstractProcessor {
         // State might be broadcast to all instances including colleagues of
         // another type - ignore it in the expect-nothing instances
     }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/GroupP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/GroupP.java
@@ -104,6 +104,11 @@ public class GroupP<K, A, R, OUT> extends AbstractProcessor {
         return emitFromTraverser(resultTraverser);
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     private class ResultTraverser implements Traverser<Entry<K, A>> {
         private final Iterator<Entry<K, A>> iter = keyToAcc.entrySet().iterator();
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/HashJoinCollectP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/HashJoinCollectP.java
@@ -85,6 +85,11 @@ public class HashJoinCollectP<K, T, V> extends AbstractProcessor {
         return tryEmit(lookupTable);
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     // We need a custom ArrayList subclass because the user's V type could be
     // ArrayList and then the logic that relies on instanceof would break
     static final class HashJoinArrayList extends ArrayList<Object> {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/HashJoinP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/HashJoinP.java
@@ -126,6 +126,11 @@ public class HashJoinP<E0> extends AbstractProcessor {
         return lookupTableForOrdinal.get(key);
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     private class CombinationsTraverser<OUT> implements Traverser<OUT> {
         private final BiFunction<E0, Object[], OUT> mapTupleToOutputFn;
         private final Object[] lookedUpValues;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/InsertWatermarksP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/InsertWatermarksP.java
@@ -88,6 +88,11 @@ public class InsertWatermarksP<T> extends AbstractProcessor {
         return true;
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     private enum Keys {
         LAST_EMITTED_WM
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/SessionWindowP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/SessionWindowP.java
@@ -292,6 +292,11 @@ public class SessionWindowP<K, A, R, OUT> extends AbstractProcessor {
         return true;
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     private void addItem(int ordinal, Windows<A> w, K key, long timestamp, Object item) {
         aggrOp.accumulateFn(ordinal).accept(resolveAcc(w, key, timestamp), item);
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
@@ -356,6 +356,11 @@ public class SlidingWindowP<K, A, R, OUT> extends AbstractProcessor {
         return true;
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     private Traverser<Object> windowTraverserAndEvictor(long wm) {
         long rangeStart = startingWindowTs(wm);
         if (rangeStart == Long.MIN_VALUE) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/SortP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/SortP.java
@@ -58,4 +58,9 @@ public class SortP<T> extends AbstractProcessor {
     public boolean complete() {
         return emitFromTraverser(resultTraverser);
     }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/TransformBatchedP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/TransformBatchedP.java
@@ -53,4 +53,9 @@ public class TransformBatchedP<T, R> extends AbstractProcessor {
             outputTraverser = null;
         }
     }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/TransformStatefulP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/TransformStatefulP.java
@@ -143,6 +143,11 @@ public class TransformStatefulP<T, K, S, R> extends AbstractProcessor {
         return tryProcessWatermark(FLUSHING_WATERMARK);
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
+
     private class EvictingTraverser implements Traverser<Traverser<?>> {
         private Iterator<Entry<K, TimestampedItem<S>>> keyToStateIterator;
         private final ResettableSingletonTraverser<Watermark> wmTraverser = new ResettableSingletonTraverser<>();


### PR DESCRIPTION
Explicitly define closeIsCooperative() method for Processors that inherit empty close() implementation or have a cooperative implementation to avoid offloading to another thread.

Some Processors have non-cooperative close due to the lack of cooperativeness requirement for passed functions:
* ConvenientSourceP
* WriteBufferedP (also not cooperative generally)
* AbstractTransformUsingServiceP and all subclasses

Fixes #18730 for `Processor`, `ProcessorSupplier` may get similar treatment in the future.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

