### PR TITLE
Avoid state sharing for test methods and sub-classes of SqlOrderByTest

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlOrderByTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlOrderByTest.java
@@ -101,9 +101,9 @@ public class SqlOrderByTest extends SqlTestSupport {
     private static final int DATA_SET_SIZE = 4096;
     private static final int DATA_SET_MAX_POSITIVE = DATA_SET_SIZE / 2;
 
-    private static final TestHazelcastFactory FACTORY = new TestHazelcastFactory();
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
 
-    private static List<HazelcastInstance> members;
+    private List<HazelcastInstance> members;
 
     @Parameter
     public SerializationMode serializationMode;
@@ -135,12 +135,9 @@ public class SqlOrderByTest extends SqlTestSupport {
 
     @Before
     public void before() {
-        // Start members if needed
-        if (members == null) {
-            members = new ArrayList<>(membersCount);
-            for (int i = 0; i < membersCount; ++i) {
-                members.add(FACTORY.newHazelcastInstance(memberConfig()));
-            }
+        members = new ArrayList<>(membersCount);
+        for (int i = 0; i < membersCount; ++i) {
+            members.add(factory.newHazelcastInstance(memberConfig()));
         }
 
         if (isPortable()) {
@@ -200,8 +197,7 @@ public class SqlOrderByTest extends SqlTestSupport {
 
     @After
     public void after() {
-        FACTORY.shutdownAll();
-        members = null;
+        factory.shutdownAll();
     }
 
     protected Config memberConfig() {


### PR DESCRIPTION
Before this PR, the state was shared through static fields of `SqlOrderByTest`. Apparently, that was done to optimize the startup/shutdown time, but each test method still does the full startup-shutdown cycle, so the optimization gives nothing. Probably, that's just a leftover of some debugging session done via `@Repeat` on some test method.

If some test method of `SqlOrderByTest` (or of its sub-classes: `HDSqlOrderByTest`, `TSSqlOrderByTest`, `SqlOrderBySlowTest`) leaves the shared fields (`FACTORY` and `members`) in some inconsistent state, this starts the chain reaction: new members try to form a cluster with unrelated members started by the previous test, or members totally missing because the previous test wasn't able to startup or shutdown properly, or tests reusing members from some other unrelated test, etc. This PR fixes that.

The failure that was starting the chain reaction is fixed by https://github.com/hazelcast/hazelcast-enterprise/pull/5318.