### PR TITLE
Add additional asserts to stress tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
@@ -121,8 +121,9 @@ public class MapStableReadStressTest extends StressTestSupport {
 
             while (!isStopped()) {
                 int key = random.nextInt(MAP_SIZE);
-                int value = map.get(key);
-                assertEquals("The value for the key was not consistent", key, value);
+                Integer value = map.get(key);
+                assertNotNull("The entry with key: " + key + " is missing", value);
+                assertEquals("The value for the key was not consistent", key, value.intValue());
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
@@ -29,6 +29,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * This tests puts a lot of key/values in a map, where the value is the same as the key. With a client these
@@ -55,6 +56,8 @@ public class MapStableReadStressTest extends StressTestSupport {
         clientConfig.getNetworkConfig().setRedoOperation(true);
         client = HazelcastClient.newHazelcastClient(clientConfig);
         map = client.getMap("map");
+
+        assertNotNull("client.getMap() returned null", map);
 
         stressThreads = new StressThread[CLIENT_THREAD_COUNT];
         for (int k = 0; k < stressThreads.length; k++) {
@@ -114,6 +117,8 @@ public class MapStableReadStressTest extends StressTestSupport {
 
         @Override
         public void doRun() throws Exception {
+            assertNotNull("The map read by StressThread is null", map);
+
             while (!isStopped()) {
                 int key = random.nextInt(MAP_SIZE);
                 int value = map.get(key);

--- a/hazelcast/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
@@ -117,6 +117,8 @@ public class MapStableReadStressTest extends StressTestSupport {
 
         @Override
         public void doRun() throws Exception {
+            System.out.println("Starting StressThread");
+
             assertNotNull("The map read by StressThread is null", map);
 
             while (!isStopped()) {

--- a/hazelcast/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
@@ -146,6 +146,8 @@ public class MapUpdateStressTest extends StressTestSupport {
 
         @Override
         public void doRun() throws Exception {
+            System.out.println("Starting StressThread");
+
             assertNotNull("The map read by StressThread is null", map);
 
             while (!isStopped()) {

--- a/hazelcast/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
@@ -153,7 +153,8 @@ public class MapUpdateStressTest extends StressTestSupport {
                 int increment = random.nextInt(10);
                 increments[key] += increment;
                 for (; ; ) {
-                    int oldValue = map.get(key);
+                    Integer oldValue = map.get(key);
+                    assertNotNull("The entry with key: " + key + " is missing", oldValue);
                     if (map.replace(key, oldValue, oldValue + increment)) {
                         break;
                     }

--- a/hazelcast/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -57,6 +58,8 @@ public class MapUpdateStressTest extends StressTestSupport {
         clientConfig.getNetworkConfig().setRedoOperation(true);
         client = HazelcastClient.newHazelcastClient(clientConfig);
         map = client.getMap("map");
+
+        assertNotNull("client.getMap() returned null", map);
 
         stressThreads = new StressThread[CLIENT_THREAD_COUNT];
         for (int k = 0; k < stressThreads.length; k++) {
@@ -143,6 +146,8 @@ public class MapUpdateStressTest extends StressTestSupport {
 
         @Override
         public void doRun() throws Exception {
+            assertNotNull("The map read by StressThread is null", map);
+
             while (!isStopped()) {
                 int key = random.nextInt(MAP_SIZE);
                 int increment = random.nextInt(10);


### PR DESCRIPTION
Additional asserts for:
- https://github.com/hazelcast/hazelcast/issues/22669
- https://github.com/hazelcast/hazelcast/issues/19755
- https://github.com/hazelcast/hazelcast/issues/19739

Those two tests fail with NPE on map method invocation in ```StresThread```. The map looks like if it is properly passed to new threads. The ```map``` field is set before starting the thread, and both filling and starting are done in the same thread. I'm adding two asserts to see if the ```map``` field is set to ```null``` or is something wrong with publication of that field

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
