### PR TITLE
Update Elastic to 7.17.7

### DIFF
--- a/extensions/elasticsearch/elasticsearch-7/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-7/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>7.16.3</version>
+            <version>7.17.7</version>
         </dependency>
 
         <!-- TEST -->

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticCatClient.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticCatClient.java
@@ -160,11 +160,15 @@ public class ElasticCatClient implements Closeable {
         // TODO IndexShardState.STARTED but this is deeply inside elastic, should we mirror the enum?
         if ("STARTED".equals(object.get("state").asString())) {
             String id = object.get("id").asString();
+            JsonValue docsValue = object.get("docs");
+            int docsCount = docsValue != null
+                    && !docsValue.equals(Json.NULL)
+                    ? Integer.parseInt(docsValue.asString()) : 0;
             Shard shard = new Shard(
                     object.get("index").asString(),
                     Integer.parseInt(object.get("shard").asString()),
                     Prirep.valueOf(object.get("prirep").asString()),
-                    object.get("docs") != null ? Integer.parseInt(object.get("docs").asString()) : 0,
+                    docsCount,
                     object.get("state").asString(),
                     object.get("ip").asString(),
                     idToAddress.get(id),

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
@@ -29,8 +29,12 @@ import static com.hazelcast.jet.elastic.ElasticClients.client;
 
 public final class ElasticSupport {
 
-    public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName.parse("elasticsearch:7.10.1")
+    public static final String TEST_ELASTIC_VERSION = System.getProperty("test.elastic.version", "7.17.7");
+
+    public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName
+            .parse("elasticsearch:" + TEST_ELASTIC_VERSION)
             .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch");
+
     public static final int PORT = 9200;
 
     // Elastic container takes long time to start up, reusing the container for speedup


### PR DESCRIPTION
Use latest 7.x client and server (for tests).

Removes some medium vulnerabilities.

After updating the server there was a failure in parsing the shard info. The server response has changed between 7.15.x and 7.16.x, but when we last updated elastic client, the server wasn't updated, therefore we didn't see the failure for client 7.16.x.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

No backports.