### PR TITLE
Await MapStore initialization before tests [HZ-1695]

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -534,7 +534,7 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
     /**
      * Awaits successful initialization, if the initialization failed it throws an exception
      */
-    private void awaitInitFinished() {
+    void awaitInitFinished() {
         try {
             boolean finished = initFinished.await(initTimeoutMillis, MILLISECONDS);
             if (!finished) {

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
@@ -78,10 +78,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         createTable(mapName);
 
         createMapStore();
-
-        assertTrueEventually(() -> {
-            assertRowsAnyOrder(hz, "SHOW MAPPINGS", newArrayList(new Row(MAPPING_PREFIX + mapName)));
-        }, 5);
+        awaitMappingCreated();
     }
 
     @Test
@@ -113,9 +110,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         awaitMappingCreated();
 
         mapStore.destroy();
-        assertTrueEventually(() -> {
-            assertRowsAnyOrder(hz, "SHOW MAPPINGS", newArrayList());
-        }, 5);
+        awaitMappingDestroyed();
     }
 
     @Test
@@ -127,9 +122,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
 
         GenericMapStore<Object> mapStoreNotMaster = createMapStore(instances()[1]);
         mapStoreNotMaster.destroy();
-        assertTrueEventually(() -> {
-            assertRowsAnyOrder(hz, "SHOW MAPPINGS", newArrayList());
-        }, 5);
+        awaitMappingDestroyed();
     }
 
     @Test
@@ -611,6 +604,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
 
         GenericMapStore<K> mapStore = new GenericMapStore<>();
         mapStore.init(instance, properties, mapName);
+        mapStore.awaitInitFinished();
         return mapStore;
     }
 
@@ -628,4 +622,9 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         }, 5);
     }
 
+    private void awaitMappingDestroyed() {
+        assertTrueEventually(() -> {
+            assertRowsAnyOrder(hz, "SHOW MAPPINGS", newArrayList());
+        }, 5);
+    }
 }


### PR DESCRIPTION
Some tests in `GenericMapStoreTest` seemingly end before MapStore is initialized, which prevents the mapping from being destroyed by `SimpleTestInClusterSupport#supportAfter`.

Additionally, some refactoring is done.

Fixes #21993