### PR TITLE
Handle null values of AddMapConfigMessageTask's nullable fields

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -76,17 +76,17 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
         this.clientMessage = clientMessage;
         this.logger = node.getLogger(getClass());
         this.node = node;
-        this.nodeEngine = node.nodeEngine;
+        this.nodeEngine = node.getNodeEngine();
         this.serializationService = node.getSerializationService();
         this.connection = (ServerConnection) connection;
-        this.clientEngine = node.clientEngine;
+        this.clientEngine = node.getClientEngine();
         this.endpointManager = clientEngine.getEndpointManager();
         this.endpoint = initEndpoint();
     }
 
     @SuppressWarnings("unchecked")
     public <S> S getService(String serviceName) {
-        return (S) node.nodeEngine.getService(serviceName);
+        return (S) node.getNodeEngine().getService(serviceName);
     }
 
     private ClientEndpoint initEndpoint() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -63,9 +63,16 @@ public class AddMapConfigMessageTask
             config.setEntryListenerConfigs(
                     (List<EntryListenerConfig>) adaptListenerConfigs(parameters.listenerConfigs));
         }
-        config.setMerkleTreeConfig(parameters.merkleTreeConfig);
-        config.setEventJournalConfig(parameters.eventJournalConfig);
-        config.setHotRestartConfig(parameters.hotRestartConfig);
+        if (parameters.merkleTreeConfig != null) {
+            config.setMerkleTreeConfig(parameters.merkleTreeConfig);
+        }
+        if (parameters.eventJournalConfig != null) {
+            config.setEventJournalConfig(parameters.eventJournalConfig);
+        }
+        if (parameters.hotRestartConfig != null) {
+            config.setHotRestartConfig(parameters.hotRestartConfig);
+        }
+
         config.setInMemoryFormat(InMemoryFormat.valueOf(parameters.inMemoryFormat));
         config.setAttributeConfigs(parameters.attributeConfigs);
         config.setReadBackupData(parameters.readBackupData);
@@ -76,8 +83,12 @@ public class AddMapConfigMessageTask
         }
         config.setTimeToLiveSeconds(parameters.timeToLiveSeconds);
         config.setMaxIdleSeconds(parameters.maxIdleSeconds);
-        config.setEvictionConfig(parameters.evictionConfig.asEvictionConfg(serializationService));
-        config.setMergePolicyConfig(mergePolicyConfig(parameters.mergePolicy, parameters.mergeBatchSize));
+        if (parameters.evictionConfig != null) {
+            config.setEvictionConfig(parameters.evictionConfig.asEvictionConfg(serializationService));
+        }
+        if (parameters.mergePolicy != null) {
+            config.setMergePolicyConfig(mergePolicyConfig(parameters.mergePolicy, parameters.mergeBatchSize));
+        }
         if (parameters.nearCacheConfig != null) {
             config.setNearCacheConfig(parameters.nearCacheConfig.asNearCacheConfig(serializationService));
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/MapStoreConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/MapStoreConfigHolder.java
@@ -149,7 +149,9 @@ public class MapStoreConfigHolder {
             config.setFactoryClassName(factoryClassName);
         }
         config.setInitialLoadMode(InitialLoadMode.valueOf(initialLoadMode));
-        config.setProperties(PropertiesUtil.fromMap(properties));
+        if (properties != null) {
+            config.setProperties(PropertiesUtil.fromMap(properties));
+        }
         config.setWriteBatchSize(writeBatchSize);
         config.setWriteCoalescing(writeCoalescing);
         config.setWriteDelaySeconds(writeDelaySeconds);

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTaskTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.dynamicconfig;
+
+import com.hazelcast.client.impl.ClientEndpoint;
+import com.hazelcast.client.impl.ClientEndpointManager;
+import com.hazelcast.client.impl.ClientEngine;
+import com.hazelcast.client.impl.protocol.ClientExceptionFactory;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddMapConfigCodec;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.instance.impl.NodeExtension;
+import com.hazelcast.internal.dynamicconfig.ClusterWideConfigurationService;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
+import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.internal.nio.ConnectionType;
+import com.hazelcast.internal.server.ServerConnection;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+
+import static com.hazelcast.cluster.Address.createUnresolvedAddress;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class AddMapConfigMessageTaskTest {
+    private Node mockNode;
+    private Connection mockConnection;
+
+    @Before
+    public void setup() {
+        // setup mocks
+        mockNode = mock(Node.class);
+        mockConnection = mock(ServerConnection.class);
+        ClientEngine mockClientEngine = mock(ClientEngine.class);
+        ClientEndpointManager mockClientEndpointManager = mock(ClientEndpointManager.class);
+        ClientEndpoint mockClientEndpoint = mock(ClientEndpoint.class);
+        NodeEngineImpl mockNodeEngineImpl = mock(NodeEngineImpl.class);
+        NodeExtension mockNodeExtension = mock(NodeExtension.class);
+        ClusterWideConfigurationService mockConfigurationService = mock(ClusterWideConfigurationService.class);
+        InternalCompletableFuture<Object> mockFuture = mock(InternalCompletableFuture.class);
+
+        when(mockNode.getClientEngine()).thenReturn(mockClientEngine);
+        when(mockNode.getConfig()).thenReturn(new Config());
+        when(mockNode.getLogger(any(Class.class))).thenReturn(Logger.getLogger(AddMapConfigMessageTaskTest.class));
+        when(mockNode.getNodeExtension()).thenReturn(mockNodeExtension);
+        when(mockNode.getNodeEngine()).thenReturn(mockNodeEngineImpl);
+
+        when(mockClientEngine.getEndpointManager()).thenReturn(mockClientEndpointManager);
+        when(mockClientEngine.getExceptionFactory()).thenReturn(new ClientExceptionFactory(false,
+                new Config().getClassLoader()));
+
+        when(mockClientEndpoint.getClientType()).thenReturn(ConnectionType.JAVA_CLIENT);
+        when(mockClientEndpoint.isAuthenticated()).thenReturn(true);
+        when(mockClientEndpointManager.getEndpoint(mockConnection)).thenReturn(mockClientEndpoint);
+
+        when(mockNodeEngineImpl.getConfig()).thenReturn(new DynamicConfigurationAwareConfig(
+                new Config(),
+                new HazelcastProperties(new Config()))
+        );
+        when(mockNodeEngineImpl.getService(ClusterWideConfigurationService.SERVICE_NAME)).thenReturn(mockConfigurationService);
+
+        when(mockConfigurationService.broadcastConfigAsync(any(IdentifiedDataSerializable.class)))
+                .thenReturn(mockFuture);
+        when(mockNodeExtension.isStartCompleted()).thenReturn(true);
+        when(mockConnection.getRemoteAddress()).thenReturn(createUnresolvedAddress("127.0.0.1", 5701));
+    }
+
+    @Test
+    public void doNotThrowException_whenNullValuesProvidedForNullableFields() {
+        MapConfig mapConfig = new MapConfig("my-map");
+        ClientMessage addMapConfigClientMessage = DynamicConfigAddMapConfigCodec.encodeRequest(
+                mapConfig.getName(),
+                mapConfig.getBackupCount(),
+                mapConfig.getAsyncBackupCount(),
+                mapConfig.getTimeToLiveSeconds(),
+                mapConfig.getMaxIdleSeconds(),
+                null,
+                mapConfig.isReadBackupData(),
+                mapConfig.getCacheDeserializedValues().name(),
+                mapConfig.getMergePolicyConfig().getPolicy(),
+                mapConfig.getMergePolicyConfig().getBatchSize(),
+                mapConfig.getInMemoryFormat().name(),
+                null,
+                null,
+                mapConfig.isStatisticsEnabled(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                mapConfig.getMetadataPolicy().getId()
+        );
+        AddMapConfigMessageTask addMapConfigMessageTask = new AddMapConfigMessageTask(addMapConfigClientMessage, mockNode, mockConnection);
+        addMapConfigMessageTask.run();
+        MapConfig transmittedMapConfig = (MapConfig) addMapConfigMessageTask.getConfig();
+        assertEquals(mapConfig, transmittedMapConfig);
+    }
+}


### PR DESCRIPTION
This PR adds necessary null checks to the fields of `AddMapConfigMessageTask` that are mistakenly marked as nullable in the client protocol which are actually not nullable.

backport of #21417