### PR TITLE
Download Hazelcast 3 jar in build [HZ-1753]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,6 +546,7 @@
                         <phase>generate-test-resources</phase>
                         <configuration>
                             <artifact>com.hazelcast:hazelcast:${hazelcast-3.version}</artifact>
+                            <artifact>com.hazelcast:hazelcast:${hazelcast-3.version}:jar:tests</artifact>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
We were already downloading the regular jar, this adds the test jar as well. The failing test (Hazelcast3StarterTest) doesn't use SQL or EE so those jars are not needed.

Fixes #19783
Fixes #21447

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
