### PR TITLE
Download Hazelcast 3 jar in build [HZ-1753] [5.2.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,6 +540,7 @@
                         <phase>generate-test-resources</phase>
                         <configuration>
                             <artifact>com.hazelcast:hazelcast:${hazelcast-3.version}</artifact>
+                            <artifact>com.hazelcast:hazelcast:${hazelcast-3.version}:jar:tests</artifact>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
We were already downloading the regular jar, this adds the test jar as well. This test doesnt't use SQL or enterprise so those jars are not needed.

Fixes #19783
Backport of #22813


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
