### PR TITLE
Adding OS 4.1.10 release notes along with that of all 4.1.z series.

### DIFF
--- a/hazelcast/src/main/resources/release_notes.txt
+++ b/hazelcast/src/main/resources/release_notes.txt
@@ -1,96 +1,283 @@
-This document lists the new features, enhancements, fixed issues and, removed or deprecated features for Hazelcast IMDG 3.12 release. The numbers in the square brackets refer to the issues in Hazelcast's GitHub repositories.
+This document lists the new features, enhancements, fixed issues and, removed or deprecated features for Hazelcast IMDG 4.1.z releases. The numbers in the square brackets refer to the issues in Hazelcast's GitHub repositories.
 
+==== 4.1.10 ====
 
-==== 3.12 ====
+## Enhancements
 
-1. Breaking Changes
+* Improved connection handling. #21644
+* To decrease the load on the Management Center for large clusters, the level of network related metrics has been changed to DEBUG. When you need these metrics, you can use the hazelcast.metrics.debug.enabled property. #21260
 
-* Support for JDK 6 and 7 has been dropped. The minimum Java version that Hazelcast supports now is Java 8. See the Supports JVMs section.
+## Fixes
 
-2. New Features
+* Fixed an issue where replication over WAN was failing on the source cluster members, when there are multiple batch publishers configured in a single WAN replication. #22498
+* Fixed an issue where the cluster was failing to operate since the indexes on backup partitions were removed by `map.ClearBackupOperation`. #22305
+* Fixed an issue where a cluster could not be formed when security is enabled, various client permissions are set, and multiple members are started simultaneously. #21507
 
-Hazelcast IMDG Enterprise New Features:
+==== 4.1.9 ====
 
-* **Blue-Green and Disaster Recovery for Java Clients:** Introduced the support for Hazelcast Java clients to switch between alternative clusters. See the Blue Green Deployment and Disaster Recovery section.
+## Enhancements
+
+* Enabled XXE (XML External Entity Reference) protection for XMLInputFactory. The related issue was reported through https://huntr.dev/bounties/d63972a2-b910-480a-a86b-d1f75d24d563/. #20943
+
+## Fixes
+
+* Fixed an issue where a cluster was unresponsive when you perform a health check to see the members are in the safe state; cluster members were hanging in the REPLICA_NOT_SYNC state during such health checks. #21205
+* Fixed an issue where the list of members in the cluster was reset to an empty list when member IDs change after a cluster restart: this was causing startup failures since Hazelcast could not manage the events due to the empty member list after a restart. #21181
+* Fixed an issue where the statistics like puts and removals were not increasing when these operations are executed through Transactional interface. #21100
+* Fixed an issue where Hazelcast clients, which have only the IP address of a member to connect (but the member also has a hostname), were not able to connect to the cluster. #20632
+
+==== 4.1.8 ====
+
+* For the distributions packages of IMDG, we updated the vulnerable version of log4j2 in Management Center to 2.17.0. No changes were made to the IMDG code.
+
+==== 4.1.7 ====
+
+* For the distributions packages of IMDG, we updated the vulnerable version of log4j2 in Management Center to 2.15.0. No changes were made to the IMDG code.
+
+==== 4.1.6 ====
+
+## Enhancements
+
+* Improved the log message that is displayed when using the hazelcast.io.selectorMode property to decrease the high CPU usage. The previous misleading message read as "Recreated Selector because of possible java/network stack bug". It has been changed to "Selector was rebuilt, consider updating Java and/or your network stack drivers". #19761
+* Introduced the hazelcast.internal.map.expired.key.scan.timeout.nanos property to limit the execution time of the cleanup operations, i.e., entry expiration tasks of a map; this is to prevent the increased CPU usage as the partition size grows. #19663
+
+## Fixes
+
+* Hazelcast was executing cluster wide operations when you query the state of a member using the health check endpoint - it was causing to kill all the members in a cluster; this issue has been fixed. #19837
+* The increment command (incr) in the Memcache client was returning the ASCII code of the expected result; this interpretation issue has been fixed. #19681
+
+==== 4.1.5 ====
+
+## Fixes
+
+* Fixed an issue where a high amount of garbage collection pressure was occurring during repartitioning especially when having a high partition count. #19295
+* Fixed an issue where the client state listener was not properly working with failover clients (in blue-green deployments); it was failing with invalid configuration exception. #19116
+
+## Deprecated/Removed Features
+
+* Deprecated the following properties:
+  ** hazelcast.client.statistics.period.seconds
+  ** hazelcast.client.statistics.enabled
+  #19234
+
+==== 4.1.4 ====
+
+## Fixes
+
+* Fixed an issue where the updates made to a persistent map store might be lost when the write coalescing is enabled. #18924
+* Fixed an issue where the maximum size policy for a map was being ignored when the policy is PER_NODE and the cluster is scaled down (due to losing or killing a member). #18871
+* Fixed an issue where the map’s Near Cache was setting its maximum size as 10.000 even if the configured eviction policy is NONE. #18834
+* The LRU eviction policy now takes last access time value into account to prevent premature removal of the lately added but not yet accessed map entries. #18632
+
+==== 4.1.3 ====
+
+## Enhancements
+
+* Introduced a new mechanism in the background expiration tasks; now a thread local array controls the allocations for these tasks otherwise which may cause increased garbage collection pressure and CPU usage spikes when you use aggressive expiration configurations, e.g., low time-to-live values. #18480
+* Updated the Hazelcast Kubernetes plugin dependency version to 2.2.2. #18331
+* Added the ability to register the class definition of the parent generic record and check the class definition compatibility for nested portable fields. #18284
+
+## Fixes
+
+* The difference between the Near Cache configurations before and after a client is recreated with the same client failover configuration is fixed now. #18361
+* The eviction of the idle entries is now stable in IMDG 4.x series by aligning the behaviors of index-scan and full-scan in maps. #18346
+* The IllegalArgumentException is not thrown anymore when there is Near Cache configured for both the member and client sides for the same map and serialize-keys option is false. #18313
+
+==== 4.1.2 ====
+
+## Fixes
+
+* Fixed an issue where the Java client was not receiving membership events when a member with Hot Restart Persistence is restarted. #18268
+* Fixed an issue where the Near Cache configuration of a map in client was not the same after the client is recreated with the same client failover configuration. #18356
+* Fixed an issue that prohibited Hazelcast from being used as Tomcat session manager when it is also deployed in a web application context: When a client application that uses Hazelcast tries to connect to the Hazelcast cluster and this application’s web sessions are persisted using Hazelcast’s Tomcat session manager, the session manager could not connect to the cluster. This has been fixed by improving Hazelcast’s service loader mechanism. #18116
+* Fixed an issue where the metrics for map hits statistics in Management Center were decreasing as the map entries are being expired. #18112
+* When the in-memory format of a map is NATIVE and the uploaded user code has missing classes (in case the user code deployment feature is used), the resulting exception could not be seen on the client side when a map query is run. This was causing the client to hang indefinitely and fixed by improving the failure handling for this case. #18084
+* Fixed an issue where the queue items were being delivered more than once when they are reproduced after a member leaves the cluster. #18057
+* When the user code deployment is used and the classes to be deployed have com.hazelcast prefix, it was causing failures in other Hazelcast products, e.g., Jet. This has been fixed by making use of the context classloader when loading such classes. #17915
+* The -c parameter of the cp-subsystem.sh script was used for both cluster name and group variables. This has been fixed by introducing the -g parameter for groups. #17907
+* Fixed an issue where the remove() and delete() operations of maps were not updating the local map statistics. #17750
+
+==== 4.1.1 ====
+
+## New Features
+
+* Node Aware Partition Grouping: Added the support of partition grouping mechanism in the Hazelcast discovery plugin for Kubernetes. You can create partition groups according to the name of the node which is provided by this plugin and on which the containers/pods run. See the NODE_AWARE section of the IMDG Reference Manual for more information.
+
+## Enhancements
+
+* Introduced a configuration property to ignore errors during enabling the XXE protection. This protection works with JAXP 1.5 (Java 7 Update 40) and newer. When an older JAXP implementation is added to the classpath, e.g., Xerces and Xalan, an exception is thrown. The newly introduced property, namely hazelcast.ignoreXxeProtectionFailures, allows you to ignore those exceptions. See the System Properties appendix of the IMDG Reference Manual for more information.
+* Updated the Hazelcast Kubernetes plugin dependency to 2.2.1. #17928
+* Separated the hazelcast-sql Maven module into hazelcast-sql-core and hazelcast-sql. #17922
+* Implemented the IMap.entrySet() method for the partition ID set. #17886
+
+## Fixes
+
+* Fixed an issue where the clients were opening two connections to the same member when the member is behind a private network. #17888
+* Fixed an issue where the Javadoc of release methods for session-aware semaphore structure was incorrectly addressing "threads" instead of "Hazelcast instances". #17827
+* Fixed an issue where the Hazelcast Java client was not able to resolve the new address of a restarted member, e.g., for a setup in Docker environment. #17062
+
+==== 4.1 ====
+
+## New Features
 
 Hazelcast IMDG Open Source New Features:
 
-* **CP Subsystem:** Implementing the https://raft.github.io/[Raft consensus algorithm], Hazelcast introduces its CP subsystem which runs within a Hazelcast cluster and offers linearizable implementations of Hazelcast's concurrency APIs. See the CP Subsystem chapter.
-* **Querying JSON Strings:**  You can now query JSON strings stored inside your Hazelcast clusters. See the Querying JSON Strings section.
-* **Pipelining:** Introduced pipelining mechanism using which you can send multiple requests in parallel to Hazelcast members or clients, and read the responses in a single step. See the Pipelining section.
-* **Support for Multiple Endpoints When Configuring Member’s Networking:** Added the ability to configure the Hazelcast members with separate server sockets for different protocols. See the Advanced Network Configuration section.
-* **YAML Configuration Support:** Added the support for configuring Hazelcast in YAML. See the Configuring Declaratively with YAML section.
+* SQL Implementation: Implemented the SQL engine that supports map scans, index scans, projections and filters. It also introduces the hazelcast-sql module to handle the SQL engine’s dependencies on Apache Calcite. See the SQL section.
+* Automatic Discovery Strategy Detection: Hazelcast now automatically detects the cloud environment it’s running on (Kubernetes, AWS, GCP or Azure) and applies the necessary discovery strategy for the environment. This allows automatically forming the Hazelcast clusters in cloud environments without any configuration. See the Auto Detection section.
+* Overriding Configuration: You can now override the configuration entries of your cluster without changing the declarative configuration files (XML/YAML). See the Overriding Configuration section.
+* Instance Tracking: Hazelcast now writes a file on a Hazelcast member startup at the configured location. This file contains metadata about the member such as version, product name and process ID, and it is not deleted on the member shutdown. See the Instance Tracking section.
 
-3. Enhancements
+Hazelcast IMDG Enterprise New Features:
 
-Hazelcast IMDG Enterprise Enhancements:
+* Security Audit Logging: This feature allows observing some important cluster events. Auditable events have a unique type ID, and contain a timestamp and importance level. See the Logging Auditable Events section.
 
-* **Sharing Hot Restart `base-dir` among Multiple Members:** The base directory for the Hot Restart feature (`base-dir`) is now used as a shared directory between multiple members, and each member uses a unique sub-directory
-inside this base directory. This allows using the same configuration on all the members. Previously, each member had to use a separate directory which complicated the deployments on cloud-like environments. During the restart, a member tries to lock an already existing Hot Restart directory inside the base directory. If it cannot acquire any, then it creates a fresh new directory. See the Configuring Hot Restart section.
-* **Lower Latencies and Higher Throughput in WAN Replication:** Improved the design of the WAN replication mechanism to allow configuring it for lower latencies and higher throughput. See the Tuning WAN Replication For Lower Latencies and Higher Throughput section.
-* **Add/Remove WAN Publishers in a Running Cluster:** Introduced the ability to dynamically add or remove WAN publishers (target clusters). See the Dynamically Adding WAN Publishers section.
-* **Automatic Removal of Stale Hot Restart Data:** Introduced an option that allows the stale Hot Restart data to be removed automatically. See the description of the `auto-remove-stale-data` configuration element in the Configuring Hot Restart section.
-* **Client Permission Handling When a New Member Joins:** Introduced a declarative configuration attribute `on-join-operation` for the client permission in the Security configuration (its programmatic configuration equivalent is the `setOnJoinPermissionOperation()` method). This attribute allows to choose whether a new member joining to a cluster will apply the client permissions stored in its own configuration, or will use the ones defined in the cluster. See the Handling Permissions When a New Member Joins section.
-* **Automatic Cluster Version Change after a Rolling Upgrade:** Introduced the ability to automatically upgrade the cluster version after a rolling upgrade. See the Upgrading Cluster Version section.
-* **FIPS 140-2 Validation:** Hazelcast now can be configured to use a FIPS 140-2 validated module. See the FIPS 140-2 section.
+## Breaking Changes
+
+* Starting a standalone Hazelcast instance requires disabling Auto Detection joiner (before it required disabling Multicast joiner). #17112
+* In a CP subsystem session, a generic IllegalStateException was being thrown when Hazelcast is shutdown. Now the same situation throws HazelcastInstanceNotActiveException. #17120
+* Implemented and/or overridden the default methods in Java 8 collections, such as computeIfAbsent(), forEach() compute() and replaceAll() for maps. #14913
+
+## Enhancements
 
 Hazelcast IMDG Open Source Enhancements:
 
-* **Client Instance Names and Labels:** You can now retrieve the names of client instances on the member side. Moreover, client labels have been introduced so that you can group your clients and/or perform special operations for specific clients. See the Defining Client Labels section.
-* **Composite Indexes:** Introduced the ability to recognize the queries that use all the indexed properties and treat them as a composite, e.g., `foo = 1 and bar = 2 and foobar = 3`. See the Composite Indexes section.
-* **REST Endpoint Groups:** With this enhancement you can enable or disable the REST API completely, Memcache protocol and REST endpoint groups. See the Using the REST Endpoint Groups section.
+* Improvements in Partial Network Disconnections: Introduced properties to be configured to detect and resolve the partial network issues among the Hazelcast IMDG members. See #16680 and the Partial Network Partitions section.
+* Parallel Independent Migrations: Parallelized the partition replica migrations so that the time needed for rebalancing the partitions after adding or removing a member to/from a cluster is reduced. See the hazelcast.partition.max.parallel.migrations property explanation in the System Properties appendix.
+* CP Subsystem Listeners and Metrics: Added membership and group availability listeners for CP Subsystem. Also, added support for publishing CP Subsystem and CP data structure statistics via Metrics. See the CP Subsystem Listeners section.
+* GenericRecord: Added support for accessing domain objects without domain classes. See the GenericRecord section.
+* Thread Affinity: Introduced the CPU thread affinity; threads can have affinity for particular CPUs and using this you have a better control on the latency and a better throughput. See the CPU Thread Affinity section.
+* Trusted Interfaces: It is now possible to restrict the source IP addresses from which the Management Center operations are allowed. See the Limiting Source Addresses section.
+* Priority Queue: Added support for the queues with comparators. Using Priority Queue, you can define items with higher priority to be polled first. See the Priority Queue section.
+* Statistics for Durable and Scheduled Executor Services: Added the statistics for scheduled and durable executor services, and for the executor of offloaded entry processors to be monitored by Management Center.
+
+Hazelcast IMDG Enterprise Enhancements:
+
+* Out-of-the-Box Kerberos Support: Introduced support for Kerberos authentication protocol which is one of the standard solutions for single-sign-on. It also adds the GSSAPI authentication support in LDAP configuration. See the Kerberos Authentication Type section.
+* Multiple Persistent Directories: Added support for multiple mounting directories in the persistent memory configuration and also thread affinity for NVMs (Non-Volatile Main Memories). See the Using Persistent Memory section.
+* WAN Throttling Mechanism: This prevents the WAN consumers from getting overloaded by the WAN producers if transferring the WAN events takes less time than processing them in the target cluster. This can be the case with WAN synchronization if the network latency is low enough. It can be configured using the following properties:
+  ** hazelcast.wan.consumer.invocation.threshold
+  ** hazelcast.wan.consumer.ack.delay.backoff.init
+  ** hazelcast.wan.consumer.ack.delay.backoff.max
+  ** hazelcast.wan.consumer.ack.delay.backoff.multiplier
+  #17113
+* Implemented a new concurrent High-Density Memory Store index for the queries, based on B+ tree that is enabled by default; brings better performance for lookup queries and enables SQL queries.
 
 The following are the other improvements performed to solve the enhancement issues opened by the Hazelcast customers/team.
 
-* Improved the YAML configuration so that you can configure multiple WAN member sockets. [#14800] 
-* Members now fail fast when the `max-idle-seconds` element for the entries in a map is set to 1 second. See the note in the Configuring Map Eviction section for this element. [#14697]
-* Removed group password from the Hazelcast’s default XML configuration file. Also improved the non-empty password `INFO` message. It's now only logged if security is disabled, password is not empty and password is not the Hazelcast default one. [#14603]
-* Improved the code comments for the `HazelcastInstance` interface. [#14439]
-* Improved the Javadoc of `HazelcastClient` so that the code comments now use "unisocket client" instead of "dumb client". [#14213]
-* Added the ability to perform an LDAP `subtree` search for groups in Hazelcast Management Center’s LDAP authenticator. [#14118]
-* Added the ability to set the `EvictionConfig.comparatorClassName()` in the client’s declarative configuration, too. [#14093]
-* Introduced the `/ready` endpoint to the REST API to allow checking a member if it is ready to be used after it joins to the cluster. [#14089]
-* Improved the syncing of XSD files. [#14070]
-* The `IMap.removeAll()` method now supports `PartitionPredicate`. [#12238]
-* Improved the diagnostics tool so that it automatically creates the configured directory for the diagnostic outputs. [#11946]
+* Added the missing replicatedmap-permission support to the XML and YAML configuration handlers. #17812
+* Replaced the word "should" with "must" in the exception messages to improve the user focus and indicate obligation rather than advice. #17710
+* Added the getAndDecrement() operation support for the IAtomicLong data structure. #17699
+* Introduced the mode configuration attribute for the persistent memory. It defines operational mode of it which can be either MOUNTED or SYSTEM_MEMORY. #17696
+* Added the support for checking duplicate fields when building class definitions. #17682
+* Added the support for IList with nullable items to the client protocol. #17690
+* Improved the robustness of the diagnostics log writer and its plugins. #17665
+* Added the client name tag to the client related metrics. #17654
+* Added a check for IMap READ permissions for the maps involved in the SQL query executions. #17612
+* Added the support for accessing the Hazelcast instance in the login modules and credential factories. #17605
+* Introduced a simplified configuration of Kerberos authentication for simple scenarios. #17573
+* Added statistics support for IBM, OpenJ9, ZGC and Shenandoah. #17561
+* Introduced a state-tracking mechanism for the external configuration parser; all mismatched/unapplied configuration entries coming from environment variables or system properties are now logged. #17559
+* Updated the jackson.version to 2.11.2 and SnakeYAML to 2.1. #17484, #17446
+* Added support for the merge operation in IMap. #17419
+* Added public classes to expose the member- and client-side caching provider implementations (in the JCache implementation) without referring to internal classes. #17320
+* Improved the entry processing mechanism so that the read-only processors on backups are not executed anymore. #17318
+* Improved CacheSimpleConfig so that it now accepts cache name in its constructors. #17287
+* Cleaned up the noisy initial log messages on Hazelcast startups. #17243
+* Introduced auto-disposable tasks for the scheduled executor service. #17215
+* Added client labels to ClientEndpointImpl.toString() to simplify the client identification (in addition to client uuid) on the Hazelcast member side. #17178
+* Added exception handling when creating caches with tenant control. #17122
+* Added support for IMap.compute(). #17030
+* Added support to allow submitting and executing operations while a member is shutting down to increase the availability of a cluster more that keeps large data. #17028
+* Added ExtendedMapEntry in order to create a mechanism for setting TTLs in entry processors. #16991
+* Added hazelcast-azure discovery plugin to the hazelcast-all module. #16982
+* Introduced the ConfigRecognition API that determines if a provided declarative configuration is recognized by the rules defined in a given implementation. Along with the API the following three implementations are added:
+  ** MemberConfigRecognizer for recognizing member XML and YAML configurations
+  ** ClientConfigRecognizer for recognizing client XML and YAML configurations
+  ** ClientFailoverConfigRecognizer for recognizing failover client XML and YAML configurations
+  #16958
+* Added the publishAll(), publishAllAsync() and publishAsync() methods to ITopic. #16946
+* Made the diagnostics logs cloud-friendly so that they can also be sent to stdout in addition to sending to local files. #16941
+* Improved the mechanism of partition table updates to eliminate the latencies when these updates are sent to the clients by a member. #16939
+* Improved the client configuration such that when the client failover configuration is provided, the reconnect mode cannot be set as off; it now fails fast in this case. #16886
+* Introduced the forEach() loop support for IMap. #16877
+* Added the load() method to Config, ClientConfig and ClientFailoverConfig classes. This method loads the configuration with the known locations. If not found, the default configuration is returned. #16864
+* Improved the deleteAll() (MapStore) and ITopic Javadocs. #16862, #16861,
+* Added support for IMap.computeIfAbsent(). #16808
+* Added the setAll() and setAllAsync() methods for IMap. #16787
+* Added the creation time metric for the executor service. #16775
+* Improved an unclear exception message for credentials. #16756
+* Updated the related aspects of Hazelcast IMDG after the changes done on the client protocol side to add the ability to add new parameters, methods, services, events and custom types to codecs. #16718
+* Introduced the putAllAsync() method for MultiMap. #16698
+* Defined metrics for ISet and IList collections. #16665
+* Upgraded log4j2 version to 2.13.0. #16654
+* Improved the computeIfPresent() implementation so that now it keeps a clone of the old/existing value and uses that for replace/delete operations. #16636
+* Introduced the hazelcast.logging.details.enabled property to make the logging of cluster version, name and IP optional to decrease the noise in the logs when, for example, you have a single-member cluster. #16622
+* Upgraded the Hazelcast Kubernetes plugin version to 2.0.1. #16590
+* Added the support for automatically detecting the classloader of a type for the user code deployment feature. #16585
+* Made IMap.putAllAsync() and IMap.submitToKeys() methods public API. #16449
+* Clarified the exception message when you connect to a cluster with an invalid cluster name. #15099
+* Refactored the check and retry initialization logic of ReplicatedMapProxy so that they are performed in parallel for different partitions. #14331
+* Improved the behavior of ConcurrentMap.computeIfPresent: combined single client-server round trips instead of two (for get and replace methods). #11958
 
-4. Fixes
+## Fixes
 
-* Fixed an issue where the state of member list on the clients were broken after a hot restart in the cluster. [#14839]
-* Fixed an issue where the outbound pipeline was not waking up properly after merging the write-through changes. [#14830]
-* Fixed an issue where a Hazelcast Java client was not able to connect to the cluster (which has the `advanced-network` configuration) after a split-brain syndrome is healed. [#14768]
-* Fixed an issue where the `like` and `ilike` predicates didn’t catch any entity with the `text` field containing the '\n' character. [#14751]
-* Fixed an issue where ``NullPointerException``s was thrown recursively when a client is connected to an unreachable member during a split-brain. [#14722]
-* Fixed an issue where Hazelcast running on RHEL (OpenJDK8) shows `unknown gc` in the logs, instead of `major gc` and `minor gc`. [#14701]
-* Fixed an issue where the IP client selector was not working for the local clients. [#14654]
-* Fixed the wording of a misleading error in the first attempt to connect to a wrongly configured cluster. The error message has been changed to “Unable to connect to any cluster”.  https://github.com/hazelcast/hazelcast/issues/14574[[#14574]]
-* Fixed an issue where a connection configured using `AdvancedNetworkConfig` was not denied correctly for some inappropriate endpoints. [#14532]
-* Fixed the REST service which was not working when the REST endpoint is configured for   `AdvancedNetworkConfig`. [#14516]
-* Fixed an issue where the `setAsync()` method was throwing `NullPointerException`. [#14445]
-* Fixed an issue where the collection attributes indexed with `[any]` were causing incorrect SQL query results, if the first data inserted to the map has no value for the attribute or the collection is empty. [#14358]
-* Fixed an issue where `mapEvictionPolicy` couldn’t be specified in the JSON configuration file. [#14092]
-* Fixed an issue where the rolling upgrade was failing when all members change their IP addresses. [#14088]
-* Fixed an issue where the resources were not wholly cleared when destroying `DurableExecutorService` causing some resources to be left in the heap. [#14087]
-* Fixed an issue where the REST API was not handling the HTTP requests without headers correctly: when a client sends an HTTP request without headers to the Hazelcast REST API, the `HttpCommand` class was wrongly expecting an additional new line. [#14353]
-* Fixed an issue where `QueryCache` was not returning the copies of the found objects. [#14333]
-* Fixed an issue where the MultiMap's `RemoveOperation` was iterating through the backing collection, which caused performance degradation (when using the `SET` collection type). [#14145]
-* Fixed an issue where the user code deployment feature was throwing `NullPointerException` while loading multiple nested classes and using entry processors. [#14105]
-* Fixed an issue where the newly joining members could not form a cluster when the existing members are killed. [#14051]
-* Fixed an issue where the `IMap.get()` method was not resetting the idle time counter when `read-backup-data` is enabled. [#14026]
-* Fixed an issue where the `addIndex()` method was performing a full copy of entries when a new member joins the cluster, which is not needed. [#13964]
-* Fixed an issue where the initialization failure of `discoveryService` was causing some threads to remain open and the JVM could not be terminated because of these threads. [#13821]
-* Fixed the discrepancy between the XSD on the website and the one in the download package. [#13011]
-* `PagingPredicate` with comparator was failing to serialize when sending from the client or member when the cluster size is more than 1. This has been fixed by making the `PagingPredicateQuery` comparator serializable. [#12208]
-* Fixed an issue where `TcpIpConnectionManager` was putting the connections in a map under the remote endpoint bind address but not under the address to which Hazelcast connects. [#11256]
+* Fixed an exception in the /node-state REST calls when the member is not fully activated. #17798
+* Fixed an issue where Hazelcast was not releasing the acquired lock sessions that fail for the reasons other than session expiration and wait key cancellation. #17697
+* Fixed an issue where Hazelcast was returning false if a client is successfully deregistered from any member, but events are still delivered for the non-deregistered ones. #17646
+* Fixed a data loss issue that was happening while promoting a lite member to a data member. #17621
+* Fixed an issue where the configuration was not updating entries' time-to-live values if the entry processor implements the Offloadable interface. #17606
+* Fixed an issue where the caller stacktrace was missing on the rethrown async runtime exceptions. #17546
+* Fixed the rendering of diagnostics in case there is an exception inside a diagnostics plugin. #17501
+* Fixed an exception that is thrown when using the entry store API and issuing a put into the IMap for an item which is not in the map but exists in the backing store. #17441
+* Fixed an issue where the custom load balancers could not be configured declaratively. #17415
+* Fixed a race issue when creating a cache (JCache) using multiple methods with the same cache name but having different keys. #17286
+* Fixed an issue where the repeated calls of executeOnKeys() in Hazelcast clients for NATIVE maps was causing a continuous increase in the used memory and exhaustion of the memory pool after a while. #17276
+* Fixed an issue where ReliableTopicMessageListener was firing a warning when the client is shutting down. #17153
+* Fixed an issue where the client was stuck with an outdated member list after a split-brain scenario. #17147
+* Fixed the member side user code deployment; it was throwing an exception when inner classes are used to be loaded. #17044
+* Fixed the broken interoperability between the CompletableFuture methods. #17020
+* Fixed an issue where touching a map entry having an entry processor working on it was modifying its time-to-live. #16987
+* Fixed an issue in the cache service where its pre-join operation was considering CacheConfig as resolved: it was assuming that key/value types, user customizations and other cache configurations have been loaded. This was an issue when the cache is not touched yet. #16917
+* Fixed an issue where Management Center was not working as expected when the cluster is set up using advanced network configuration. #16910
+* Fixed an issue where ServiceLoader was round-tripping between URL and URI, and consequently loses the associated URLStreamHandler when trying to load Hazelcast from a custom class loader. #16846
+* Fixed an issue where the class definitions, that are registered explicitly in the serialization configuration and have the same class ID in different factories, were not handled properly. #16831
+* Fixed the NullPointerException in IndexCopyBehavior.NEVER mode. #16784
+* Fixed an issue where the client XML configuration could not properly handle the empty Near Cache name. #16768
+* Fixed an issue where the client permissions for Reliable Topic and Ringbuffer were missing. #16755
+* Fixed an issue where the type information was missing the Metrics MBeans. #16747
+* Fixed an issue where the REST API was always requiring the call URLs to end with a slash character. #16688
+* Fixed an issue where the service URL for Eureka could not be set using the declarative configuration. #16679
+* Fixed an issue where the wait key of a blocking call within a Raft invocation was still being reported as a live operation, when the key times out. #16614
+* Fixed an issue where the upload of classes using the client user code deployment were not successful when they are retrieved not in their created order. #16612
+* Fixed an issue where the size() method was returning a negative value when map, cache and multimap contain more than Integer.MAX_VALUE entries. #16594
+* Fixed an invalidation issue when using a transactional map from a cache with a Near Cache: the cache invalidation event occurs when the transactionalMap.put method is called. As a result, the entry was getting invalidated before the change is committed to the map. #16579
+* Fixed an issue where InPredicate was not invoking value comparison when the read attribute is null. #15100
+* Fixed an issue where Map, Cache, MultiMap data structures were returning negative values (size()) when the size is more than Integer.MAX_VALUE. #14935
+* Fixed an issue when a Hazelcast client calls the distributed executor service and the callable throws an exception with a custom type, then the exception was not being transported to the client. #9753
 
-5. Removed/Deprecated Features
+## Contributors
 
-* `ILock` interface and implementation of `ILock` has been deprecated, and `FencedLock` has been introduced.
-* The original implementations of `IAtomicLong`, `IAtomicReference`, `ISemaphore` and `ICountDownLatch` have been deprecated. Instead, the implementations provided by the CP Subsystem have been introduced.
-* The following system properties are deprecated:
-  ** `hazelcast.rest.enabled`
-  ** `hazelcast.mc.url.change.enabled`
-  ** `hazelcast.memcache.enabled`
-  ** `hazelcast.http.healthcheck.enabled`
+We would like to thank the contributors from our open source community who worked on this release:
 
-
+Inel Pandzic
+Omid Pourhadi
+Ryan Lindeborg
+Santhosh Kumar
+Bartek Kowalczyk
+Ashutosh Agrawal
+Ádám Berkecz
+HugeOrangeDev
+Harry Tran
+Stephen Russett
+Ulf Adams
+Abdul Aziz Ali
+Dmitry Konstantinov
+Anmol Chaddha
+lprimak
+keteracel
+Burak Sezer
+wangumer
+Marcin L
+Stefan Birkner
+André Wölfing
+ndeevy


### PR DESCRIPTION


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
