### PR TITLE
Fix race in NonSmartClientTest [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/NonSmartClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/NonSmartClientTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
+import com.hazelcast.jet.core.JobNotFoundException;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.jet.impl.JetServiceBackend;
@@ -41,8 +42,10 @@ import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 
 import static com.hazelcast.jet.core.TestProcessors.streamingDag;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.isOrHasCause;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -198,11 +201,18 @@ public class NonSmartClientTest extends SimpleTestInClusterSupport {
         assertEquals(job1.getSubmissionTime(), job2.getSubmissionTime());
         assertFalse(job1.getFuture().isDone());
         assertFalse(job2.getFuture().isDone());
-        // cancel requested through client connected to the master, but job is coordinated by the other member
+        // Cancel requested through client connected to the master, but job is coordinated by the other member.
+        // The jobX.getFuture() invokes JoinSubmittedJobOperation on a member asynchronously. The jobX.cancel()
+        // invokes TerminateJobOperation. We have no control over which of these operation's doRun() method executes
+        // first. If JoinSubmittedJobOperation is first, then join() throws CancellationException. If
+        // TerminateJobOperation is first (that results later in removing of light master context) then the join() throws
+        // CompletionException.
         job1.cancel();
         try {
             job1.join();
             fail("join didn't fail");
+        } catch (CompletionException e) {
+            assert isOrHasCause(e, JobNotFoundException.class);
         } catch (CancellationException ignored) { }
     }
 


### PR DESCRIPTION
Backport of: https://github.com/hazelcast/hazelcast/pull/22710

Fixes: https://github.com/hazelcast/hazelcast/issues/22380

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

Co-authored-by: Viliam Durina <viliam-durina@users.noreply.github.com>
(cherry picked from commit 9f6f66bcb83305c5402b1d13614e502331cdd21b)