### PR TITLE
Optimizer buffers for single watermark S2S JOIN [HZ-1755]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/IStreamToStreamJoinBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/IStreamToStreamJoinBuffer.java
@@ -43,7 +43,8 @@ public abstract class IStreamToStreamJoinBuffer implements Iterable<JetSqlRow> {
     public IStreamToStreamJoinBuffer(
             JetJoinInfo joinInfo,
             boolean isLeftInput,
-            List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
+            List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors
+    ) {
         this.joinInfo = joinInfo;
         this.isLeft = isLeftInput;
         this.shouldProduceNullRow = (isLeftInput && joinInfo.isLeftOuter()) || (!isLeftInput && joinInfo.isRightOuter());

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/IStreamToStreamJoinBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/IStreamToStreamJoinBuffer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.processors;
+
+import com.hazelcast.function.ToLongFunctionEx;
+import com.hazelcast.jet.sql.impl.ExpressionUtil;
+import com.hazelcast.jet.sql.impl.JetJoinInfo;
+import com.hazelcast.sql.impl.expression.ConstantExpression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.row.JetSqlRow;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+public abstract class IStreamToStreamJoinBuffer implements Iterable<JetSqlRow> {
+    protected final JetJoinInfo joinInfo;
+    protected final boolean isLeft;
+    protected final boolean shouldProduceNullRow;
+
+    protected final List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors;
+
+    protected JetSqlRow emptyLeftRow;
+    protected JetSqlRow emptyRightRow;
+
+    public IStreamToStreamJoinBuffer(
+            JetJoinInfo joinInfo,
+            boolean isLeft,
+            List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
+        this.joinInfo = joinInfo;
+        this.isLeft = isLeft;
+        this.shouldProduceNullRow = (isLeft && joinInfo.isLeftOuter()) || (!isLeft && joinInfo.isRightOuter());
+        this.timeExtractors = timeExtractors;
+    }
+
+    public void init(JetSqlRow left, JetSqlRow right) {
+        this.emptyLeftRow = left;
+        this.emptyRightRow = right;
+    }
+
+    public abstract void add(JetSqlRow row);
+
+    public abstract Iterator<JetSqlRow> iterator();
+
+    public abstract int size();
+
+    public abstract boolean isEmpty();
+
+    // for testing purposes only
+    abstract Collection<JetSqlRow> content();
+
+    /**
+     * Clears expired items in current buffer, and returns a new minimums time array.
+     *
+     * @param limits              array of limits for
+     * @param unusedEventsTracker set of unused events, method will produce null-filled row in case if JOIN is OUTER
+     * @param pendingOutput       queue of joined rows, is used only if JOIN is OUTER.
+     * @param eec                 Jet's expression evaluation context
+     * @return a new minimums time array.
+     */
+    public abstract long[] clearExpiredItems(long[] limits,
+                                             @Nonnull Set<JetSqlRow> unusedEventsTracker,
+                                             @Nonnull Queue<Object> pendingOutput,
+                                             @Nonnull ExpressionEvalContext eec);
+
+    protected JetSqlRow composeRowWithNulls(JetSqlRow row, ExpressionEvalContext eec) {
+        JetSqlRow joinedRow = null;
+        if (!isLeft && joinInfo.isRightOuter()) {
+            // fill LEFT side with nulls
+            joinedRow = ExpressionUtil.join(row, emptyLeftRow, ConstantExpression.TRUE, eec);
+
+        } else if (isLeft && joinInfo.isLeftOuter()) {
+            // fill RIGHT side with nulls
+            joinedRow = ExpressionUtil.join(row, emptyRightRow, ConstantExpression.TRUE, eec);
+        }
+        return joinedRow;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinBuffer.java
@@ -29,7 +29,7 @@ import java.util.function.Consumer;
 abstract class StreamToStreamJoinBuffer implements Iterable<JetSqlRow> {
     protected final List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors;
 
-    public StreamToStreamJoinBuffer(List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
+    StreamToStreamJoinBuffer(List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
         this.timeExtractors = timeExtractors;
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinBuffer.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-public abstract class IStreamToStreamJoinBuffer implements Iterable<JetSqlRow> {
+public abstract class StreamToStreamJoinBuffer implements Iterable<JetSqlRow> {
     protected final JetJoinInfo joinInfo;
     protected final boolean isLeft;
     protected final boolean shouldProduceNullRow;
@@ -40,7 +40,7 @@ public abstract class IStreamToStreamJoinBuffer implements Iterable<JetSqlRow> {
 
     protected JetSqlRow emptyRow;
 
-    public IStreamToStreamJoinBuffer(
+    public StreamToStreamJoinBuffer(
             JetJoinInfo joinInfo,
             boolean isLeftInput,
             List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
@@ -42,7 +42,7 @@ class StreamToStreamJoinHeapBuffer extends StreamToStreamJoinBuffer {
 
     @Override
     public void add(JetSqlRow row) {
-        buffer.offer(row);
+        buffer.add(row);
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
@@ -32,7 +32,7 @@ class StreamToStreamJoinHeapBuffer extends StreamToStreamJoinBuffer {
     private final PriorityQueue<JetSqlRow> buffer;
     private final ToLongFunctionEx<JetSqlRow> timeExtractor;
 
-    public StreamToStreamJoinHeapBuffer(List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
+    StreamToStreamJoinHeapBuffer(List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
         super(timeExtractors);
         assert timeExtractors.size() == 1;
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
@@ -36,14 +36,8 @@ class StreamToStreamJoinHeapBuffer extends StreamToStreamJoinBuffer {
         super(timeExtractors);
         assert timeExtractors.size() == 1;
 
-        timeExtractor = timeExtractors.iterator().next().getValue();
-
-        Comparator<JetSqlRow> comparator = (row1, row2) -> {
-            ToLongFunctionEx<JetSqlRow> extractor = timeExtractor;
-            return Long.compare(extractor.applyAsLong(row1), extractor.applyAsLong(row2));
-        };
-
-        this.buffer = new PriorityQueue<>(comparator);
+        timeExtractor = timeExtractors.get(0).getValue();
+        buffer = new PriorityQueue<>(Comparator.comparingLong(timeExtractor));
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
@@ -85,8 +85,7 @@ public class StreamToStreamJoinHeapBuffer extends IStreamToStreamJoinBuffer {
             @Nonnull ExpressionEvalContext eec) {
         assert limits.length == 1;
 
-        JetSqlRow row = buffer.peek();
-        while (row != null && timeExtractor.applyAsLong(row) < limits[0]) {
+        for (JetSqlRow row; (row = buffer.peek()) != null && timeExtractor.applyAsLong(row) < limits[0]; ) {
             if (shouldProduceNullRow && unusedEventsTracker.remove(row)) {
                 // 5.4 : If doing an outer join, emit events removed from the buffer,
                 // with `null`s for the other side, if the event was never joined.
@@ -95,8 +94,7 @@ public class StreamToStreamJoinHeapBuffer extends IStreamToStreamJoinBuffer {
                     pendingOutput.add(joinedRow);
                 }
             }
-            buffer.poll();
-            row = buffer.peek();
+            buffer.remove();
         }
 
         if (buffer.size() > 0) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
@@ -37,9 +37,9 @@ public class StreamToStreamJoinHeapBuffer extends IStreamToStreamJoinBuffer {
 
     public StreamToStreamJoinHeapBuffer(
             JetJoinInfo joinInfo,
-            boolean isLeft,
+            boolean isLeftInput,
             List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
-        super(joinInfo, isLeft, timeExtractors);
+        super(joinInfo, isLeftInput, timeExtractors);
         assert timeExtractors.size() == 1;
 
         timeExtractor = timeExtractors.iterator().next().getValue();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
@@ -31,7 +31,7 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 
-public class StreamToStreamJoinHeapBuffer extends IStreamToStreamJoinBuffer {
+public class StreamToStreamJoinHeapBuffer extends StreamToStreamJoinBuffer {
     private final PriorityQueue<JetSqlRow> buffer;
     private final ToLongFunctionEx<JetSqlRow> timeExtractor;
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinHeapBuffer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.processors;
+
+import com.hazelcast.function.ToLongFunctionEx;
+import com.hazelcast.jet.sql.impl.JetJoinInfo;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.row.JetSqlRow;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+
+public class StreamToStreamJoinHeapBuffer extends IStreamToStreamJoinBuffer {
+    private final PriorityQueue<JetSqlRow> buffer;
+    private final ToLongFunctionEx<JetSqlRow> timeExtractor;
+
+    public StreamToStreamJoinHeapBuffer(
+            JetJoinInfo joinInfo,
+            boolean isLeft,
+            List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
+        super(joinInfo, isLeft, timeExtractors);
+        assert timeExtractors.size() == 1;
+
+        timeExtractor = timeExtractors.iterator().next().getValue();
+
+        Comparator<JetSqlRow> comparator = (row1, row2) -> {
+            ToLongFunctionEx<JetSqlRow> extractor = timeExtractor;
+            return Long.compare(extractor.applyAsLong(row1), extractor.applyAsLong(row2));
+        };
+
+        this.buffer = new PriorityQueue<>(comparator);
+    }
+
+    @Override
+    public void add(JetSqlRow row) {
+        buffer.offer(row);
+    }
+
+    @Override
+    public Iterator<JetSqlRow> iterator() {
+        return buffer.iterator();
+    }
+
+    @Override
+    public int size() {
+        return buffer.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return buffer.isEmpty();
+    }
+
+    @Override
+    public Collection<JetSqlRow> content() {
+        return buffer;
+    }
+
+    @Override
+    public long[] clearExpiredItems(
+            long[] limits,
+            @Nonnull Set<JetSqlRow> unusedEventsTracker,
+            @Nonnull Queue<Object> pendingOutput,
+            @Nonnull ExpressionEvalContext eec) {
+        assert limits.length == 1;
+
+        JetSqlRow row = buffer.peek();
+        while (row != null && timeExtractor.applyAsLong(row) < limits[0]) {
+            if (shouldProduceNullRow && unusedEventsTracker.remove(row)) {
+                // 5.4 : If doing an outer join, emit events removed from the buffer,
+                // with `null`s for the other side, if the event was never joined.
+                JetSqlRow joinedRow = composeRowWithNulls(row, eec);
+                if (joinedRow != null) {
+                    pendingOutput.add(joinedRow);
+                }
+            }
+            buffer.poll();
+            row = buffer.peek();
+        }
+
+        if (buffer.size() > 0) {
+            return new long[]{timeExtractor.applyAsLong(buffer.element())};
+        } else {
+            return new long[]{Long.MAX_VALUE};
+        }
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinListBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinListBuffer.java
@@ -71,7 +71,8 @@ public class StreamToStreamJoinListBuffer extends IStreamToStreamJoinBuffer {
             long[] limits,
             @Nonnull Set<JetSqlRow> unusedEventsTracker,
             @Nonnull Queue<Object> pendingOutput,
-            @Nonnull ExpressionEvalContext eec) {
+            @Nonnull ExpressionEvalContext eec
+    ) {
         long[] newMinimums = new long[timeExtractors.size()];
         Arrays.fill(newMinimums, Long.MAX_VALUE);
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinListBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinListBuffer.java
@@ -74,12 +74,12 @@ class StreamToStreamJoinListBuffer extends StreamToStreamJoinBuffer {
                 times[idx] = timeExtractors.get(idx).getValue().applyAsLong(row);
                 if (times[idx] < limits[idx]) {
                     remove = true;
-                    clearedRowsConsumer.accept(row);
                 }
             }
 
             if (remove) {
                 iterator.remove();
+                clearedRowsConsumer.accept(row);
             } else {
                 for (int i = 0; i < times.length; i++) {
                     newMinimums[i] = Math.min(times[i], newMinimums[i]);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinListBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinListBuffer.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-public class StreamToStreamJoinListBuffer extends IStreamToStreamJoinBuffer {
+public class StreamToStreamJoinListBuffer extends StreamToStreamJoinBuffer {
     private final List<JetSqlRow> buffer = new LinkedList<>();
 
     public StreamToStreamJoinListBuffer(

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinListBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinListBuffer.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.processors;
+
+import com.hazelcast.function.ToLongFunctionEx;
+import com.hazelcast.jet.sql.impl.JetJoinInfo;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.row.JetSqlRow;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+public class StreamToStreamJoinListBuffer extends IStreamToStreamJoinBuffer {
+    private final List<JetSqlRow> buffer = new LinkedList<>();
+
+    public StreamToStreamJoinListBuffer(
+            JetJoinInfo joinInfo,
+            boolean isLeft,
+            List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
+        super(joinInfo, isLeft, timeExtractors);
+    }
+
+    @Override
+    public void add(JetSqlRow row) {
+        buffer.add(row);
+    }
+
+    @Override
+    public Iterator<JetSqlRow> iterator() {
+        return buffer.iterator();
+    }
+
+    @Override
+    public int size() {
+        return buffer.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return buffer.isEmpty();
+    }
+
+    @Override
+    public Collection<JetSqlRow> content() {
+        return buffer;
+    }
+
+    @Override
+    public long[] clearExpiredItems(
+            long[] limits,
+            @Nonnull Set<JetSqlRow> unusedEventsTracker,
+            @Nonnull Queue<Object> pendingOutput,
+            @Nonnull ExpressionEvalContext eec) {
+        long[] newMinimums = new long[timeExtractors.size()];
+        Arrays.fill(newMinimums, Long.MAX_VALUE);
+
+        final Iterator<JetSqlRow> iterator = buffer.iterator();
+        long[] times = new long[timeExtractors.size()];
+        while (iterator.hasNext()) {
+            JetSqlRow row = iterator.next();
+            boolean remove = false;
+            for (int idx = 0; idx < timeExtractors.size(); idx++) {
+                times[idx] = timeExtractors.get(idx).getValue().applyAsLong(row);
+                if (times[idx] < limits[idx]) {
+                    remove = true;
+                    if (shouldProduceNullRow && unusedEventsTracker.remove(row)) {
+                        // 5.4 : If doing an outer join, emit events removed from the buffer,
+                        // with `null`s for the other side, if the event was never joined.
+                        JetSqlRow joinedRow = composeRowWithNulls(row, eec);
+                        if (joinedRow != null) {
+                            pendingOutput.add(joinedRow);
+                        }
+                    }
+                }
+            }
+
+            if (remove) {
+                iterator.remove();
+            } else {
+                for (int i = 0; i < times.length; i++) {
+                    newMinimums[i] = Math.min(times[i], newMinimums[i]);
+                }
+            }
+        }
+
+        return newMinimums;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinListBuffer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinListBuffer.java
@@ -31,7 +31,7 @@ import java.util.function.Consumer;
 class StreamToStreamJoinListBuffer extends StreamToStreamJoinBuffer {
     private final List<JetSqlRow> buffer = new LinkedList<>();
 
-    public StreamToStreamJoinListBuffer(List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
+    StreamToStreamJoinListBuffer(List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> timeExtractors) {
         super(timeExtractors);
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
@@ -70,7 +70,7 @@ public class StreamToStreamJoinP extends AbstractProcessor {
     final Object2LongHashMap<Byte> minimumBufferTimes = new Object2LongHashMap<>(Long.MIN_VALUE);
 
     // package-visible for tests
-    final IStreamToStreamJoinBuffer[] buffer;
+    final StreamToStreamJoinBuffer[] buffer;
 
     private final JetJoinInfo joinInfo;
     private final int outerJoinSide;
@@ -369,7 +369,7 @@ public class StreamToStreamJoinP extends AbstractProcessor {
         return joinedRow;
     }
 
-    private IStreamToStreamJoinBuffer[] createBuffers(
+    private StreamToStreamJoinBuffer[] createBuffers(
             final List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> leftTimeExtractors,
             final List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> rightTimeExtractors
     ) {
@@ -383,12 +383,12 @@ public class StreamToStreamJoinP extends AbstractProcessor {
             assert leftTimeExtractors.size() == 1;
             assert rightTimeExtractors.size() == 1;
 
-            return new IStreamToStreamJoinBuffer[]{
+            return new StreamToStreamJoinBuffer[]{
                     new StreamToStreamJoinHeapBuffer(joinInfo, true, leftTimeExtractors),
                     new StreamToStreamJoinHeapBuffer(joinInfo, false, rightTimeExtractors)
             };
         } else {
-            return new IStreamToStreamJoinBuffer[]{
+            return new StreamToStreamJoinBuffer[]{
                     new StreamToStreamJoinListBuffer(joinInfo, true, leftTimeExtractors),
                     new StreamToStreamJoinListBuffer(joinInfo, false, rightTimeExtractors)
             };

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
@@ -164,8 +164,8 @@ public class StreamToStreamJoinP extends AbstractProcessor {
         emptyRightRow = new JetSqlRow(ss, new Object[columnCounts.f1()]);
         maxProcessorAccumulatedRecords = context.maxProcessorAccumulatedRecords();
 
-        buffer[0].init(emptyLeftRow, emptyRightRow);
-        buffer[1].init(emptyLeftRow, emptyRightRow);
+        buffer[0].init(emptyRightRow);
+        buffer[1].init(emptyLeftRow);
     }
 
     @SuppressWarnings("checkstyle:NestedIfDepth")

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
@@ -41,7 +41,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -375,26 +374,14 @@ public class StreamToStreamJoinP extends AbstractProcessor {
     }
 
     private StreamToStreamJoinBuffer[] createBuffers() {
-        Set<Byte> wmCountTracker = new HashSet<>();
-        for (Entry<Byte, Map<Byte, Long>> outerEntry : postponeTimeMap.entrySet()) {
-            wmCountTracker.add(outerEntry.getKey());
-            wmCountTracker.addAll(outerEntry.getValue().keySet());
-        }
-
-        if (wmCountTracker.size() == 2) {
-            assert leftTimeExtractors.size() == 1;
-            assert rightTimeExtractors.size() == 1;
-
-            return new StreamToStreamJoinBuffer[]{
-                    new StreamToStreamJoinHeapBuffer(leftTimeExtractors),
-                    new StreamToStreamJoinHeapBuffer(rightTimeExtractors)
-            };
-        } else {
-            return new StreamToStreamJoinBuffer[]{
-                    new StreamToStreamJoinListBuffer(leftTimeExtractors),
-                    new StreamToStreamJoinListBuffer(rightTimeExtractors)
-            };
-        }
+        return new StreamToStreamJoinBuffer[]{
+                leftTimeExtractors.size() == 1
+                        ? new StreamToStreamJoinHeapBuffer(leftTimeExtractors)
+                        : new StreamToStreamJoinListBuffer(leftTimeExtractors),
+                rightTimeExtractors.size() == 1
+                        ? new StreamToStreamJoinHeapBuffer(rightTimeExtractors)
+                        : new StreamToStreamJoinListBuffer(rightTimeExtractors)
+        };
     }
 
     public static final class StreamToStreamJoinProcessorSupplier implements ProcessorSupplier, DataSerializable {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
@@ -70,7 +70,6 @@ public class StreamToStreamJoinP extends AbstractProcessor {
     final Object2LongHashMap<Byte> minimumBufferTimes = new Object2LongHashMap<>(Long.MIN_VALUE);
 
     // package-visible for tests
-    @SuppressWarnings("unchecked")
     final IStreamToStreamJoinBuffer[] buffer;
 
     private final JetJoinInfo joinInfo;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
@@ -148,7 +148,7 @@ public class StreamToStreamJoinP extends AbstractProcessor {
             throw new IllegalArgumentException("Not enough time bounds in postponeTimeMap");
         }
 
-        this.buffer = createBuffers(this.leftTimeExtractors, this.rightTimeExtractors);
+        this.buffer = createBuffers();
     }
 
     @Override
@@ -374,10 +374,7 @@ public class StreamToStreamJoinP extends AbstractProcessor {
         return joinedRow;
     }
 
-    private StreamToStreamJoinBuffer[] createBuffers(
-            final List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> leftTimeExtractors,
-            final List<Map.Entry<Byte, ToLongFunctionEx<JetSqlRow>>> rightTimeExtractors
-    ) {
+    private StreamToStreamJoinBuffer[] createBuffers() {
         Set<Byte> wmCountTracker = new HashSet<>();
         for (Entry<Byte, Map<Byte, Long>> outerEntry : postponeTimeMap.entrySet()) {
             wmCountTracker.add(outerEntry.getKey());

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
@@ -69,6 +69,10 @@ public class StreamToStreamJoinP extends AbstractProcessor {
      */
     final Object2LongHashMap<Byte> minimumBufferTimes = new Object2LongHashMap<>(Long.MIN_VALUE);
 
+    // package-visible for tests
+    @SuppressWarnings("unchecked")
+    final IStreamToStreamJoinBuffer[] buffer;
+
     private final JetJoinInfo joinInfo;
     private final int outerJoinSide;
     private final List<Entry<Byte, ToLongFunctionEx<JetSqlRow>>> leftTimeExtractors;
@@ -76,13 +80,6 @@ public class StreamToStreamJoinP extends AbstractProcessor {
     private final Map<Byte, Map<Byte, Long>> postponeTimeMap;
     private final Tuple2<Integer, Integer> columnCounts;
     private long maxProcessorAccumulatedRecords;
-
-    // NOTE: we are using LinkedList, because we are expecting:
-    //  (1) removals at any position,
-    //  (2) no index-based access, only full traversal
-    // package-visible for tests
-    @SuppressWarnings("unchecked")
-    final IStreamToStreamJoinBuffer[] buffer;
 
     private ExpressionEvalContext evalContext;
     private Iterator<JetSqlRow> iterator;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
@@ -148,7 +148,6 @@ public class StreamToStreamJoinP extends AbstractProcessor {
             throw new IllegalArgumentException("Not enough time bounds in postponeTimeMap");
         }
 
-        // Everything else is initialized, except runtime objects like EEC, etc.
         this.buffer = createBuffers(this.leftTimeExtractors, this.rightTimeExtractors);
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinPInnerTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinPInnerTest.java
@@ -121,13 +121,13 @@ public class StreamToStreamJoinPInnerTest extends JetTestSupport {
                         out(jetRow(12L, 13L, 9L)),
                         processorAssertion((StreamToStreamJoinP p) -> {
                             assertEquals(asList(jetRow(12L, 9L), jetRow(12L, 13L)), p.buffer[0].content());
-                            assertEquals(singletonList(jetRow(9L)), p.buffer[1].content());
+                            assertEquals(jetRow(9L), p.buffer[1].content().iterator().next());
                         }),
                         in(1, wm(15L, (byte) 2)),
                         out(wm(9L, (byte) 2)),
                         processorAssertion((StreamToStreamJoinP p) -> {
                             assertEquals(singletonList(jetRow(12L, 13L)), p.buffer[0].content());
-                            assertEquals(singletonList(jetRow(9L)), p.buffer[1].content());
+                            assertEquals(jetRow(9L), p.buffer[1].content().iterator().next());
                         }),
                         in(0, wm(12L, (byte) 1)),
                         out(wm(12L, (byte) 1)),
@@ -341,16 +341,16 @@ public class StreamToStreamJoinPInnerTest extends JetTestSupport {
      * From the postponeTimeMap create the equivalent condition for the join processor.
      * <p>
      * For example, this join condition (`l` has `time1` and `time2` columns, `r` has `time`):
-     *     l.time2 BETWEEN r.time - 1 AND r.time + 4
+     * l.time2 BETWEEN r.time - 1 AND r.time + 4
      * <p>
      * Is transformed to:
-     *     l.time2 >= r.time - 1
-     *     r.time >= l.time2 - 4
+     * l.time2 >= r.time - 1
+     * r.time >= l.time2 - 4
      * <p>
      * For which this postponeTimeMap is created:
-     *     0: {}
-     *     1: {2:4}
-     *     2: {1:1}
+     * 0: {}
+     * 1: {2:4}
+     * 2: {1:1}
      *
      * @param wmKeyToColumnIndex Remapping of WM keys to joined column indexes. Contains
      *                           a sequence of `wmKey1`, `index1`, `wmKey2`, `index2, ... If WM key == index,

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinPInnerTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinPInnerTest.java
@@ -341,16 +341,16 @@ public class StreamToStreamJoinPInnerTest extends JetTestSupport {
      * From the postponeTimeMap create the equivalent condition for the join processor.
      * <p>
      * For example, this join condition (`l` has `time1` and `time2` columns, `r` has `time`):
-     * l.time2 BETWEEN r.time - 1 AND r.time + 4
+     *     l.time2 BETWEEN r.time - 1 AND r.time + 4
      * <p>
      * Is transformed to:
-     * l.time2 >= r.time - 1
-     * r.time >= l.time2 - 4
+     *     l.time2 >= r.time - 1
+     *     r.time >= l.time2 - 4
      * <p>
      * For which this postponeTimeMap is created:
-     * 0: {}
-     * 1: {2:4}
-     * 2: {1:1}
+     *     0: {}
+     *     1: {2:4}
+     *     2: {1:1}
      *
      * @param wmKeyToColumnIndex Remapping of WM keys to joined column indexes. Contains
      *                           a sequence of `wmKey1`, `index1`, `wmKey2`, `index2, ... If WM key == index,


### PR DESCRIPTION
This patch introduces the generalization of buffers access in the stream-to-stream JOIN processor. There are two kinds of buffers available:  1) `PriorityQueue` for the _simplest_ case, when a single WM per input exists; 2) `LinkedList` for any other cases. Since the _simplest_ case is most common, such optimization makes sense.