### PR TITLE
Make 'MetadataRaftGroupSnapshot' class immutable since it is stored in the RaftLog snapshot [HZ-1398] [4.1.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MembershipChangeSchedule.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MembershipChangeSchedule.java
@@ -26,11 +26,13 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
 
 /**
  * When there is a membership change in CP Subsystem,
@@ -163,11 +165,13 @@ public class MembershipChangeSchedule implements IdentifiedDataSerializable {
             groupId = in.readObject();
             membersCommitIndex = in.readLong();
             int len = in.readInt();
-            members = new HashSet<>(len);
+            // The initial incoming implementation for the 'members' variable in a constructor is LinkedHashSet
+            Set<RaftEndpoint> membersSet = new LinkedHashSet<>(len);
             for (int i = 0; i < len; i++) {
                 RaftEndpoint member = in.readObject();
-                members.add(member);
+                membersSet.add(member);
             }
+            members = unmodifiableSet(membersSet);
             memberToAdd = in.readObject();
             memberToRemove = in.readObject();
         }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -222,16 +222,9 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
             logger.fine("Taking snapshot for commit-index: " + commitIndex);
         }
 
-        MetadataRaftGroupSnapshot snapshot = new MetadataRaftGroupSnapshot();
-        snapshot.setMembers(activeMembers);
-        snapshot.setMembersCommitIndex(activeMembersCommitIndex);
-        snapshot.setGroups(groups.values());
-        snapshot.setMembershipChangeSchedule(membershipChangeSchedule);
-        snapshot.setInitialCPMembers(initialCPMembers);
-        snapshot.setInitializedCPMembers(initializedCPMembers);
-        snapshot.setInitializationStatus(initializationStatus);
-        snapshot.setInitializationCommitIndices(initializationCommitIndices);
-
+        MetadataRaftGroupSnapshot snapshot = new MetadataRaftGroupSnapshot(activeMembers, activeMembersCommitIndex,
+                groups.values(), membershipChangeSchedule, initialCPMembers, initializedCPMembers, initializationStatus,
+                initializationCommitIndices);
         return snapshot;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupSnapshot.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupSnapshot.java
@@ -27,9 +27,15 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.unmodifiableCollection;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
 
 /**
  * Snapshot of the Metadata Raft group state
+ * This class should be IMMUTABLE since it is stored in the RaftLog's SnapshotEntry
  */
 public final class MetadataRaftGroupSnapshot implements IdentifiedDataSerializable {
 
@@ -38,75 +44,63 @@ public final class MetadataRaftGroupSnapshot implements IdentifiedDataSerializab
     private final Collection<CPGroupInfo> groups = new ArrayList<>();
     private MembershipChangeSchedule membershipChangeSchedule;
     private List<CPMemberInfo> initialCPMembers;
-    private Set<CPMemberInfo> initializedCPMembers = new HashSet<>();
+    private final Set<CPMemberInfo> initializedCPMembers = new HashSet<>();
     private MetadataRaftGroupInitStatus initializationStatus;
-    private Set<Long> initializationCommitIndices = new HashSet<>();
+    private final Set<Long> initializationCommitIndices = new HashSet<>();
 
-    public void setGroups(Collection<CPGroupInfo> groups) {
-        for (CPGroupInfo group : groups) {
-            // Deep copy CPGroupInfo, because it's a mutable object.
-            this.groups.add(new CPGroupInfo(group));
-        }
+    public MetadataRaftGroupSnapshot() {
     }
 
-    public void setMembers(Collection<CPMemberInfo> members) {
+    public MetadataRaftGroupSnapshot(Collection<CPMemberInfo> members,
+                                     long membersCommitIndex,
+                                     Collection<CPGroupInfo> groups,
+                                     MembershipChangeSchedule membershipChangeSchedule,
+                                     List<CPMemberInfo> initialCPMembers,
+                                     Set<CPMemberInfo> initializedCPMembers,
+                                     MetadataRaftGroupInitStatus initializationStatus,
+                                     Set<Long> initializationCommitIndices) {
         this.members.addAll(members);
+        this.membersCommitIndex = membersCommitIndex;
+        // Deep copy CPGroupInfo, because it's a mutable object.
+        groups.stream().map(CPGroupInfo::new).forEach(this.groups::add);
+        this.membershipChangeSchedule = membershipChangeSchedule;
+        this.initialCPMembers = initialCPMembers;
+        this.initializedCPMembers.addAll(initializedCPMembers);
+        this.initializationStatus = initializationStatus;
+        this.initializationCommitIndices.addAll(initializationCommitIndices);
     }
 
     public Collection<CPMemberInfo> getMembers() {
-        return members;
+        return unmodifiableCollection(members);
     }
 
     public long getMembersCommitIndex() {
         return membersCommitIndex;
     }
 
-    public void setMembersCommitIndex(long membersCommitIndex) {
-        this.membersCommitIndex = membersCommitIndex;
-    }
-
     public Collection<CPGroupInfo> getGroups() {
-        return groups;
+        // Deep copy CPGroupInfo, because it's a mutable object.
+        return groups.stream().map(CPGroupInfo::new).collect(Collectors.toList());
     }
 
     public MembershipChangeSchedule getMembershipChangeSchedule() {
         return membershipChangeSchedule;
     }
 
-    public void setMembershipChangeSchedule(MembershipChangeSchedule membershipChangeSchedule) {
-        this.membershipChangeSchedule = membershipChangeSchedule;
-    }
-
     public Set<CPMemberInfo> getInitializedCPMembers() {
-        return initializedCPMembers;
-    }
-
-    public void setInitializedCPMembers(Collection<CPMemberInfo> initializedCPMembers) {
-        this.initializedCPMembers.addAll(initializedCPMembers);
+        return unmodifiableSet(initializedCPMembers);
     }
 
     public List<CPMemberInfo> getInitialCPMembers() {
-        return initialCPMembers;
-    }
-
-    public void setInitialCPMembers(List<CPMemberInfo> initialCPMembers) {
-        this.initialCPMembers = initialCPMembers;
+        return unmodifiableList(initialCPMembers);
     }
 
     public MetadataRaftGroupInitStatus getInitializationStatus() {
         return initializationStatus;
     }
 
-    public void setInitializationStatus(MetadataRaftGroupInitStatus initializationStatus) {
-        this.initializationStatus = initializationStatus;
-    }
-
     public Set<Long> getInitializationCommitIndices() {
-        return initializationCommitIndices;
-    }
-
-    public void setInitializationCommitIndices(Set<Long> initializationCommitIndices) {
-        this.initializationCommitIndices.addAll(initializationCommitIndices);
+        return unmodifiableSet(initializationCommitIndices);
     }
 
     @Override
@@ -187,5 +181,19 @@ public final class MetadataRaftGroupSnapshot implements IdentifiedDataSerializab
             long commitIndex = in.readLong();
             initializationCommitIndices.add(commitIndex);
         }
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataRaftGroupSnapshot{"
+                + "members=" + members
+                + ", membersCommitIndex=" + membersCommitIndex
+                + ", groups=" + groups
+                + ", membershipChangeSchedule=" + membershipChangeSchedule
+                + ", initialCPMembers=" + initialCPMembers
+                + ", initializedCPMembers=" + initializedCPMembers
+                + ", initializationStatus=" + initializationStatus
+                + ", initializationCommitIndices=" + initializationCommitIndices
+                + '}';
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.cp.IAtomicLong;
 import com.hazelcast.cp.exception.CPGroupDestroyedException;
 import com.hazelcast.cp.internal.raft.impl.RaftNodeImpl;
 import com.hazelcast.cp.internal.raft.impl.command.UpdateRaftGroupMembersCmd;
+import com.hazelcast.cp.internal.raft.impl.log.SnapshotEntry;
 import com.hazelcast.cp.internal.raftop.metadata.GetActiveCPMembersOp;
 import com.hazelcast.cp.internal.raftop.metadata.GetMembershipChangeScheduleOp;
 import com.hazelcast.cp.internal.raftop.metadata.GetRaftGroupOp;
@@ -813,6 +814,57 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         });
     }
 
+    // test for https://github.com/hazelcast/hazelcast/issues/21438
+    @Test
+    public void when_snapshotIsTakenWhileRemovingCPLeader_newMemberInstalledSnapshot_shouldBeImmutable() throws Exception {
+        int nodeCount = 3;
+        int commitIndexAdvanceCountToSnapshot = 50;
+        Config config = createConfig(nodeCount, nodeCount);
+        config.getCPSubsystemConfig().getRaftAlgorithmConfig().setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
+
+        HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
+        for (int i = 0; i < nodeCount; i++) {
+            instances[i] = factory.newHazelcastInstance(config);
+        }
+
+        assertClusterSizeEventually(nodeCount, instances);
+        waitUntilCPDiscoveryCompleted(instances);
+
+        HazelcastInstance leaderInstance = getLeaderInstance(instances, getMetadataGroupId(instances[0]));
+
+        // `commitIndexAdvanceCountToSnapshot - 5` is selected on purpose to partially include removal of CP member in snapshot.
+        // Specifically, RemoveCPMemberOp will be in snapshot but CompleteRaftGroupMembershipChangesOp will not.
+        for (int i = 0; i < commitIndexAdvanceCountToSnapshot - 5; i++) {
+            getRaftInvocationManager(leaderInstance).invoke(getMetadataGroupId(instances[0]), new GetActiveCPMembersOp()).get();
+        }
+
+        // This will add 3 entries, RemoveCPMemberOp, ChangeRaftGroupMembersCmd and CompleteRaftGroupMembershipChangesOp.
+        // RemoveCPMemberOp will be in snapshot but CompleteRaftGroupMembershipChangesOp will not be included.
+        leaderInstance.shutdown();
+
+        HazelcastInstance newInstance = factory.newHazelcastInstance(config);
+        newInstance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember().toCompletableFuture().join();
+
+        List<CPMember> cpMembers = new ArrayList<>(newInstance.getCPSubsystem().getCPSubsystemManagementService().getCPMembers().toCompletableFuture().join());
+
+        // Waiting for newInstance to apply the snapshot and update its active group members
+        assertTrueEventually(() -> {
+            RaftService service = getRaftService(newInstance);
+            List<CPMemberInfo> activeMembers = new ArrayList<>(service.getMetadataGroupManager().getActiveMembers());
+            assertEquals(cpMembers, activeMembers);
+        });
+
+        // Getting SnapshotEntry from newInstance and leader instances RaftLog
+        RaftNodeImpl newInstanceRaftNode = getRaftNode(newInstance, getMetadataGroupId(newInstance));
+        SnapshotEntry newInstanceSnapshotEntry = (SnapshotEntry) getSnapshotEntry(newInstanceRaftNode);
+        RaftNodeImpl leaderRaftNode = getRaftNode(getInstance(newInstanceRaftNode.getLeader()), getMetadataGroupId(newInstance));
+        SnapshotEntry leaderSnapshotEntry = (SnapshotEntry) getSnapshotEntry(leaderRaftNode);
+
+        // Verifying that the newInstance's SnapshotEntry hasn't mutated after group members' state update,
+        // and equals to the initial leader's SnapshotEntry.
+        // The 'toString' method is used here to compare states so as not to add 'equals' methods to a bunch of classes.
+        assertEquals(leaderSnapshotEntry.toString(true), newInstanceSnapshotEntry.toString(true));
+    }
 
     @Test
     public void when_newCPMemberIsAddedToTheMetadataGroupAfterRestart_newMemberCommitsMetadataGroupLogEntries() throws ExecutionException, InterruptedException {


### PR DESCRIPTION
When the RaftNode state is restored from the RaftLog's SnapshotEntry, further node's state updates also mutate the snapshot of the Metadata Raft group state ('MetadataRaftGroupSnapshot' class). If another RaftNode is restored from this mutated snapshot, it will not be in the expected state.

So, the 'MetadataRaftGroupSnapshot' class should be immutable.

Fixes #21438
Fixes https://github.com/hazelcast/hazelcast/issues/16574

Backport of: https://github.com/hazelcast/hazelcast/pull/22793

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
