### PR TITLE
Improve exception in case of missing entry during Map stress tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
@@ -115,8 +115,9 @@ public class MapStableReadStressTest extends StressTestSupport {
         @Override
         public void doRun() throws Exception {
             while (!isStopped()) {
-                int key = random.nextInt(MAP_SIZE);
-                int value = map.get(key);
+                // do not want to get NPE when map does not contain key
+                Integer key = random.nextInt(MAP_SIZE);
+                Integer value = map.get(key);
                 assertEquals("The value for the key was not consistent", key, value);
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -101,8 +102,8 @@ public class MapUpdateStressTest extends StressTestSupport {
         Set<Integer> failedKeys = new HashSet<Integer>();
         for (int k = 0; k < MAP_SIZE; k++) {
             int expectedValue = increments[k];
-            int foundValue = map.get(k);
-            if (expectedValue != foundValue) {
+            Integer foundValue = map.get(k);
+            if (foundValue == null || expectedValue != foundValue) {
                 failedKeys.add(k);
             }
         }
@@ -148,7 +149,8 @@ public class MapUpdateStressTest extends StressTestSupport {
                 int increment = random.nextInt(10);
                 increments[key] += increment;
                 for (; ; ) {
-                    int oldValue = map.get(key);
+                    Integer oldValue = map.get(key);
+                    assertNotNull("Key missing from the map", oldValue);
                     if (map.replace(key, oldValue, oldValue + increment)) {
                         break;
                     }


### PR DESCRIPTION
When map did not contain key, NullPointerException was thrown instead of more readable assertion failure. This exception is not expected during successful test run, but occurs when something goes wrong like in #22626

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
