### PR TITLE
Upgrade Calcite to 1.32.0

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -44,7 +44,6 @@
                     <includedLicenses combine.children="append">
                         <includedLicense>CDDL</includedLicense>
                         <includedLicense>CDDL 1.1</includedLicense>
-                        <includedLicense>Eclipse Distribution License - v 1.0</includedLicense>
                         <includedLicense>Lesser General Public License (LGPL)</includedLicense>
                         <includedLicense>The GNU General Public License, v2 with FOSS exception</includedLicense>
                         <includedLicense>The Go license</includedLicense>

--- a/extensions/hadoop-dist/pom.xml
+++ b/extensions/hadoop-dist/pom.xml
@@ -86,7 +86,6 @@
                         <includedLicense>The Go license</includedLicense>
                         <includedLicense>CDDL</includedLicense>
                         <includedLicense>CDDL 1.1</includedLicense>
-                        <includedLicense>Eclipse Distribution License - v 1.0</includedLicense>
                     </includedLicenses>
                 </configuration>
             </plugin>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -38,7 +38,7 @@
 
         <checkstyle.headerLocation>${project.parent.basedir}/checkstyle/ClassHeaderHazelcastCommunity.txt</checkstyle.headerLocation>
 
-        <calcite.version>1.31.0</calcite.version>
+        <calcite.version>1.32.0</calcite.version>
         <confluent.version>6.2.2</confluent.version>
         <jaxb.version>2.3.1</jaxb.version>
         <immutables.version>2.9.1</immutables.version>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -53,21 +53,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-third-party</id>
-                        <configuration>
-                            <includedLicenses combine.children="append">
-                                <includedLicense>Eclipse Distribution License - v 1.0</includedLicense>
-                            </includedLicenses>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -53,6 +53,21 @@
 
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-third-party</id>
+                        <configuration>
+                            <includedLicenses combine.children="append">
+                                <includedLicense>Eclipse Distribution License - v 1.0</includedLicense>
+                            </includedLicenses>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
@@ -231,7 +246,7 @@
                                     <include>com.google.guava:guava</include>
                                     <include>com.google.guava:listenablefuture</include>
                                     <include>com.google.guava:failureaccess</include>
-                                    <include>com.esri.geometry:esri-geometry-api</include>
+                                    <include>org.locationtech.jts:jts-core</include>
                                     <include>org.slf4j:slf4j-api</include>
                                     <include>com.fasterxml.jackson.core:jackson-databind</include>
                                 </includes>
@@ -280,8 +295,8 @@
                                     <shadedPattern>${relocation.root}.com.google</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>com.esri.core.geometry</pattern>
-                                    <shadedPattern>${relocation.root}.com.esri.core.geometry</shadedPattern>
+                                    <pattern>org.locationtech.jts</pattern>
+                                    <shadedPattern>${relocation.root}.org.locationtech.jts</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.slf4</pattern>
@@ -396,7 +411,7 @@
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>com.esri.geometry:esri-geometry-api</artifact>
+                                    <artifact>org.locationtech.jts:jts-core</artifact>
                                     <excludes>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
                                     </excludes>
@@ -532,6 +547,15 @@
                 <exclusion>
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-stdlib-jdk8</artifactId>
+                </exclusion>
+                <!-- Unused geospatial libraries (only jts-core is required) -->
+                <exclusion>
+                    <groupId>org.locationtech.jts.io</groupId>
+                    <artifactId>jts-io-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.proj4j</groupId>
+                    <artifactId>proj4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -495,6 +495,7 @@
                                 <includedLicense>MIT License</includedLicense>
                                 <includedLicense>Public Domain</includedLicense>
                                 <includedLicense>EPL 2.0</includedLicense>
+                                <includedLicense>Eclipse Distribution License - v 1.0</includedLicense>
                                 <includedLicense>BSD 3-Clause License</includedLicense>
                                 <includedLicense>BSD 2-Clause License</includedLicense>
                                 <includedLicense>The JSON License</includedLicense>


### PR DESCRIPTION
Fixes #22261

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

Should not be backported to 5.2.z and older versions.

Calcite changelog: https://calcite.apache.org/docs/history.html#v1-32-0