### PR TITLE
Use assertTrueEventually in AuthenticationInformationLeakTest API-1652

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
@@ -49,6 +49,7 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY;
 import static com.hazelcast.test.Accessors.getClientEngineImpl;
@@ -58,8 +59,8 @@ import static com.hazelcast.test.HazelcastTestSupport.assertNotContains;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({ QuickTest.class })
@@ -90,48 +91,45 @@ public class AuthenticationInformationLeakTest {
 
     @Test
     public void testAuthenticationExceptionDoesNotLeakInfo() {
-        // See testAuthenticationExceptionDoesNotLeakInfoInternal for why we use assertTrueEventually here.
+        AtomicReference<ClientMessage> res = new AtomicReference<>();
         assertTrueEventually(() -> {
-            assertTrue(testAuthenticationExceptionDoesNotLeakInfoInternal());
+            res.set(tryGettingKeyValueWithoutAuthentication());
+            assertNotNull(res.get());
         });
+        assertEquals(res.get().getMessageType(), ErrorsCodec.EXCEPTION_MESSAGE_TYPE);
+        ClientExceptionFactory factory = new ClientExceptionFactory(false, Thread.currentThread().getContextClassLoader());
+        Throwable err = factory.createException(res.get());
+        String message = err.getMessage();
+        assertInstanceOf(AuthenticationException.class, err.getCause());
+        assertContains(message, "must authenticate before any operation");
+        String messageLowerCase = message.toLowerCase();
+        assertNotContains(messageLowerCase, "connection");
+        assertNotContains(messageLowerCase, "authenticated");
+        assertNotContains(messageLowerCase, "creationTime");
+        assertNotContains(messageLowerCase, "clientAttributes");
     }
 
     /**
-     * This functions uses a tcp socket to be able to write messages that we want without authenticating.
+     * This function uses a tcp socket to be able to write a message without authenticating.
      * <p>
      * In case of an authentication failure, the server sends an exception message and immediately closes the connection
      * without waiting the message to be written to the client connection. It's possible that we receive EOF from socket,
-     * which will make getKeyValue() throw.
-     * <p>
-     * Therefore, this function should be used with a retry mechanism.
+     * which will make getKeyValue() throw IOException. In any kind of IOException, value null will be returned.
      *
-     * @return true if no IOException happened, false otherwise
+     * @return null if IOException happened, otherwise return the response received from the server as a ClientMessage
      */
-    private boolean testAuthenticationExceptionDoesNotLeakInfoInternal() {
+    private ClientMessage tryGettingKeyValueWithoutAuthentication() {
         SerializationService ss = new DefaultSerializationServiceBuilder().build();
         InetSocketAddress endpoint = instance.getCluster().getLocalMember().getSocketAddress();
         try (Socket socket = new Socket()) {
             socket.setReuseAddress(true);
             socket.connect(endpoint);
-            ClientMessage res;
             try (OutputStream os = socket.getOutputStream(); InputStream is = socket.getInputStream()) {
                 os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
-                res = getKeyValue(ss, os, is);
+                return getKeyValue(ss, os, is);
             }
-            assertEquals(res.getMessageType(), ErrorsCodec.EXCEPTION_MESSAGE_TYPE);
-            ClientExceptionFactory factory = new ClientExceptionFactory(false, Thread.currentThread().getContextClassLoader());
-            Throwable err = factory.createException(res);
-            String message = err.getMessage();
-            assertInstanceOf(AuthenticationException.class, err.getCause());
-            assertContains(message, "must authenticate before any operation");
-            String messageLowerCase = message.toLowerCase();
-            assertNotContains(messageLowerCase, "connection");
-            assertNotContains(messageLowerCase, "authenticated");
-            assertNotContains(messageLowerCase, "creationTime");
-            assertNotContains(messageLowerCase, "clientAttributes");
-            return true;
         } catch (IOException e) {
-            return false;
+            return null;
         }
     }
 


### PR DESCRIPTION
The test failure was due to the client connection being closed before the exception message was able to be written. Upon closing, write queues of the connection being drained and this means no exception message will be sent to the client. To fix this, I used assertTrueEventually in the test.

See debug ss: 
![Screenshot from 2022-11-17 09-05-48](https://user-images.githubusercontent.com/32355782/202370920-05b69583-5f9d-4ba6-b079-72244c492fb7.png)

Alternative ways of fixing this test failure is that:

1. We can delay closing the connection in AbstractMessageTask, (we think this is not the ideal solution)
2. We can change the logic so that we dont close the client connection at all. 

Will be backported to 5.2.z as well upon merging. 

Fixes #22564

Breaking changes (list specific methods/types/messages):
* None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
