### PR TITLE
Fix com.hazelcast.multimap.LocalMultiMapStatsTest.testPutAllAndHitsGeneratedKey [HZ-1760]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/multimap/LocalMultiMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/LocalMultiMapStatsTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
@@ -47,8 +48,8 @@ public class LocalMultiMapStatsTest extends HazelcastTestSupport {
     private static final int OPERATION_COUNT = 10;
 
     private HazelcastInstance instance;
-    private String mapName = "mapName";
-    private String mapNameSet = "mapNameSet";
+    private final String mapName = "mapName";
+    private final String mapNameSet = "mapNameSet";
 
     @Before
     public void setUp() {
@@ -140,7 +141,9 @@ public class LocalMultiMapStatsTest extends HazelcastTestSupport {
         Map<Integer, Collection<? extends Integer>> expectedMultiMap = new HashMap<>();
         testPutAllAndHitsGeneratedTemplate(expectedMultiMap,
                 (o) -> {
-                    o.putAllAsync(expectedMultiMap);
+                    // We need to wait for putAllAsync() call to finish because
+                    // stats are being updated after the putAllAsync() completes
+                    o.putAllAsync(expectedMultiMap).toCompletableFuture().join();
                 }
         );
     }
@@ -150,9 +153,14 @@ public class LocalMultiMapStatsTest extends HazelcastTestSupport {
         Map<Integer, Collection<? extends Integer>> expectedMultiMap = new HashMap<>();
         testPutAllAndHitsGeneratedTemplate(expectedMultiMap,
                 (o) -> {
-                    for (int i = 0; i < 100; ++i) {
-                        o.putAllAsync(i, expectedMultiMap.get(i));
+                    // We need to wait for all putAllAsync() calls to finish because
+                    // stats are being updated after the putAllAsync() completes
+                    int loopLimit = 100;
+                    CompletableFuture<Void>[] futureList = new CompletableFuture[loopLimit];
+                    for (int i = 0; i < loopLimit; ++i) {
+                        futureList[i] = o.putAllAsync(i, expectedMultiMap.get(i)).toCompletableFuture();
                     }
+                    CompletableFuture.allOf(futureList).join();
                 }
         );
     }


### PR DESCRIPTION

Backport of: (https://github.com/hazelcast/hazelcast/pull/22836)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
