### PR TITLE
Fix com.hazelcast.durableexecutor.DurableExecutorServiceTest.durable_executor_collects_statistics_when_stats_enabled  [HZ-1765]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableExecutorServiceTest.java
@@ -602,12 +602,15 @@ public class DurableExecutorServiceTest extends ExecutorServiceTestSupport {
         DurableExecutorService executor = instance.getDurableExecutorService(executorName);
         executor.submit(new OneSecondSleepingTask()).get();
 
-        // collect metrics
-        Map<String, List<Long>> metrics = collectMetrics(DURABLE_EXECUTOR_PREFIX, instance);
-
-        // check results
-        assertMetricsCollected(metrics, 1000, 0,
-                1, 1, 0, 1, 0);
+        // Metrics are updated after the response is sent
+        assertTrueEventually(() -> {
+                    // collect metrics
+                    Map<String, List<Long>> metrics = collectMetrics(DURABLE_EXECUTOR_PREFIX, instance);
+                    // check results
+                    assertMetricsCollected(metrics, 1000, 0,
+                            1, 1, 0, 1, 0);
+                }
+        );
     }
 
     @Test


### PR DESCRIPTION
…executor_collects_statistics_when_stats_enabled  [HZ-1765]

- Wait for metricsCollected eventually

gh : https://github.com/hazelcast/hazelcast/issues/22788

ecklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible

[HZ-1765]: https://hazelcast.atlassian.net/browse/HZ-1765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ