### PR TITLE
Print exception in MulticastDiscoveryStrategyDeserializationTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyDeserializationTest.java
@@ -41,8 +41,8 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests if safe-serialization property works in {@link MulticastDiscoveryStrategy}.
@@ -78,7 +78,9 @@ public class MulticastDiscoveryStrategyDeserializationTest {
             }
             datadgramsThread = null;
         }
-        assertNull(ExceptionUtil.toString(datagramsThreadException), datagramsThreadException);
+        if (datagramsThreadException != null) {
+            fail(ExceptionUtil.toString(datagramsThreadException));
+        }
         HazelcastInstanceFactory.terminateAll();
         TestDeserialized.isDeserialized = false;
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyDeserializationTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
+import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import example.serialization.TestDeserialized;
@@ -77,7 +78,7 @@ public class MulticastDiscoveryStrategyDeserializationTest {
             }
             datadgramsThread = null;
         }
-        assertNull(datagramsThreadException);
+        assertNull(ExceptionUtil.toString(datagramsThreadException), datagramsThreadException);
         HazelcastInstanceFactory.terminateAll();
         TestDeserialized.isDeserialized = false;
 


### PR DESCRIPTION
This PR prints exception properly if the test fails. The new failure
seems different from the older one. My guess is `joinGroup()` throws
`SocketException: Can't assign requested address` if there is an issue
with sockets availability. I would wrap this area and retry a few times,
but I wanted to be sure that the issue is there. I will mark that issue 
as `waiting-for-next-failure`.

Related https://github.com/hazelcast/hazelcast/issues/20823
