### PR TITLE
Wait for database to be up before returning URL

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -97,7 +97,7 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
      * Timeout for initialization of GenericMapStore
      */
     public static final HazelcastProperty MAPSTORE_INIT_TIMEOUT
-            = new HazelcastProperty("hazelcast.mapstore.init.timeout", 5, SECONDS);
+            = new HazelcastProperty("hazelcast.mapstore.init.timeout", 30, SECONDS);
 
     static final String MAPPING_PREFIX = "__map-store.";
 

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
@@ -20,25 +20,17 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
-import static com.hazelcast.internal.util.Preconditions.checkState;
-
 public class H2DatabaseProvider implements TestDatabaseProvider {
+
+    private static final int LOGIN_TIMEOUT = 15;
 
     private String jdbcUrl;
 
     @Override
     public String createDatabase(String dbName) {
         jdbcUrl = "jdbc:h2:mem:" + dbName + ";DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1";
-        init();
+        waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
-    }
-
-    private void init() {
-        try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
-            checkState(!conn.isClosed(), "at this point the connection should be open");
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
@@ -20,6 +20,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import static com.hazelcast.internal.util.Preconditions.checkState;
+
 public class H2DatabaseProvider implements TestDatabaseProvider {
 
     private String jdbcUrl;
@@ -27,7 +29,16 @@ public class H2DatabaseProvider implements TestDatabaseProvider {
     @Override
     public String createDatabase(String dbName) {
         jdbcUrl = "jdbc:h2:mem:" + dbName + ";DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1";
+        init();
         return jdbcUrl;
+    }
+
+    private void init() {
+        try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
+            checkState(!conn.isClosed(), "at this point the connection should be open");
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
@@ -22,7 +22,7 @@ import java.sql.SQLException;
 
 public class H2DatabaseProvider implements TestDatabaseProvider {
 
-    private static final int LOGIN_TIMEOUT = 15;
+    private static final int LOGIN_TIMEOUT = 60;
 
     private String jdbcUrl;
 

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
@@ -18,14 +18,32 @@ package com.hazelcast.test.jdbc;
 
 import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static com.hazelcast.internal.util.Preconditions.checkState;
+
 public class MySQLDatabaseProvider implements TestDatabaseProvider {
+
+    private static final int LOGIN_TIMEOUT = 5;
 
     private String jdbcUrl;
 
     @Override
     public String createDatabase(String dbName) {
         jdbcUrl = "jdbc:tc:mysql:8.0.29:///" + dbName + "?TC_DAEMON=true&sessionVariables=sql_mode=ANSI";
+        waitForDb();
         return jdbcUrl;
+    }
+
+    private void waitForDb() {
+        DriverManager.setLoginTimeout(LOGIN_TIMEOUT);
+        try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
+            checkState(!conn.isClosed(), "at this point the connection should be open");
+        } catch (SQLException e) {
+            throw new RuntimeException("error while starting database", e);
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
@@ -18,12 +18,6 @@ package com.hazelcast.test.jdbc;
 
 import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-
-import static com.hazelcast.internal.util.Preconditions.checkState;
-
 public class MySQLDatabaseProvider implements TestDatabaseProvider {
 
     private static final int LOGIN_TIMEOUT = 5;
@@ -33,17 +27,8 @@ public class MySQLDatabaseProvider implements TestDatabaseProvider {
     @Override
     public String createDatabase(String dbName) {
         jdbcUrl = "jdbc:tc:mysql:8.0.29:///" + dbName + "?TC_DAEMON=true&sessionVariables=sql_mode=ANSI";
-        waitForDb();
+        waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
-    }
-
-    private void waitForDb() {
-        DriverManager.setLoginTimeout(LOGIN_TIMEOUT);
-        try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
-            checkState(!conn.isClosed(), "at this point the connection should be open");
-        } catch (SQLException e) {
-            throw new RuntimeException("error while starting database", e);
-        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
@@ -20,7 +20,7 @@ import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
 public class MySQLDatabaseProvider implements TestDatabaseProvider {
 
-    private static final int LOGIN_TIMEOUT = 5;
+    private static final int LOGIN_TIMEOUT = 120;
 
     private String jdbcUrl;
 

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/PostgresDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/PostgresDatabaseProvider.java
@@ -20,7 +20,7 @@ import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
 public class PostgresDatabaseProvider implements TestDatabaseProvider {
 
-    private static final int LOGIN_TIMEOUT = 5;
+    private static final int LOGIN_TIMEOUT = 120;
     private String jdbcUrl;
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/PostgresDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/PostgresDatabaseProvider.java
@@ -18,12 +18,6 @@ package com.hazelcast.test.jdbc;
 
 import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-
-import static com.hazelcast.internal.util.Preconditions.checkState;
-
 public class PostgresDatabaseProvider implements TestDatabaseProvider {
 
     private static final int LOGIN_TIMEOUT = 5;
@@ -32,17 +26,8 @@ public class PostgresDatabaseProvider implements TestDatabaseProvider {
     @Override
     public String createDatabase(String dbName) {
         jdbcUrl = "jdbc:tc:postgresql:10.21:///" + dbName + "?TC_DAEMON=true";
-        waitForDb();
+        waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
-    }
-
-    private void waitForDb() {
-        DriverManager.setLoginTimeout(LOGIN_TIMEOUT);
-        try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
-            checkState(!conn.isClosed(), "at this point the connection should be open");
-        } catch (SQLException e) {
-            throw new RuntimeException("error while starting database", e);
-        }
     }
 
     @Override


### PR DESCRIPTION
GenericMapStore init creates mapping, resolves fields etc. and has just 5 second to do that. For some tests we use H2 Mem database, which will be up after the first call is made. This means that H2 startup time was added to GenericMapStore init's startup time. In some cases like overloaded Jenkins, this may cause init to fail.

In this change I'm explicitly initializing connection to test databases, so that slow startup in case of overload won't affect GenericMapStore's init (at least, not that much)

Fixes: #22205 #22758

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
