### PR TITLE
fixed a very small typo in CompactUtil.java:207

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -208,7 +208,7 @@ public final class CompactUtil {
                 + "cannot be serialized with zero configuration Compact "
                 + "serialization because this type can be serialized with another "
                 + "serialization mechanism. If you want to serialize "
-                + "'" + clazz + "' which uses this class in its fields, consider"
+                + "'" + clazz + "' which uses this class in its fields, consider "
                 + "overriding that serialization mechanism.");
     }
 


### PR DESCRIPTION
I got here because of an exception with my serialization and found this. It needs to be fixed asap ;) - for the feeling

> I don't think that needs the checklist, because it's such a small change.

There is nearly no way that this could be "breaking" to some sort. The only thing that possibly could brake is if some maniac out there parses the error messages to do stuff with it...

I think it's obvious that this does not need to be mentioned in the changelog.