### PR TITLE
Fix some hz-cli quirks on Windows

### DIFF
--- a/distribution/src/bin-filemode-755/hz
+++ b/distribution/src/bin-filemode-755/hz
@@ -22,7 +22,6 @@ function findScriptDir() {
 }
 
 findScriptDir
-
 . "$SCRIPT_DIR"/common.sh
 
 if [ -z "$LOGGING_CONFIG" ]; then

--- a/distribution/src/bin-filemode-755/hz-cli
+++ b/distribution/src/bin-filemode-755/hz-cli
@@ -56,4 +56,4 @@ if [ "$(command -v cygpath)" != "" ]; then
   CLASSPATH=$(cygpath -w -p "$CLASSPATH")
 fi
 
-$JAVA "${JAVA_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.client.console.HazelcastCommandLine "$@"
+"$JAVA" "${JAVA_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.client.console.HazelcastCommandLine "$@"

--- a/distribution/src/bin-filemode-755/hz-cli
+++ b/distribution/src/bin-filemode-755/hz-cli
@@ -46,4 +46,14 @@ $JVM_OPTIONS \
 $JAVA_OPTS \
 )
 
+# trim CLASSPATH
+CLASSPATH="${CLASSPATH##:}"
+CLASSPATH="${CLASSPATH%%:}"
+
+# Bash on Windows may produce paths such as /c/path/to/lib and Java wants c:\path\to\lib
+# and, in this case, the cygpath command *should* be available - use it to format paths
+if [ "$(command -v cygpath)" != "" ]; then
+  CLASSPATH=$(cygpath -w -p "$CLASSPATH")
+fi
+
 $JAVA "${JAVA_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.client.console.HazelcastCommandLine "$@"

--- a/distribution/src/bin-filemode-755/hz-cli
+++ b/distribution/src/bin-filemode-755/hz-cli
@@ -46,14 +46,4 @@ $JVM_OPTIONS \
 $JAVA_OPTS \
 )
 
-# trim CLASSPATH
-CLASSPATH="${CLASSPATH##:}"
-CLASSPATH="${CLASSPATH%%:}"
-
-# Bash on Windows may produce paths such as /c/path/to/lib and Java wants c:\path\to\lib
-# and, in this case, the cygpath command *should* be available - use it to format paths
-if [ "$(command -v cygpath)" != "" ]; then
-  CLASSPATH=$(cygpath -w -p "$CLASSPATH")
-fi
-
 "$JAVA" "${JAVA_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.client.console.HazelcastCommandLine "$@"

--- a/distribution/src/bin-regular/common.bat
+++ b/distribution/src/bin-regular/common.bat
@@ -1,0 +1,85 @@
+
+:: detect Java
+
+if "x%JAVA_HOME%" == "x" (
+    set RUN_JAVA=java
+) else (
+    set "RUN_JAVA=%JAVA_HOME%\bin\java"
+)
+
+"%RUN_JAVA%" -version 1>nul 2>nul || (
+    echo JAVA could not be found in your system.
+    echo Please install Java 1.8 or higher and ensure either JAVA_HOME
+    echo is defined, or the java executable is in the PATH.
+    exit /b 2
+)
+
+:: %~dp0 is the drive+path where this script lives
+if "x%HAZELCAST_HOME%" == "x" (
+    set HAZELCAST_HOME=%~dp0..
+)
+
+:: options
+
+:: ******* you can enable following variables by uncommenting them
+
+:: ******* minimum heap size
+:: set MIN_HEAP_SIZE=1G
+
+:: ******* maximum heap size
+:: set MAX_HEAP_SIZE=1G
+
+
+if NOT "%MIN_HEAP_SIZE%" == "" (
+	set JAVA_OPTS=%JAVA_OPTS% -Xms%MIN_HEAP_SIZE%
+)
+
+if NOT "%MAX_HEAP_SIZE%" == "" (
+	set JAVA_OPTS=%JAVA_OPTS% -Xmx%MAX_HEAP_SIZE%
+)
+
+:: options
+
+FOR /F "tokens=* USEBACKQ" %%F IN (`CALL "%RUN_JAVA%" -cp "%HAZELCAST_HOME%\lib\*" com.hazelcast.internal.util.JavaVersion`) DO SET JAVA_VERSION=%%F
+
+IF %JAVA_VERSION% GEQ 9 (
+    SET JAVA_OPTS=%JAVA_OPTS%^
+        --add-modules java.se^
+        --add-exports java.base/jdk.internal.ref=ALL-UNNAMED^
+        --add-opens java.base/java.lang=ALL-UNNAMED^
+        --add-opens java.base/sun.nio.ch=ALL-UNNAMED^
+        --add-opens java.management/sun.management=ALL-UNNAMED^
+        --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+
+    FOR /F "tokens=2 delims== USEBACKQ" %%A IN (`CALL "%RUN_JAVA%" -XshowSettings:properties -version 2^>^&1 ^| findstr /c:"java.vm.name"`) DO SET VM_NAME=%%A
+    :: trim leading ws, trainling ws
+    FOR /F "tokens=* delims= " %%A IN ("%VM_NAME%") DO SET VM_NAME=%%~A
+    FOR /L %%a in (1,1,15) DO IF "!VM_NAME:~-1!"==" " SET VM_NAME=!VM_NAME:~0,-1!
+
+    IF NOT "x%VM_NAME:OpenJ9=%"=="x%VM_NAME%" (
+    	REM OpenJ9 detected, adding additional exports
+    	set JAVA_OPTS=%JAVA_OPTS% --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED
+    )
+)
+
+:: HAZELCAST_CONFIG holds path to the configuration file. The path is relative to the Hazelcast installation (HAZELCAST_HOME).
+if "x%HAZELCAST_CONFIG%" == "x" (
+    set HAZELCAST_CONFIG=config\hazelcast.xml
+    if not exist "%HAZELCAST_HOME%\!HAZELCAST_CONFIG!" (
+      set HAZELCAST_CONFIG=config\hazelcast.yaml
+    )
+    if not exist "%HAZELCAST_HOME%\!HAZELCAST_CONFIG!" (
+      set HAZELCAST_CONFIG=config\hazelcast.yml
+    )
+    if not exist "%HAZELCAST_HOME%\!HAZELCAST_CONFIG!" (
+      echo "Configuration file is missing. Create hazelcast.[xml|yaml|yml] in %HAZELCAST_HOME%\config or set the HAZELCAST_CONFIG environment variable."
+      exit /b 2
+    )
+)
+
+set JAVA_OPTS=%JAVA_OPTS%^
+    -Dhazelcast.config="%HAZELCAST_HOME%\%HAZELCAST_CONFIG%"
+
+:: classpath
+
+set CLASSPATH="%HAZELCAST_HOME%\lib\*;%HAZELCAST_HOME%\bin\user-lib;%HAZELCAST_HOME%\bin\user-lib\*;%CLASSPATH%"

--- a/distribution/src/bin-regular/common.sh
+++ b/distribution/src/bin-regular/common.sh
@@ -3,7 +3,9 @@ if [ -z "$SCRIPT_DIR" ]; then
   exit 1;
 fi;
 
-export HAZELCAST_HOME="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [ -z "$HAZELCAST_HOME"]; then
+  export HAZELCAST_HOME="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
 
 if [ "$JAVA_HOME" ]; then
     JAVA="$JAVA_HOME/bin/java"

--- a/distribution/src/bin-regular/common.sh
+++ b/distribution/src/bin-regular/common.sh
@@ -3,6 +3,8 @@ if [ -z "$SCRIPT_DIR" ]; then
   exit 1;
 fi;
 
+export HAZELCAST_HOME="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 if [ "$JAVA_HOME" ]; then
     JAVA="$JAVA_HOME/bin/java"
 else

--- a/distribution/src/bin-regular/common.sh
+++ b/distribution/src/bin-regular/common.sh
@@ -18,6 +18,13 @@ if [ -z "$JAVA" ]; then
     exit 1
 fi
 
+# Bash on Windows may produce paths such as /c/path/to/lib and Java wants c:\path\to\lib
+# and, in this case, the cygpath command *should* be available - and then we will use it
+CYGPATH=""
+if [ "$(command -v cygpath)" != "" ]; then
+  CYGPATH=cygpath
+fi
+
 #### you can enable following variables by uncommenting them
 
 #### minimum heap size
@@ -53,8 +60,29 @@ if [ "$JAVA_VERSION" -ge "9" ]; then
     fi
 fi
 
+# ensure CLASSPATH_DEFAULT is unix style + trimmed
+if [ -n "${CLASSPATH_DEFAULT}" ]; then
+  if [ -n "${CYGPATH}" ]; then
+    CLASSPATH_DEFAULT=$(cygpath -u -p "$CLASSPATH_DEFAULT")
+  fi
+  CLASSPATH_DEFAULT="${CLASSPATH_DEFAULT##:}"
+  CLASSPATH_DEFAULT="${CLASSPATH_DEFAULT%%:}"
+fi
+
+# ensure CLASSPATH is unix style + trimmed
 if [ -n "${CLASSPATH}" ]; then
-  export CLASSPATH="${CLASSPATH_DEFAULT}:${CLASSPATH}"
+  if [ -n "${CYGPATH}" ]; then
+    CLASSPATH=$(cygpath -u -p "$CLASSPATH")
+  fi
+  CLASSPATH="${CLASSPATH##:}"
+  CLASSPATH="${CLASSPATH%%:}"
+fi
+
+# combine CLASSPATH and CLASSPATH_DEFAULT
+if [ -n "${CLASSPATH}" ]; then
+  if [ -n "${CLASSPATH_DEFAULT}" ]; then
+    export CLASSPATH="${CLASSPATH_DEFAULT}:${CLASSPATH}"
+  fi
 else
   export CLASSPATH="${CLASSPATH_DEFAULT}"
 fi
@@ -83,3 +111,12 @@ function readJvmOptionsFile {
     # Evaluate variables in the options, allowing to use e.g. HAZELCAST_HOME variable
     JVM_OPTIONS=$(eval echo $JVM_OPTIONS)
 }
+
+# trim CLASSPATH
+CLASSPATH="${CLASSPATH##:}"
+CLASSPATH="${CLASSPATH%%:}"
+
+# ensure CLASSPATH is windows style on Windows
+if [ -n "${CYGPATH}" ]; then
+  CLASSPATH=$(cygpath -w -p "$CLASSPATH")
+fi

--- a/distribution/src/bin-regular/common.sh
+++ b/distribution/src/bin-regular/common.sh
@@ -3,10 +3,6 @@ if [ -z "$SCRIPT_DIR" ]; then
   exit 1;
 fi;
 
-if [ -z "$HAZELCAST_HOME"]; then
-  export HAZELCAST_HOME="$(cd "$SCRIPT_DIR/.." && pwd)"
-fi
-
 if [ "$JAVA_HOME" ]; then
     JAVA="$JAVA_HOME/bin/java"
 else

--- a/distribution/src/bin-regular/hz-cli.bat
+++ b/distribution/src/bin-regular/hz-cli.bat
@@ -6,7 +6,6 @@ if NOT DEFINED JAVA_HOME goto error
 set RUN_JAVA=%JAVA_HOME%\bin\java
 set HAZELCAST_HOME=%~dp0..
 set CLASSPATH="%HAZELCAST_HOME%\lib\*";%CLASSPATH%
-set JAVA_OPTS=%JAVA_OPTS% "-Dhazelcast.client.config=%HAZELCAST_HOME%\config\hazelcast-client.yaml"
 
 "%RUN_JAVA%" %JAVA_OPTS% -cp %CLASSPATH% com.hazelcast.client.console.HazelcastCommandLine %*
 goto endofscript

--- a/distribution/src/bin-regular/hz-cli.bat
+++ b/distribution/src/bin-regular/hz-cli.bat
@@ -1,19 +1,10 @@
 @echo off
 
-SETLOCAL
+SETLOCAL ENABLEDELAYEDEXPANSION
 
-if NOT DEFINED JAVA_HOME goto error
-set RUN_JAVA=%JAVA_HOME%\bin\java
-set HAZELCAST_HOME=%~dp0..
-set CLASSPATH="%HAZELCAST_HOME%\lib\*";%CLASSPATH%
+CALL common.bat
 
+echo "%RUN_JAVA%" %JAVA_OPTS% -cp %CLASSPATH% com.hazelcast.client.console.HazelcastCommandLine %*
 "%RUN_JAVA%" %JAVA_OPTS% -cp %CLASSPATH% com.hazelcast.client.console.HazelcastCommandLine %*
-goto endofscript
-
-:error
-echo JAVA_HOME not defined, cannot start the JVM
-pause
-
-:endofscript
 
 ENDLOCAL

--- a/distribution/src/bin-regular/hz-start.bat
+++ b/distribution/src/bin-regular/hz-start.bat
@@ -2,76 +2,7 @@
 
 SETLOCAL ENABLEDELAYEDEXPANSION
 
-if "x%JAVA_HOME%" == "x" (
-    echo JAVA_HOME environment variable not available.
-    set RUN_JAVA=java
-) else (
-    set "RUN_JAVA=%JAVA_HOME%\bin\java"
-)
-
-"%RUN_JAVA%" -version 1>nul 2>nul || (
-    echo JAVA could not be found in your system.
-    echo Please install Java 1.8 or higher
-    exit /b 2
-)
-set HAZELCAST_HOME=%~dp0..
-
-REM ******* you can enable following variables by uncommenting them
-
-REM ******* minimum heap size
-REM set MIN_HEAP_SIZE=1G
-
-REM ******* maximum heap size
-REM set MAX_HEAP_SIZE=1G
-
-
-if NOT "%MIN_HEAP_SIZE%" == "" (
-	set JAVA_OPTS=%JAVA_OPTS% -Xms%MIN_HEAP_SIZE%
-)
-
-if NOT "%MAX_HEAP_SIZE%" == "" (
-	set JAVA_OPTS=%JAVA_OPTS% -Xmx%MAX_HEAP_SIZE%
-)
-
-FOR /F "tokens=* USEBACKQ" %%F IN (`CALL "%RUN_JAVA%" -cp "%HAZELCAST_HOME%\lib\*" com.hazelcast.internal.util.JavaVersion`) DO SET JAVA_VERSION=%%F
-
-IF NOT "%JAVA_VERSION%" == "8" (
-	set JAVA_OPTS=%JAVA_OPTS% --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-
-    for /f "tokens=2 delims== usebackq" %%a in (`java -XshowSettings:properties -version 2^>^&1 ^| findstr /c:"java.vm.name"`) do (
-    		set VM_NAME=%%a
-    )
-
-    echo "!VM_NAME!" | find /I "OpenJ9" && (
-    	REM OpenJ9 detected, adding additional exports
-    	set JAVA_OPTS=%JAVA_OPTS% --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED
-    )
-
-)
-
-REM HAZELCAST_CONFIG holds path to the configuration file. The path is relative to the Hazelcast installation (HAZELCAST_HOME).
-if "x%HAZELCAST_CONFIG%" == "x" (
-    set HAZELCAST_CONFIG=config\hazelcast.xml
-    if not exist "%HAZELCAST_HOME%\!HAZELCAST_CONFIG!" (
-      set HAZELCAST_CONFIG=config\hazelcast.yaml
-    )
-    if not exist "%HAZELCAST_HOME%\!HAZELCAST_CONFIG!" (
-      set HAZELCAST_CONFIG=config\hazelcast.yml
-    )
-    if not exist "%HAZELCAST_HOME%\!HAZELCAST_CONFIG!" (
-      echo "Configuration file is missing. Create hazelcast.[xml|yaml|yml] in %HAZELCAST_HOME%\config or set the HAZELCAST_CONFIG environment variable."
-      exit /b 2
-    )
-)
-
-set JAVA_OPTS=%JAVA_OPTS%^
- "-Dhazelcast.logging.type=log4j2"^
- "-Dlog4j.configurationFile=file:%HAZELCAST_HOME%\config\log4j2.properties"^
- "-Dhazelcast.config=%HAZELCAST_HOME%\%HAZELCAST_CONFIG%"
-
-set "LOGGING_PATTERN=%%d [%%highlight{%%5p}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=magenta}] [%%style{%%t{1.}}{cyan}] [%%style{%%c{1.}}{blue}]: %%m%%n"
-
-set CLASSPATH="%HAZELCAST_HOME%\lib\*;%HAZELCAST_HOME%\bin\user-lib;%HAZELCAST_HOME%\bin\user-lib\*";%CLASSPATH%
+CALL common.bat
 
 ECHO ########################################
 ECHO # RUN_JAVA=%RUN_JAVA%


### PR DESCRIPTION
The `hz-cli` shell script fails to run in bash on Windows because it uses a colon-separated `CLASSPATH` where each path is a linux-style path, whereas Java on Windows expect a semicolon-separated `CLASSPATH` where each path is a Windows-style path, even when started from bash. This PR adds logic to cook the `CLASSPATH` on Windows.

The `hz-cli.bat` cmd script forces the `hazelcast.client.config` variable in `JAVA_OPTS` which means that if the specified file does not exist, the command fails. This is annoying when someone wants to specify an alternate file. This PR removes the line.

In fact, the Windows scripts are lagging behind Bash scripts. This PR refactors the Windows scripts to align them with what is done with Bash (same JAVA_OPTS, for instance, and same everything else). Also deals with `hz-start.bat` via a unique `common.bat` file, same as `common.sh` for Bash.

Review: should ensure that Bash scripts just still work all right on Linux, and then that they work on Bash on Windows too, and then that Windows scripts work too.

Fixes #22883

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- n/a New public APIs have `@Nonnull/@Nullable` annotations
- n/a New public APIs have `@since` tags in Javadoc
