### PR TITLE
Wrap exceptions to JetException is any exception in chain is a HazelcastSerializationException

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -103,8 +103,8 @@ public final class ExceptionUtil {
 
     /**
      * If {@code t} is either of {@link CompletionException}, {@link ExecutionException}
-     * or {@link InvocationTargetException}, returns its cause, peeling it recursively.
-     * Otherwise returns {@code t}.
+     * {@link JetException} or {@link InvocationTargetException}, returns its cause, peeling it recursively.
+     * Otherwise, returns {@code t}.
      *
      * @param t Throwable to peel
      * @see #peeledAndUnchecked(Throwable)
@@ -112,7 +112,8 @@ public final class ExceptionUtil {
     public static Throwable peel(@Nullable Throwable t) {
         while ((t instanceof CompletionException
                 || t instanceof ExecutionException
-                || t instanceof InvocationTargetException)
+                || t instanceof InvocationTargetException
+                || t instanceof JetException)
                 && t.getCause() != null
                 && t.getCause() != t
         ) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -120,8 +120,7 @@ public final class ExceptionUtil {
     private static boolean isPeelableException(@Nullable Throwable t) {
         return t instanceof CompletionException
                 || t instanceof ExecutionException
-                || t instanceof InvocationTargetException
-                || t instanceof JetException;
+                || t instanceof InvocationTargetException;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ExceptionUtilTest.java
@@ -62,7 +62,9 @@ public class ExceptionUtilTest extends JetTestSupport {
     @Test
     public void when_throwableIsExecutionExceptionWithNullCause_then_returnHazelcastException() {
         ExecutionException exception = new ExecutionException(null);
-        assertThrows(JetException.class, () -> { throw rethrow(exception); });
+        assertThrows(JetException.class, () -> {
+            throw rethrow(exception);
+        });
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ExceptionUtilTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.TestProcessors.MockP;
-import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -65,21 +64,6 @@ public class ExceptionUtilTest extends JetTestSupport {
         assertThrows(JetException.class, () -> {
             throw rethrow(exception);
         });
-    }
-
-    @Test
-    public void when_throwableIsJetExceptionWithNullCause_then_returnItself() {
-        JetException exception = new JetException("here stacktrace", null);
-        Throwable result = peel(exception);
-        assertEquals(exception, result);
-    }
-
-    @Test
-    public void when_throwableIsJetExceptionWithNonNullCause_then_returnCause() {
-        JetException exception = new JetException("here stacktrace", new HazelcastSerializationException("oh no"));
-        Throwable result = peel(exception);
-        assertEquals("oh no", result.getMessage());
-        assertEquals(HazelcastSerializationException.class, result.getClass());
     }
 
     @Test


### PR DESCRIPTION
If processor throw JetException with a non-serializable cause, then the result cannot be send - `peel` method doesn't see HazecastSerializationException due to JetException not being included in the definition. That's why it's better to just check whole `cause` chain.

See https://github.com/hazelcast/hazelcast/pull/22497/files#r996878225

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases