### PR TITLE
Fix setReuseAddress should be called before bind in MulticastDiscoveryStrategy.java

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
@@ -81,6 +81,7 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
             MulticastDiscoverySerializationHelper serializationHelper = new MulticastDiscoverySerializationHelper(
                     safeSerialization);
             multicastSocket = new MulticastSocket(null);
+            multicastSocket.setReuseAddress(true);
             multicastSocket.bind(new InetSocketAddress(port));
             if (discoveryNode != null) {
                 // See MulticastService.createMulticastService(...)
@@ -89,7 +90,6 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
                     multicastSocket.setInterface(inetAddress);
                 }
             }
-            multicastSocket.setReuseAddress(true);
             multicastSocket.setTimeToLive(SOCKET_TIME_TO_LIVE);
             multicastSocket.setReceiveBufferSize(DATA_OUTPUT_BUFFER_SIZE);
             multicastSocket.setSendBufferSize(DATA_OUTPUT_BUFFER_SIZE);


### PR DESCRIPTION
If setReuseAddress is called after the bind() method it still works on Windows and MAC, however this behavior is undefined as documented in setReuseAddress () javadoc and it is better to fix in just in case. See https://docs.oracle.com/javase/7/docs/api/java/net/Socket.html#setReuseAddress(boolean) 

**The behaviour when SO_REUSEADDR is enabled or disabled after a socket is bound (See isBound()) is not defined.**
 Related test cases : 
https://github.com/hazelcast/hazelcast/issues/22863
https://github.com/hazelcast/hazelcast/issues/20823

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
