### PR TITLE
Use custom Hikari pool names to improve testability [HZ-1746] [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImplTest.java
@@ -39,7 +39,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Properties;
 
-import static classloading.ThreadLeakTestUtils.getThreads;
+import static com.hazelcast.datastore.impl.HikariTestUtil.assertDataSourceClosed;
+import static com.hazelcast.datastore.impl.HikariTestUtil.assertEventuallyNoHikariThreads;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -47,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
+    private static final String TEST_CONFIG_NAME = ExternalDataStoreServiceImplTest.class.getSimpleName();
 
     private final Config config = smallInstanceConfig();
     private final TestHazelcastInstanceFactory hazelcastInstanceFactory = createHazelcastInstanceFactory(1);
@@ -57,7 +59,7 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
         Properties properties = new Properties();
         properties.put("jdbcUrl", "jdbc:h2:mem:" + ExternalDataStoreServiceImplTest.class.getSimpleName());
         ExternalDataStoreConfig externalDataStoreConfig = new ExternalDataStoreConfig()
-                .setName("test-data-store")
+                .setName(TEST_CONFIG_NAME)
                 .setClassName("com.hazelcast.datastore.JdbcDataStoreFactory")
                 .setProperties(properties);
         config.addExternalDataStoreConfig(externalDataStoreConfig);
@@ -67,19 +69,21 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
     @After
     public void tearDown() throws Exception {
         hazelcastInstanceFactory.shutdownAll();
-        assertTrueEventually("No Hikari threads", () -> assertThat(getThreads()).noneMatch(t -> t.getName().contains("HikariPool-")));
+        assertEventuallyNoHikariThreads(TEST_CONFIG_NAME);
     }
 
     @Test
     public void should_return_working_datastore() throws Exception {
-        ExternalDataStoreFactory<?> dataStoreFactory = externalDataStoreService.getExternalDataStoreFactory("test-data-store");
+        ExternalDataStoreFactory<?> dataStoreFactory = externalDataStoreService.getExternalDataStoreFactory(TEST_CONFIG_NAME);
         assertInstanceOf(JdbcDataStoreFactory.class, dataStoreFactory);
 
         DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).getDataStore();
 
-        ResultSet resultSet = executeQuery(dataSource, "select 'some-name' as name");
-        resultSet.next();
-        String actualName = resultSet.getString(1);
+        String actualName;
+        try (ResultSet resultSet = executeQuery(dataSource, "select 'some-name' as name")) {
+            resultSet.next();
+            actualName = resultSet.getString(1);
+        }
 
         assertThat(actualName).isEqualTo("some-name");
     }
@@ -93,14 +97,12 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
 
     @Test
     public void should_close_factories() {
-        ExternalDataStoreFactory<?> dataStoreFactory = externalDataStoreService.getExternalDataStoreFactory("test-data-store");
+        ExternalDataStoreFactory<?> dataStoreFactory = externalDataStoreService.getExternalDataStoreFactory(TEST_CONFIG_NAME);
 
         DataSource dataSource = ((JdbcDataStoreFactory) dataStoreFactory).getDataStore();
         externalDataStoreService.close();
 
-        assertThatThrownBy(() -> executeQuery(dataSource, "select 'some-name' as name"))
-                .isInstanceOf(SQLException.class)
-                .hasMessageMatching("HikariDataSource HikariDataSource \\(HikariPool-\\d+\\) has been closed.");
+        assertDataSourceClosed(dataSource, TEST_CONFIG_NAME);
     }
 
     private ExternalDataStoreService getExternalDataStoreService() {

--- a/hazelcast/src/test/java/com/hazelcast/datastore/impl/HikariTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/impl/HikariTestUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.datastore.impl;
+
+import com.hazelcast.internal.util.StringUtil;
+import com.zaxxer.hikari.HikariDataSource;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static classloading.ThreadLeakTestUtils.getThreads;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public final class HikariTestUtil {
+    private HikariTestUtil() {
+    }
+
+    public static void assertEventuallyNoHikariThreads(String configName) {
+        assertTrueEventually("No Hikari threads", () -> assertThat(getThreads())
+                .noneMatch(t -> t.getName().matches(hikariPoolRegex(configName))));
+    }
+
+    private static String hikariPoolRegex(String configName) {
+        String suffix = StringUtil.isNullOrEmpty(configName) ? "" : "-" + configName;
+        return "HikariPool-\\d+" + suffix;
+    }
+
+    public static void assertDataSourceClosed(DataSource closeableDataSource, String configName) {
+        assertThatThrownBy(() -> executeQuery(closeableDataSource, "select 'some-name' as name"))
+                .isInstanceOf(SQLException.class)
+                .hasMessageMatching("HikariDataSource HikariDataSource \\(" + hikariPoolRegex(configName) + "\\) has been closed.");
+    }
+
+    private static void executeQuery(DataSource dataSource, String sql) throws SQLException {
+        try (PreparedStatement preparedStatement = dataSource.getConnection().prepareStatement(sql);
+             ResultSet ignored = preparedStatement.executeQuery()) {
+            //NOP
+        }
+    }
+
+    public static void assertPoolNameEndsWith(DataSource dataSource, String suffix) throws SQLException {
+        String poolName = dataSource.unwrap(HikariDataSource.class).getPoolName();
+        assertThat(poolName).matches(hikariPoolRegex(suffix));
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/22890

Use custom Hikari pool names for external data stores to make tests stable

Fixes https://github.com/hazelcast/hazelcast/issues/22747

Related to https://github.com/hazelcast/hazelcast/pull/22783

(cherry picked from commit e320cbd3c37425065c8737122f9b2fb4bde9016c)
