### PR TITLE
Refactor DynamicMapConfigTest [HZ-960]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/DynamicMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/DynamicMapConfigTest.java
@@ -32,7 +32,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.ChangeLoggingRule;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -52,7 +52,7 @@ import static org.junit.Assert.assertTrue;
  * Map configuration can be updated dynamically at runtime by using management center ui.
  * This test verifies that the changes will be reflected to corresponding IMap at runtime.
  */
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class DynamicMapConfigTest extends HazelcastTestSupport {
 


### PR DESCRIPTION
This PR refactors `DynamicMapConfigTest`. Now instead of relaying 
internals, it uses `EntryExpiredListener`. Also, this test now uses 
`HazelcastSerialClassRunner` as it's better to not use parallel runner if 
there is only one test inside a class.

See https://github.com/hazelcast/hazelcast/pull/22882#issuecomment-1322021212

Related https://github.com/hazelcast/hazelcast/pull/22882
Related https://github.com/hazelcast/hazelcast/pull/20926

Fixes https://github.com/hazelcast/hazelcast/issues/20589
