### PR TITLE
Make ClientXATest use mock network API-1657

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/txn/ClientXATest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/txn/ClientXATest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
 import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static com.hazelcast.test.HazelcastTestSupport.sleepAtLeastSeconds;
@@ -175,8 +176,10 @@ public class ClientXATest {
     @Test
     public void testRecovery() throws Exception {
         HazelcastInstance instance = Hazelcast.newHazelcastInstance();
-        Hazelcast.newHazelcastInstance();
-        Hazelcast.newHazelcastInstance();
+        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance();
+        HazelcastInstance instance3 = Hazelcast.newHazelcastInstance();
+
+        assertClusterSize(3, instance, instance2, instance3);
 
         HazelcastXAResource xaResource = instance.getXAResource();
         Xid myXid = new SerializableXID(42, "globalTransactionId".getBytes(), "branchQualifier".getBytes());

--- a/hazelcast/src/test/java/com/hazelcast/client/txn/ClientXATest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/txn/ClientXATest.java
@@ -17,8 +17,7 @@
 package com.hazelcast.client.txn;
 
 import com.atomikos.icatch.jta.UserTransactionManager;
-import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.core.Hazelcast;
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.collection.IQueue;
@@ -62,6 +61,7 @@ import static org.junit.Assert.fail;
 @Category(SlowTest.class)
 public class ClientXATest {
 
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
     static final Random random = new Random(System.currentTimeMillis());
     static final ILogger logger = Logger.getLogger(ClientXATest.class);
 
@@ -91,22 +91,20 @@ public class ClientXATest {
         cleanAtomikosLogs();
         tm = new UserTransactionManager();
         tm.setTransactionTimeout(60);
-        HazelcastClient.shutdownAll();
-        Hazelcast.shutdownAll();
+        hazelcastFactory.terminateAll();
     }
 
     @After
     public void cleanup() {
         tm.close();
         cleanAtomikosLogs();
-        HazelcastClient.shutdownAll();
-        Hazelcast.shutdownAll();
+        hazelcastFactory.terminateAll();
     }
 
     @Test
     public void testRollbackOnTimeout() throws Exception {
-        Hazelcast.newHazelcastInstance();
-        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
         String name = randomString();
         IQueue<Object> queue = client.getQueue(name);
@@ -132,8 +130,8 @@ public class ClientXATest {
 
     @Test
     public void testWhenLockedOutOfTransaction() throws Exception {
-        Hazelcast.newHazelcastInstance();
-        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Object, Object> map = client.getMap("map");
         map.put("key", "value");
         HazelcastXAResource xaResource = client.getXAResource();
@@ -151,8 +149,8 @@ public class ClientXATest {
 
     @Test
     public void testRollback() throws Exception {
-        Hazelcast.newHazelcastInstance();
-        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         HazelcastXAResource xaResource = client.getXAResource();
 
         tm.begin();
@@ -175,9 +173,9 @@ public class ClientXATest {
 
     @Test
     public void testRecovery() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance();
-        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance();
-        HazelcastInstance instance3 = Hazelcast.newHazelcastInstance();
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance instance3 = hazelcastFactory.newHazelcastInstance();
 
         assertClusterSize(3, instance, instance2, instance3);
 
@@ -190,7 +188,7 @@ public class ClientXATest {
         xaResource.prepare(myXid);
         instance.shutdown();
 
-        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         HazelcastXAResource clientXaResource = client.getXAResource();
         Xid[] recovered = clientXaResource.recover(0);
         for (Xid xid : recovered) {
@@ -201,11 +199,11 @@ public class ClientXATest {
 
     @Test
     public void testIsSame() throws Exception {
-        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance();
-        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance();
+        HazelcastInstance instance1 = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
         XAResource resource1 = instance1.getXAResource();
         XAResource resource2 = instance2.getXAResource();
-        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         XAResource clientResource = client.getXAResource();
         assertTrue(clientResource.isSameRM(resource1));
         assertTrue(clientResource.isSameRM(resource2));
@@ -213,8 +211,8 @@ public class ClientXATest {
 
     @Test
     public void testParallel() throws Exception {
-        Hazelcast.newHazelcastInstance();
-        final HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        hazelcastFactory.newHazelcastInstance();
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         // this is needed due to a racy bug in atomikos
         txn(client);
         int size = 100;
@@ -242,8 +240,8 @@ public class ClientXATest {
 
     @Test
     public void testSequential() throws Exception {
-        Hazelcast.newHazelcastInstance();
-        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         int count = 100;
         for (int i = 0; i < count; i++) {
             txn(client);


### PR DESCRIPTION
The test failed with a log that includes explicit suspicion requests. Instance1 that is used to start transaction received explicit suspicion requests from the other members and it closed connections to those members. The cluster size did not become 3 as it supposed to be. Also there are logs like these in the logs: 

`New join request has been received from current master address. The UUID in the join request (62a29dcc-f128-4b24-b442-5f6a09e64dfe) is different from the known master one (08032ec1-...`

and there is no member with uuid 62a29dcc-f128-4b24-b442-5f6a09e64dfe among the 3 members.

I think the problem is the same as with the one discussed at https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1668592206511029 

Note that this test uses real network but I don't think the runner is wrongly set for this test. It runs in serial, not parallel. I wonder if we can port this test to mock network. Any idea why it uses a real network? 

The fix converts the test to use HazelcastFactory and testRecovery waits for cluster size to be 3 before starting to run actual code.
Will be backported to all other branches until 4.0.x, because the test is really old.

Fixes #22271

Breaking changes (list specific methods/types/messages):
- None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc


