### PR TITLE
Fix mappings not cleared after test

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.mapstore;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
@@ -551,6 +552,11 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
         } catch (InterruptedException e) {
             throw new HazelcastException(e);
         }
+    }
+
+    @VisibleForTesting
+    boolean initHasFinished() {
+        return initFinished.getCount() == 0;
     }
 
     private static class GenericMapStoreProperties {

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/mysql/MySQLGenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/mysql/MySQLGenericMapStoreTest.java
@@ -27,7 +27,7 @@ import org.junit.experimental.categories.Category;
 public class MySQLGenericMapStoreTest extends GenericMapStoreTest {
 
     @BeforeClass
-    public static void beforeClass() throws Exception {
+    public static void beforeClass()  {
         initialize(new MySQLDatabaseProvider());
     }
 

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/postgres/PostgresGenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/postgres/PostgresGenericMapStoreTest.java
@@ -27,7 +27,7 @@ import org.junit.experimental.categories.Category;
 public class PostgresGenericMapStoreTest extends GenericMapStoreTest {
 
     @BeforeClass
-    public static void beforeClass() throws Exception {
+    public static void beforeClass()  {
         initialize(new PostgresDatabaseProvider());
     }
 


### PR DESCRIPTION
If destroy() method is not called, then mapping can be still present, failing next test.

Fixes #22910

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible