### PR TITLE
Fix StreamKafkaPTest.when_eventsInAllPartitions_then_watermarkOutputImmediately [HZ-1773] [5.2.z]

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -225,8 +225,8 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
                 for (int i = 0; i < 2 * messageCount; i++) {
                     Entry<Integer, String> entry1 = createEntry(i);
                     Entry<Integer, String> entry2 = createEntry(i - messageCount);
-                    assertTrue("missing entry: " + entry1.toString(), list.contains(entry1));
-                    assertTrue("missing entry: " + entry2.toString(), list.contains(entry2));
+                    assertTrue("missing entry: " + entry1, list.contains(entry1));
+                    assertTrue("missing entry: " + entry2, list.contains(entry2));
                 }
             }, 10);
         }
@@ -247,7 +247,8 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         for (int i = 0; i < INITIAL_PARTITION_COUNT; i++) {
             Entry<Integer, String> event = entry(i + 100, Integer.toString(i));
             System.out.println("produced event " + event);
-            kafkaTestSupport.produce(topic1Name, i, null, event.getKey(), event.getValue());
+            //Wait for the event to be published to Kafka, the processor can access Kafka metadata
+            kafkaTestSupport.produce(topic1Name, i, null, event.getKey(), event.getValue()).get();
             if (i == INITIAL_PARTITION_COUNT - 1) {
                 assertEquals(new Watermark(100 - LAG), consumeEventually(processor, outbox));
             }


### PR DESCRIPTION
In the test logs, there was an error message as below. **"Unable to get partition metadata, ignoring:
org.apache.kafka.common.errors.TimeoutException: Timeout expired while fetching topic metadata"**

This indicates that Kafka was not ready when the processor was trying to read metadata. The test was publishing to Kafka asynchronously. The fix is changing this and publishing to Kafka synchronously, assuming that if the call succeeds, Kafka partitions should be ready. Then processor should be able to access metadata

closes : https://github.com/hazelcast/hazelcast/issues/22858

Backport of #22913

Breaking changes (list specific methods/types/messages):

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Request reviewers if possible
