### PR TITLE
Guard pip install with flock [HZ-1756] [5.2.z]

### DIFF
--- a/extensions/python/src/main/resources/jet_to_python_init.sh
+++ b/extensions/python/src/main/resources/jet_to_python_init.sh
@@ -5,8 +5,10 @@ set -e -x
 
 python3 -m venv jet_to_python_env --system-site-packages
 source jet_to_python_env/bin/activate
-python3 -m pip install --upgrade pip
-python3 -m pip install protobuf==@protobuf.version@ grpcio==@grpc.version@
+
+flock --exclusive ~/.jet-pip.lock python3 -m pip install --upgrade pip
+flock --exclusive ~/.jet-pip.lock python3 -m pip install protobuf==@protobuf.version@ grpcio==@grpc.version@
+
 [[ -f requirements.txt ]] && python3 -m pip install -r requirements.txt
 source ./jet_to_python_params.sh
 if [[ -f init.sh ]]; then


### PR DESCRIPTION
The tests run multiple instances, each instance using a different virtual environment.

The issue looks similar to this https://github.com/pypa/pip/issues/2361

It seems there are still issues with concurrent pip runs.

Added flock to guard all pip executions.

Fixes #22599

Backport of #22829


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
