### PR TITLE
Use client drivers in ClientQueryCacheBounceTest [5.2.z] [API-1661]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientQueryBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientQueryBounceTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.map;
 import com.hazelcast.map.QueryBounceTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -28,5 +29,8 @@ import org.junit.runner.RunWith;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
 public class ClientQueryBounceTest extends QueryBounceTest {
-
+    @Override
+    protected BounceTestConfiguration.DriverType getDriverType() {
+        return BounceTestConfiguration.DriverType.CLIENT;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
@@ -55,7 +55,7 @@ public class QueryBounceTest {
             BounceMemberRule.with(getConfig())
                     .clusterSize(4)
                     .driverCount(4)
-                    .driverType(BounceTestConfiguration.DriverType.MEMBER)
+                    .driverType(getDriverType())
                     .useTerminate(useTerminate())
                     .build();
 
@@ -80,6 +80,10 @@ public class QueryBounceTest {
     // nice with rules: parameters are injected after rules instantiation.
     protected boolean useTerminate() {
         return false;
+    }
+
+    protected BounceTestConfiguration.DriverType getDriverType() {
+        return BounceTestConfiguration.DriverType.MEMBER;
     }
 
     private void prepareAndRunQueryTasks(boolean withIndexes) {


### PR DESCRIPTION
The test was not setting the driver to be used, and was using everything from the superclass as it is.

It was causing the test to use member drivers. To solve it, I made the driver type configurable and set it to the client driver type only in the ClientQueryCacheBounceTest.

clean backport of #22867