### PR TITLE
Remove left over unlock line from TxnLockAndGetOpSteps [HZ-1797]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnLockAndGetOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnLockAndGetOpSteps.java
@@ -38,7 +38,6 @@ public enum TxnLockAndGetOpSteps implements IMapOpStep {
             boolean blockReads = state.isBlockReads();
             long callId = state.getOperation().getCallId();
 
-            recordStore.unlock(dataKey, ownerUuid, threadId, callId);
             if (!recordStore.txnLock(dataKey, ownerUuid, threadId, callId, ttl, blockReads)) {
                 throw new TransactionException("Transaction couldn't obtain lock.");
             }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWithTransactionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWithTransactionsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.mapstore;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.map.MapStoreAdapter;
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalMap;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParametrizedRunner.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({ParallelJVMTest.class, QuickTest.class})
+public class MapStoreWithTransactionsTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameters(name = "offload: {0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][] {
+                {true},
+                {false}
+        });
+    }
+
+    @Parameterized.Parameter
+    public boolean offload;
+
+    private static final String MAP_NAME = "map-with-map-store";
+    private static final int KEY_COUNT = 1_001;
+
+    @Override
+    public Config getConfig() {
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
+        config.getMapConfig(MAP_NAME)
+                .getMapStoreConfig()
+                .setEnabled(true)
+                .setOffload(offload)
+                .setImplementation(new MapStoreAdapter());
+        return config;
+    }
+
+    @Test
+    public void lock_count_is_same_with_before_after_txn_commits() {
+        HazelcastInstance node = createHazelcastInstance();
+
+        IMap map = node.getMap(MAP_NAME);
+
+        for (int i = 0; i < KEY_COUNT; i++) {
+            map.set(i, i);
+        }
+
+        for (int i = 0; i < KEY_COUNT; i++) {
+            map.lock(i);
+        }
+
+        TransactionContext context = newTransactionContext(node, TWO_PHASE);
+        context.beginTransaction();
+
+        TransactionalMap txnMap = context.getMap(MAP_NAME);
+
+        for (int i = 0; i < KEY_COUNT; i++) {
+            txnMap.set(i, i * 2);
+        }
+
+        context.commitTransaction();
+
+        for (int i = 0; i < KEY_COUNT; i++) {
+            assertTrue(map.isLocked(i));
+        }
+
+    }
+
+    private static TransactionContext newTransactionContext(HazelcastInstance node,
+                                                            TransactionOptions.TransactionType twoPhase) {
+        TransactionOptions options = new TransactionOptions()
+                .setTransactionType(twoPhase);
+        return node.newTransactionContext(options);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -192,14 +192,24 @@ public abstract class HazelcastTestSupport {
         return shrinkInstanceConfig(new Config());
     }
 
-    public static Config shrinkInstanceConfig(Config config) {
+    public static Config smallInstanceConfigWithoutJetAndMetrics() {
+        return smallInstanceConfigWithoutJetAndMetrics(new Config());
+    }
+
+    private static Config smallInstanceConfigWithoutJetAndMetrics(Config config) {
         // make the test instances consume less resources per default
         config.setProperty(ClusterProperty.PARTITION_COUNT.getName(), "11")
                 .setProperty(ClusterProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "2")
                 .setProperty(ClusterProperty.GENERIC_OPERATION_THREAD_COUNT.getName(), "2")
                 .setProperty(ClusterProperty.EVENT_THREAD_COUNT.getName(), "1");
-        config.getJetConfig().setEnabled(true).setCooperativeThreadCount(2);
+        config.getMetricsConfig().setEnabled(false);
+        config.getJetConfig().setEnabled(false);
+        return config;
+    }
 
+    public static Config shrinkInstanceConfig(Config config) {
+        smallInstanceConfigWithoutJetAndMetrics(config);
+        config.getJetConfig().setEnabled(true).setCooperativeThreadCount(2);
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -209,6 +209,7 @@ public abstract class HazelcastTestSupport {
 
     public static Config shrinkInstanceConfig(Config config) {
         smallInstanceConfigWithoutJetAndMetrics(config);
+        config.getMetricsConfig().setEnabled(true);
         config.getJetConfig().setEnabled(true).setCooperativeThreadCount(2);
         return config;
     }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/22674 (thanks @orcunc for bringing it to me)
closes https://github.com/hazelcast/hazelcast/issues/22937

**Fix:**
This is a copy/paste error, line with unlock must not be there.