### PR TITLE
Send PreJoin ops from joining to master in JoinRequest [HZ-1733]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -57,6 +57,7 @@ import com.hazelcast.internal.cluster.impl.MulticastJoiner;
 import com.hazelcast.internal.cluster.impl.MulticastService;
 import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage;
 import com.hazelcast.internal.cluster.impl.TcpIpJoiner;
+import com.hazelcast.internal.cluster.impl.operations.OnJoinOp;
 import com.hazelcast.internal.config.AliasedDiscoveryConfigUtils;
 import com.hazelcast.internal.config.DiscoveryConfigReadOnly;
 import com.hazelcast.internal.config.MemberAttributeConfigReadOnly;
@@ -97,6 +98,7 @@ import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.eventservice.impl.operations.OnJoinRegistrationOperation;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -106,6 +108,7 @@ import com.hazelcast.version.Version;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -870,9 +873,11 @@ public class Node {
         MemberImpl localMember = getLocalMember();
         CPMemberInfo localCPMember = getLocalCPMember();
         UUID cpMemberUUID = localCPMember != null ? localCPMember.getUuid() : null;
+        OnJoinRegistrationOperation preJoinOps = nodeEngine.getEventService().getPreJoinOperation();
+        OnJoinOp onJoinOp = preJoinOps != null ? new OnJoinOp(Collections.singletonList(preJoinOps)) : null;
         return new JoinRequest(Packet.VERSION, buildInfo.getBuildNumber(), version, address,
                 localMember.getUuid(), localMember.isLiteMember(), createConfigCheck(), credentials,
-                localMember.getAttributes(), excludedMemberUuids, localMember.getAddressMap(), cpMemberUUID);
+                localMember.getAttributes(), excludedMemberUuids, localMember.getAddressMap(), cpMemberUUID, onJoinOp);
     }
 
     private CPMemberInfo getLocalCPMember() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -799,7 +799,6 @@ public class ClusterJoinManager {
 
                 // post join operations must be lock free, that means no locks at all:
                 // no partition locks, no key-based locks, no service level locks!
-                OnJoinOp preJoinOp = preparePreJoinOps();
                 OnJoinOp postJoinOp = preparePostJoinOp();
 
                 // this is the current partition assignment state, not taking into account the

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -765,7 +765,7 @@ public class ClusterJoinManager {
     /**
      * Starts join process on master member.
      *
-     * @param preJoinOperation
+     * @param preJoinOperation joining member's preJoinOperation, not master's
      */
     private void startJoin(OnJoinOp preJoinOperation) {
         logger.fine("Starting join...");
@@ -790,6 +790,8 @@ public class ClusterJoinManager {
                 if (!clusterService.updateMembers(newMembersView, node.getThisAddress(), thisUuid, thisUuid)) {
                     return;
                 }
+
+                OnJoinOp preJoinOp = preparePreJoinOps();
 
                 if (preJoinOperation != null) {
                     nodeEngine.getOperationService().run(preJoinOperation);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl;
 
+import com.hazelcast.internal.cluster.impl.operations.OnJoinOp;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.cluster.MemberInfo;
@@ -40,8 +41,9 @@ import static java.util.Collections.unmodifiableSet;
 
 public class JoinRequest extends JoinMessage {
 
-    // RU_COMPAT 5.1
-    private static final String VERSION_5_2_0 = "5.2.0";
+    // RU_COMPAT 5.2
+    private static final String VERSION_5_3_0 = "5.3.0";
+    private static final MemberVersion CURRENT = MemberVersion.of(VERSION_5_3_0);
 
     private Credentials credentials;
     private int tryCount;
@@ -50,6 +52,7 @@ public class JoinRequest extends JoinMessage {
     // see Member.getAddressMap
     private Map<EndpointQualifier, Address> addresses;
     private UUID cpMemberUUID;
+    private OnJoinOp preJoinOperation;
 
     public JoinRequest() {
     }
@@ -57,7 +60,8 @@ public class JoinRequest extends JoinMessage {
     @SuppressWarnings("checkstyle:parameternumber")
     public JoinRequest(byte packetVersion, int buildNumber, MemberVersion version, Address address, UUID uuid,
                        boolean liteMember, ConfigCheck config, Credentials credentials, Map<String, String> attributes,
-                       Set<UUID> excludedMemberUuids, Map<EndpointQualifier, Address> addresses, UUID cpMemberUUID) {
+                       Set<UUID> excludedMemberUuids, Map<EndpointQualifier, Address> addresses, UUID cpMemberUUID,
+                       OnJoinOp preJoinOperation) {
         super(packetVersion, buildNumber, version, address, uuid, liteMember, config);
         this.credentials = credentials;
         this.attributes = attributes;
@@ -66,6 +70,7 @@ public class JoinRequest extends JoinMessage {
         }
         this.addresses = addresses;
         this.cpMemberUUID = cpMemberUUID;
+        this.preJoinOperation = preJoinOperation;
     }
 
     @SuppressWarnings("checkstyle:parameternumber")
@@ -73,7 +78,7 @@ public class JoinRequest extends JoinMessage {
                        boolean liteMember, ConfigCheck config, Credentials credentials, Map<String, String> attributes,
                        Set<UUID> excludedMemberUuids, Map<EndpointQualifier, Address> addresses) {
         this(packetVersion, buildNumber, version, address, uuid, liteMember, config, credentials, attributes,
-                excludedMemberUuids, addresses, null);
+                excludedMemberUuids, addresses, null, null);
     }
 
     public Credentials getCredentials() {
@@ -94,6 +99,10 @@ public class JoinRequest extends JoinMessage {
 
     public Set<UUID> getExcludedMemberUuids() {
         return excludedMemberUuids;
+    }
+
+    public OnJoinOp getPreJoinOperation() {
+        return preJoinOperation;
     }
 
     public MemberInfo toMemberInfo() {
@@ -120,11 +129,10 @@ public class JoinRequest extends JoinMessage {
 
         this.excludedMemberUuids = unmodifiableSet(excludedMemberUuids);
         this.addresses = readMap(in);
-        // RU_COMPAT 5.1
-        MemberVersion current = MemberVersion.of(VERSION_5_2_0);
-        if (MemberVersion.MAJOR_MINOR_VERSION_COMPARATOR.compare(this.memberVersion, current) >= 0) {
-            // member is at least 5.2, we expect cpMemberUuid exists in the incoming packet
-            cpMemberUUID = UUIDSerializationUtil.readUUID(in);
+        cpMemberUUID = UUIDSerializationUtil.readUUID(in);
+        // RU_COMPAT 5.2
+        if (MemberVersion.MAJOR_MINOR_VERSION_COMPARATOR.compare(this.memberVersion, CURRENT) >= 0) {
+            preJoinOperation = in.readObject();
         }
     }
 
@@ -144,6 +152,7 @@ public class JoinRequest extends JoinMessage {
         }
         writeMap(addresses, out);
         UUIDSerializationUtil.writeUUID(out, cpMemberUUID);
+        out.writeObject(preJoinOperation);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinRequestOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinRequestOp.java
@@ -21,8 +21,12 @@ import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.JoinRequest;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.OperationAccessor;
 
 import java.io.IOException;
+
+import static com.hazelcast.spi.impl.operationservice.OperationResponseHandlerFactory.createEmptyResponseHandler;
 
 public class JoinRequestOp extends AbstractClusterOperation {
 
@@ -38,7 +42,22 @@ public class JoinRequestOp extends AbstractClusterOperation {
     @Override
     public void run() {
         ClusterServiceImpl cm = getService();
+        preparePreOp(request.getPreJoinOperation());
         cm.getClusterJoinManager().handleJoinRequest(request, getConnection());
+    }
+
+    private void preparePreOp(OnJoinOp preOp) {
+        if (preOp == null) {
+            return;
+        }
+
+        ClusterServiceImpl clusterService = getService();
+        NodeEngineImpl nodeEngine = clusterService.getNodeEngine();
+
+        preOp.setNodeEngine(nodeEngine);
+        OperationAccessor.setCallerAddress(preOp, getCallerAddress());
+        OperationAccessor.setConnection(preOp, getConnection());
+        preOp.setOperationResponseHandler(createEmptyResponseHandler());
     }
 
     public JoinRequest getRequest() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/services/PreJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/services/PreJoinAwareService.java
@@ -22,8 +22,8 @@ import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 
 /**
  * Services which need to perform operations on a joining member just before the member is set as joined must implement
- * this interface. These operations are executed on the joining member before it is set as joined, in contrast to
- * {@link PostJoinAwareService#getPostJoinOperation()}s which are executed on the joining member after it is set as joined.
+ *  * this interface. These operations are executed on the joining member before it is set as joined, in contrast to
+ *  * {@link PostJoinAwareService#getPostJoinOperation()}s which are executed on the joining member after it is set as joined.
  * The practical outcome is that pre-join operations are already executed before the {@link com.hazelcast.core.HazelcastInstance}
  * is returned to the caller, while post-join operations may be still executing.
  * Additionally, pre-join operations must implement {@link AllowedDuringPassiveState}, since they have to be executed
@@ -39,7 +39,7 @@ public interface PreJoinAwareService<T extends Operation & AllowedDuringPassiveS
      * locks, no database interaction are allowed. Additionally, a pre-join operation is executed while the cluster
      * lock is being held on the joining member, so it is important that the operation finishes quickly and does not
      * interact with other locks.
-     *
+     * <p>
      * The {@link Operation#getPartitionId()} method should return a negative value.
      * This means that the operations should not implement {@link PartitionAwareOperation}.
      * <p>

--- a/hazelcast/src/main/java/com/hazelcast/internal/services/PreJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/services/PreJoinAwareService.java
@@ -22,8 +22,8 @@ import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 
 /**
  * Services which need to perform operations on a joining member just before the member is set as joined must implement
- *  * this interface. These operations are executed on the joining member before it is set as joined, in contrast to
- *  * {@link PostJoinAwareService#getPostJoinOperation()}s which are executed on the joining member after it is set as joined.
+ * this interface. These operations are executed on the joining member before it is set as joined, in contrast to
+ * {@link PostJoinAwareService#getPostJoinOperation()}s which are executed on the joining member after it is set as joined.
  * The practical outcome is that pre-join operations are already executed before the {@link com.hazelcast.core.HazelcastInstance}
  * is returned to the caller, while post-join operations may be still executing.
  * Additionally, pre-join operations must implement {@link AllowedDuringPassiveState}, since they have to be executed

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/EventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/EventService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.eventservice;
 
 import com.hazelcast.internal.nio.Packet;
+import com.hazelcast.internal.services.PostJoinAwareService;
 import com.hazelcast.internal.services.PreJoinAwareService;
 import com.hazelcast.spi.impl.eventservice.impl.operations.OnJoinRegistrationOperation;
 import com.hazelcast.spi.properties.ClusterProperty;
@@ -29,7 +30,7 @@ import java.util.function.Consumer;
 /**
  * Component responsible for handling events like topic events or map.listener events. The events are divided into topics.
  */
-public interface EventService extends Consumer<Packet>, PreJoinAwareService<OnJoinRegistrationOperation> {
+public interface EventService extends Consumer<Packet>, PreJoinAwareService<OnJoinRegistrationOperation>, PostJoinAwareService {
 
     /**
      * Returns the event thread count.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/EventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/EventService.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spi.impl.eventservice;
 
 import com.hazelcast.internal.nio.Packet;
-import com.hazelcast.internal.services.PostJoinAwareService;
 import com.hazelcast.internal.services.PreJoinAwareService;
 import com.hazelcast.spi.impl.eventservice.impl.operations.OnJoinRegistrationOperation;
 import com.hazelcast.spi.properties.ClusterProperty;
@@ -30,7 +29,7 @@ import java.util.function.Consumer;
 /**
  * Component responsible for handling events like topic events or map.listener events. The events are divided into topics.
  */
-public interface EventService extends Consumer<Packet>, PreJoinAwareService<OnJoinRegistrationOperation>, PostJoinAwareService {
+public interface EventService extends Consumer<Packet>, PreJoinAwareService<OnJoinRegistrationOperation> {
 
     /**
      * Returns the event thread count.
@@ -135,9 +134,9 @@ public interface EventService extends Consumer<Packet>, PreJoinAwareService<OnJo
      * @throws IllegalArgumentException if the listener or filter is {@code null}
      */
     CompletableFuture<EventRegistration> registerListenerAsync(@Nonnull String serviceName,
-                                       @Nonnull String topic,
-                                       @Nonnull EventFilter filter,
-                                       @Nonnull Object listener);
+                                                               @Nonnull String topic,
+                                                               @Nonnull EventFilter filter,
+                                                               @Nonnull Object listener);
 
     /**
      * Deregisters a listener with the given registration ID.
@@ -167,8 +166,8 @@ public interface EventService extends Consumer<Packet>, PreJoinAwareService<OnJo
      * @see #registerLocalListener(String, String, Object)
      */
     CompletableFuture<Boolean> deregisterListenerAsync(@Nonnull String serviceName,
-                               @Nonnull String topic,
-                               @Nonnull Object id);
+                                                       @Nonnull String topic,
+                                                       @Nonnull Object id);
 
     /**
      * Deregisters all listeners belonging to the given service and topic.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -18,7 +18,6 @@ package com.hazelcast.spi.impl.eventservice.impl;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.impl.MemberImpl;
-import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
@@ -677,16 +676,9 @@ public class EventServiceImpl implements EventService, StaticMetricsProvider {
 
     @Override
     public OnJoinRegistrationOperation getPreJoinOperation() {
-        // pre-join operations are only sent by master member
+        // EventService's pre-join operations are only sent by master member
+        // also EventService's pre-join op is sent from joining member to master in JoinRequest
         return getOnJoinRegistrationOperation();
-    }
-
-    @Override
-    public Operation getPostJoinOperation() {
-        ClusterService clusterService = nodeEngine.getClusterService();
-        // Send post join registration operation only if this is the newly joining member.
-        // Master will send registrations with pre-join operation.
-        return clusterService.isMaster() ? null : getOnJoinRegistrationOperation();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -681,6 +681,15 @@ public class EventServiceImpl implements EventService, StaticMetricsProvider {
         return getOnJoinRegistrationOperation();
     }
 
+    @Override
+    public Operation getPostJoinOperation() {
+        // The post join operation can reach another member with some delay.
+        // This could lead to an issue (for example, the proxy creation on a secondary member) if it was used for the
+        // event registration (see https://github.com/hazelcast/hazelcast/issues/18381#issuecomment-952843577)
+
+        return null;
+    }
+
     /**
      * Collects all non-local registrations and returns them as a {@link OnJoinRegistrationOperation}.
      *

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -741,17 +741,15 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
     @Test
     public void testListenerRegistrationWhileANewMemberJoining() {
         CountDownLatch latch = new CountDownLatch(1);
+        Config config = getConfigWithService(new PostJoinAwareServiceImpl(latch), PostJoinAwareServiceImpl.SERVICE_NAME);
 
-        Config masterConfig = getConfigWithService(new PostJoinAwareServiceImpl(latch), PostJoinAwareServiceImpl.SERVICE_NAME);
-        HazelcastInstance hz1 = factory.newHazelcastInstance(masterConfig);
-
-        Config joiningConfig = getConfigWithService(new PostJoinAwareServiceImpl(latch), PostJoinAwareServiceImpl.SERVICE_NAME);
         EntryListenerConfig listenerConfig = new EntryListenerConfig();
-        CountDownLatch entryAddedLatch = new CountDownLatch(1);
+        CountDownLatch entryAddedLatch = new CountDownLatch(2);
         listenerConfig.setImplementation((EntryAddedListener) event -> entryAddedLatch.countDown());
-        joiningConfig.getMapConfig("test").addEntryListenerConfig(listenerConfig);
+        config.getMapConfig("test").addEntryListenerConfig(listenerConfig);
 
-        factory.newHazelcastInstance(joiningConfig);
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance(config);
 
         IMap<Object, Object> map = hz1.getMap("test");
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConfigAccessor;
+import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.StaticMemberNodeContext;
@@ -32,6 +33,8 @@ import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.services.PostJoinAwareService;
 import com.hazelcast.internal.services.PreJoinAwareService;
+import com.hazelcast.map.IMap;
+import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -733,6 +736,30 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         assertClusterSize(2, instance2);
         assertFalse(service.otherOpExecutedBeforePreJoin.get());
         assertTrue(service.preJoinOpExecutionCompleted.get());
+    }
+
+    @Test
+    public void testListenerRegistrationWhileANewMemberJoining() {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        Config masterConfig = getConfigWithService(new PostJoinAwareServiceImpl(latch), PostJoinAwareServiceImpl.SERVICE_NAME);
+        HazelcastInstance hz1 = factory.newHazelcastInstance(masterConfig);
+
+        Config joiningConfig = getConfigWithService(new PostJoinAwareServiceImpl(latch), PostJoinAwareServiceImpl.SERVICE_NAME);
+        EntryListenerConfig listenerConfig = new EntryListenerConfig();
+        CountDownLatch entryAddedLatch = new CountDownLatch(1);
+        listenerConfig.setImplementation((EntryAddedListener) event -> entryAddedLatch.countDown());
+        joiningConfig.getMapConfig("test").addEntryListenerConfig(listenerConfig);
+
+        factory.newHazelcastInstance(joiningConfig);
+
+        IMap<Object, Object> map = hz1.getMap("test");
+
+        map.put(1, 1);
+
+        //Let post join continue only after put happened
+        latch.countDown();
+        assertOpenEventually(entryAddedLatch);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
@@ -41,7 +41,6 @@ import com.hazelcast.spi.impl.eventservice.EventFilter;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
 import com.hazelcast.spi.impl.eventservice.impl.operations.OnJoinRegistrationOperation;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import javax.annotation.Nonnull;
@@ -331,11 +330,6 @@ public class MockServerContext implements ServerContext {
 
             @Override
             public void close(EventRegistration eventRegistration) {
-            }
-
-            @Override
-            public Operation getPostJoinOperation() {
-                return null;
             }
 
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/MockServerContext.java
@@ -41,6 +41,7 @@ import com.hazelcast.spi.impl.eventservice.EventFilter;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
 import com.hazelcast.spi.impl.eventservice.impl.operations.OnJoinRegistrationOperation;
+import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import javax.annotation.Nonnull;
@@ -330,6 +331,11 @@ public class MockServerContext implements ServerContext {
 
             @Override
             public void close(EventRegistration eventRegistration) {
+            }
+
+            @Override
+            public Operation getPostJoinOperation() {
+                return null;
             }
 
             @Override


### PR DESCRIPTION
Make the PreJoin operation a part of `JoinRequest` to run it after authentication on the master, and remove it from the `FinalizeJoinOp`.

This should prevent "losing" proxy creation on secondary.
Details in the comment:  https://github.com/hazelcast/hazelcast/issues/18381#issuecomment-952843577
Based on unfinished PR https://github.com/hazelcast/hazelcast/pull/19859

Fixes #19988

Breaking changes (list specific methods/types/messages):
- Introduce a new parameter `OnJoinOp` in `JoinRequest`

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
