### PR TITLE
Increase Kafka timeouts in WriteKafkaPTest

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/DockerizedKafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/DockerizedKafkaTestSupport.java
@@ -28,7 +28,7 @@ import java.util.Properties;
 
 class DockerizedKafkaTestSupport extends KafkaTestSupport {
 
-    private static final String TEST_KAFKA_VERSION = System.getProperty("test.kafka.version", "7.1.1");
+    private static final String TEST_KAFKA_VERSION = System.getProperty("test.kafka.version", "7.3.0");
     private static final Logger LOGGER = LoggerFactory.getLogger(DockerizedKafkaTestSupport.class);
 
     private KafkaContainer kafkaContainer;

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.kafka.impl;
 
-import com.hazelcast.test.DockerTestUtil;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewPartitions;
@@ -46,6 +45,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.test.DockerTestUtil.dockerEnabled;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -55,16 +55,16 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public abstract class KafkaTestSupport {
-    static final long KAFKA_MAX_BLOCK_MS = MINUTES.toMillis(10);
+    static final long KAFKA_MAX_BLOCK_MS = MINUTES.toMillis(2);
     protected Admin admin;
     protected KafkaProducer<Integer, String> producer;
     protected String brokerConnectionString;
     private KafkaProducer<String, String> stringStringProducer;
 
     public static KafkaTestSupport create() {
-        if (!DockerTestUtil.dockerEnabled()) {
+        if (!dockerEnabled()) {
             if (System.getProperties().containsKey("test.kafka.version")) {
-                throw new IllegalArgumentException("'test.kafka.version' system property requires docker and x86_64 CPU");
+                throw new IllegalArgumentException("'test.kafka.version' system property requires docker enabled");
             }
             return new EmbeddedKafkaTestSupport();
         } else {

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
@@ -57,6 +57,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.kafka.impl.KafkaTestSupport.KAFKA_MAX_BLOCK_MS;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static org.junit.Assert.assertEquals;
@@ -69,7 +70,7 @@ public class WriteKafkaPTest extends SimpleTestInClusterSupport {
 
     private static KafkaTestSupport kafkaTestSupport;
 
-    private String sourceIMapName = randomMapName();
+    private final String sourceIMapName = randomMapName();
     private Properties properties;
     private String topic;
     private IMap<Integer, String> sourceIMap;
@@ -87,6 +88,7 @@ public class WriteKafkaPTest extends SimpleTestInClusterSupport {
         properties.setProperty("bootstrap.servers", kafkaTestSupport.getBrokerConnectionString());
         properties.setProperty("key.serializer", IntegerSerializer.class.getName());
         properties.setProperty("value.serializer", StringSerializer.class.getName());
+        properties.setProperty("max.block.ms", String.valueOf(KAFKA_MAX_BLOCK_MS));
 
         topic = randomName();
         kafkaTestSupport.createTopic(topic, PARTITION_COUNT);

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
@@ -16,11 +16,6 @@
 
 package com.hazelcast.internal.util;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-
 /**
  * Helper methods related to operating system on which the code is actually running.
  */
@@ -59,31 +54,6 @@ public final class OsHelper {
      */
     public static boolean isMac() {
         return (OS.contains("mac") || OS.contains("darwin"));
-    }
-
-    /**
-     * Returns {@code true} if the system is a Mac OS with Arm CPU, e.g. M1.
-     *
-     * @return {@code true} if the system is a Mac OS with Arm CPU, e.g. M1.
-     */
-    public static boolean isArmMac() {
-        if (!isMac()) {
-            return false;
-        }
-        try {
-            Process process = new ProcessBuilder("sysctl", "-n", "hw.optional.arm64")
-                    .redirectErrorStream(true)
-                    .start();
-            process.waitFor();
-            try (InputStream is = process.getInputStream()) {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(is));
-                String line = reader.readLine();
-                return line.equals("1");
-            }
-        } catch (IOException | InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return false;
-        }
     }
 
     /**


### PR DESCRIPTION
To make test less likely to be flaky, I've:
- increased timeout of operations
- bumped image to newest versions, so that Mac users will be able to test everything normally.

Fixes #21792

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
