### PR TITLE
Fix flaky HibernateIT tests [HZ-1791]

### DIFF
--- a/hazelcast-it/distribution-it/pom.xml
+++ b/hazelcast-it/distribution-it/pom.xml
@@ -17,7 +17,7 @@
         <activation.version>1.1.1</activation.version>
         <hsqldb.version>2.7.0</hsqldb.version>
         <hibernate-core.version>5.3.7.Final</hibernate-core.version>
-        <hazelcast-hibernate53.version>2.2.1</hazelcast-hibernate53.version>
+        <hazelcast-hibernate53.version>5.0.0</hazelcast-hibernate53.version>
     </properties>
 
     <dependencies>

--- a/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/hibernate/HibernateIT.java
+++ b/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/hibernate/HibernateIT.java
@@ -86,6 +86,10 @@ public class HibernateIT extends HazelcastTestSupport {
         tx.commit();
         session.close();
 
+        //test can fail on macOS docker-desktop due to small (1-2ms) clock drifts on VM
+        //`HazelcastTimestamper.nextTimestamp` returns future time which leads to cache misses
+        sleepMillis(10);
+
         for (int i = 0; i < 10; i++) {
             session = sessionFactory.openSession();
             AnnotatedEntity retrieved = session.get(AnnotatedEntity.class, (long) 1);


### PR DESCRIPTION
- Upgraded `hazelcast-hibernate` to the fixed version
- Removed flakiness on macOS machines (tests can fail on macOS docker-desktop due to small (1-2ms) clock drifts on VM)

Fixes https://github.com/hazelcast/hazelcast/issues/22730
Fixes https://hazelcast.atlassian.net/browse/HZ-1791