### PR TITLE
Fix assert in LocalIndexStatsTest.testInsertsTracking [HZ-1792] [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 
 import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_COUNT;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -490,8 +491,8 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
             totalMeasuredLatency += Timer.nanosElapsed(startNanos);
 
             assertEquals(i, keyStats().getInsertCount());
-            assertTrue(keyStats().getTotalInsertLatency() > previousTotalInsertLatency);
-            assertTrue(keyStats().getTotalInsertLatency() <= totalMeasuredLatency);
+            assertThat(keyStats().getTotalInsertLatency()).isGreaterThanOrEqualTo(previousTotalInsertLatency);
+            assertThat(keyStats().getTotalInsertLatency()).isLessThanOrEqualTo(totalMeasuredLatency);
 
             previousTotalInsertLatency = keyStats().getTotalInsertLatency();
         }


### PR DESCRIPTION
The cost of index insert operation is calculated with only 1 function call. Call sequence is below AbstractIndex.putEntry <- get timestamp
GlobalPerIndexStats.onInsert <- find elapsed time

Probably these calls are executed very fast and elapsed time is 0 nanoseconds. The test case assumes that current getTotalInsertLatency > previous getTotalInsertLatency

However this assumption may not hold. Therefore, I am changing the logic to become current getTotalInsertLatency >= previous getTotalInsertLatency

Fixes : https://github.com/hazelcast/hazelcast/issues/19375

Backport of : https://github.com/hazelcast/hazelcast/pull/22930

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

