### PR TITLE
Reset migration listener counters on migration start [HZ-1771]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -390,17 +390,14 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
         }
 
         /**
-         * Migration can be re-started due to some timing issues,
+         * Migration can be re-started due to some issues,
          * this reset is used to track whether we have expected
-         * number of migrations in case of a successful run.
+         * number of migration started and completed events.
+         * Per each start we expect one matching completion.
          */
         public void reset() {
             migrationStarted.set(0);
             migrationCompleted.set(0);
-            for (int i = 0; i < numberOfPartitions; i++) {
-                replicaMigrationCompleted[i].set(0);
-                replicaMigrationFailed[i].set(0);
-            }
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -147,7 +147,7 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
         MigrationEventsPack secondEventsPack = eventsPackList.get(1);
 
         if (secondEventsPack.migrationProcessCompleted.getCompletedMigrations() == 1
-            && !secondEventsPack.migrationsCompleted.get(0).isSuccess()) {
+                && !secondEventsPack.migrationsCompleted.get(0).isSuccess()) {
             // There is a failed migration process
             // because migrations restarted before 3rd member is ready.
             // This migration process is failed immediately
@@ -371,24 +371,42 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
 
     private static class CountingMigrationListener implements MigrationListener {
 
+        final int numberOfPartitions;
         final AtomicInteger migrationStarted;
         final AtomicInteger migrationCompleted;
         final AtomicInteger[] replicaMigrationCompleted;
         final AtomicInteger[] replicaMigrationFailed;
 
         CountingMigrationListener(int partitionCount) {
+            numberOfPartitions = partitionCount;
             migrationStarted = new AtomicInteger();
             migrationCompleted = new AtomicInteger();
-            replicaMigrationCompleted = new AtomicInteger[partitionCount];
-            replicaMigrationFailed = new AtomicInteger[partitionCount];
-            for (int i = 0; i < partitionCount; i++) {
+            replicaMigrationCompleted = new AtomicInteger[numberOfPartitions];
+            replicaMigrationFailed = new AtomicInteger[numberOfPartitions];
+            for (int i = 0; i < numberOfPartitions; i++) {
                 replicaMigrationCompleted[i] = new AtomicInteger();
                 replicaMigrationFailed[i] = new AtomicInteger();
             }
         }
 
+        /**
+         * Migration can be re-started due to some timing issues,
+         * this reset is used to track whether we have expected
+         * number of migrations in case of a successful run.
+         */
+        public void reset() {
+            migrationStarted.set(0);
+            migrationCompleted.set(0);
+            for (int i = 0; i < numberOfPartitions; i++) {
+                replicaMigrationCompleted[i].set(0);
+                replicaMigrationFailed[i].set(0);
+            }
+        }
+
         @Override
         public void migrationStarted(MigrationState state) {
+            // reset counter in every start
+            reset();
             migrationStarted.incrementAndGet();
         }
 


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/17776

please see short reasoning here: https://github.com/hazelcast/hazelcast/pull/22952/files#diff-db7eadb24d613f215e885dded0bac730c99382286e228ff87923e5ceaca4d018R393

for details, you can see @vbekiaris comment: https://github.com/hazelcast/hazelcast/issues/16299#issuecomment-775201557