### PR TITLE
Improve WAN Sync publishing mechanism [HZ-1416]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/SchemaReplicator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/schema/SchemaReplicator.java
@@ -328,7 +328,7 @@ public class SchemaReplicator {
 
     // Not private for tests
     InternalCompletableFuture<Collection<UUID>> sendRequestForPreparation(Schema schema) {
-        return InvocationUtil.invokeOnStableClusterParallel(
+        return InvocationUtil.invokeOnStableClusterParallelExcludeLocal(
                 nodeEngine,
                 new PrepareSchemaReplicationOperationSupplier(schema, nodeEngine),
                 MAX_RETRIES_FOR_REQUESTS
@@ -337,7 +337,7 @@ public class SchemaReplicator {
 
     // Not private for tests
     InternalCompletableFuture<Collection<UUID>> sendRequestForAcknowledgment(long schemaId) {
-        return InvocationUtil.invokeOnStableClusterParallel(
+        return InvocationUtil.invokeOnStableClusterParallelExcludeLocal(
                 nodeEngine,
                 new AckSchemaReplicationOperationSupplier(schemaId, nodeEngine),
                 MAX_RETRIES_FOR_REQUESTS

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static com.hazelcast.internal.util.IterableUtil.map;
@@ -46,6 +47,8 @@ import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFutur
  * Utility methods for invocations.
  */
 public final class InvocationUtil {
+    private static final Predicate<Member> ALL_MEMBERS_FILTER = member -> true;
+    private static final Predicate<Member> EXCLUDE_LOCAL_MEMBERS_FILTER = member -> !member.localMember();
 
     private InvocationUtil() {
     }
@@ -53,10 +56,12 @@ public final class InvocationUtil {
     /**
      * Invoke operation on all cluster members.
      *
+     * <p>
      * The invocation is serial: It iterates over all members starting from the oldest member to the youngest one.
      * If there is a cluster membership change while invoking then it will restart invocations on all members. This
      * implies the operation should be idempotent.
      *
+     * <p>
      * If there is an exception - other than {@link com.hazelcast.core.MemberLeftException} or
      * {@link com.hazelcast.spi.exception.TargetNotMemberException} while invoking then the iteration
      * is interrupted and the exception is propagated to the caller.
@@ -116,14 +121,33 @@ public final class InvocationUtil {
         return execution;
     }
 
+    public static InternalCompletableFuture<Collection<UUID>> invokeOnStableClusterParallel(
+            NodeEngine nodeEngine,
+            Supplier<Operation> operationSupplier,
+            int maxRetries
+    ) {
+        return invokeOnStableClusterParallel(nodeEngine, operationSupplier, maxRetries, ALL_MEMBERS_FILTER);
+    }
+
+    public static InternalCompletableFuture<Collection<UUID>> invokeOnStableClusterParallelExcludeLocal(
+            NodeEngine nodeEngine,
+            Supplier<Operation> operationSupplier,
+            int maxRetries
+    ) {
+        return invokeOnStableClusterParallel(nodeEngine, operationSupplier, maxRetries, EXCLUDE_LOCAL_MEMBERS_FILTER);
+    }
+
     /**
-     * Invokes the given operation on all cluster members (excluding this
-     * member), in parallel.
+     * Invokes the given operation on all cluster members that
+     * {@code memberFilter} returns {@code true}.
+     *
      * <p>
      * The operation is retried until the cluster is stable between the start
      * and the end of the invocations.
+     *
      * <p>
      * The operations invoked with this method should be idempotent.
+     *
      * <p>
      * If one of the invocations throw any exception other than the
      * {@link ClusterTopologyChangedException}, {@link MemberLeftException},
@@ -131,24 +155,26 @@ public final class InvocationUtil {
      * {@link HazelcastInstanceNotActiveException} the method fails with that
      * exception. When invocations fail with <b>only</b>
      * {@code ClusterTopologyChangedException}, the invocations are retried.
-     * When invocations fail with <b>only<b/> {@code MemberLeftException},
+     * When invocations fail with <b>only</b> {@code MemberLeftException},
      * {@code TargetNotMemberException}, or
      * {@code HazelcastInstanceNotActiveException} the exceptions are ignored
      * and the method returns the current member UUIDs, in a similar manner to
      * {@link #invokeOnStableClusterSerial(NodeEngine, Supplier, int)}.
+     *
      * <p>
      * Between each retry, the parallel invocations are delayed for
      * {@link ClusterProperty#INVOCATION_RETRY_PAUSE} milliseconds.
      *
-     * @return the collection of the member UUIDs that the operations are
-     * invoked on
+     * @return the UUID collection of the members in stable cluster
      */
     public static InternalCompletableFuture<Collection<UUID>> invokeOnStableClusterParallel(
             NodeEngine nodeEngine,
             Supplier<Operation> operationSupplier,
-            int maxRetries
+            int maxRetries,
+            Predicate<Member> memberFilter
     ) {
-        ParallelOperationInvoker invoker = new ParallelOperationInvoker(nodeEngine, operationSupplier, maxRetries);
+        ParallelOperationInvoker invoker
+                = new ParallelOperationInvoker(nodeEngine, operationSupplier, maxRetries, memberFilter);
         return invoker.invoke();
     }
 
@@ -159,8 +185,9 @@ public final class InvocationUtil {
         private final long retryDelayMillis;
         private volatile int lastRetryCount;
 
-        InvokeOnMemberFunction(Supplier<? extends Operation> operationSupplier, NodeEngine nodeEngine,
-                RestartingMemberIterator memberIterator) {
+        InvokeOnMemberFunction(Supplier<? extends Operation> operationSupplier,
+                               NodeEngine nodeEngine,
+                               RestartingMemberIterator memberIterator) {
             this.operationSupplier = operationSupplier;
             this.nodeEngine = nodeEngine;
             this.memberIterator = memberIterator;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -47,8 +47,8 @@ import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFutur
  * Utility methods for invocations.
  */
 public final class InvocationUtil {
-    private static final Predicate<Member> ALL_MEMBERS_FILTER = member -> true;
-    private static final Predicate<Member> EXCLUDE_LOCAL_MEMBERS_FILTER = member -> !member.localMember();
+    private static final Predicate<Member> ALL_MEMBERS_MATCH = member -> true;
+    private static final Predicate<Member> ALL_BUT_LOCAL_MEMBERS_MATCH = member -> !member.localMember();
 
     private InvocationUtil() {
     }
@@ -126,7 +126,7 @@ public final class InvocationUtil {
             Supplier<Operation> operationSupplier,
             int maxRetries
     ) {
-        return invokeOnStableClusterParallel(nodeEngine, operationSupplier, maxRetries, ALL_MEMBERS_FILTER);
+        return invokeOnStableClusterParallel(nodeEngine, operationSupplier, maxRetries, ALL_MEMBERS_MATCH);
     }
 
     public static InternalCompletableFuture<Collection<UUID>> invokeOnStableClusterParallelExcludeLocal(
@@ -134,7 +134,7 @@ public final class InvocationUtil {
             Supplier<Operation> operationSupplier,
             int maxRetries
     ) {
-        return invokeOnStableClusterParallel(nodeEngine, operationSupplier, maxRetries, EXCLUDE_LOCAL_MEMBERS_FILTER);
+        return invokeOnStableClusterParallel(nodeEngine, operationSupplier, maxRetries, ALL_BUT_LOCAL_MEMBERS_MATCH);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -139,7 +139,7 @@ public final class InvocationUtil {
 
     /**
      * Invokes the given operation on all cluster members that
-     * {@code memberFilter} returns {@code true}.
+     * {@code memberFilter} returns {@code true} in parallel.
      *
      * <p>
      * The operation is retried until the cluster is stable between the start

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ParallelOperationInvoker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ParallelOperationInvoker.java
@@ -76,7 +76,7 @@ class ParallelOperationInvoker {
 
     private void doInvoke() {
         members = clusterService.getMembers();
-        InternalCompletableFuture[] futures = invokeOnFilteredMembers(members);
+        InternalCompletableFuture[] futures = invokeOnMatchingMembers(members);
         CompletableFuture.allOf(futures)
                 .whenCompleteAsync(
                         (ignored, throwable) -> completeFutureOrRetry(throwable == null, futures),
@@ -87,7 +87,7 @@ class ParallelOperationInvoker {
         nodeEngine.getExecutionService().schedule(this::doInvoke, retryDelayMillis, TimeUnit.MILLISECONDS);
     }
 
-    private InternalCompletableFuture[] invokeOnFilteredMembers(Collection<Member> members) {
+    private InternalCompletableFuture[] invokeOnMatchingMembers(Collection<Member> members) {
         return members.stream()
                 .filter(memberFilter)
                 .map(this::invokeOnMember)

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ParallelOperationInvoker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ParallelOperationInvoker.java
@@ -98,7 +98,7 @@ class ParallelOperationInvoker {
         Operation operation = operationSupplier.get();
         String serviceName = operation.getServiceName();
         Address target = member.getAddress();
-        return nodeEngine.getOperationService().invokeOnTarget(serviceName, operation, target);
+        return nodeEngine.getOperationService().invokeOnTargetAsync(serviceName, operation, target);
     }
 
     private void completeFutureOrRetry(boolean noExceptionReceived, InternalCompletableFuture[] futures) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/OperationService.java
@@ -132,6 +132,8 @@ public interface OperationService {
 
     <E> InvocationFuture<E> invokeOnTarget(String serviceName, Operation op, Address target);
 
+    <E> InvocationFuture<E> invokeOnTargetAsync(String serviceName, Operation op, Address target);
+
     <E> InvocationFuture<E> invokeOnMaster(String serviceName, Operation op);
 
     InvocationBuilder createInvocationBuilder(String serviceName, Operation op, int partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -373,6 +373,15 @@ public final class OperationServiceImpl implements StaticMetricsProvider, LiveOp
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public <E> InvocationFuture<E> invokeOnTargetAsync(String serviceName, Operation op, Address target) {
+        op.setServiceName(serviceName);
+
+        return new TargetInvocation(invocationContext, op, target, invocationMaxRetryCount, invocationRetryPauseMillis,
+                DEFAULT_CALL_TIMEOUT, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
+    }
+
+    @Override
     public <E> InvocationFuture<E> invokeOnMaster(String serviceName, Operation op) {
         op.setServiceName(serviceName);
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/InternalWanPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/InternalWanPublisher.java
@@ -57,10 +57,9 @@ public interface InternalWanPublisher<T> extends WanPublisher<T> {
      * event or trigger processing.
      * NOTE: used only in Hazelcast Enterprise.
      *
-     * @param event              the WAN anti-entropy event
-     * @param wanReplicationName the WAN replication config name
+     * @param event the WAN anti-entropy event
      */
-    default void publishAntiEntropyEvent(WanAntiEntropyEvent event, String wanReplicationName) {
+    default void publishAntiEntropyEvent(WanAntiEntropyEvent event) {
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanAntiEntropyEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanAntiEntropyEvent.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.wan.impl;
 
-import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -24,6 +23,11 @@ import java.util.UUID;
  * different types, e.g. consistency check or synchronization event.
  */
 public interface WanAntiEntropyEvent {
+
+    String getWanReplicationName();
+
+    String getWanPublisherId();
+
     /**
      * Returns the source cluster-wide unique ID for this anti-entropy event.
      *
@@ -39,11 +43,4 @@ public interface WanAntiEntropyEvent {
      * @return the object name on which this event occurred
      */
     String getObjectName();
-
-    /**
-     * Returns the set of partition IDs on which this event occurred.
-     *
-     * @return the set of partition IDs
-     */
-    Set<Integer> getPartitionSet();
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ParallelOperationInvokerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ParallelOperationInvokerTest.java
@@ -36,21 +36,28 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.version.MemberVersion;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.instance.impl.TestUtil.getNode;
 import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterParallel;
+import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterParallelExcludeLocal;
 import static com.hazelcast.spi.properties.ClusterProperty.INVOCATION_RETRY_PAUSE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -58,7 +65,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class})
 public class ParallelOperationInvokerTest extends HazelcastTestSupport {
-
+    @Rule
+    public TestName testNameRule = new TestName();
     private final TestHazelcastFactory factory = new TestHazelcastFactory();
 
     private Config config;
@@ -81,6 +89,11 @@ public class ParallelOperationInvokerTest extends HazelcastTestSupport {
         factory.terminateAll();
     }
 
+    @AfterClass
+    public static void afterClass() throws Exception {
+        InvokedMemberRecordingOperation.TEST_NAME_TO_INVOKED_MEMBER_UUIDS.clear();
+    }
+
     @Test
     public void testInvoke() {
         Node node = getNode(instance1);
@@ -92,6 +105,47 @@ public class ParallelOperationInvokerTest extends HazelcastTestSupport {
 
         Collection<UUID> expectedUuids = getUuidsOfInstances(instance1, instance2, instance3);
         assertThat(uuids)
+                .containsExactlyInAnyOrderElementsOf(expectedUuids);
+    }
+
+    @Test
+    public void testInvokeWithFilter() {
+        String testName = testNameRule.getMethodName();
+
+        Node node = getNode(instance1);
+        Collection<UUID> uuids = invokeOnStableClusterParallel(
+                node.getNodeEngine(),
+                () -> new InvokedMemberRecordingOperation(testName),
+                0,
+                member -> member.getUuid().equals(instance2.getLocalEndpoint().getUuid())
+        ).join();
+
+        Collection<UUID> expectedUuids = getUuidsOfInstances(instance1, instance2, instance3);
+        assertThat(uuids)
+                .containsExactlyInAnyOrderElementsOf(expectedUuids);
+
+        expectedUuids = getUuidsOfInstances(instance2);
+        assertThat(InvokedMemberRecordingOperation.TEST_NAME_TO_INVOKED_MEMBER_UUIDS.get(testName))
+                .containsExactlyInAnyOrderElementsOf(expectedUuids);
+    }
+
+    @Test
+    public void testInvokeWithExcludeLocalFilter() {
+        String testName = testNameRule.getMethodName();
+
+        Node node = getNode(instance1);
+        Collection<UUID> uuids = invokeOnStableClusterParallelExcludeLocal(
+                node.getNodeEngine(),
+                () -> new InvokedMemberRecordingOperation(testName),
+                0
+        ).join();
+
+        Collection<UUID> expectedUuids = getUuidsOfInstances(instance1, instance2, instance3);
+        assertThat(uuids)
+                .containsExactlyInAnyOrderElementsOf(expectedUuids);
+
+        expectedUuids = getUuidsOfInstances(instance2, instance3);
+        assertThat(InvokedMemberRecordingOperation.TEST_NAME_TO_INVOKED_MEMBER_UUIDS.get(testName))
                 .containsExactlyInAnyOrderElementsOf(expectedUuids);
     }
 
@@ -281,7 +335,11 @@ public class ParallelOperationInvokerTest extends HazelcastTestSupport {
 
         @Override
         public void run() throws Exception {
-            while (getNodeEngine().getClusterService().getMembers().size() != expectedMemberCount) {
+
+            // We exclude local because local execution may be run instead of executed.
+            // This means that it will block the method from returning the future.
+            while (!executedLocally()
+                    && getNodeEngine().getClusterService().getMembers().size() != expectedMemberCount) {
                 Thread.sleep(100);
             }
             super.run();
@@ -297,6 +355,38 @@ public class ParallelOperationInvokerTest extends HazelcastTestSupport {
         protected void readInternal(ObjectDataInput in) throws IOException {
             super.readInternal(in);
             expectedMemberCount = in.readInt();
+        }
+    }
+
+    private static class InvokedMemberRecordingOperation extends Operation {
+        private static final Map<String, Collection<UUID>> TEST_NAME_TO_INVOKED_MEMBER_UUIDS = new ConcurrentHashMap<>();
+        private String testName;
+
+        InvokedMemberRecordingOperation() {
+        }
+
+        InvokedMemberRecordingOperation(String testName) {
+            this.testName = testName;
+        }
+
+        @Override
+        public void run() throws Exception {
+            TEST_NAME_TO_INVOKED_MEMBER_UUIDS
+                    .computeIfAbsent(testName, k -> Collections.newSetFromMap(new ConcurrentHashMap<>()))
+                    .add(getNodeEngine().getLocalMember().getUuid());
+            super.run();
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            super.writeInternal(out);
+            out.writeString(testName);
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            super.readInternal(in);
+            testName = in.readString();
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ParallelOperationInvokerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ParallelOperationInvokerTest.java
@@ -335,11 +335,7 @@ public class ParallelOperationInvokerTest extends HazelcastTestSupport {
 
         @Override
         public void run() throws Exception {
-
-            // We exclude local because local execution may be run instead of executed.
-            // This means that it will block the method from returning the future.
-            while (!executedLocally()
-                    && getNodeEngine().getClusterService().getMembers().size() != expectedMemberCount) {
+            while (getNodeEngine().getClusterService().getMembers().size() != expectedMemberCount) {
                 Thread.sleep(100);
             }
             super.run();


### PR DESCRIPTION
This PR improves sync publishing mechanism.

- Removes sync event publishing retry mechanism, which was broken.
- Includes `wanReplicationName` and `wanPublisherId` in
  `AbstractWanAntiEntropyEvent` instead of passing as method parameters
  everywhere.
- Merkle sync was only replying with synced partitions, which makes sync
  fail. Now it replies including all processed (owned) partitions.
- Once sync status become FAILED, we may never exit previously, now we
  can.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/5507
