### PR TITLE
Add missing txn op steps

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -51,6 +51,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.function.Predicate;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 /**
  * Context which is needed by a map service.
  * <p>
@@ -83,6 +85,13 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport,
     HazelcastProperty FORCE_OFFLOAD_ALL_OPERATIONS
             = new HazelcastProperty(PROP_FORCE_OFFLOAD_ALL_OPERATIONS,
             DEFAULT_FORCE_OFFLOAD_ALL_OPERATIONS);
+
+    long DEFAULT_MAX_SUCCESSIVE_OFFLOADED_OP_RUN_NANOS = 0;
+    String PROP_MAX_SUCCESSIVE_OFFLOADED_OP_RUN_NANOS
+            = "hazelcast.internal.map.mapstore.max.successive.offloaded.operation.run.nanos";
+    HazelcastProperty MAX_SUCCESSIVE_OFFLOADED_OP_RUN_NANOS
+            = new HazelcastProperty(PROP_MAX_SUCCESSIVE_OFFLOADED_OP_RUN_NANOS,
+            DEFAULT_MAX_SUCCESSIVE_OFFLOADED_OP_RUN_NANOS, NANOSECONDS);
 
 
     Object toObject(Object data);
@@ -230,6 +239,24 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport,
      * operations are enabled, otherwise {@code false}.
      */
     boolean isForceOffloadEnabled();
+
+    /**
+     * By default, returns zero.
+     * <p>
+     * Independent of the number of queued offloaded operations, a
+     * {@link com.hazelcast.map.impl.operation.steps.engine.StepRunner}
+     * tries to run all queued operation in one go. This may
+     * cause biased usage of partition thread for the favour of
+     * operating map. To prevent this, one can put max execution
+     * time-limit, so partition
+     * operations of other maps don't wait longer but if there
+     * is a few maps, this limit can cause increased latencies
+     * as a side effect.
+     *
+     * @see #MAX_SUCCESSIVE_OFFLOADED_OP_RUN_NANOS
+     * @see com.hazelcast.map.impl.operation.steps.engine.StepRunner
+     */
+    long getMaxSuccessiveOffloadedOpRunNanos();
 
     Semaphore getNodeWideLoadedKeyLimiter();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -151,6 +151,7 @@ class MapServiceContextImpl implements MapServiceContext {
      */
     private final Semaphore nodeWideLoadedKeyLimiter;
     private final boolean forceOffloadEnabled;
+    private final long maxSuccessiveOffloadedOpRunNanos;
 
     private MapService mapService;
 
@@ -182,6 +183,8 @@ class MapServiceContextImpl implements MapServiceContext {
         this.logger = nodeEngine.getLogger(getClass());
         this.forceOffloadEnabled = nodeEngine.getProperties()
                 .getBoolean(FORCE_OFFLOAD_ALL_OPERATIONS);
+        this.maxSuccessiveOffloadedOpRunNanos = nodeEngine.getProperties()
+                .getNanos(MAX_SUCCESSIVE_OFFLOADED_OP_RUN_NANOS);
         if (this.forceOffloadEnabled) {
             logger.info("Force offload is enabled for all maps. This "
                     + "means all map operations will run as if they have map-store configured. "
@@ -192,6 +195,11 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public boolean isForceOffloadEnabled() {
         return forceOffloadEnabled;
+    }
+
+    @Override
+    public long getMaxSuccessiveOffloadedOpRunNanos() {
+        return maxSuccessiveOffloadedOpRunNanos;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -46,6 +46,7 @@ public abstract class BasePutOperation
     @Override
     protected void innerBeforeRun() throws Exception {
         super.innerBeforeRun();
+
         if (getStaticParams().isCheckIfLoaded() && recordStore != null) {
             recordStore.checkIfLoaded();
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -50,8 +50,8 @@ public abstract class KeyBasedMapOperation extends MapOperation
     public State createState() {
         return super.createState()
                 .setKey(dataKey)
-                .setThreadId(threadId)
-                .setNewValue(dataValue);
+                .setNewValue(dataValue)
+                .setThreadId(threadId);
     }
 
     public final Data getKey() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -198,11 +198,6 @@ public abstract class MapOperation extends AbstractNamedOperation
                 .setDisableWanReplicationEvent(disableWanReplicationEvent());
     }
 
-    @Override
-    public void applyState(State state) {
-        //
-    }
-
     protected void runInternal() {
         // Intentionally empty method body.
         // Concrete classes can override this method.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnPrepareOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnPrepareOpSteps.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation.steps;
+
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.ReachedMaxSizeException;
+import com.hazelcast.map.impl.mapstore.writebehind.TxnReservedCapacityCounter;
+import com.hazelcast.map.impl.operation.MapOperation;
+import com.hazelcast.map.impl.operation.steps.engine.State;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
+import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.transaction.TransactionException;
+
+import java.util.UUID;
+
+import static com.hazelcast.map.impl.tx.TxnPrepareOperation.LOCK_TTL_MILLIS;
+
+public enum TxnPrepareOpSteps implements IMapOpStep {
+
+    PREPARE() {
+        @Override
+        public void runStep(State state) {
+
+            RecordStore recordStore = state.getRecordStore();
+
+            Data dataKey = state.getKey();
+            long threadId = state.getThreadId();
+            UUID ownerUuid = state.getOwnerUuid();
+            UUID transactionId = state.getTxnId();
+            MapOperation operation = state.getOperation();
+            TxnReservedCapacityCounter wbqCapacityCounter
+                    = operation.wbqCapacityCounter();
+
+            try {
+                wbqCapacityCounter.increment(transactionId, false);
+            } catch (ReachedMaxSizeException e) {
+                throw new TransactionException(e);
+            }
+
+            if (!recordStore.extendLock(dataKey, ownerUuid, threadId, LOCK_TTL_MILLIS)) {
+                ILogger logger = recordStore.getMapContainer().getMapStoreContext()
+                        .getLogger(operation.getClass());
+                if (logger.isFinestEnabled()) {
+                    logger.finest("Locked: [" + recordStore.isLocked(dataKey)
+                            + "], key: [" + dataKey + ']');
+                }
+
+                wbqCapacityCounter.decrement(transactionId);
+                throw new TransactionException("Lock is not owned by the transaction! ["
+                        + recordStore.getLockOwnerInfo(dataKey) + ']');
+            }
+        }
+
+        @Override
+        public Step nextStep(State state) {
+            return UtilSteps.SEND_RESPONSE;
+        }
+    };
+
+    TxnPrepareOpSteps() {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnRollbackOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnRollbackOpSteps.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation.steps;
+
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.impl.mapstore.writebehind.TxnReservedCapacityCounter;
+import com.hazelcast.map.impl.operation.MapOperation;
+import com.hazelcast.map.impl.operation.steps.engine.State;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
+import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.transaction.TransactionException;
+
+import java.util.UUID;
+
+public enum TxnRollbackOpSteps implements IMapOpStep {
+
+    ROLLBACK() {
+        @Override
+        public void runStep(State state) {
+            RecordStore recordStore = state.getRecordStore();
+
+            Data dataKey = state.getKey();
+            long threadId = state.getThreadId();
+            UUID ownerUuid = state.getOwnerUuid();
+            UUID transactionId = state.getTxnId();
+            MapOperation operation = state.getOperation();
+            long callId = operation.getCallId();
+            TxnReservedCapacityCounter wbqCapacityCounter
+                    = operation.wbqCapacityCounter();
+
+            wbqCapacityCounter.decrement(transactionId);
+            if (recordStore.isLocked(dataKey)
+                    && !recordStore.unlock(dataKey, ownerUuid, threadId, callId)) {
+                throw new TransactionException("Lock is not owned by the transaction! Owner: "
+                        + recordStore.getLockOwnerInfo(dataKey));
+            }
+        }
+
+        @Override
+        public Step nextStep(State state) {
+            return UtilSteps.SEND_RESPONSE;
+        }
+    };
+
+    TxnRollbackOpSteps() {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnUnlockOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/TxnUnlockOpSteps.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation.steps;
+
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.impl.operation.MapOperation;
+import com.hazelcast.map.impl.operation.steps.engine.State;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
+import com.hazelcast.map.impl.recordstore.RecordStore;
+
+import java.util.UUID;
+
+public enum TxnUnlockOpSteps implements IMapOpStep {
+
+    UNLOCK() {
+        @Override
+        public void runStep(State state) {
+            RecordStore recordStore = state.getRecordStore();
+
+            Data dataKey = state.getKey();
+            long threadId = state.getThreadId();
+            UUID ownerUuid = state.getOwnerUuid();
+            MapOperation operation = state.getOperation();
+            long callId = operation.getCallId();
+
+            recordStore.unlock(dataKey, ownerUuid, threadId, callId);
+        }
+
+        @Override
+        public Step nextStep(State state) {
+            return UtilSteps.SEND_RESPONSE;
+        }
+    };
+
+    TxnUnlockOpSteps() {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepAwareOperation.java
@@ -29,9 +29,13 @@ public interface StepAwareOperation<S> {
     S createState();
 
     /**
-     * @param state state to be applied to operation
+     * @param state state to be applied to
+     * operation after execution of all step chain
      */
-    void applyState(S state);
+    default void applyState(S state) {
+        // No need to implement, if there
+        // is no state to apply after run.
+    }
 
     /**
      * @return starting {@link Step} for this operation

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplier.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl.operation.steps.engine;
 
 import com.hazelcast.core.Offloadable;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.steps.UtilSteps;
 import com.hazelcast.memory.NativeOutOfMemoryError;
@@ -141,8 +140,6 @@ public class StepSupplier implements Supplier<Runnable> {
         boolean metWithPreconditions = true;
         try {
             try {
-                log(step, state);
-
                 if (runningOnPartitionThread && state.getThrowable() == null && firstStep) {
                     metWithPreconditions = operationRunner.metWithPreconditions(state.getOperation());
                     if (!metWithPreconditions) {
@@ -188,14 +185,6 @@ public class StepSupplier implements Supplier<Runnable> {
 
     private void rerunWithForcedEviction(Runnable step) {
         runStepWithForcedEvictionStrategies(state.getOperation(), step);
-    }
-
-    private static void log(Step currentStep, State state) {
-        MapOperation operation = state.getOperation();
-        ILogger logger = operation.getNodeEngine().getLogger(operation.getClass());
-        if (logger.isFinestEnabled()) {
-            logger.finest(currentStep.toString() + " ==> " + operation.hashCode());
-        }
     }
 
     public void handleOperationError(Throwable throwable) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
@@ -16,14 +16,17 @@
 
 package com.hazelcast.map.impl.tx;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.steps.TxnPrepareOpSteps;
+import com.hazelcast.map.impl.operation.steps.engine.State;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -38,7 +41,7 @@ import java.util.UUID;
 public class TxnPrepareOperation extends KeyBasedMapOperation
         implements BackupAwareOperation, MutatingOperation {
 
-    private static final long LOCK_TTL_MILLIS = 10000L;
+    public static final long LOCK_TTL_MILLIS = 10000L;
 
     private UUID ownerUuid;
     private UUID transactionId;
@@ -72,6 +75,18 @@ public class TxnPrepareOperation extends KeyBasedMapOperation
             throw new TransactionException("Lock is not owned by the transaction! ["
                     + recordStore.getLockOwnerInfo(getKey()) + ']');
         }
+    }
+
+    @Override
+    public State createState() {
+        return super.createState()
+                .setTxnId(transactionId)
+                .setOwnerUuid(ownerUuid);
+    }
+
+    @Override
+    public Step getStartingStep() {
+        return TxnPrepareOpSteps.PREPARE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -17,13 +17,16 @@
 package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.internal.locksupport.LockWaitNotifyKey;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.steps.TxnRollbackOpSteps;
+import com.hazelcast.map.impl.operation.steps.engine.State;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.Notifier;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -61,6 +64,18 @@ public class TxnRollbackOperation
             throw new TransactionException("Lock is not owned by the transaction! Owner: "
                     + recordStore.getLockOwnerInfo(getKey()));
         }
+    }
+
+    @Override
+    public State createState() {
+        return super.createState()
+                .setTxnId(transactionId)
+                .setOwnerUuid(ownerUuid);
+    }
+
+    @Override
+    public Step getStartingStep() {
+        return TxnRollbackOpSteps.ROLLBACK;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.map.impl.tx;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.operation.LockAwareOperation;
+import com.hazelcast.map.impl.operation.steps.TxnUnlockOpSteps;
+import com.hazelcast.map.impl.operation.steps.engine.State;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -61,6 +64,18 @@ public class TxnUnlockOperation extends LockAwareOperation
     @Override
     protected void runInternal() {
         recordStore.unlock(dataKey, ownerUuid, threadId, getCallId());
+    }
+
+    @Override
+    public State createState() {
+        return super.createState()
+                .setVersion(version)
+                .setOwnerUuid(ownerUuid);
+    }
+
+    @Override
+    public Step getStartingStep() {
+        return TxnUnlockOpSteps.UNLOCK;
     }
 
     @Override


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/22954

**Issue:**
To have lock-unlock order, regardless of the map-store api call happens inside a txn operation, all txn map operations must be done over offloading mechanism when a map has map-store configured.

**Modifications:**
- Add offload support for all missing txn map operations
- During investigations i have seen we also miss offload support for setTtl operation and i have added it.
- Removed unneeded log statement and refactored maxRunNanos constant retrieval code to get it 1 time, previously there was contention for it by all step-runners, this is a scalability issue.