### PR TITLE
Wait for mapping creation where possible and avoid doubled init invocation

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -291,7 +291,7 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
 
     @Override
     public void destroy() {
-        awaitSuccessfulInit();
+        awaitInitFinished();
         dropMapping(mapping);
     }
 

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -196,7 +196,7 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
             queries = new Queries(mapping, properties.idColumn, columnMetadataList);
         } catch (Exception e) {
             // We create the mapping on the first member initializing the MapStore
-            // Other members trying to concurrently initialize
+            // Other members trying to concurrently initialize will fail and just read the mapping
             if (e.getMessage() != null && e.getMessage().startsWith("Mapping or view already exists:")) {
                 readExistingMapping();
             } else {

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -156,8 +156,6 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
 
         // Init can run on partition thread, creating a mapping uses other maps, so it needs to run elsewhere
         asyncExecutor.submit(() -> {
-            // We create the mapping only on the master node
-            // On other members we wait until the mapping has been created
             createMappingForMapStore(mapName);
         });
     }
@@ -197,6 +195,8 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
             }
             queries = new Queries(mapping, properties.idColumn, columnMetadataList);
         } catch (Exception e) {
+            // We create the mapping on the first member initializing the MapStore
+            // Other members trying to concurrently initialize
             if (e.getMessage() != null && e.getMessage().startsWith("Mapping or view already exists:")) {
                 readExistingMapping();
             } else {

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlTestSupport;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecord;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder;
-import com.hazelcast.sql.SqlResult;
-import com.hazelcast.sql.SqlRow;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
@@ -88,14 +86,6 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
             mapStore.destroy();
             mapStore = null;
         }
-
-        try (SqlResult result = sqlService.execute("SHOW MAPPINGS")) {
-            for (SqlRow next : result) {
-                Object name = next.getObject(0);
-                logger.warning("Mapping " + name + " exists after test, dropping");
-                sqlService.execute("DROP MAPPING IF EXISTS " + name).close();
-            }
-        }
     }
 
     @Test
@@ -146,7 +136,6 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         assertMappingCreated();
 
         GenericMapStore<Object> mapStoreNotMaster = createMapStore(instances()[1]);
-        mapStoreNotMaster.awaitInitFinished();
         mapStoreNotMaster.destroy();
         assertMappingDestroyed();
     }

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
@@ -234,7 +234,6 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         assertThatThrownBy(() -> mapStore.load(0))
                 .isInstanceOf(HazelcastException.class)
                 .hasStackTraceContaining("Column 'age' not found");
-        mapStore = null;
     }
 
     @Test
@@ -250,7 +249,6 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         secondProps.setProperty(COLUMNS_PROPERTY, "id,name,age");
         mapStore = createMapStore(secondProps, hz, false);
         mapStore.init(hz, secondProps, mapName);
-        mapStore.awaitInitFinished();
 
         assertThatThrownBy(() -> mapStore.load(0))
                 .isInstanceOf(HazelcastException.class)

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
@@ -43,7 +43,6 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
@@ -22,10 +22,10 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.impl.compact.CompactGenericRecord;
 import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlTestSupport;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecord;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.After;
@@ -61,8 +61,8 @@ import static org.assertj.core.util.Lists.newArrayList;
  * This test runs the MapStore methods directly, but it runs within real Hazelcast instance
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
-public class GenericMapStoreTest extends JdbcSqlTestSupport {
+@Category({ QuickTest.class, SerialTest.class })
+    public class GenericMapStoreTest extends JdbcSqlTestSupport {
 
     public String mapName;
 
@@ -101,7 +101,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         createTable(mapName);
         insertItems(mapName, 1);
 
-        GenericMapStore<Object> mapStore = createMapStore(instances()[1]);
+        mapStore = createMapStore(instances()[1]);
         GenericRecord record = mapStore.load(0);
         assertThat(record).isNotNull();
     }
@@ -129,13 +129,14 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
     }
 
     @Test
-    public void whenMapStoreDestroyOnNonMaster_thenDropMapping() throws Exception {
+        public void whenMapStoreDestroyOnNonMaster_thenDropMapping() throws Exception {
         createTable(mapName);
 
         mapStore = createMapStore();
         awaitMappingCreated();
 
         GenericMapStore<Object> mapStoreNotMaster = createMapStore(instances()[1]);
+        mapStoreNotMaster.awaitInitFinished();
         mapStoreNotMaster.destroy();
         awaitMappingDestroyed();
     }
@@ -231,19 +232,20 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         createTable(mapName, "id INT PRIMARY KEY", "name VARCHAR(100)", "age INT");
         executeJdbc("INSERT INTO " + mapName + " VALUES(0, 'name-0', 42)");
         createMapping(mapName, MAPPING_PREFIX + mapName);
-
+        awaitMappingCreated();
         // This simulates a second map store on a different instance. The mapping is created, but must be validated
         // (e.g. the config might differ on members)
         Properties secondProps = new Properties();
         secondProps.setProperty(EXTERNAL_REF_ID_PROPERTY, TEST_DATABASE_REF);
         secondProps.setProperty(COLUMNS_PROPERTY, "id,name,age");
-        mapStore = createMapStore(secondProps, hz);
+        mapStore = createMapStore(secondProps, hz, false);
         mapStore.init(hz, secondProps, mapName);
+        mapStore.awaitInitFinished();
 
         assertThatThrownBy(() -> mapStore.load(0))
                 .isInstanceOf(HazelcastException.class)
                 .hasStackTraceContaining("Column 'age' not found");
-        mapStore = null;
+        mapStore.destroy();
     }
 
     @Test
@@ -347,7 +349,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
     @Test
     public void givenRowDoesNotExist_whenLoadAll_thenReturnEmptyMap() throws Exception {
         createTable(mapName);
-        GenericMapStore<Integer> mapStore = createMapStore();
+        mapStore = createMapStore();
 
         Map<Integer, GenericRecord> records = mapStore.loadAll(newArrayList(0));
         assertThat(records).isEmpty();
@@ -356,7 +358,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
     @Test
     public void givenRow_whenLoadAllKeys_thenReturnKeys() throws Exception {
         createTable(mapName);
-        GenericMapStore<Integer> mapStore = createMapStore();
+        mapStore = createMapStore();
 
         insertItems(mapName, 1);
 
@@ -382,7 +384,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
     @Test
     public void givenNoRows_whenLoadAllKeys_thenEmptyIterable() throws Exception {
         createTable(mapName);
-        GenericMapStore<Integer> mapStore = createMapStore();
+        mapStore = createMapStore();
 
         Iterable<Integer> ids = mapStore.loadAllKeys();
         assertThat(ids).isEmpty();
@@ -412,7 +414,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
     @Test
     public void givenIdColumn_whenStore_thenTableContainsRow() throws Exception {
         createTable(mapName);
-        GenericMapStore<Integer> mapStore = createMapStore();
+        mapStore = createMapStore();
 
         GenericRecord person = GenericRecordBuilder.compact("Person")
                                                    .setInt32("id", 0)
@@ -491,7 +493,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
     @Test
     public void whenStoreAllWithNoRecords_thenDoNothing() throws Exception {
         createTable(mapName);
-        GenericMapStore<Integer> mapStore = createMapStore();
+        mapStore = createMapStore();
 
         mapStore.storeAll(emptyMap());
 
@@ -520,7 +522,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         properties.setProperty(EXTERNAL_REF_ID_PROPERTY, TEST_DATABASE_REF);
 
         properties.setProperty(ID_COLUMN_PROPERTY, "person-id");
-        GenericMapStore<Integer> mapStore = createMapStore(properties, hz);
+        mapStore = createMapStore(properties, hz);
         mapStore.delete(0);
 
         assertJdbcRowsAnyOrder(mapName,
@@ -620,7 +622,7 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         properties.setProperty(EXTERNAL_REF_ID_PROPERTY, TEST_DATABASE_REF);
 
         properties.setProperty("columns", "id,name");
-        GenericMapStore<Integer> mapStore = createMapStore(properties, hz);
+        mapStore = createMapStore(properties, hz);
 
         GenericRecord person = GenericRecordBuilder.compact(mapName)
                 .setInt32("id", 1)
@@ -645,14 +647,20 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
         return createMapStore(properties, instance);
     }
 
-    private <K> GenericMapStore<K> createMapStore(Properties properties, HazelcastInstance instance) {
+    private <K> GenericMapStore<K> createMapStore(Properties properties, HazelcastInstance instance, boolean init) {
         MapConfig mapConfig = createMapConfigWithMapStore(mapName);
         instance.getConfig().addMapConfig(mapConfig);
 
         GenericMapStore<K> mapStore = new GenericMapStore<>();
-        mapStore.init(instance, properties, mapName);
-        mapStore.awaitInitFinished();
+        if (init) {
+            mapStore.init(instance, properties, mapName);
+            mapStore.awaitInitFinished();
+        }
         return mapStore;
+    }
+
+    private <K> GenericMapStore<K> createMapStore(Properties properties, HazelcastInstance instance) {
+        return createMapStore(properties, instance, true);
     }
 
     private static MapConfig createMapConfigWithMapStore(String mapName) {
@@ -666,12 +674,12 @@ public class GenericMapStoreTest extends JdbcSqlTestSupport {
     private void awaitMappingCreated() {
         assertTrueEventually(() -> {
             assertRowsAnyOrder(hz, "SHOW MAPPINGS", newArrayList(new Row(MAPPING_PREFIX + mapName)));
-        }, 5);
+        }, 60);
     }
 
     private void awaitMappingDestroyed() {
         assertTrueEventually(() -> {
             assertRowsAnyOrder(hz, "SHOW MAPPINGS", newArrayList());
-        }, 5);
+        }, 60);
     }
 }


### PR DESCRIPTION
Fixes #22946
Fixes #22049

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
