### PR TITLE
Fix flaky HibernateIT tests [HZ-1791] (#22947) [5.2.z]

### DIFF
--- a/hazelcast-it/distribution-it/pom.xml
+++ b/hazelcast-it/distribution-it/pom.xml
@@ -17,7 +17,7 @@
         <activation.version>1.1.1</activation.version>
         <hsqldb.version>2.7.0</hsqldb.version>
         <hibernate-core.version>5.3.7.Final</hibernate-core.version>
-        <hazelcast-hibernate53.version>2.2.1</hazelcast-hibernate53.version>
+        <hazelcast-hibernate53.version>5.0.0</hazelcast-hibernate53.version>
     </properties>
 
     <dependencies>

--- a/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/hibernate/HibernateIT.java
+++ b/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/hibernate/HibernateIT.java
@@ -86,17 +86,23 @@ public class HibernateIT extends HazelcastTestSupport {
         tx.commit();
         session.close();
 
-        for (int i = 0; i < 10; i++) {
-            session = sessionFactory.openSession();
-            AnnotatedEntity retrieved = session.get(AnnotatedEntity.class, (long) 1);
-            assertThat(retrieved.getTitle()).isEqualTo("some-title");
-            session.close();
-        }
 
         Statistics stats = sessionFactory.getStatistics();
         assertThat(stats.getEntityInsertCount()).isEqualTo(1);
         assertThat(stats.getSecondLevelCachePutCount()).isEqualTo(1);
-        assertThat(stats.getSecondLevelCacheHitCount()).isEqualTo(10);
+
+        // The assertion below can fail the first time on macOS docker-desktop due to small (1-2ms) clock drifts on VM.
+        // See https://github.com/docker/for-mac/issues/2076
+        assertTrueEventually(() -> {
+            stats.clear();
+            for (int i = 0; i < 10; i++) {
+                Session session2 = sessionFactory.openSession();
+                AnnotatedEntity retrieved = session2.get(AnnotatedEntity.class, (long) 1);
+                assertThat(retrieved.getTitle()).isEqualTo("some-title");
+                session2.close();
+            }
+            assertThat(stats.getSecondLevelCacheHitCount()).isEqualTo(9);
+        });
     }
 
     private SessionFactory createSessionFactory(Properties props) {


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/22947

- Upgraded `hazelcast-hibernate` to the fixed version
- Removed flakiness on macOS machines (tests can fail on macOS docker-desktop due to small (1-2ms) clock drifts on VM)

Fixes https://github.com/hazelcast/hazelcast/issues/22730 Fixes https://hazelcast.atlassian.net/browse/HZ-1791

(cherry picked from commit 4b12ab0342a9f2844e653a55eea2d3b47edb02df)
