### PR TITLE
Wait for database to be up before returning URL [5.2.z]

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -97,7 +97,7 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
      * Timeout for initialization of GenericMapStore
      */
     public static final HazelcastProperty MAPSTORE_INIT_TIMEOUT
-            = new HazelcastProperty("hazelcast.mapstore.init.timeout", 5, SECONDS);
+            = new HazelcastProperty("hazelcast.mapstore.init.timeout", 30, SECONDS);
 
     static final String MAPPING_PREFIX = "__map-store.";
 

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
@@ -22,11 +22,14 @@ import java.sql.SQLException;
 
 public class H2DatabaseProvider implements TestDatabaseProvider {
 
+    private static final int LOGIN_TIMEOUT = 60;
+
     private String jdbcUrl;
 
     @Override
     public String createDatabase(String dbName) {
         jdbcUrl = "jdbc:h2:mem:" + dbName + ";DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1";
+        waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
@@ -20,11 +20,14 @@ import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
 public class MySQLDatabaseProvider implements TestDatabaseProvider {
 
+    private static final int LOGIN_TIMEOUT = 120;
+
     private String jdbcUrl;
 
     @Override
     public String createDatabase(String dbName) {
         jdbcUrl = "jdbc:tc:mysql:8.0.29:///" + dbName + "?TC_DAEMON=true&sessionVariables=sql_mode=ANSI";
+        waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/PostgresDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/PostgresDatabaseProvider.java
@@ -20,11 +20,13 @@ import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
 public class PostgresDatabaseProvider implements TestDatabaseProvider {
 
+    private static final int LOGIN_TIMEOUT = 120;
     private String jdbcUrl;
 
     @Override
     public String createDatabase(String dbName) {
         jdbcUrl = "jdbc:tc:postgresql:10.21:///" + dbName + "?TC_DAEMON=true";
+        waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
     }
 


### PR DESCRIPTION
GenericMapStore init creates mapping, resolves fields etc. and has just 5 second to do that. For some tests we use H2 Mem database, which will be up after the first call is made. This means that H2 startup time was added to GenericMapStore init's startup time. In some cases like overloaded Jenkins, this may cause init to fail.

In this change I'm explicitly initializing connection to test databases, so that slow startup in case of overload won't affect GenericMapStore's init (at least, not that much)

Backport of #22868

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
