### PR TITLE
Prevent multiple search statement

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -78,11 +78,7 @@ public final class TypeConverters {
         @Override
         Comparable convertInternal(Comparable value) {
             String enumString = value.toString();
-            if (enumString.contains(".")) {
-                // there is a dot  in the value specifier, keep part after last dot
-                enumString = enumString.substring(1 + enumString.lastIndexOf('.'));
-            }
-            return enumString;
+            return enumString.substring(1 + enumString.lastIndexOf('.'));
         }
 
     }


### PR DESCRIPTION
There are multiple exists check which are  contains() & indexOf() .  Even if contains(".") are false following statement always returns same value (without create any new substring)  enumString.substring(1 + enumString.lastIndexOf('.'));

<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

INSERT_PR_DESCRIPTION_HERE

Fixes INSERT_LINK_TO_THE_ISSUE_HERE

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
