### PR TITLE
Mention about the possibility of TargetNotMemberException in the PN Counter documentation [5.1.z] [API-1654]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/crdt/pncounter/PNCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/crdt/pncounter/PNCounter.java
@@ -53,15 +53,24 @@ import com.hazelcast.partition.NoDataMemberInClusterException;
  * no replica with the previously observed state is reachable, the session
  * guarantees are lost and the method invocation will throw a
  * {@link ConsistencyLostException}. This does not mean
- * that an update is lost. All of the updates are part of some replica and
+ * that an update is lost. All the updates are part of some replica and
  * will be eventually reflected in the state of all other replicas. This
  * exception just means that you cannot observe your own writes because
  * all replicas that contain your updates are currently unreachable.
  * After you have received a {@link ConsistencyLostException}, you can either
  * wait for a sufficiently up-to-date replica to become reachable in which
- * case the session can be continued or you can reset the session by calling
+ * case the session can be continued, or you can reset the session by calling
  * the {@link #reset()} method. If you have called the {@link #reset()} method,
  * a new session is started with the next invocation to a CRDT replica.
+ * <p>
+ * If the PN Counter is used through a client, the invocations might throw
+ * {@link com.hazelcast.spi.exception.TargetNotMemberException}, indicating that
+ * the invocation targets are not members of the cluster anymore. That might
+ * happen when the client is connected to a new cluster, but the member list is
+ * not updated yet, or all the replica members of the PN Counter is dead but
+ * the corresponding member list update is not received yet. Upon receiving
+ * the exception, one has to wait until the member list is updated on the
+ * client side and try again.
  * <p>
  * <b>NOTE:</b>
  * The CRDT state is kept entirely on non-lite (data) members. If there
@@ -76,8 +85,6 @@ public interface PNCounter extends DistributedObject {
      *
      * @throws NoDataMemberInClusterException if the cluster does not contain
      *                                        any data members
-     * @throws UnsupportedOperationException  if the cluster version is less
-     *                                        than 3.10
      * @throws ConsistencyLostException       if the session guarantees have
      *                                        been lost (see class level javadoc)
      * @see ClusterService#getClusterVersion()
@@ -91,8 +98,6 @@ public interface PNCounter extends DistributedObject {
      * @return the previous value
      * @throws NoDataMemberInClusterException if the cluster does not contain
      *                                        any data members
-     * @throws UnsupportedOperationException  if the cluster version is less
-     *                                        than 3.10
      * @throws ConsistencyLostException       if the session guarantees have
      *                                        been lost (see class level javadoc)
      * @see ClusterService#getClusterVersion()
@@ -106,8 +111,6 @@ public interface PNCounter extends DistributedObject {
      * @return the updated value
      * @throws NoDataMemberInClusterException if the cluster does not contain
      *                                        any data members
-     * @throws UnsupportedOperationException  if the cluster version is less
-     *                                        than 3.10
      * @throws ConsistencyLostException       if the session guarantees have
      *                                        been lost (see class level javadoc)
      * @see ClusterService#getClusterVersion()
@@ -121,8 +124,6 @@ public interface PNCounter extends DistributedObject {
      * @return the previous value
      * @throws NoDataMemberInClusterException if the cluster does not contain
      *                                        any data members
-     * @throws UnsupportedOperationException  if the cluster version is less
-     *                                        than 3.10
      * @throws ConsistencyLostException       if the session guarantees have
      *                                        been lost (see class level javadoc)
      * @see ClusterService#getClusterVersion()
@@ -136,8 +137,6 @@ public interface PNCounter extends DistributedObject {
      * @return the updated value
      * @throws NoDataMemberInClusterException if the cluster does not contain
      *                                        any data members
-     * @throws UnsupportedOperationException  if the cluster version is less
-     *                                        than 3.10
      * @throws ConsistencyLostException       if the session guarantees have
      *                                        been lost (see class level javadoc)
      * @see ClusterService#getClusterVersion()
@@ -150,8 +149,6 @@ public interface PNCounter extends DistributedObject {
      * @return the updated value
      * @throws NoDataMemberInClusterException if the cluster does not contain
      *                                        any data members
-     * @throws UnsupportedOperationException  if the cluster version is less
-     *                                        than 3.10
      * @throws ConsistencyLostException       if the session guarantees have
      *                                        been lost (see class level javadoc)
      * @see ClusterService#getClusterVersion()
@@ -164,8 +161,6 @@ public interface PNCounter extends DistributedObject {
      * @return the updated value
      * @throws NoDataMemberInClusterException if the cluster does not contain
      *                                        any data members
-     * @throws UnsupportedOperationException  if the cluster version is less
-     *                                        than 3.10
      * @throws ConsistencyLostException       if the session guarantees have
      *                                        been lost (see class level javadoc)
      * @see ClusterService#getClusterVersion()
@@ -178,8 +173,6 @@ public interface PNCounter extends DistributedObject {
      * @return the previous value
      * @throws NoDataMemberInClusterException if the cluster does not contain
      *                                        any data members
-     * @throws UnsupportedOperationException  if the cluster version is less
-     *                                        than 3.10
      * @throws ConsistencyLostException       if the session guarantees have
      *                                        been lost (see class level javadoc)
      * @see ClusterService#getClusterVersion()
@@ -192,10 +185,8 @@ public interface PNCounter extends DistributedObject {
      * @return the previous value
      * @throws NoDataMemberInClusterException if the cluster does not contain
      *                                        any data members
-     * @throws UnsupportedOperationException  if the cluster version is less
-     *                                        than 3.10
      * @throws ConsistencyLostException       if the session guarantees have
-     *                                        beenlost (see class level javadoc)
+     *                                        been lost (see class level javadoc)
      * @see ClusterService#getClusterVersion()
      */
     long getAndIncrement();

--- a/hazelcast/src/test/java/com/hazelcast/client/pncounter/ClientPNCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/pncounter/ClientPNCounterTest.java
@@ -28,6 +28,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static org.junit.Assert.assertTrue;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientPNCounterTest {
@@ -49,7 +54,30 @@ public class ClientPNCounterTest {
         pnCounter.incrementAndGet();
 
         instance.shutdown();
-        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance newInstance = hazelcastFactory.newHazelcastInstance();
+        UUID newInstanceUuid = newInstance.getLocalEndpoint().getUuid();
+
+        // PN counter invocation targets are determined with the help of the
+        // member list. When the client connects to a new cluster, the member list
+        // event comes later, and in the meantime, the client operates with
+        // the last known member list. At that time, invocation targets are the old
+        // member UUIDs for the PN counter. However, when the client cannot find
+        // a connection to that old member UUID, it routes the invocation to a
+        // random connection, hoping that member can route the invocation
+        // to the correct member. That creates a problem, because the old member
+        // is not part of the new cluster the client connected to. So, the new
+        // member throws TargetNotMemberException saying that the old member
+        // is not in its member list. That exception is not retryable for
+        // targeted invocations, and that is passed to the user directly, when
+        // there are no more targets to retry. That means, we have to wait
+        // until the member list updated in the client side to be able to
+        // continue working with the PN counter.
+        assertTrueEventually(() -> {
+            assertTrue(client.getCluster().getMembers()
+                    .stream()
+                    .anyMatch(m -> m.getUuid().equals(newInstanceUuid))
+            );
+        });
 
         pnCounter.incrementAndGet();
     }


### PR DESCRIPTION
It is possible to get the TargetNotMemberException for client operations when the client connects to a new cluster, but the member list is not updated yet. Or, all the replica data members of the cluster die, but the member list is not updated yet.

The client routes targeted invocations to random members, if a connection to the target cannot be found, hoping that the member could route the invocation to the correct target member.

That is problematic when the client tries to route PN counter invocations to dead members, that it has no connection. The invocation service will happily route that invocation to a random member, and that member will throw TargetNotMemberException because the actual target of the invocation is not in its member list.

That exception is fatal for targeted exceptions, so they are not retried. Upon receiving an exception for an invocation, the PN counter proxy tries to select a new target using the member list. If all possible targets in the member list are retried, the last exception is propagated to the user.

There is really not much we could do on the client side for this kind of situation. We have to have that invoking on random connections if the target connection is not available logic because the client can lose connections to target members at any moment, even if they are perfectly healthy, and we want the client to continue operating if possible in that situation. We can't really change the way member list events are received on the client side, there is always a possibility of a late member list event.

Probably the best we can do is to document the behavior, and this PR does that.

I have also updated a couple of existing documentations: Corrected a couple
of typos, and removed the possibility of UnsupportedOperationException as 5.x clients and members cannot connect to 3.10 clusters.

I have also updated the ClientPNCounterTest#testClusterRestart so that it now takes care of the possibility of TargetNotMemberException.

clean backport of https://github.com/hazelcast/hazelcast/pull/22963