### PR TITLE
Fix race in SplitBrainTest [HZ-1796] [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -89,6 +89,9 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
         Future[] minorityJobFutureRef = new Future[1];
 
         BiConsumer<HazelcastInstance[], HazelcastInstance[]> onSplit = (firstSubCluster, secondSubCluster) -> {
+            // Wait for the MockPS to be closed on all members before releasing the processor
+            assertTrueEventually(() -> assertEquals(clusterSize, MockPS.closeCount.get()));
+
             NoOutputSourceP.proceedLatch.countDown();
 
             assertTrueEventually(() ->


### PR DESCRIPTION
There was a race between `JetServiceBackend#memberRemoved` (called after split brain is created) and `NoOutputSourceP.proceedLatch.countDown();` in the `onSplit` section. If the onSplit runs first it releases the latch and the processor completes normally, resulting in missing `MockPS.receivedCloseErrors`.

The fix waits for the MockPS to be closed on all members before releasing the latch.

Fixes #22789

Backport of #22986

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
