### PR TITLE
Fix @Category annotations on tests [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheListenerTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -51,7 +50,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@Category(QuickTest.class)
 public class CacheListenerTest extends HazelcastTestSupport {
 
     protected HazelcastInstance hazelcastInstance;

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
@@ -25,7 +25,6 @@ import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,10 +39,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
+import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
 import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
 import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceName;
 import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByLocation;
-import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
 import static com.hazelcast.cache.jsr.JsrTestUtil.cleanup;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -51,7 +50,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@Category(QuickTest.class)
 public class CachingProviderTest extends HazelcastTestSupport {
 
     protected static final int INSTANCE_COUNT = 3;

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
@@ -26,13 +26,9 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
@@ -42,9 +38,8 @@ import java.util.concurrent.CountDownLatch;
 import static com.hazelcast.cache.CacheTestSupport.createClientCachingProvider;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
 public class CacheClientListenerTest extends CacheListenerTest {
+
     @Before
     @After
     public void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCachingProviderTest.java
@@ -23,12 +23,8 @@ import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import javax.cache.spi.CachingProvider;
 import java.io.IOException;
@@ -42,8 +38,6 @@ import static com.hazelcast.cache.jsr.JsrTestUtil.clearCachingProviderRegistry;
 import static com.hazelcast.cache.jsr.JsrTestUtil.clearSystemProperties;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
 public class ClientCachingProviderTest extends CachingProviderTest {
 
     private static final String CONFIG_CLASSPATH_LOCATION = "test-hazelcast-client-jcache.xml";

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapPartitionIteratorBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapPartitionIteratorBouncingTest.java
@@ -17,17 +17,10 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.map.MapPartitionIteratorBouncingTest;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 /**
  * Member implementation for basic map methods nullability tests
  */
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientMapPartitionIteratorBouncingTest extends MapPartitionIteratorBouncingTest {
     @Override
     protected boolean isClientDriver() {

--- a/hazelcast/src/test/java/com/hazelcast/config/replacer/AbstractPbeReplacerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/replacer/AbstractPbeReplacerTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.config.replacer;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AssumptionViolatedException;
 import org.junit.Test;
@@ -40,7 +39,7 @@ import static org.junit.Assert.assertThat;
  * Unit tests for {@link AbstractPbeReplacer}.
  */
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({ QuickTest.class, ParallelJVMTest.class })
+@Category(QuickTest.class)
 public class AbstractPbeReplacerTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/replacer/EncryptionReplacerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/replacer/EncryptionReplacerTest.java
@@ -17,15 +17,13 @@
 package com.hazelcast.config.replacer;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
@@ -49,7 +47,6 @@ import static org.junit.Assume.assumeNotNull;
  * Unit tests for {@link EncryptionReplacer}.
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class})
 public class EncryptionReplacerTest extends AbstractPbeReplacerTest {
 
     private static final ILogger LOGGER = Logger.getLogger(EncryptionReplacerTest.class);

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedMultiendpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedMultiendpointTest.java
@@ -20,15 +20,8 @@ import com.hazelcast.config.AdvancedNetworkConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.ServerSocketEndpointConfig;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
-@RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
-public class MemcachedMultiendpointTest
-        extends MemcachedTest {
+public class MemcachedMultiendpointTest extends MemcachedTest {
 
     @Override
     protected Config createConfig() {


### PR DESCRIPTION
Using `@Category` on a subclass doesn't replace the categories on superclass, but it adds to the categories. So if you declare QuickTest and ParallelJVMTest on parent and only QuickTest on child it will run in parallel phase in PR builder. Fixed all cases like this in hazelcast module.

If the child uses either SlowTest or NightlyTest it is ok, because it will run during respective executions and Quick/Parallel are not considered at all, so I left these cases as they are.

Possibly affected tests: #21318, #21156

Backport of #22837

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
