### PR TITLE
Use TestHazelcastFactory in OrderedProcessingMultipleMemberTest [HZ-1827]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
@@ -40,7 +40,6 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -64,7 +63,7 @@ import static com.hazelcast.jet.core.test.JetAssert.fail;
 @RunWith(HazelcastParametrizedRunner.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category(QuickTest.class)
-public class OrderedProcessingMultipleMemberTest extends SimpleTestInClusterSupport implements Serializable {
+public class OrderedProcessingMultipleMemberTest extends SimpleTestInClusterSupport {
 
     // Used to set the LP of the stage with the higher value than upstream parallelism
     private static final int HIGH_LOCAL_PARALLELISM = 11;
@@ -244,7 +243,7 @@ public class OrderedProcessingMultipleMemberTest extends SimpleTestInClusterSupp
         StreamStage<Map.Entry<Long, Long>> applied = srcStage.apply(transform);
 
         applied.groupingKey(Map.Entry::getKey)
-                .mapStateful(() -> create(keyCount), this::orderValidator)
+                .mapStateful(() -> create(keyCount), OrderedProcessingMultipleMemberTest::orderValidator)
                 .writeTo(AssertionSinks.assertCollectedEventually(60,
                         list -> {
                             assertTrue("when", itemCount <= list.size());
@@ -277,7 +276,7 @@ public class OrderedProcessingMultipleMemberTest extends SimpleTestInClusterSupp
         return state;
     }
 
-    private boolean orderValidator(LongAccumulator[] s, Long key, Map.Entry<Long, Long> entry) {
+    private static boolean orderValidator(LongAccumulator[] s, Long key, Map.Entry<Long, Long> entry) {
         LongAccumulator acc = s[key.intValue()];
         long value = entry.getValue();
         if (acc.get() >= value) {

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
@@ -18,14 +18,12 @@ package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EventJournalConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.PredicateEx;
-import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.accumulator.LongAccumulator;
-import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
@@ -33,7 +31,6 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -67,7 +64,7 @@ import static com.hazelcast.jet.core.test.JetAssert.fail;
 @RunWith(HazelcastParametrizedRunner.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category(QuickTest.class)
-public class OrderedProcessingMultipleMemberTest extends JetTestSupport implements Serializable {
+public class OrderedProcessingMultipleMemberTest extends SimpleTestInClusterSupport implements Serializable {
 
     // Used to set the LP of the stage with the higher value than upstream parallelism
     private static final int HIGH_LOCAL_PARALLELISM = 11;
@@ -77,7 +74,6 @@ public class OrderedProcessingMultipleMemberTest extends JetTestSupport implemen
     private static final String JOURNALED_MAP_PREFIX = "test-map-";
 
     private static Pipeline p;
-    private static JetInstance[] instances;
 
     @Parameter(value = 0)
     public int idx;
@@ -96,22 +92,13 @@ public class OrderedProcessingMultipleMemberTest extends JetTestSupport implemen
                 .getEventJournalConfig();
         eventJournalConfig.setEnabled(true);
         eventJournalConfig.setCapacity(30000); // 30000/271 ~= 111 item per partition
-        instances = new JetInstance[INSTANCE_COUNT];
-        for (int i = 0; i < INSTANCE_COUNT; i++) {
-            instances[i] = (JetInstance) Hazelcast.newHazelcastInstance(config).getJet();
-        }
+
+        initialize(INSTANCE_COUNT, config);
     }
 
     @Before
     public void setup() {
         p = Pipeline.create().setPreserveOrder(true);
-    }
-
-    @AfterClass
-    public static void cleanup() {
-        for (int i = 0; i < INSTANCE_COUNT; i++) {
-            instances[i].shutdown();
-        }
     }
 
     @Parameters(name = "{index}: transform={2}")
@@ -265,12 +252,12 @@ public class OrderedProcessingMultipleMemberTest extends JetTestSupport implemen
                         }
                 ));
 
-        IMap<Long, Long> testMap = instances[0].getMap(mapName);
+        IMap<Long, Long> testMap = instance().getMap(mapName);
         LongStream.range(0, itemCount)
                 .boxed()
                 .forEachOrdered(i -> testMap.put(i % keyCount, i));
 
-        Job job = instances[0].newJob(p);
+        Job job = instance().getJet().newJob(p);
         try {
             job.join();
             fail("Job should have completed with an AssertionCompletedException, but completed normally");


### PR DESCRIPTION
The failure was caused by a wrong environment setup - the container running the build wasn't isolated from others and another instance joined the cluster:

```
23:15:31,673  WARN || - [NodeMulticastListener] hz.eager_chandrasekhar.MulticastThread - [127.0.0.1]:5702 [dev] [5.2-SNAPSHOT] New join request has been received from current master address. The UUID in the join request (cadb25fe-b130-4604-8b7c-95414c1c11ab) is different from the known master one (082dc3f5-b171-47c4-9add-a88aa5cdedb9). Suspecting the master address: [127.0.0.1]:5701
23:15:31,673  WARN || - [MembershipManager] hz.eager_chandrasekhar.MulticastThread - [127.0.0.1]:5702 [dev] [5.2-SNAPSHOT] Member [127.0.0.1]:5701 - 082dc3f5-b171-47c4-9add-a88aa5cdedb9 is suspected to be dead for reason: New join request has been received from current master address. The UUID in the join request (cadb25fe-b130-4604-8b7c-95414c1c11ab) is different from the known master one (082dc3f5-b171-47c4-9add-a88aa5cdedb9). Suspecting the master address: [127.0.0.1]:5701
```

The UUID `cadb25fe-b130-4604-8b7c-95414c1c11ab` doesn't appear anywhere else in the log of the test or the whole build.

The test used real Hazelcast instance, which is really not needed in this case. So this commit changes that to TestHazelcastFactory and it will use the mock network.

Fixes #21532

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
