### PR TITLE
Improve assert in ElasticSinkBuilderTest [HZ-936]

### DIFF
--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ClientHolder.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ClientHolder.java
@@ -16,13 +16,17 @@
 
 package com.hazelcast.jet.elastic;
 
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.client.RestClient;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 import static java.util.Collections.synchronizedList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /**
  * Holder for created Elastic clients during tests
@@ -31,5 +35,14 @@ final class ClientHolder implements Serializable {
     static List<RestClient> elasticClients = synchronizedList(new ArrayList<>());
 
     private ClientHolder() {
+    }
+
+    static void assertAllClientsNotRunning() {
+        assertTrueEventually(() -> {
+            for (RestClient client : elasticClients) {
+                CloseableHttpAsyncClient httpClient = getFieldValueReflectively(client, "client");
+                assertThat(httpClient.isRunning()).isFalse();
+            }
+        });
     }
 }

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ClientHolder.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ClientHolder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic;
+
+import org.elasticsearch.client.RestClient;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.synchronizedList;
+
+/**
+ * Holder for created Elastic clients during tests
+ */
+final class ClientHolder implements Serializable {
+    static List<RestClient> elasticClients = synchronizedList(new ArrayList<>());
+
+    private ClientHolder() {
+    }
+}

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
@@ -33,9 +32,7 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 import static java.util.Collections.emptyMap;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -74,11 +71,6 @@ public class ElasticSinkBuilderTest extends PipelineTestSupport {
             // ignore - elastic is not running
         }
 
-        assertTrueEventually(() -> {
-            for (RestClient client : ClientHolder.elasticClients) {
-                CloseableHttpAsyncClient httpClient = getFieldValueReflectively(client, "client");
-                assertThat(httpClient.isRunning()).isFalse();
-            }
-        });
+        ClientHolder.assertAllClientsNotRunning();
     }
 }

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -39,9 +39,6 @@ import static org.mockito.Mockito.when;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSinkBuilderTest extends PipelineTestSupport {
 
-    // Use static logger to avoid serialization issue with logger from parent class
-    private static final ILogger logger = Logger.getLogger(ElasticSinkBuilderTest.class);
-
     @Test
     public void when_writeToFailingSink_then_shouldCloseClient() {
         ClientHolder.elasticClients.clear();

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -19,8 +19,6 @@ package com.hazelcast.jet.elastic;
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.test.TestSources;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import org.apache.http.HttpHost;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
@@ -33,9 +32,6 @@ import org.junit.Test;
 
 import java.util.Collections;
 
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -84,12 +80,7 @@ public class LocalElasticSinkTest extends CommonElasticSinksTest {
 
         hz.getJet().newJob(p).join();
 
-        assertTrueEventually(() -> {
-            for (RestClient client : ClientHolder.elasticClients) {
-                CloseableHttpAsyncClient httpClient = getFieldValueReflectively(client, "client");
-                assertThat(httpClient.isRunning()).isFalse();
-            }
-        });
+        ClientHolder.assertAllClientsNotRunning();
     }
 
 }

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/LocalElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/LocalElasticSourcesTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -30,9 +29,6 @@ import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.collect.ImmutableMap.of;
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -105,12 +101,7 @@ public class LocalElasticSourcesTest extends CommonElasticSourcesTest {
 
         submitJob(p);
 
-        assertTrueEventually(() -> {
-            for (RestClient client : ClientHolder.elasticClients) {
-                CloseableHttpAsyncClient httpClient = getFieldValueReflectively(client, "client");
-                assertThat(httpClient.isRunning()).isFalse();
-            }
-        });
+        ClientHolder.assertAllClientsNotRunning();
     }
 
 }

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/LocalElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/LocalElasticSourcesTest.java
@@ -22,22 +22,19 @@ import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.junit.After;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
 import static com.google.common.collect.ImmutableMap.of;
-import static java.util.Collections.synchronizedList;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -60,6 +57,7 @@ public class LocalElasticSourcesTest extends CommonElasticSourcesTest {
 
     @Test
     public void given_nonColocatedCluster_whenReadFromElasticSourceWithCoLocation_then_shouldThrowException() {
+        ClientHolder.elasticClients.clear();
         indexDocument("my-index", of("name", "Frantisek"));
 
         Pipeline p = Pipeline.create();
@@ -80,7 +78,9 @@ public class LocalElasticSourcesTest extends CommonElasticSourcesTest {
     }
 
     @Test
-    public void when_readFromElasticSource_then_shouldCloseAllCreatedClients() throws IOException {
+    public void when_readFromElasticSource_then_shouldCloseAllCreatedClients() {
+        ClientHolder.elasticClients.clear();
+
         indexDocument("my-index", of("name", "Frantisek"));
 
         Pipeline p = Pipeline.create();
@@ -90,7 +90,7 @@ public class LocalElasticSourcesTest extends CommonElasticSourcesTest {
                     RestClientBuilder builder = spy(ElasticSupport.elasticClientSupplier().get());
                     when(builder.build()).thenAnswer(invocation -> {
                         Object result = invocation.callRealMethod();
-                        RestClient elasticClient = (RestClient) spy(result);
+                        RestClient elasticClient = (RestClient) result;
                         ClientHolder.elasticClients.add(elasticClient);
                         return elasticClient;
                     });
@@ -105,12 +105,12 @@ public class LocalElasticSourcesTest extends CommonElasticSourcesTest {
 
         submitJob(p);
 
-        for (RestClient elasticClient : ClientHolder.elasticClients) {
-            verify(elasticClient).close();
-        }
+        assertTrueEventually(() -> {
+            for (RestClient client : ClientHolder.elasticClients) {
+                CloseableHttpAsyncClient httpClient = getFieldValueReflectively(client, "client");
+                assertThat(httpClient.isRunning()).isFalse();
+            }
+        });
     }
 
-    static class ClientHolder implements Serializable {
-        static List<RestClient> elasticClients = synchronizedList(new ArrayList<>());
-    }
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ClientHolder.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ClientHolder.java
@@ -16,13 +16,17 @@
 
 package com.hazelcast.jet.elastic;
 
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.client.RestClient;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 import static java.util.Collections.synchronizedList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /**
  * Holder for created Elastic clients during tests
@@ -31,5 +35,14 @@ final class ClientHolder implements Serializable {
     static List<RestClient> elasticClients = synchronizedList(new ArrayList<>());
 
     private ClientHolder() {
+    }
+
+    static void assertAllClientsNotRunning() {
+        assertTrueEventually(() -> {
+            for (RestClient client : elasticClients) {
+                CloseableHttpAsyncClient httpClient = getFieldValueReflectively(client, "client");
+                assertThat(httpClient.isRunning()).isFalse();
+            }
+        });
     }
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ClientHolder.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ClientHolder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic;
+
+import org.elasticsearch.client.RestClient;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.synchronizedList;
+
+/**
+ * Holder for created Elastic clients during tests
+ */
+final class ClientHolder implements Serializable {
+    static List<RestClient> elasticClients = synchronizedList(new ArrayList<>());
+
+    private ClientHolder() {
+    }
+}

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
@@ -33,9 +32,7 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 import static java.util.Collections.emptyMap;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -74,12 +71,7 @@ public class ElasticSinkBuilderTest extends PipelineTestSupport {
             // ignore - elastic is not running
         }
 
-        assertTrueEventually(() -> {
-            for (RestClient client : ClientHolder.elasticClients) {
-                CloseableHttpAsyncClient httpClient = getFieldValueReflectively(client, "client");
-                assertThat(httpClient.isRunning()).isFalse();
-            }
-        });
+        ClientHolder.assertAllClientsNotRunning();
     }
 
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -39,9 +39,6 @@ import static org.mockito.Mockito.when;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ElasticSinkBuilderTest extends PipelineTestSupport {
 
-    // Use static logger to avoid serialization issue with logger from parent class
-    private static final ILogger logger = Logger.getLogger(ElasticSinkBuilderTest.class);
-
     @Test
     public void when_writeToFailingSink_then_shouldCloseClient() {
         ClientHolder.elasticClients.clear();

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
@@ -32,14 +33,10 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -49,7 +46,7 @@ public class ElasticSinkBuilderTest extends PipelineTestSupport {
     private static final ILogger logger = Logger.getLogger(ElasticSinkBuilderTest.class);
 
     @Test
-    public void when_writeToFailingSink_then_shouldCloseClient() throws IOException {
+    public void when_writeToFailingSink_then_shouldCloseClient() {
         ClientHolder.elasticClients.clear();
 
         Sink<String> elasticSink = new ElasticSinkBuilder<>()
@@ -57,15 +54,14 @@ public class ElasticSinkBuilderTest extends PipelineTestSupport {
                     RestClientBuilder builder = spy(RestClient.builder(HttpHost.create("localhost:9200")));
                     when(builder.build()).thenAnswer(invocation -> {
                         Object result = invocation.callRealMethod();
-                        RestClient client = (RestClient) spy(result);
-                        logger.fine("Created client " + client);
+                        RestClient client = (RestClient) result;
                         ClientHolder.elasticClients.add(client);
                         return client;
                     });
                     return builder;
                 })
                 .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE))
-                .mapToRequestFn((String item) -> new IndexRequest("my-index").source(Collections.emptyMap()))
+                .mapToRequestFn((String item) -> new IndexRequest("my-index").source(emptyMap()))
                 .retries(0)
                 .build();
 
@@ -78,14 +74,12 @@ public class ElasticSinkBuilderTest extends PipelineTestSupport {
             // ignore - elastic is not running
         }
 
-        logger.fine("Clients to close: " + ClientHolder.elasticClients.size());
-        for (RestClient client : ClientHolder.elasticClients) {
-            logger.fine("Closing client " + client);
-            verify(client).close();
-        }
+        assertTrueEventually(() -> {
+            for (RestClient client : ClientHolder.elasticClients) {
+                CloseableHttpAsyncClient httpClient = getFieldValueReflectively(client, "client");
+                assertThat(httpClient.isRunning()).isFalse();
+            }
+        });
     }
 
-    static class ClientHolder implements Serializable {
-        static Set<RestClient> elasticClients = Collections.synchronizedSet(new HashSet<>());
-    }
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -19,8 +19,6 @@ package com.hazelcast.jet.elastic;
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.test.TestSources;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpHost;

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import org.apache.http.HttpHost;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
@@ -33,9 +32,6 @@ import org.junit.Test;
 
 import java.util.Collections;
 
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -84,12 +80,7 @@ public class LocalElasticSinkTest extends CommonElasticSinksTest {
 
         hz.getJet().newJob(p).join();
 
-        assertTrueEventually(() -> {
-            for (RestClient client : ClientHolder.elasticClients) {
-                CloseableHttpAsyncClient httpClient = getFieldValueReflectively(client, "client");
-                assertThat(httpClient.isRunning()).isFalse();
-            }
-        });
+        ClientHolder.assertAllClientsNotRunning();
     }
 
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/LocalElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/LocalElasticSourcesTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -30,9 +29,6 @@ import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.collect.ImmutableMap.of;
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -104,11 +100,6 @@ public class LocalElasticSourcesTest extends CommonElasticSourcesTest {
 
         submitJob(p);
 
-        assertTrueEventually(() -> {
-            for (RestClient client : ClientHolder.elasticClients) {
-                CloseableHttpAsyncClient httpClient = getFieldValueReflectively(client, "client");
-                assertThat(httpClient.isRunning()).isFalse();
-            }
-        });
+        ClientHolder.assertAllClientsNotRunning();
     }
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/LocalElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/LocalElasticSourcesTest.java
@@ -86,7 +86,7 @@ public class LocalElasticSourcesTest extends CommonElasticSourcesTest {
                     when(builder.build()).thenAnswer(invocation -> {
                         Object result = invocation.callRealMethod();
                         RestClient elasticClient = (RestClient) result;
-                        com.hazelcast.jet.elastic.ClientHolder.elasticClients.add(elasticClient);
+                        ClientHolder.elasticClients.add(elasticClient);
                         return elasticClient;
                     });
                     return builder;

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAutoRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAutoRemoveTest.java
@@ -20,8 +20,8 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -31,9 +31,7 @@ import java.util.Collection;
 
 import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween;
 import static com.hazelcast.test.SplitBrainTestSupport.unblockCommunicationBetween;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAutoRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAutoRemoveTest.java
@@ -20,8 +20,8 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -31,6 +31,7 @@ import java.util.Collection;
 
 import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween;
 import static com.hazelcast.test.SplitBrainTestSupport.unblockCommunicationBetween;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAutoRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAutoRemoveTest.java
@@ -33,6 +33,7 @@ import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween
 import static com.hazelcast.test.SplitBrainTestSupport.unblockCommunicationBetween;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)


### PR DESCRIPTION
It is not guaranteed that all cleanup logic (e.g Processor#close) methods are called when `job.join();` returns.

Use assertTrueEventually to wait for all clients to be closed instead. Also, stop using Mockito to verify that the client was closed and use an internal field via reflection instead to rule out any issue with thread safety in Mockito.

Fixes #19637

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
