### PR TITLE
Skip assert in TestSourcesTest when long hiccup is recorded [HZ-1832]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/test/TestSourcesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/test/TestSourcesTest.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.jet.pipeline.test;
 
+import com.hazelcast.jet.datamodel.WindowResult;
 import com.hazelcast.jet.pipeline.PipelineTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.jitter.JitterRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -32,6 +34,7 @@ import static com.hazelcast.jet.aggregate.AggregateOperations.counting;
 import static com.hazelcast.jet.pipeline.WindowDefinition.tumbling;
 import static com.hazelcast.jet.pipeline.test.Assertions.assertCollectedEventually;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -156,17 +159,27 @@ public class TestSourcesTest extends PipelineTestSupport {
     public void test_itemStream_in_expected_range() throws Throwable {
         int itemsPerSecond = 109;
 
+        int windowSize = 1000;
         p.readFrom(TestSources.itemStream(itemsPerSecond))
-                .withNativeTimestamps(0)
-                .window(tumbling(1000))
-                .aggregate(counting())
-                .apply(assertCollectedEventually(10, windowResults -> {
+         .withNativeTimestamps(0)
+         .window(tumbling(windowSize))
+         .aggregate(counting())
+         .apply(assertCollectedEventually(10, windowResults -> {
                     // first window may be incomplete
                     assertTrue("sink list should contain some items", windowResults.size() > 1);
-                    assertTrue("emitted items is more than twice lower then expected itemsPerSecond",
-                            (long) windowResults.get(1).result() > itemsPerSecond / 2);
-                    assertTrue("emitted items is more than twice higher then expected itemsPerSecond",
-                            (long) windowResults.get(1).result() < itemsPerSecond * 2);
+                    WindowResult<Long> windowResult = windowResults.get(1);
+
+                    long pauses = JitterRule.getPausesBetween(windowResult.start(), windowResult.end());
+                    // Ignore if a long pause was recorded
+                    if (pauses < (windowSize / 2)) {
+                        assertThat(windowResult.result())
+                                .isGreaterThan(itemsPerSecond / 2)
+                                .describedAs("emitted items is more than twice lower then expected itemsPerSecond");
+
+                        assertThat(windowResult.result())
+                                .isLessThan(itemsPerSecond * 2)
+                                .describedAs("emitted items is more than twice higher then expected itemsPerSecond");
+                    }
                 }));
 
         expectAssertionsCompleted();

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterRule.java
@@ -123,4 +123,13 @@ public class JitterRule implements TestRule {
             }
         };
     }
+
+    public static long getPausesBetween(long startTime, long stopTime) {
+        Iterable<Slot> slots = JitterMonitor.getSlotsBetween(startTime, stopTime);
+        long totalPauses = 0;
+        for (Slot slot : slots) {
+            totalPauses += slot.getAccumulatedHiccupsNanos();
+        }
+        return totalPauses;
+    }
 }


### PR DESCRIPTION
The failing run has recorded a hiccup longer than 1 s. Use JitterRule to get pauses in the window and if the pauses exceed half the window ignore the result.

Fixes #21893

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
