### PR TITLE
Use assertTrueEventually in AuthenticationInformationLeakTest API-1652 [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/AuthenticationInformationLeakTest.java
@@ -49,14 +49,17 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY;
 import static com.hazelcast.test.Accessors.getClientEngineImpl;
 import static com.hazelcast.test.HazelcastTestSupport.assertContains;
 import static com.hazelcast.test.HazelcastTestSupport.assertInstanceOf;
 import static com.hazelcast.test.HazelcastTestSupport.assertNotContains;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -87,28 +90,46 @@ public class AuthenticationInformationLeakTest {
     }
 
     @Test
-    public void testAuthenticationExceptionDoesNotLeakInfo() throws IOException {
+    public void testAuthenticationExceptionDoesNotLeakInfo() {
+        AtomicReference<ClientMessage> res = new AtomicReference<>();
+        assertTrueEventually(() -> {
+            res.set(tryGettingKeyValueWithoutAuthentication());
+            assertNotNull(res.get());
+        });
+        assertEquals(res.get().getMessageType(), ErrorsCodec.EXCEPTION_MESSAGE_TYPE);
+        ClientExceptionFactory factory = new ClientExceptionFactory(false, Thread.currentThread().getContextClassLoader());
+        Throwable err = factory.createException(res.get());
+        String message = err.getMessage();
+        assertInstanceOf(AuthenticationException.class, err.getCause());
+        assertContains(message, "must authenticate before any operation");
+        String messageLowerCase = message.toLowerCase();
+        assertNotContains(messageLowerCase, "connection");
+        assertNotContains(messageLowerCase, "authenticated");
+        assertNotContains(messageLowerCase, "creationTime");
+        assertNotContains(messageLowerCase, "clientAttributes");
+    }
+
+    /**
+     * This function uses a tcp socket to be able to write a message without authenticating.
+     * <p>
+     * In case of an authentication failure, the server sends an exception message and immediately closes the connection
+     * without waiting the message to be written to the client connection. It's possible that we receive EOF from socket,
+     * which will make getKeyValue() throw IOException. In any kind of IOException, value null will be returned.
+     *
+     * @return null if IOException happened, otherwise return the response received from the server as a ClientMessage
+     */
+    private ClientMessage tryGettingKeyValueWithoutAuthentication() {
         SerializationService ss = new DefaultSerializationServiceBuilder().build();
         InetSocketAddress endpoint = new InetSocketAddress("127.0.0.1", 5701);
         try (Socket socket = new Socket()) {
             socket.setReuseAddress(true);
             socket.connect(endpoint);
-            ClientMessage res;
             try (OutputStream os = socket.getOutputStream(); InputStream is = socket.getInputStream()) {
                 os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
-                res = getKeyValue(ss, os, is);
+                return getKeyValue(ss, os, is);
             }
-            assertEquals(res.getMessageType(), ErrorsCodec.EXCEPTION_MESSAGE_TYPE);
-            ClientExceptionFactory factory = new ClientExceptionFactory(false, Thread.currentThread().getContextClassLoader());
-            Throwable err = factory.createException(res);
-            String message = err.getMessage();
-            assertInstanceOf(AuthenticationException.class, err.getCause());
-            assertContains(message, "must authenticate before any operation");
-            String messageLowerCase = message.toLowerCase();
-            assertNotContains(messageLowerCase, "connection");
-            assertNotContains(messageLowerCase, "authenticated");
-            assertNotContains(messageLowerCase, "creationTime");
-            assertNotContains(messageLowerCase, "clientAttributes");
+        } catch (IOException e) {
+            return null;
         }
     }
 


### PR DESCRIPTION
Clean backport of #22857 to 5.2.z

Backport of: #22857

Breaking changes (list specific methods/types/messages):
- None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
