### PR TITLE
Fix little endian jet related issues [HZ-1783] [HZ-1793] [HZ-1800] (#22941) [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -23,6 +23,8 @@ import com.hazelcast.internal.nio.Disposable;
 import com.hazelcast.internal.serialization.impl.InternalGenericRecord;
 import com.hazelcast.internal.serialization.impl.compact.Schema;
 import com.hazelcast.internal.serialization.impl.portable.PortableContext;
+import com.hazelcast.jet.impl.ExplodeSnapshotP;
+import com.hazelcast.jet.impl.util.AsyncSnapshotWriterImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.PartitioningStrategy;
@@ -75,7 +77,24 @@ public interface InternalSerializationService extends SerializationService, Disp
 
     void writeObject(ObjectDataOutput out, Object obj);
 
-    <T> T readObject(ObjectDataInput in);
+    default <T> T readObject(ObjectDataInput in) {
+        return readObject(in, false);
+    }
+
+    /**
+     * This method is only exposed to read Jet snapshots in {@link
+     * ExplodeSnapshotP}. This method should not be called to read top
+     * level objects like {@link SerializationService#toObject(Object)}
+     * as this doesn't cache classes.
+     *
+     * @param in                           input to read object from
+     * @param useBigEndianForReadingTypeId is {@code typeId} serialized with big endian
+     * @param <T>                          type of the object read
+     * @return the object read
+     * @see InternalSerializationService#getByteOrder()
+     * @see AsyncSnapshotWriterImpl
+     */
+    <T> T readObject(ObjectDataInput in, boolean useBigEndianForReadingTypeId);
 
     <T> T readObject(ObjectDataInput in, Class aClass);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -339,9 +339,14 @@ public abstract class AbstractSerializationService implements InternalSerializat
     }
 
     @Override
-    public final <T> T readObject(final ObjectDataInput in) {
+    public final <T> T readObject(final ObjectDataInput in, boolean useBigEndianForReadingTypeId) {
         try {
-            final int typeId = in.readInt();
+            final int typeId;
+            if (useBigEndianForReadingTypeId && in instanceof BufferObjectDataInput) {
+                typeId = ((BufferObjectDataInput) in).readInt(BIG_ENDIAN);
+            } else {
+                typeId = in.readInt();
+            }
             final SerializerAdapter serializer = serializerFor(typeId);
             if (serializer == null) {
                 if (active) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/ExplodeSnapshotP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/ExplodeSnapshotP.java
@@ -62,11 +62,11 @@ public class ExplodeSnapshotP extends AbstractProcessor {
         BufferObjectDataInput in = serializationService.createObjectDataInput(data);
 
         return () -> uncheckCall(() -> {
-            Object key = in.readObject();
+            Object key = serializationService.readObject(in, true);
             if (key == SnapshotDataValueTerminator.INSTANCE) {
                 return null;
             }
-            Object value = in.readObject();
+            Object value = serializationService.readObject(in, true);
             return key instanceof BroadcastKey
                     ? new BroadcastEntry(key, value)
                     : entry(key, value);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImpl.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.internal.nio.Bits;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.serialization.impl.SerializationConstants;
 import com.hazelcast.jet.impl.JetServiceBackend;
@@ -85,7 +85,7 @@ public class AsyncSnapshotWriterImpl implements AsyncSnapshotWriter {
                                    String vertexName,
                                    int memberIndex,
                                    int memberCount,
-                                   SerializationService serializationService) {
+                                   InternalSerializationService serializationService) {
         this(DEFAULT_CHUNK_SIZE, nodeEngine, snapshotContext, vertexName, memberIndex, memberCount, serializationService);
     }
 
@@ -96,7 +96,7 @@ public class AsyncSnapshotWriterImpl implements AsyncSnapshotWriter {
                             String vertexName,
                             int memberIndex,
                             int memberCount,
-                            SerializationService serializationService) {
+                            InternalSerializationService serializationService) {
         if (Integer.bitCount(chunkSize) != 1) {
             throw new IllegalArgumentException("chunkSize must be a power of two, but is " + chunkSize);
         }
@@ -108,10 +108,12 @@ public class AsyncSnapshotWriterImpl implements AsyncSnapshotWriter {
         this.memberCount = memberCount;
         currentSnapshotId = snapshotContext.currentSnapshotId();
 
-        useBigEndian = !nodeEngine.getHazelcastInstance().getConfig().getSerializationConfig().isUseNativeByteOrder()
-                || ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
+        useBigEndian = serializationService.getByteOrder().equals(ByteOrder.BIG_ENDIAN);
+
+        // outermost typeId should always be serialized with big endian
+        // see InternalSerializationService#getByteOrder()
         Bits.writeInt(serializedByteArrayHeader, Bits.INT_SIZE_IN_BYTES, SerializationConstants.CONSTANT_TYPE_BYTE_ARRAY,
-                useBigEndian);
+                true);
 
         buffers = createAndInitBuffers(chunkSize, partitionService.getPartitionCount(), serializedByteArrayHeader);
         JetServiceBackend jetServiceBackend = nodeEngine.getService(JetServiceBackend.SERVICE_NAME);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
@@ -97,7 +97,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
         when(snapshotContext.currentMapName()).thenReturn("map1");
         when(snapshotContext.currentSnapshotId()).thenReturn(0L);
         writer = new AsyncSnapshotWriterImpl(128, nodeEngine, snapshotContext, "vertex", 0, 1,
-                nodeEngine.getSerializationService());
+                (InternalSerializationService) nodeEngine.getSerializationService());
         when(snapshotContext.currentSnapshotId()).thenReturn(1L); // simulates starting new snapshot
         map = instance.getMap("map1");
         assertTrue(writer.usableChunkCapacity > 0);
@@ -115,7 +115,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
         for (int i = 64; i < 196; i++) {
             when(snapshotContext.currentMapName()).thenReturn(randomMapName());
             writer = new AsyncSnapshotWriterImpl(128, nodeEngine, snapshotContext, "vertex", 0, 1,
-                    nodeEngine.getSerializationService());
+                    (InternalSerializationService) nodeEngine.getSerializationService());
             try {
                 assertTrue(writer.offer(entry(serialize("k"), serialize(String.join("", nCopies(i, "a"))))));
                 assertTrue(writer.flushAndResetMap());
@@ -208,9 +208,9 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
         byte[] data = map.get(new SnapshotDataKey(partitionKey, 1, "vertex", 0));
         assertEquals(data.length + Bits.INT_SIZE_IN_BYTES, writer.getTotalPayloadBytes());
         BufferObjectDataInput in = serializationService.createObjectDataInput(data);
-        assertEquals(key, in.readObject());
-        assertEquals(value, in.readObject());
-        assertEquals(SnapshotDataValueTerminator.INSTANCE, in.readObject());
+        assertEquals(key, serializationService.readObject(in, true));
+        assertEquals(value, serializationService.readObject(in, true));
+        assertEquals(SnapshotDataValueTerminator.INSTANCE, serializationService.readObject(in, true));
     }
 
     @Test
@@ -290,8 +290,8 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
         });
 
         BufferObjectDataInput in = serializationService.createObjectDataInput(os.toByteArray());
-        Assert.assertEquals("foo", in.readObject());
-        Assert.assertEquals("bar", in.readObject());
+        Assert.assertEquals("foo", serializationService.readObject(in, true));
+        Assert.assertEquals("bar", serializationService.readObject(in, true));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
@@ -111,8 +111,8 @@ public class SamplingSerializationService implements InternalSerializationServic
     }
 
     @Override
-    public <T> T readObject(ObjectDataInput in) {
-        return (T) delegate.readObject(in);
+    public <T> T readObject(ObjectDataInput in, boolean useBigEndianForReadingTypeId) {
+        return (T) delegate.readObject(in, useBigEndianForReadingTypeId);
     }
 
     @Override


### PR DESCRIPTION

This PR does 3 things: 
 - `ExplodeSnapshotP` now reads `typeId` of the object with big endian
 - `AsyncSnapshotWriterImpl` writes first `typeId` with big endian
- `AsyncSnapshotWriterImpl` uses InternalSerializationService#getByteOrder()
   to determine `useBigEndian`

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/5498 Fixes https://github.com/hazelcast/hazelcast/issues/22933 Fixes https://github.com/hazelcast/hazelcast/issues/22944

All enterprise tests in `com.hazelcast.jet.enterprise` passed in my local
To test in local, use
`-Dhazelcast.serialization.byteOrder=LITTLE_ENDIAN`

Also see
http://jenkins.hazelcast.com/job/ramiz-Hazelcast-master-nightly-little-endian/1/ Also see
http://jenkins.hazelcast.com/job/ramiz-Hazelcast-master-little-endian/2/

Backport of: https://github.com/hazelcast/hazelcast/pull/22941