### PR TITLE
Increase error tolerance in CardinalityEstimatorStressTest [HZ-1799] (#22967) [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorStressTest.java
@@ -43,8 +43,13 @@ public class CardinalityEstimatorStressTest extends HazelcastTestSupport {
         // timeout helps to make sure the encoding engine used is the correct one.
         long expected = 10 * 1000 * 1000;
 
-        float tolerancePct = .3f;
-        long acceptableDelta = (long) ((tolerancePct / 100) * expected);
+        float sigma = 0.008125f;
+
+        // This test is deterministic, actual value never changes.
+        // So we can pick 0.003 for big endian and ~0.012 for little endian.
+        // I picked two times sigma arbitrarily.
+        // Also see https://en.wikipedia.org/wiki/Chebyshev's_inequality
+        long acceptableDelta = (long) (2 * sigma * expected);
 
         int loggingFrequency = 100 * 1000;
         for (int i = 0; i < expected; i++) {


### PR DESCRIPTION
Increase error tolerance of `CardinalityEstimatorStressTest`. This behavior is normal given std dev is ~0.81. If you iterate from `1_000_000_000` to `1_010_000_000` you will see more than 1% error in big endian too.

Fixes https://github.com/hazelcast/hazelcast/issues/22932

Backport of: https://github.com/hazelcast/hazelcast/pull/22967