### PR TITLE
Fix index in WriteJdbcPTest debug code

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -133,11 +133,11 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
         ) {
             ResultSetMetaData metaData = resultSet.getMetaData();
             List<String> connections = new ArrayList<>();
-            for (int i = 0; i < metaData.getColumnCount(); i++) {
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
                 connections.add(metaData.getColumnName(i) + "|");
             }
             while (resultSet.next()) {
-                for (int i = 0; i < metaData.getColumnCount(); i++) {
+                for (int i = 1; i <= metaData.getColumnCount(); i++) {
                     connections.add(resultSet.getObject(i) + "|");
                 }
             }


### PR DESCRIPTION
JDBC for some reason is 1-based (consistency FTW!)

Fixes #22931

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible