### PR TITLE
Fix connection number exceeding max in WriteJdbcPTest [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -131,11 +131,11 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
         ) {
             ResultSetMetaData metaData = resultSet.getMetaData();
             List<String> connections = new ArrayList<>();
-            for (int i = 0; i < metaData.getColumnCount(); i++) {
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
                 connections.add(metaData.getColumnName(i) + "|");
             }
             while (resultSet.next()) {
-                for (int i = 0; i < metaData.getColumnCount(); i++) {
+                for (int i = 1; i <= metaData.getColumnCount(); i++) {
                     connections.add(resultSet.getObject(i) + "|");
                 }
             }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -147,13 +147,6 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
         }
     }
 
-    @After
-    public void tearDown() throws Exception {
-        if (hikariDataSource != null) {
-            hikariDataSource.close();
-        }
-    }
-
     @Test
     public void test() throws SQLException {
         Pipeline p = Pipeline.create();


### PR DESCRIPTION
1. Max connection number increased
2. After each test all remaining connections will be closed (in case of a bug in DS, not Hz).

Fixes #22931
Backport of https://github.com/hazelcast/hazelcast/pull/22968

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases