### PR TITLE
Use non-default multicast port in ClientToMemberDiscoveryTest [5.2.z] [API-1660]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClusterDiscoveryServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClusterDiscoveryServiceBuilder.java
@@ -265,7 +265,6 @@ class ClusterDiscoveryServiceBuilder {
         if (isAutoDetectionEnabled && isEmptyDiscoveryStrategies(discoveryService)) {
             return null;
         }
-        discoveryService.start();
         return discoveryService;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spi.discovery.multicast;
 
 import com.hazelcast.config.properties.ValidationException;
-import com.hazelcast.config.properties.ValueValidator;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
@@ -50,12 +49,11 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
     private static final String DEFAULT_MULTICAST_GROUP = "224.2.2.3";
     private static final Boolean DEFAULT_SAFE_SERIALIZATION = Boolean.FALSE;
 
-    private DiscoveryNode discoveryNode;
-    private MulticastSocket multicastSocket;
+    private final DiscoveryNode discoveryNode;
+    private final ILogger logger;
     private Thread thread;
     private MulticastDiscoveryReceiver multicastDiscoveryReceiver;
     private MulticastDiscoverySender multicastDiscoverySender;
-    private ILogger logger;
     private boolean isClient;
 
     public MulticastDiscoveryStrategy(DiscoveryNode discoveryNode, ILogger logger, Map<String, Comparable> properties) {
@@ -67,8 +65,7 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
     private void initializeMulticastSocket() {
         try {
             int port = getOrDefault(MulticastProperties.PORT, DEFAULT_MULTICAST_PORT);
-            PortValueValidator validator = new PortValueValidator();
-            validator.validate(port);
+            PortValueValidator.validate(port);
             String group = getOrDefault(MulticastProperties.GROUP, DEFAULT_MULTICAST_GROUP);
             boolean safeSerialization = getOrDefault(MulticastProperties.SAFE_SERIALIZATION, DEFAULT_SAFE_SERIALIZATION);
             if (!safeSerialization) {
@@ -80,7 +77,8 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
             }
             MulticastDiscoverySerializationHelper serializationHelper = new MulticastDiscoverySerializationHelper(
                     safeSerialization);
-            multicastSocket = new MulticastSocket(null);
+            MulticastSocket multicastSocket = new MulticastSocket(null);
+            multicastSocket.setReuseAddress(true);
             multicastSocket.bind(new InetSocketAddress(port));
             if (discoveryNode != null) {
                 // See MulticastService.createMulticastService(...)
@@ -89,7 +87,6 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
                     multicastSocket.setInterface(inetAddress);
                 }
             }
-            multicastSocket.setReuseAddress(true);
             multicastSocket.setTimeToLive(SOCKET_TIME_TO_LIVE);
             multicastSocket.setReceiveBufferSize(DATA_OUTPUT_BUFFER_SIZE);
             multicastSocket.setSendBufferSize(DATA_OUTPUT_BUFFER_SIZE);
@@ -103,7 +100,7 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
             }
         } catch (Exception e) {
             logger.finest(e.getMessage());
-            rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -150,11 +147,11 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
     /**
      * Validator for valid network ports
      */
-    private static class PortValueValidator implements ValueValidator<Integer> {
+    private static class PortValueValidator {
         private static final int MIN_PORT = 0;
         private static final int MAX_PORT = 65535;
 
-        public void validate(Integer value) throws ValidationException {
+        public static void validate(int value) throws ValidationException {
             if (value < MIN_PORT) {
                 throw new ValidationException("hz-port number must be greater 0");
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySender.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySender.java
@@ -30,13 +30,13 @@ import static java.lang.Thread.currentThread;
 public class MulticastDiscoverySender implements Runnable {
 
     private static final int SLEEP_DURATION = 2000;
-    private MulticastSocket multicastSocket;
-    private MulticastMemberInfo multicastMemberInfo;
-    private DatagramPacket datagramPacket;
+    private final MulticastSocket multicastSocket;
     private final ILogger logger;
     private final String group;
     private final int port;
     private final MulticastDiscoverySerializationHelper serializationHelper;
+    private MulticastMemberInfo multicastMemberInfo;
+    private DatagramPacket datagramPacket;
     private volatile boolean stop;
 
     public MulticastDiscoverySender(DiscoveryNode discoveryNode, MulticastSocket multicastSocket, ILogger logger, String group,

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.client.impl.spi.impl.discovery;
 
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientClasspathXmlConfig;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.DiscoveryConfig;
@@ -30,7 +30,6 @@ import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.PropertyTypeConverter;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -48,9 +47,8 @@ import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Test;
@@ -81,19 +79,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(SlowTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
 public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
     private static final ILogger LOGGER = Logger.getLogger(ClientDiscoverySpiTest.class);
 
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
     @After
     public void cleanup() {
-        HazelcastClient.shutdownAll();
-        Hazelcast.shutdownAll();
+        hazelcastFactory.terminateAll();
     }
 
     @Test
@@ -111,7 +111,6 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Category(QuickTest.class)
     public void testParsing() {
         String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
         InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
@@ -143,7 +142,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         interfaces.setEnabled(true);
         interfaces.addInterface("127.0.0.1");
 
-        List<DiscoveryNode> discoveryNodes = new CopyOnWriteArrayList<DiscoveryNode>();
+        List<DiscoveryNode> discoveryNodes = new CopyOnWriteArrayList<>();
         DiscoveryStrategyFactory factory = new CollectingDiscoveryStrategyFactory(discoveryNodes);
 
         JoinConfig join = config.getNetworkConfig().getJoin();
@@ -154,31 +153,26 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.emptyMap());
         discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
-        final HazelcastInstance hazelcastInstance1 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance hazelcastInstance2 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance hazelcastInstance3 = Hazelcast.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance1 = hazelcastFactory.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance2 = hazelcastFactory.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance3 = hazelcastFactory.newHazelcastInstance(config);
 
-        try {
-            ClientConfig clientConfig = new ClientConfig();
-            clientConfig.setProperty("hazelcast.discovery.enabled", "true");
-            discoveryConfig = clientConfig.getNetworkConfig().getDiscoveryConfig();
-            discoveryConfig.getDiscoveryStrategyConfigs().clear();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty("hazelcast.discovery.enabled", "true");
+        discoveryConfig = clientConfig.getNetworkConfig().getDiscoveryConfig();
+        discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
-            strategyConfig = new DiscoveryStrategyConfig(factory, Collections.emptyMap());
-            discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
+        strategyConfig = new DiscoveryStrategyConfig(factory, Collections.emptyMap());
+        discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
-            final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
-            assertNotNull(hazelcastInstance1);
-            assertNotNull(hazelcastInstance2);
-            assertNotNull(hazelcastInstance3);
-            assertNotNull(client);
+        assertNotNull(hazelcastInstance1);
+        assertNotNull(hazelcastInstance2);
+        assertNotNull(hazelcastInstance3);
+        assertNotNull(client);
 
-            assertClusterSizeEventually(3, hazelcastInstance1, hazelcastInstance2, hazelcastInstance3, client);
-        } finally {
-            HazelcastClient.shutdownAll();
-            Hazelcast.shutdownAll();
-        }
+        assertClusterSizeEventually(3, hazelcastInstance1, hazelcastInstance2, hazelcastInstance3, client);
     }
 
     @Test
@@ -209,7 +203,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.emptyMap());
         discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
-        final HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance(config);
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setProperty("hazelcast.discovery.enabled", "true");
         discoveryConfig = clientConfig.getNetworkConfig().getDiscoveryConfig();
@@ -218,14 +212,13 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         strategyConfig = new DiscoveryStrategyConfig(factory, Collections.emptyMap());
         discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
-        final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         assertNotNull(hazelcastInstance);
         assertNotNull(client);
 
         //When
-        HazelcastClient.shutdownAll();
-        Hazelcast.shutdownAll();
+        hazelcastFactory.terminateAll();
 
         //Then
         assertOpenEventually(startLatch);
@@ -237,7 +230,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         Config config = new Config();
         config.getNetworkConfig().setPort(50001);
 
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance(config);
         Address address = instance.getCluster().getLocalMember().getAddress();
         ClientConfig clientConfig = new ClientConfig();
 
@@ -247,7 +240,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.emptyMap());
         discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
-        HazelcastClient.newHazelcastClient(clientConfig);
+        hazelcastFactory.newHazelcastClient(clientConfig);
     }
 
     @Test
@@ -292,7 +285,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         config.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(2000);
 
         try {
-            HazelcastClient.newHazelcastClient(config);
+            hazelcastFactory.newHazelcastClient(config);
         } catch (IllegalStateException expected) {
             // no server available
         }
@@ -312,7 +305,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         networkConfig.getDiscoveryConfig().setDiscoveryServiceProvider(discoveryServiceProvider);
 
         try {
-            HazelcastClient.newHazelcastClient(config);
+            hazelcastFactory.newHazelcastClient(config);
             fail("Client cannot start, discovery nodes is null!");
         } catch (NullPointerException expected) {
             // discovered nodes is null
@@ -334,7 +327,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         networkConfig.getDiscoveryConfig().setDiscoveryServiceProvider(discoveryServiceProvider);
 
         try {
-            HazelcastClient.newHazelcastClient(config);
+            hazelcastFactory.newHazelcastClient(config);
         } catch (IllegalStateException expected) {
             // no server available
         }
@@ -343,7 +336,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalStateException.class)
     public void testDiscoveryEnabledNoLocalhost() {
-        Hazelcast.newHazelcastInstance();
+        hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setProperty(ClusterProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
@@ -353,25 +346,43 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         networkConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(
                 new DiscoveryStrategyConfig(new NoMemberDiscoveryStrategyFactory(), Collections.emptyMap()));
 
-        HazelcastClient.newHazelcastClient(clientConfig);
+        hazelcastFactory.newHazelcastClient(clientConfig);
     }
 
     @Test
     public void testDiscoveryDisabledLocalhost() {
-        Hazelcast.newHazelcastInstance();
+        hazelcastFactory.newHazelcastInstance();
 
         // should not throw any exception, localhost is added into the list of addresses
-        HazelcastClient.newHazelcastClient();
+        hazelcastFactory.newHazelcastClient();
     }
 
     @Test(expected = IllegalStateException.class)
     public void testMulticastDiscoveryEnabledNoLocalhost() {
-        Hazelcast.newHazelcastInstance();
+        hazelcastFactory.newHazelcastInstance();
 
         ClientClasspathXmlConfig clientConfig = new ClientClasspathXmlConfig(
                 "hazelcast-client-dummy-multicast-discovery-test.xml");
 
-        HazelcastClient.newHazelcastClient(clientConfig);
+        hazelcastFactory.newHazelcastClient(clientConfig);
+    }
+
+    @Test
+    public void testCustomDiscovery_startCalledOnce() {
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
+
+        ClientConfig config = new ClientConfig();
+        config.setProperty(ClusterProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
+
+        final DiscoveryService discoveryService = mock(DiscoveryService.class);
+        when(discoveryService.discoverNodes()).thenReturn(Collections.singletonList(new SimpleDiscoveryNode(instance.getCluster().getLocalMember().getAddress())));
+        DiscoveryServiceProvider discoveryServiceProvider = arg0 -> discoveryService;
+        ClientNetworkConfig networkConfig = config.getNetworkConfig();
+        networkConfig.getDiscoveryConfig().setDiscoveryServiceProvider(discoveryServiceProvider);
+
+        hazelcastFactory.newHazelcastClient(config);
+
+        verify(discoveryService, times(1)).start();
     }
 
     private DiscoveryServiceSettings buildDiscoveryServiceSettings(DiscoveryConfig config) {
@@ -428,7 +439,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         private final Collection<PropertyDefinition> propertyDefinitions;
 
         public TestDiscoveryStrategyFactory() {
-            List<PropertyDefinition> propertyDefinitions = new ArrayList<PropertyDefinition>();
+            List<PropertyDefinition> propertyDefinitions = new ArrayList<>();
             propertyDefinitions.add(new SimplePropertyDefinition("key-string", PropertyTypeConverter.STRING));
             propertyDefinitions.add(new SimplePropertyDefinition("key-int", PropertyTypeConverter.INTEGER));
             propertyDefinitions.add(new SimplePropertyDefinition("key-boolean", PropertyTypeConverter.BOOLEAN));

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientToMemberDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/ClientToMemberDiscoveryTest.java
@@ -58,8 +58,8 @@ public class ClientToMemberDiscoveryTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        String serverXmlFileName = "hazelcast-multicast-plugin.xml";
-        String clientXmlFileName = "hazelcast-client-multicast-plugin.xml";
+        String serverXmlFileName = "hazelcast-multicast-plugin-non-default-port.xml";
+        String clientXmlFileName = "hazelcast-client-multicast-plugin-non-default-port.xml";
 
         InputStream xmlResource = MulticastDiscoveryStrategy.class.getClassLoader().getResourceAsStream(serverXmlFileName);
         serverConfig = new XmlConfigBuilder(xmlResource).build();

--- a/hazelcast/src/test/resources/hazelcast-client-multicast-plugin-non-default-port.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-multicast-plugin-non-default-port.xml
@@ -27,6 +27,9 @@
     <network>
         <discovery-strategies>
             <discovery-strategy enabled="true" class="com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy">
+                <properties>
+                    <property name="port">54329</property>
+                </properties>
             </discovery-strategy>
         </discovery-strategies>
     </network>

--- a/hazelcast/src/test/resources/hazelcast-multicast-plugin-non-default-port.xml
+++ b/hazelcast/src/test/resources/hazelcast-multicast-plugin-non-default-port.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
+
+    <properties>
+        <property name="hazelcast.discovery.enabled">true</property>
+    </properties>
+
+    <network>
+        <port>6001</port>
+        <join>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="false" />
+            <aws enabled="false"/>
+            <discovery-strategies>
+                <discovery-strategy enabled="true" class="com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy">
+                    <properties>
+                        <property name="port">54329</property>
+                    </properties>
+                </discovery-strategy>
+            </discovery-strategies>
+        </join>
+    </network>
+
+</hazelcast>


### PR DESCRIPTION
This test was failing when the servers where started with `safe-serialization` disabled on members, but enabled on client from time to time.

Upon investigation, I believe there are no problematic parts in the multicast discovery code that would cause such a client to deserialize messages sent by such members.

I believe this test could only fail if the client somehow reads a multicast message serialized by `safe-serialization` enabled members. This could happen because, we were using the default multicast ip and port, and the `safe-serialization` is enabled by default. So, if we had another test(from another test run, because this one is run in serial mode) to send the multicast message and the client reads it, it can discover the members in the `clientSerializationMismatchTest` test.

To probably solve this issue, I have started using a different port in this test for multicast discovery.

Also, I saw a couple of small, problematic, but not-so-related codes here and there and fixed them.

- The `DiscoveryService#start` was being called twice, instead of once, in the client startup(once in the
`ClusterDiscoveryServiceBuilder` and once in the
`CandidateClusterContext`). I have eliminated the first one.
- There were a couple of fields that could have been final, and I made them so.
- There was a variable that could have been a local variable, and I made it so.
- There was an unnecessary object creation (around the PortValidator ) and I have eliminated it.

clean backport of https://github.com/hazelcast/hazelcast/pull/22920
this also backports this single-line change https://github.com/hazelcast/hazelcast/pull/22895