### PR TITLE
Add wait to complete the CP discovery [HZ-1837]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberAddRemoveTest.java
@@ -946,6 +946,8 @@ public class CPMemberAddRemoveTest extends HazelcastRaftTestSupport {
         assertEquals(newMetadataGroupId.getSeed(), getRaftService(newInstance1).getMetadataGroupId().getSeed());
         assertEquals(newMetadataGroupId.getSeed(), getRaftService(newInstance2).getMetadataGroupId().getSeed());
 
+        waitUntilCPDiscoveryCompleted(instances[0], newInstance1, newInstance2);
+
         for (int i = 0; i < commitIndexAdvanceCountToSnapshot; i++) {
             getRaftInvocationManager(instances[0]).invoke(getMetadataGroupId(instances[0]), new GetActiveCPMembersOp()).get();
         }


### PR DESCRIPTION
In a test-failure log, there are no messages that CP Subsystem is initialized after reset, which should be in a normal case. 
The `waitUntilCPDiscoveryCompleted` adds an explicit wait before starting the next operation.

Fix #22513

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
