### PR TITLE
Queue priority test fix [HZ-1096]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueuePriorityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueuePriorityTest.java
@@ -55,9 +55,13 @@ public class QueuePriorityTest extends HazelcastTestSupport {
     public void before() {
         Config config = smallInstanceConfig();
         config.getQueueConfig("default")
-              .setPriorityComparatorClassName("com.hazelcast.collection.impl.queue.model.PriorityElementComparator");
+                .setPriorityComparatorClassName("com.hazelcast.collection.impl.queue.model.PriorityElementComparator");
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances(config);
+
+        assertClusterSizeEventually(3, instances);
+        warmUpPartitions(instances);
+
         queue = instances[0].getQueue(generateKeyOwnedBy(instances[1]));
         threadPool = Executors.newCachedThreadPool();
     }
@@ -92,7 +96,6 @@ public class QueuePriorityTest extends HazelcastTestSupport {
 
     @Test
     public void testPriorityQueue_whenHighestOfferedFirst_thenTakeHighest() {
-
         PriorityElement elementLow = new PriorityElement(false, 1);
         PriorityElement elementHigh = new PriorityElement(true, 1);
 
@@ -119,7 +122,6 @@ public class QueuePriorityTest extends HazelcastTestSupport {
 
     @Test
     public void testPriorityQueue_whenTwoHighest_thenTakeFirstVersionAgain() {
-
         PriorityElement elementHigh1 = new PriorityElement(true, 1);
         PriorityElement elementHigh2 = new PriorityElement(true, 2);
 


### PR DESCRIPTION
Wait for cluster to be formed and partitions warmup before starting tests.

Forward port of #21268 to 4.2.z
Fixes #21375
Fixes #22887
