### PR TITLE
Wait and assert no running instances in tests and prefix test instances [HZ-1842]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/MobyNames.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/MobyNames.java
@@ -24,7 +24,7 @@ import java.util.Collections;
  * Java port of the Moby Project random name generator (https://github.com/moby/moby).
  */
 public final class MobyNames {
-    public static final String MOBY_NAMING_PREFIX = "hazelcast.member.naming.moby.prefix";
+    public static final String MOBY_NAMING_PREFIX = "hazelcast.internal.member.naming.moby.prefix";
 
     private static final String NAME_FORMAT = "%s_%s";
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/MobyNames.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/MobyNames.java
@@ -23,7 +23,8 @@ import java.util.Collections;
 /**
  * Java port of the Moby Project random name generator (https://github.com/moby/moby).
  */
-final class MobyNames {
+public final class MobyNames {
+    public static final String MOBY_NAMING_PREFIX = "hazelcast.member.naming.moby.prefix";
 
     private static final String NAME_FORMAT = "%s_%s";
 
@@ -1047,18 +1048,23 @@ final class MobyNames {
     }
 
     /**
-     * Returns a name from the list of names formatted as "adjective_surname",
-     * for example 'focused_turing'. The list is randomized on class
+     * Returns a name from the list of names formatted as "prefix_adjective_surname" (or "adjective_surname" is prefix is null),
+     * for example 'foo_focused_turing' (or 'focused_turing' if prefix is null). The list is randomized on class
      * initialization, but the answers from repeated calls with the same number
      * are stable.
      *
      * @param number index into the sequence of names
      * @return a Moby name
      */
-    static String getRandomName(int number) {
+    public static String getRandomName(int number) {
         int combinationIdx = number % (LEFT.length * RIGHT.length);
         int rightIdx = combinationIdx / LEFT.length;
         int leftIdx = combinationIdx % LEFT.length;
-        return String.format(NAME_FORMAT, LEFT[leftIdx], RIGHT[rightIdx]);
+        String name = String.format(NAME_FORMAT, LEFT[leftIdx], RIGHT[rightIdx]);
+        String prefix = System.getProperty(MOBY_NAMING_PREFIX);
+        if (prefix != null) {
+            name = prefix + "_" + name;
+        }
+        return name;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/MobyNamesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/MobyNamesTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -29,6 +30,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmptyAfterTrim;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -37,10 +39,24 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class MobyNamesTest extends HazelcastTestSupport {
 
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty(MobyNames.MOBY_NAMING_PREFIX);
+    }
+
     @Test
     public void getRandomNameNotEmpty() {
         String randomName = MobyNames.getRandomName(0);
         assertFalse(isNullOrEmptyAfterTrim(randomName));
+    }
+
+    @Test
+    public void getRandomNameWithPrefix() {
+        System.setProperty(MobyNames.MOBY_NAMING_PREFIX, "foo");
+        String randomName = MobyNames.getRandomName(0);
+        assertFalse(isNullOrEmptyAfterTrim(randomName));
+        assertThat(randomName).startsWith("foo_");
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -20,13 +20,13 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.impl.JetServiceBackend;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.PacketFiltersUtil;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -42,7 +42,6 @@ import java.util.stream.Collectors;
 import static com.hazelcast.jet.Util.idToString;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -60,7 +59,7 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
     private static HazelcastInstance client;
 
     protected static void initialize(int memberCount, @Nullable Config config) {
-        assertTrueEventually(SimpleTestInClusterSupport::assertNoRunningInstances, 30);
+        assertTrueEventually(HazelcastTestSupport::assertNoRunningInstances, 30);
 
         assert factory == null : "already initialized";
         factory = new TestHazelcastFactory();
@@ -194,9 +193,5 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
      */
     protected static HazelcastInstance client() {
         return client;
-    }
-
-    private static void assertNoRunningInstances() {
-        assertThat(Hazelcast.getAllHazelcastInstances()).as("There should be no running instances").isEmpty();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -60,7 +60,7 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
     private static HazelcastInstance client;
 
     protected static void initialize(int memberCount, @Nullable Config config) {
-        assertNoRunningInstances();
+        assertTrueEventually(SimpleTestInClusterSupport::assertNoRunningInstances, 30);
 
         assert factory == null : "already initialized";
         factory = new TestHazelcastFactory();

--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -26,7 +26,6 @@ import com.hazelcast.jet.impl.JetServiceBackend;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.PacketFiltersUtil;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -59,7 +58,7 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
     private static HazelcastInstance client;
 
     protected static void initialize(int memberCount, @Nullable Config config) {
-        assertTrueEventually(HazelcastTestSupport::assertNoRunningInstances, 30);
+        assertNoRunningInstances();
 
         assert factory == null : "already initialized";
         factory = new TestHazelcastFactory();

--- a/hazelcast/src/test/java/com/hazelcast/test/AfterClassesStatement.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AfterClassesStatement.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import static com.hazelcast.cache.jsr.JsrTestUtil.clearCachingProviderRegistry;
 import static com.hazelcast.cache.jsr.JsrTestUtil.getCachingProviderRegistrySize;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 
 class AfterClassesStatement extends Statement {
     private final Statement originalStatement;
@@ -44,6 +45,7 @@ class AfterClassesStatement extends Statement {
         if (!instances.isEmpty()) {
             String message = "Instances haven't been shut down: " + instances;
             HazelcastInstanceFactory.terminateAll();
+            assertTrueEventually(HazelcastTestSupport::assertNoRunningInstances, 30);
             throw new IllegalStateException(message);
         }
         Collection<HazelcastInstance> clientInstances = HazelcastClient.getAllHazelcastClients();

--- a/hazelcast/src/test/java/com/hazelcast/test/AfterClassesStatement.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AfterClassesStatement.java
@@ -52,6 +52,7 @@ class AfterClassesStatement extends Statement {
         if (!clientInstances.isEmpty()) {
             String message = "Client instances haven't been shut down: " + clientInstances;
             HazelcastClient.shutdownAll();
+            assertTrueEventually(HazelcastTestSupport::assertNoRunningClientInstances, 30);
             throw new IllegalStateException(message);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -57,6 +57,7 @@ import junit.framework.AssertionFailedError;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
+import org.junit.ClassRule;
 import org.junit.ComparisonFailure;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
@@ -127,6 +128,9 @@ public abstract class HazelcastTestSupport {
     private static final String COMPAT_HZ_INSTANCE_FACTORY = "com.hazelcast.test.CompatibilityTestHazelcastInstanceFactory";
     private static final boolean EXPECT_DIFFERENT_HASHCODES = (new Object().hashCode() != new Object().hashCode());
     private static final ILogger LOGGER = Logger.getLogger(HazelcastTestSupport.class);
+
+    @ClassRule
+    public static MobyNamingRule mobyNamingRule = new MobyNamingRule();
 
     @Rule
     public JitterRule jitterRule = new JitterRule();

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -17,6 +17,7 @@
 package com.hazelcast.test;
 
 import classloading.ThreadLocalLeakTestUtils;
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Cluster;
 import com.hazelcast.cluster.ClusterState;
@@ -802,6 +803,10 @@ public abstract class HazelcastTestSupport {
 
     public static void assertNoRunningInstances() {
         assertThat(Hazelcast.getAllHazelcastInstances()).as("There should be no running instances").isEmpty();
+    }
+
+    public static void assertNoRunningClientInstances() {
+        assertThat(HazelcastClient.getAllHazelcastClients()).as("There should be no running client instances").isEmpty();
     }
 
     public static void assertNodeStarted(HazelcastInstance instance) {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -23,6 +23,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.instance.BuildInfoProvider;
@@ -97,6 +98,7 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -796,6 +798,10 @@ public abstract class HazelcastTestSupport {
         }
 
         assertTrue("Instances not in safe state! " + nonSafeStates, nonSafeStates.isEmpty());
+    }
+
+    public static void assertNoRunningInstances() {
+        assertThat(Hazelcast.getAllHazelcastInstances()).as("There should be no running instances").isEmpty();
     }
 
     public static void assertNodeStarted(HazelcastInstance instance) {

--- a/hazelcast/src/test/java/com/hazelcast/test/MobyNamingRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/MobyNamingRule.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import static com.hazelcast.instance.impl.MobyNames.MOBY_NAMING_PREFIX;
+
+class MobyNamingRule extends TestWatcher {
+    @Override
+    protected void starting(Description description) {
+        String className = description.getTestClass().getSimpleName();
+        System.setProperty(MOBY_NAMING_PREFIX, className);
+    }
+}


### PR DESCRIPTION
Maybe fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/5519
This PR:
- Adds waiting for asynchronous shutdown of the test instances up to 30 seconds
- Adds test class name as a prefix for the created instances to easily see find the creator of the instance
```diff
- 13:36:47,234  INFO || - [ClusterService] hz.happy_fermi.generic-operation.thread-1 - [127.0.0.1]:5702 [dev] [5.2-SNAPSHOT] 
+ 13:36:47,234  INFO || - [ClusterService] hz.TSSqlIndexTest_happy_fermi.generic-operation.thread-1 - [127.0.0.1]:5702 [dev] [5.2-SNAPSHOT] 
```

Wee see failures of `SimpleTestInClusterSupport#assertNoRunningInstances` in `@BeforeClass` but it's not obvious where from we got these leftover instances.
```
[There should be no running instances] 
Expecting empty but was:<[HazelcastInstance{name='stoic_northcutt', node=[127.0.0.1]:5701}]>
```

BTW It's odd since in `com.hazelcast.test.AfterClassesStatement` we terminate all instances  