### PR TITLE
Fix timeout failure in SqlAvroTest.test_topLevelFieldExtraction [HZ-1841] [5.2.z]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
@@ -83,7 +83,11 @@ public class SqlAvroTest extends SqlTestSupport {
 
         Properties properties = new Properties();
         properties.put("listeners", "http://0.0.0.0:0");
-        properties.put("kafkastore.bootstrap.servers", kafkaTestSupport.getBrokerConnectionString());
+        properties.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, kafkaTestSupport.getBrokerConnectionString());
+        //When Kafka is under load the schema registry may give
+        //io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException: Register operation timed out; error code: 50002
+        //Because the default timeout is 500 ms. Use a bigger timeout value to avoid it
+        properties.put(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG, "5000");
         SchemaRegistryConfig config = new SchemaRegistryConfig(properties);
         SchemaRegistryRestApplication schemaRegistryApplication = new SchemaRegistryRestApplication(config);
         schemaRegistry = schemaRegistryApplication.createServer();


### PR DESCRIPTION
Note : The fix is based on a guess because I was not able to reproduce it. The solution is found here https://groups.google.com/g/confluent-platform/c/u3A7BCZEFNg

When Kafka is under load it becomes less responsive and when a new schema is to be registered the schema registry is waiting only 500 ms. If no response is received it is throwing
io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException: Register operation timed out; error code: 50002

The code that catches up schema registry with Kafka is in io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry.java That code is using kafkastore.timeout.ms value
I have changed the test to use a bigger timeout value to avoid timeout failures

Fixes : https://github.com/hazelcast/hazelcast/issues/23027
Backport : https://github.com/hazelcast/hazelcast/pull/23037

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
