### PR TITLE
Change hazelcast-mapstore pom name to hazelcast-mapstore

### DIFF
--- a/extensions/mapstore/pom.xml
+++ b/extensions/mapstore/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>hazelcast-mapstore</artifactId>
 
     <packaging>jar</packaging>
-    <name>hazelcast-sql-mapstore</name>
+    <name>hazelcast-mapstore</name>
     <description>Ready made MapStore using Hazelcast SQL</description>
     <url>http://www.hazelcast.com/</url>
 


### PR DESCRIPTION
This was a leftover after renaming the module and artifactId from `hazelcast-sql-mapstore` to `hazelcast-mapstore`.

Fixes #22736

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
