### PR TITLE
Avoid race in JobLifecycleMetricsTest [HZ-1848]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/TestProcessors.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/TestProcessors.java
@@ -496,13 +496,15 @@ public final class TestProcessors {
         protected void init(@Nonnull Context context) throws InterruptedException {
             LOGGER.info("MockP.init called on " + Thread.currentThread().getName());
             initCount.incrementAndGet();
-            if (initError != null) {
-                throw sneakyThrow(initError);
-            }
 
+            // Block first to allow to control when the exception is thrown
             if (initBlocks) {
                 blockingSemaphore.acquire();
                 Thread.sleep(RANDOM.nextInt(500));
+            }
+
+            if (initError != null) {
+                throw sneakyThrow(initError);
             }
         }
 


### PR DESCRIPTION
The second job submitted intentionally fails. It is possible that the TerminateExecutionOperation is processed before StartExecutionOperation reaches this point:

```
ExecutionContext executionContext = executionContexts.get(executionId);
if (executionContext == null) {
    throw new ExecutionNotFoundException(String.format(
	    "%s not found for coordinator %s for '%s'",
	    jobIdAndExecutionId(jobId, executionId), callerAddress, callerOpName));
} else if (!(executionContext.coordinator().equals(callerAddress) && executionContext.jobId() == jobId)) {
```

in `JobExecutionService#assertExecutionContext`

We fix this race by blocking in `MockP#init` before throwing an exception from it. This way the StartExecutionOperation will run on all members.

Fixes #21469
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
