### PR TITLE
Fix race when start time metric can be greater that completion time [HZ-1858] [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -229,6 +229,7 @@ public class ExecutionContext implements DynamicMetricsProvider {
                 if (cl == null) {
                     cl = nodeEngine.getConfigClassLoader();
                 }
+                startTime.set(System.currentTimeMillis());
                 executionFuture = taskletExecService
                         .beginExecute(tasklets, cancellationFuture, cl)
                         .whenComplete(withTryCatch(logger, (r, t) -> setCompletionTime()))
@@ -241,7 +242,6 @@ public class ExecutionContext implements DynamicMetricsProvider {
                             }
                             return res;
                         });
-                startTime.set(System.currentTimeMillis());
             }
             return executionFuture;
         }


### PR DESCRIPTION
Makes start time metric more reliable by recording it before submitting tasklets for asynchronous execution.
Start and completion times are obtained using `System.currentTimeMillis()` so in case of it going backwards they still can be in wrong relation to each other. This however is less probable.

Fixes #23057
Backport of #23065

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases