### PR TITLE
Fix thread interrupt check in SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.testAcquire_shouldReleaseSessionsOnRuntimeError [HZ-1829] [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -73,10 +73,11 @@ public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends H
     @Test
     public void testAcquire_shouldReleaseSessionsOnRuntimeError() throws InterruptedException {
         initSemaphoreAndAcquirePermits(10, 5);
-        assertEquals(getSessionAcquireCount(), 5);
+        assertEquals(5, getSessionAcquireCount());
         Future future = spawn(() -> {
             Thread.currentThread().interrupt();
-            semaphore.acquire(5);
+            //Make the semaphore block, so that Thread.interrupt() can be detected
+            semaphore.acquire(6);
         });
 
         try {
@@ -86,13 +87,13 @@ public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends H
             assertTrue(e.getCause() instanceof HazelcastException);
             assertTrue(e.getCause().getCause() instanceof InterruptedException);
         }
-        assertEquals(getSessionAcquireCount(), 5);
+        assertEquals(5, getSessionAcquireCount());
     }
 
     @Test
     public void testTryAcquire_shouldReleaseSessionsOnRuntimeError() throws InterruptedException {
         initSemaphoreAndAcquirePermits(2, 1);
-        assertEquals(getSessionAcquireCount(), 1);
+        assertEquals(1, getSessionAcquireCount());
         Future future = spawn(() -> {
             Thread.currentThread().interrupt();
             semaphore.tryAcquire(10, TimeUnit.MINUTES);
@@ -105,13 +106,13 @@ public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends H
             assertTrue(e.getCause() instanceof HazelcastException);
             assertTrue(e.getCause().getCause() instanceof InterruptedException);
         }
-        assertEquals(getSessionAcquireCount(), 1);
+        assertEquals(1, getSessionAcquireCount());
     }
 
     @Test
     public void testDrainPermits_shouldReleaseSessionsOnRuntimeError() throws InterruptedException {
         initSemaphoreAndAcquirePermits(42, 2);
-        assertEquals(getSessionAcquireCount(), 2);
+        assertEquals(2, getSessionAcquireCount());
         Future future = spawn(() -> {
             Thread.currentThread().interrupt();
             semaphore.drainPermits();
@@ -124,7 +125,7 @@ public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends H
             assertTrue(e.getCause() instanceof HazelcastException);
             assertTrue(e.getCause().getCause() instanceof InterruptedException);
         }
-        assertEquals(getSessionAcquireCount(), 2);
+        assertEquals(2, getSessionAcquireCount());
     }
 
     private void initSemaphoreAndAcquirePermits(int initialPermits, int acquiredPermits) {


### PR DESCRIPTION
The test is failing because AbstractInvocationFuture, which is a custom implementation of CompletableFuture needs to spin over a loop to detect if thread is interrupted. However, if semaphore.acquire() response is received before the loop, the test fails.
Therefore, we need to make sure that semaphore does not respond. I have changed the semaphore acquire permit from 5 to 6 to make the semaphore not respond and allow the AbstractInvocationFuture to spin the loop to do thread.interrupt check

Fixes : https://github.com/hazelcast/hazelcast/issues/20038
Backport: https://github.com/hazelcast/hazelcast/pull/22995

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

(cherry picked from commit 98514d2a3a8f65e79ed5fbeeb43e54c991174c56)


