### PR TITLE
Return true when old value exist

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTtlOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTtlOperation.java
@@ -73,7 +73,7 @@ public class SetTtlOperation extends LockAwareOperation
     @Override
     public void applyState(State state) {
         super.applyState(state);
-        response = state.getOldValue() == null;
+        response = state.getOldValue() != null;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/map/AbstractClientMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/AbstractClientMapTest.java
@@ -53,6 +53,11 @@ public abstract class AbstractClientMapTest extends HazelcastTestSupport {
         client = hazelcastFactory.newHazelcastClient(clientConfig);
     }
 
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfigWithoutJetAndMetrics();
+    }
+
     @After
     public final void stopHazelcastInstances() {
         hazelcastFactory.terminateAll();

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -137,7 +137,7 @@ public class BasicMapTest extends HazelcastTestSupport {
     }
 
     protected Config getConfig() {
-        Config cfg = smallInstanceConfig();
+        Config cfg = smallInstanceConfigWithoutJetAndMetrics();
         cfg.getMapConfig("default")
                 .setStatisticsEnabled(statisticsEnabled)
                 .setPerEntryStatsEnabled(perEntryStatsEnabled);


### PR DESCRIPTION
follow-up of https://github.com/hazelcast/hazelcast/pull/22960

There was a mistake when copying code for setTtl return value.

see bulk failures: https://jenkins.hazelcast.com/view/force-offload-map/job/Hazelcast-EE-master-force-offload/lastCompletedBuild/testReport/