### PR TITLE
Fix http timeout in RestLogLevelTest.testDisabledRest [HZ-1865]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -27,6 +27,7 @@ import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -464,11 +465,7 @@ public class HTTPCommunicator {
             Header[] headers = httpResponse.getAllHeaders();
             Map<String, List<String>> responseHeaders = new HashMap<>();
             for (Header header : headers) {
-                List<String> values = responseHeaders.get(header.getName());
-                if (values == null) {
-                    values = new ArrayList<>();
-                    responseHeaders.put(header.getName(), values);
-                }
+                List<String> values = responseHeaders.computeIfAbsent(header.getName(), k -> new ArrayList<>());
                 values.add(header.getValue());
             }
             this.responseCode = responseCode;
@@ -591,6 +588,15 @@ public class HTTPCommunicator {
             builder.setSSLSocketFactory(new SSLConnectionSocketFactory(sslContext,
                     SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER));
         }
+
+        // configure timeout on the entire client
+        int timeout = 20;
+        RequestConfig config = RequestConfig.custom()
+                .setConnectTimeout(timeout * 1_000)
+                .setConnectionRequestTimeout(timeout * 1_000)
+                .setSocketTimeout(timeout * 1_000).build();
+
+        builder.setDefaultRequestConfig(config);
 
         return builder.build();
     }


### PR DESCRIPTION
The test is trying to access a rest endpoint which does not exist. From the logs we can see that http request blocked on read operation and the test timed out. When Apache HttpClient is not given any timeout values, it uses system default values which may not be consistent across all test environments. So I have changed the test code to use a timeout value of 20 seconds. 20 seconds is chosen because some tests require a timeout of at least 10 seconds.

Fixes : https://github.com/hazelcast/hazelcast/issues/21366

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
