### PR TITLE
Stub schema service methods before the members start in the replication tests [API-1655]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/schema/CompactSchemaReplicationSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/schema/CompactSchemaReplicationSlowTest.java
@@ -49,7 +49,7 @@ public class CompactSchemaReplicationSlowTest extends CompactSchemaReplicationTe
         // First member will always throw retryable exception
         // in the preparation phase, others will work fine.
         int stubbedMemberIndex = 0;
-        setupInstances(index -> index == 0 ? stubbedSchemaService : spy(new MemberSchemaService()));
+        setupInstances(index -> index == stubbedMemberIndex ? stubbedSchemaService : spy(new MemberSchemaService()));
         HazelcastInstance stubbed = instances[stubbedMemberIndex];
 
         assertThrows(HazelcastSerializationException.class, () -> fillMapUsing(instances[1]));

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/schema/CompactSchemaReplicationSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/schema/CompactSchemaReplicationSlowTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -40,17 +41,24 @@ public class CompactSchemaReplicationSlowTest extends CompactSchemaReplicationTe
 
     @Test
     public void testSchemaReplication_whenAMemberThrowsRetryableExceptionAllTheTime_duringPreparationPhase() {
+        MemberSchemaService stubbedSchemaService = spy(new MemberSchemaService());
         doThrow(new RetryableHazelcastException())
-                .when(getSchemaService(instance1))
+                .when(stubbedSchemaService)
                 .onSchemaPreparationRequest(SCHEMA);
 
-        assertThrows(HazelcastSerializationException.class, () -> fillMapUsing(instance2));
+        // First member will always throw retryable exception
+        // in the preparation phase, others will work fine.
+        int stubbedMemberIndex = 0;
+        setupInstances(index -> index == 0 ? stubbedSchemaService : spy(new MemberSchemaService()));
+        HazelcastInstance stubbed = instances[stubbedMemberIndex];
+
+        assertThrows(HazelcastSerializationException.class, () -> fillMapUsing(instances[1]));
 
         for (HazelcastInstance instance : instances) {
             MemberSchemaService service = getSchemaService(instance);
 
-            if (instance == instance1) {
-                // For instance1, it must fail all the time
+            if (instance == stubbed) {
+                // For stubbed member, it must fail all the time
                 verify(service, atLeast(SchemaReplicator.MAX_RETRIES_FOR_REQUESTS)).onSchemaPreparationRequest(SCHEMA);
             }
 
@@ -61,22 +69,30 @@ public class CompactSchemaReplicationSlowTest extends CompactSchemaReplicationTe
 
     @Test
     public void testSchemaReplication_whenAMemberThrowsRetryableExceptionAllTheTime_duringAcknowledgmentPhase() {
+        MemberSchemaService stubbedSchemaService = spy(new MemberSchemaService());
         doThrow(new RetryableHazelcastException())
-                .when(getSchemaService(instance4))
+                .when(stubbedSchemaService)
                 .onSchemaAckRequest(SCHEMA.getSchemaId());
 
-        assertThrows(HazelcastSerializationException.class, () -> fillMapUsing(instance1));
+        // Fourth member will always throw retryable exception
+        // in the acknowledgment phase, others will work fine.
+        int stubbedMemberIndex = 3;
+        setupInstances(index -> index == stubbedMemberIndex ? stubbedSchemaService : spy(new MemberSchemaService()));
+        HazelcastInstance stubbed = instances[stubbedMemberIndex];
+
+        HazelcastInstance initiator = instances[0];
+        assertThrows(HazelcastSerializationException.class, () -> fillMapUsing(initiator));
 
         for (HazelcastInstance instance : instances) {
             MemberSchemaService service = getSchemaService(instance);
 
-            // Everyone should call, apart from the initiator
-            if (instance != instance1) {
+            // Everyone should call onSchemaPreparationRequest, apart from the initiator
+            if (instance != initiator) {
                 verify(service, atLeastOnce()).onSchemaPreparationRequest(SCHEMA);
             }
 
-            if (instance == instance4) {
-                // For instance4, it must fail all the time
+            if (instance == stubbed) {
+                // For stubbed member, it must fail all the time
                 verify(service, atLeast(SchemaReplicator.MAX_RETRIES_FOR_REQUESTS)).onSchemaAckRequest(SCHEMA.getSchemaId());
             }
         }
@@ -85,8 +101,6 @@ public class CompactSchemaReplicationSlowTest extends CompactSchemaReplicationTe
     @Override
     public Config getConfig() {
         Config config = super.getConfig();
-        // Jet prints too many logs during the test
-        config.getJetConfig().setEnabled(false);
         config.getProperties().setProperty(INVOCATION_RETRY_PAUSE.getName(), "100");
         return config;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/schema/CompactSchemaReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/schema/CompactSchemaReplicationTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -42,19 +43,24 @@ import static org.mockito.Mockito.verify;
 public class CompactSchemaReplicationTest extends CompactSchemaReplicationTestBase {
     @Test
     public void testSchemaReplication() {
-        fillMapUsing(instance1);
+        // We won't stub any of the schema services.
+        // We will just assert call counts.
+        setupInstances(index -> spy(new MemberSchemaService()));
+
+        HazelcastInstance initiator = instances[0];
+        fillMapUsing(initiator);
 
         for (HazelcastInstance instance : instances) {
             MemberSchemaService service = getSchemaService(instance);
             SchemaReplicator replicator = service.getReplicator();
 
             // Everyone should call onSchemaPreparationRequest, apart from the initiator
-            if (instance != instance1) {
+            if (instance != initiator) {
                 verify(service, atLeastOnce()).onSchemaPreparationRequest(SCHEMA);
             }
 
             // Everyone should call onSchemaAckRequest, apart from the initiator
-            if (instance != instance1) {
+            if (instance != initiator) {
                 verify(service, atLeastOnce()).onSchemaAckRequest(SCHEMA.getSchemaId());
             }
 
@@ -65,11 +71,16 @@ public class CompactSchemaReplicationTest extends CompactSchemaReplicationTestBa
 
     @Test
     public void testSchemaReplication_whenAMemberThrows_duringPreparationPhase() {
+        MemberSchemaService stubbedSchemaService = spy(new MemberSchemaService());
         doThrow(new RuntimeException())
-                .when(getSchemaService(instance1))
+                .when(stubbedSchemaService)
                 .onSchemaPreparationRequest(any(Schema.class));
 
-        assertThrows(HazelcastSerializationException.class, () -> fillMapUsing(instance2));
+        // First member will always throw non-retryable exception
+        // in the preparation phase, others will work fine.
+        setupInstances(index -> index == 0 ? stubbedSchemaService : spy(new MemberSchemaService()));
+
+        assertThrows(HazelcastSerializationException.class, () -> fillMapUsing(instances[1]));
 
         for (HazelcastInstance instance : instances) {
             MemberSchemaService service = getSchemaService(instance);
@@ -84,27 +95,35 @@ public class CompactSchemaReplicationTest extends CompactSchemaReplicationTestBa
 
     @Test
     public void testSchemaReplication_whenAMemberThrowsRetryableExceptionForSomeTime_duringPreparationPhase() {
+        MemberSchemaService stubbedSchemaService = spy(new MemberSchemaService());
         doThrow(new RetryableHazelcastException()) // Throw once
                 .doCallRealMethod() // Then succeed
-                .when(getSchemaService(instance3))
+                .when(stubbedSchemaService)
                 .onSchemaPreparationRequest(SCHEMA);
 
-        fillMapUsing(instance4);
+        // Third member will throw retryable exception and then continue working
+        // in the preparation phase, others will work fine.
+        int stubbedMemberIndex = 2;
+        setupInstances(index -> index == stubbedMemberIndex ? stubbedSchemaService : spy(new MemberSchemaService()));
+        HazelcastInstance stubbed = instances[stubbedMemberIndex];
+
+        HazelcastInstance initiator = instances[3];
+        fillMapUsing(initiator);
 
         for (HazelcastInstance instance : instances) {
             MemberSchemaService service = getSchemaService(instance);
             SchemaReplicator replicator = service.getReplicator();
 
             // Everyone should call onSchemaPreparationRequest, apart from the initiator
-            if (instance == instance3) {
-                // For instance3, it must at least fail + succeed
+            if (instance == stubbed) {
+                // For stubbed member, it must at least fail + succeed
                 verify(service, atLeast(2)).onSchemaPreparationRequest(SCHEMA);
-            } else if (instance != instance4) {
+            } else if (instance != initiator) {
                 verify(service, atLeastOnce()).onSchemaPreparationRequest(SCHEMA);
             }
 
             // Everyone should call onSchemaAckRequest it, apart from the initiator
-            if (instance != instance4) {
+            if (instance != initiator) {
                 verify(service, atLeastOnce()).onSchemaAckRequest(SCHEMA.getSchemaId());
             }
 
@@ -115,17 +134,23 @@ public class CompactSchemaReplicationTest extends CompactSchemaReplicationTestBa
 
     @Test
     public void testSchemaReplication_whenAMemberThrows_duringAcknowledgmentPhase() {
+        MemberSchemaService stubbedSchemaService = spy(new MemberSchemaService());
         doThrow(new RuntimeException())
-                .when(getSchemaService(instance4))
+                .when(stubbedSchemaService)
                 .onSchemaAckRequest(anyLong());
 
-        assertThrows(HazelcastSerializationException.class, () -> fillMapUsing(instance1));
+        // Fourth member will always throw non-retryable exception
+        // in the acknowledgment phase, others will work fine.
+        setupInstances(index -> index == 3 ? stubbedSchemaService : spy(new MemberSchemaService()));
+
+        HazelcastInstance initiator = instances[0];
+        assertThrows(HazelcastSerializationException.class, () -> fillMapUsing(initiator));
 
         for (HazelcastInstance instance : instances) {
             MemberSchemaService service = getSchemaService(instance);
 
             // Everyone should call onSchemaPreparationRequest, apart from the initiator
-            if (instance != instance1) {
+            if (instance != initiator) {
                 verify(service, atLeastOnce()).onSchemaPreparationRequest(SCHEMA);
             }
 
@@ -136,27 +161,35 @@ public class CompactSchemaReplicationTest extends CompactSchemaReplicationTestBa
 
     @Test
     public void testSchemaReplication_whenAMemberThrowsRetryableExceptionForSomeTime_duringAcknowledgmentPhase() {
+        MemberSchemaService stubbedSchemaService = spy(new MemberSchemaService());
         doThrow(new RetryableHazelcastException()) // Throw once
                 .doCallRealMethod() // Then succeed
-                .when(getSchemaService(instance2))
+                .when(stubbedSchemaService)
                 .onSchemaAckRequest(SCHEMA.getSchemaId());
 
-        fillMapUsing(instance3);
+        // Third member will throw retryable exception and then continue working
+        // in the preparation phase, others will work fine.
+        int stubbedMemberIndex = 1;
+        setupInstances(index -> index == stubbedMemberIndex ? stubbedSchemaService : spy(new MemberSchemaService()));
+        HazelcastInstance stubbed = instances[stubbedMemberIndex];
+
+        HazelcastInstance initiator = instances[2];
+        fillMapUsing(initiator);
 
         for (HazelcastInstance instance : instances) {
             MemberSchemaService service = getSchemaService(instance);
             SchemaReplicator replicator = service.getReplicator();
 
             // Everyone should call onSchemaPreparationRequest, apart from the initiator
-            if (instance != instance3) {
+            if (instance != initiator) {
                 verify(service, atLeastOnce()).onSchemaPreparationRequest(SCHEMA);
             }
 
             // Everyone should call onSchemaAckRequest, apart from the initiator
-            if (instance == instance2) {
-                // For instance2, it must at least fail + succeed
+            if (instance == stubbed) {
+                // For stubbed member, it must at least fail + succeed
                 verify(service, atLeast(2)).onSchemaAckRequest(SCHEMA.getSchemaId());
-            } else if (instance != instance3) {
+            } else if (instance != initiator) {
                 verify(service, atLeastOnce()).onSchemaAckRequest(SCHEMA.getSchemaId());
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/schema/CompactSchemaReplicationTestBase.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/schema/CompactSchemaReplicationTestBase.java
@@ -36,14 +36,13 @@ import com.hazelcast.test.TestEnvironment;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import example.serialization.NodeDTO;
 import org.junit.After;
-import org.junit.Before;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.function.Function;
 
 import static com.hazelcast.instance.impl.TestUtil.getNode;
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.getSchemasFor;
-import static org.mockito.Mockito.spy;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockingDetails;
 
 public class CompactSchemaReplicationTestBase extends HazelcastTestSupport {
 
@@ -51,12 +50,7 @@ public class CompactSchemaReplicationTestBase extends HazelcastTestSupport {
 
     protected static final Schema SCHEMA = getSchemasFor(NodeDTO.class).iterator().next();
 
-    protected HazelcastInstance instance1;
-    protected HazelcastInstance instance2;
-    protected HazelcastInstance instance3;
-    protected HazelcastInstance instance4;
-
-    protected Collection<HazelcastInstance> instances;
+    protected HazelcastInstance[] instances;
 
     private final CustomTestInstanceFactory factory = new CustomTestInstanceFactory();
 
@@ -65,19 +59,17 @@ public class CompactSchemaReplicationTestBase extends HazelcastTestSupport {
         factory.terminateAll();
     }
 
-    @Before
-    public void setup() {
-        instance1 = factory.newHazelcastInstance(getConfig());
-        instance2 = factory.newHazelcastInstance(getConfig());
-        instance3 = factory.newHazelcastInstance(getConfig());
-        instance4 = factory.newHazelcastInstance(getConfig());
-
-        instances = Arrays.asList(instance1, instance2, instance3, instance4);
+    public void setupInstances(Function<Integer, MemberSchemaService> spyServiceCreator) {
+        int instanceCount = 4;
+        instances = new HazelcastInstance[instanceCount];
+        for (int i = 0; i < 4; i++) {
+            instances[i] = factory.newHazelcastInstance(getConfig(), spyServiceCreator.apply(i));
+        }
     }
 
     @Override
     public Config getConfig() {
-        return smallInstanceConfig();
+        return smallInstanceConfigWithoutJetAndMetrics();
     }
 
     protected void fillMapUsing(HazelcastInstance instance) {
@@ -92,8 +84,9 @@ public class CompactSchemaReplicationTestBase extends HazelcastTestSupport {
     }
 
     private static class CustomTestInstanceFactory extends TestHazelcastInstanceFactory {
-        @Override
-        public HazelcastInstance newHazelcastInstance(Config config) {
+        public HazelcastInstance newHazelcastInstance(Config config, MemberSchemaService schemaService) {
+            assertTrue(mockingDetails(schemaService).isSpy());
+
             String instanceName = config != null ? config.getInstanceName() : null;
             NodeContext nodeContext;
             if (TestEnvironment.isMockNetwork()) {
@@ -103,21 +96,23 @@ public class CompactSchemaReplicationTestBase extends HazelcastTestSupport {
                 nodeContext = new DefaultNodeContext();
             }
             return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName,
-                    new MemberSchemaServiceMockingNodeContext(nodeContext));
+                    new MemberSchemaServiceMockingNodeContext(nodeContext, schemaService));
         }
     }
 
     private static class MemberSchemaServiceMockingNodeContext implements NodeContext {
 
         private final NodeContext delegate;
+        private final MemberSchemaService schemaService;
 
-        private MemberSchemaServiceMockingNodeContext(NodeContext delegate) {
+        private MemberSchemaServiceMockingNodeContext(NodeContext delegate, MemberSchemaService schemaService) {
             this.delegate = delegate;
+            this.schemaService = schemaService;
         }
 
         @Override
         public NodeExtension createNodeExtension(Node node) {
-            return new MemberSchemaServiceMockingNodeExtension(node);
+            return new MemberSchemaServiceMockingNodeExtension(node, schemaService);
         }
 
         @Override
@@ -139,9 +134,9 @@ public class CompactSchemaReplicationTestBase extends HazelcastTestSupport {
     private static class MemberSchemaServiceMockingNodeExtension extends DefaultNodeExtension {
         private final MemberSchemaService schemaService;
 
-        MemberSchemaServiceMockingNodeExtension(Node node) {
+        MemberSchemaServiceMockingNodeExtension(Node node, MemberSchemaService schemaService) {
             super(node);
-            schemaService = spy(new MemberSchemaService());
+            this.schemaService = schemaService;
         }
 
         @Override


### PR DESCRIPTION
We were using Mockito spies to verify that the members were calling
the replication-related methods of the MemberSchemaService correctly.

However, we were stubbing some of the spied MemberSchemServices
after the members are started.

This is generally working fine, but problematic under the following
scenario, where the same schema service is accessed from different
threads at the same time.

- We call `doThrow(someException).when(schemaService)` in thread A
- At the same time, we call some method of the schema service in
thread B
- The answer (`someException`) is now being associated with the
method called in thread B
- Thread B clears the answers of the invocation container for
the spied schema service, and resets the `stubbingInProgress`
to null
- That write somehow is not visible to thread A, so it continues
with the `.onSchemaAckRequest(any())` part of the stubbing.
- It sees that there are no answers in the invocation container
for that mock, so it prepares to call the real method.
- Before that, it performs some sanity checks to make sure that
there are no stubbing in progress. However, since it can't
see the write done in thread B, it throws.

To avoid this possible scenario, we have to stub the spied
member schema service, before the members start.

This PR refactors the related tests to pass the spies directly
to the factory, where we can stub them beforehand.

closes #22175
closes #23060