### PR TITLE
`DiscoveryJoiner` was using `WAIT_SECONDS_BEFORE_JOIN` where `MAX_WAIT_SECONDS_BEFORE_JOIN` was meant

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
-import static com.hazelcast.spi.properties.ClusterProperty.WAIT_SECONDS_BEFORE_JOIN;
+import static com.hazelcast.spi.properties.ClusterProperty.MAX_WAIT_SECONDS_BEFORE_JOIN;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -49,7 +49,7 @@ public class DiscoveryJoiner
 
     public DiscoveryJoiner(Node node, DiscoveryService discoveryService, boolean usePublicAddress) {
         super(node);
-        this.maximumWaitingTimeBeforeJoinSeconds = node.getProperties().getInteger(WAIT_SECONDS_BEFORE_JOIN);
+        this.maximumWaitingTimeBeforeJoinSeconds = node.getProperties().getInteger(MAX_WAIT_SECONDS_BEFORE_JOIN);
         this.discoveryService = discoveryService;
         this.usePublicAddress = usePublicAddress;
     }


### PR DESCRIPTION
For example

https://github.com/hazelcast/hazelcast/blob/128f546f3405931bc8cad1e24049bd8ea309c412/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java#L135

looks right but here the variable was not named with _max_ so I suspect this was simply a typo at some point.
Observed while experimenting with a custom `DiscoveryStrategy` whose `start` method was getting called but `discoverNodes` was not. In a debugger I tracked this down to `DiscoveryJoiner.getPossibleAddressesForInitialJoin` skipping the call to `getPossibleAddresses`. The problem disappeared when I removed

```java
config.setProperty(ClusterProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
```

No idea how this sort of thing would be tested, sorry.