### PR TITLE
Set the cluster connect timeout to a higher value in ClientReconnectTest [API-1653] [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -134,7 +134,7 @@ public class ClientReconnectTest extends ClientTestSupport {
     public void testCallbackAfterServerShutdown() {
         final HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(2000);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(5000);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         IMap<Object, Object> test = client.getMap("test");


### PR DESCRIPTION
When the client shutdowns, we set the `client` field of the `HazelcastClientProxy` object to null.

In the test, we were setting the cluster connect timeout to 2 seconds, shutting down the server, and waiting for the client to disconnect from the server using `makeSureDisconnectedFromServer`.

The `makeSureDisconnectedFromServer` gets the `client` field of the proxy object, gets the connection manager and asserts that no connection to that member UUID exists.

The problem is that, if we try to call `makeSureDisconnectedFromServer` after the client is shutdown, we would get an NPE because the `client` field of the proxy object would be null.

That was causing the `testCallbackAfterServerShutdown` to fail because it was calling this method after shutting down the server. With some unlucky delay, the call to `makeSureDisconnectedFromServer` can be made after 2 seconds, when the client shutdowns.

As a solution, I have increased the cluster connect timeout to 5 seconds, so that such a scenario would be less likely. Note that, we could have increased the timeout to some larger value to be sure, but that would make the test longer. I would suggest using 5 seconds timeout for now, and increasing it in the future if the test continues failing.

backport of #22921