### PR TITLE
Tolerate loss of some events in RepartitioningStressTest [HZ-1868] [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/RepartitioningStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/RepartitioningStressTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
@@ -55,6 +56,9 @@ import static org.junit.Assert.fail;
 public class RepartitioningStressTest extends HazelcastTestSupport {
 
     private static final int DUPLICATE_OPS_TOLERANCE = 10;
+
+    // The event listeners are not guaranteed to run during shutdown, tolerate 10 % loss
+    private static final double LOST_EVENTS_TOLERANCE = 0.9;
 
     private static final int INITIAL_MEMBER_COUNT = 5;
     private static final int THREAD_COUNT = 10;
@@ -180,10 +184,13 @@ public class RepartitioningStressTest extends HazelcastTestSupport {
     }
 
     private void assertEqualsWithDuplicatesTolerance(String msg, long expected, long actual) {
-        if (actual < expected || actual > expected + DUPLICATE_OPS_TOLERANCE) {
-            fail(String.format("%s, expected: %d, actual %d, tolerance for duplicates: %d", msg, expected,
-                    actual, DUPLICATE_OPS_TOLERANCE));
-        }
+        assertThat(actual)
+                .as(msg + ": number of actual events lost is outside of tolerance")
+                .isGreaterThan((long) (expected * LOST_EVENTS_TOLERANCE));
+
+        assertThat(actual)
+                .as(msg + ": number of actual events duplicated is outside of tolerance")
+                .isLessThan(expected + DUPLICATE_OPS_TOLERANCE);
     }
 
     private abstract class TestThread extends Thread {


### PR DESCRIPTION
Fixes #21613

Backport of #23089

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
