### PR TITLE
Remove killing connection from WriteJdbcPTest [HZ-1869]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -117,7 +117,7 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
         listRemainingConnections();
         // kill any hanging connection
         /* language=SQL */
-        executeSql("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid()");
+        executeSql("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() and pid <> pg_backend_pid()");
     }
 
     private static void executeSql(String sql) throws SQLException {
@@ -129,7 +129,7 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
         try (
                 Connection connection = ((DataSource) createDataSource(false)).getConnection();
                 ResultSet resultSet = connection.createStatement().executeQuery(
-                        "SELECT * FROM pg_stat_activity WHERE pid <> pg_backend_pid()")
+                        "SELECT * FROM pg_stat_activity WHERE datname = current_database() and pid <> pg_backend_pid()")
         ) {
             ResultSetMetaData metaData = resultSet.getMetaData();
             List<String> rows = new ArrayList<>();

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -132,17 +132,24 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
                         "SELECT * FROM pg_stat_activity WHERE pid <> pg_backend_pid()")
         ) {
             ResultSetMetaData metaData = resultSet.getMetaData();
-            List<String> connections = new ArrayList<>();
+            List<String> rows = new ArrayList<>();
+            StringBuilder row = new StringBuilder();
             for (int i = 1; i <= metaData.getColumnCount(); i++) {
-                connections.add(metaData.getColumnName(i) + "|");
+                row.append(metaData.getColumnName(i)).append("\t|");
             }
+            rows.add(row.toString());
+
             while (resultSet.next()) {
+                row = new StringBuilder();
                 for (int i = 1; i <= metaData.getColumnCount(); i++) {
-                    connections.add(resultSet.getObject(i) + "|");
+                    row.append(resultSet.getObject(i) + "\t|\t");
                 }
+                rows.add(row.toString());
+
             }
-            if (!connections.isEmpty()) {
-                logger.warning("Remaining connections: \n" + String.join("\n", connections));
+
+            if (!rows.isEmpty()) {
+                logger.warning("Remaining connections: \n" + String.join("\n", rows));
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -115,9 +115,6 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
         }
 
         listRemainingConnections();
-        // kill any hanging connection
-        /* language=SQL */
-        executeSql("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() and pid <> pg_backend_pid()");
     }
 
     private static void executeSql(String sql) throws SQLException {


### PR DESCRIPTION
We kill all the connections while using static instance with a shared datastore. This datastore contains the connection pool with the connections we kill which results with failures like:
```
java.lang.AssertionError: pgStatement.getConnection().getAutoCommit() should not throw
```
Killing only hides the problem of leaking connections, we should rather try to found the wholes.

Also changed the format of active connections to be the tabular alike

Fixes https://github.com/hazelcast/hazelcast/issues/23061
Fixes https://hazelcast.atlassian.net/browse/HZ-1869

