### PR TITLE
Make MultiTableCacheIntegrationTest less flaky

### DIFF
--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.cdc.postgres;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.cdc.ChangeRecord;
 import com.hazelcast.jet.cdc.ParsingException;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
@@ -44,6 +45,7 @@ import java.util.stream.Collectors;
 import static com.hazelcast.jet.cdc.Operation.DELETE;
 import static com.hazelcast.jet.cdc.Operation.INSERT;
 import static com.hazelcast.jet.cdc.Operation.SYNC;
+import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -52,7 +54,7 @@ import static java.util.Objects.requireNonNull;
 public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrationTest {
 
     private static final String CACHE = "cache";
-    private static final int REPEATS = 1000;
+    private static final int REPEATS = 1001;
 
     @Test
     public void ordersOfCustomers() throws Exception {
@@ -61,8 +63,10 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
                 .build();
 
         Pipeline pipeline = Pipeline.create();
+        pipeline.setPreserveOrder(true);
         StreamStage<ChangeRecord> allRecords = pipeline.readFrom(source)
-                .withNativeTimestamps(0).setLocalParallelism(1);
+                                                       .withoutTimestamps()
+                                                       .setLocalParallelism(1);
 
         allRecords.filter(r -> r.table().equals("customers"))
                 .writeTo(Sinks.mapWithEntryProcessor(CACHE,
@@ -77,8 +81,9 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
                 ));
 
         // when
-        HazelcastInstance hz = createHazelcastInstances(1)[0];
-        hz.getJet().newJob(pipeline);
+        HazelcastInstance hz = createHazelcastInstance();
+        hz.getJet().newJob(pipeline, new JobConfig().setProcessingGuarantee(EXACTLY_ONCE));
+
         //then
         Map<Integer, OrdersOfCustomer> expected = toMap(
         new OrdersOfCustomer(
@@ -96,15 +101,15 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
         assertEqualsEventually(() -> getIMapContent(hz), expected);
 
         //when
+        executeBatch("INSERT INTO customers VALUES (1005, 'Jason', 'Bourne', 'jason@bourne.org')");
         List<String> batch = new ArrayList<>();
-        batch.add("INSERT INTO customers VALUES (1005, 'Jason', 'Bourne', 'jason@bourne.org')");
         for (int i = 1; i <= REPEATS; i++) {
-            batch.add("UPDATE customers SET first_name='Anne" + i + "' WHERE id=1004");
-            batch.add("UPDATE orders SET quantity='" + i + "' WHERE id=10004");
-
-            batch.add("DELETE FROM orders WHERE id=10003");
+            batch.addAll(createTestSqlQueries(i));
+            if (batch.size() >= 50 || i == REPEATS) {
+                executeBatch(batch.toArray(new String[0]));
+                batch.clear();
+            }
         }
-        executeBatch(batch.toArray(new String[0]));
         executeBatch("DELETE FROM customers WHERE id=1005");
         executeBatch("INSERT INTO orders VALUES (10007, '2016-02-19', 1002, 2, 106)");
 
@@ -124,6 +129,15 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
                         new Customer(1004, "Anne" + REPEATS, "Kretchmar", "annek@noanswer.org")));
         expected.put(1005, new OrdersOfCustomer());
         assertEqualsEventually(() -> getIMapContent(hz), expected);
+    }
+
+    private static List<String> createTestSqlQueries(int index) {
+        List<String> batch = new ArrayList<>();
+        batch.add("UPDATE customers SET first_name='Anne" + index + "' WHERE id=1004");
+        batch.add("UPDATE orders SET quantity='" + index + "' WHERE id=10004");
+
+        batch.add("DELETE FROM orders WHERE id=10003");
+        return batch;
     }
 
     @Nonnull


### PR DESCRIPTION
1. Batches divided into subbatches, so we are not dependent if driver or db will do some optimization of repeated queries
2. order preserve just to make everything more predictable in case of some delay (e.g. very long GC)
3. no timestamps for simplification

Cherry picked from commit 584804e286409b8585a4514de59bd44ae72e3f3c

Fixes #22185

Backport of: [#22782](https://github.com/hazelcast/hazelcast/pull/22782)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible