### PR TITLE
ClientRegressionWithMockNetworkTest instances checks [HZ-1836]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -46,7 +46,7 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -86,7 +86,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -102,7 +102,7 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
     public void cleanup() {
         hazelcastFactory.terminateAll();
 
-        checkNoRunningInstances(name.getMethodName());
+        assertNoRunningInstancesEventually(name.getMethodName());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -701,10 +701,11 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testClientReconnect_thenCheckRequestsAreRetriedWithoutException() {
+    public void testClientReconnect_thenCheckRequestsAreRetriedWithoutException() throws InterruptedException {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 
         CountDownLatch clientStartedDoingRequests = new CountDownLatch(1);
+        CountDownLatch restartFinished = new CountDownLatch(1);
         new Thread(() -> {
             try {
                 clientStartedDoingRequests.await();
@@ -714,6 +715,7 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
             hazelcastInstance.shutdown();
 
             hazelcastFactory.newHazelcastInstance();
+            restartFinished.countDown();
 
         }).start();
 
@@ -739,6 +741,7 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
                 fail("Requests should not throw exception with this configuration. Last put key: " + i);
             }
         }
+        restartFinished.await();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -46,7 +46,7 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.spi.properties.ClusterProperty;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -58,6 +58,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -85,18 +86,23 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    @Rule
+    public TestName name = new TestName();
+
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
     @After
     public void cleanup() {
-        hazelcastFactory.shutdownAll();
+        hazelcastFactory.terminateAll();
+
+        checkNoRunningInstances(name.getMethodName());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -313,6 +313,22 @@ public abstract class HazelcastTestSupport {
         }
     }
 
+    protected void checkNoRunningInstances(String methodName) {
+        // check for running Hazelcast instances
+        assertTrueEventually(() -> {
+            Set<HazelcastInstance> instances = Hazelcast.getAllHazelcastInstances();
+            if (!instances.isEmpty()) {
+                fail("After " + methodName + " following instances haven't been shut down: " + instances);
+            }
+        });
+        assertTrueEventually(() -> {
+            Collection<HazelcastInstance> clientInstances = HazelcastClient.getAllHazelcastClients();
+            if (!clientInstances.isEmpty()) {
+                fail("After " + methodName + " following client instances haven't been shut down: " + clientInstances);
+            }
+        });
+    }
+
     // ###########################################
     // ########## implementation getter ##########
     // ###########################################

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -313,7 +313,7 @@ public abstract class HazelcastTestSupport {
         }
     }
 
-    protected void checkNoRunningInstances(String methodName) {
+    protected void assertNoRunningInstancesEventually(String methodName) {
         // check for running Hazelcast instances
         assertTrueEventually(() -> {
             Set<HazelcastInstance> instances = Hazelcast.getAllHazelcastInstances();


### PR DESCRIPTION
1. shutdown changed to terminate for instant quit
2. added "instances left" assertion after each test to quickly discover which test leaked
3. tests run in serial - after 2. I saw that sometimes instance termination was causing problems with other running tests

Fixes #20590

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases