### PR TITLE
Fix javadoc for setStoreMetricsAfterJobCompletion

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -421,7 +421,7 @@
     <suppress checks="" files="[\\/]module-info"/>
 
     <suppress checks="FileLength" files="src[\\/]main[\\/]java[\\/]com[\\/]hazelcast[\\/]jet[\\/]aggregate[\\/]AggregateOperations"/>
-    <suppress checks="CyclomaticComplexity" files="src[\\/]main[\\/]java[\\/]com[\\/]hazelcast[\\/]jet[\\/]config[\\/]JobConfig"/>
+    <suppress checks="FileLength|CyclomaticComplexity" files="src[\\/]main[\\/]java[\\/]com[\\/]hazelcast[\\/]jet[\\/]config[\\/]JobConfig"/>
 
     <suppress checks="InnerAssignment|JavadocType|TrailingComment|MethodCount|OperatorWrap|ClassDataAbstractionCoupling|ClassFanOutComplexity|CyclomaticComplexity|NPathComplexity" files="[\\/]src[\\/]main[\\/]java[\\/]com[\\/]hazelcast[\\/]jet[\\/]"/>
     <suppress checks="InnerAssignment|JavadocType|TrailingComment|MethodCount|OperatorWrap|ClassDataAbstractionCoupling|ClassFanOutComplexity|CyclomaticComplexity|NPathComplexity" files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]hazelcast[\\/]jet[\\/]"/>

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -1298,7 +1298,8 @@ public class JobConfig implements IdentifiedDataSerializable {
      * completes successfully. Needs both {@link MetricsConfig#isEnabled()} and
      * {@link #isMetricsEnabled()} to be on in order to function.
      * <p>
-     * If enabled, metrics can be retrieved by calling {@link Job#getMetrics()}.
+     * If enabled, metrics can be retrieved by calling {@link
+     * Job#getMetrics()}.
      * <p>
      * It's disabled by default.
      *
@@ -1309,14 +1310,16 @@ public class JobConfig implements IdentifiedDataSerializable {
     }
 
     /**
-     * Sets whether metrics should be stored in the cluster after the job completes.
-     * If enabled, metrics can be retrieved for the configured job after it has
-     * completed successfully and it is no longer running by calling {@link Job#getMetrics()}.
+     * Sets whether metrics should be stored in the cluster after the job
+     * completes. If enabled, metrics can be retrieved for the configured job
+     * after it has completed successfully and it is no longer running by
+     * calling {@link Job#getMetrics()}.
      * <p>
-     * If disabled, once the configured job stops running {@link Job#getMetrics()}
-     * will always return empty metrics for it, regardless of the settings for
-     * {@link MetricsConfig#setEnabled global metrics collection} or
-     * {@link JobConfig#isMetricsEnabled() per job metrics collection}.
+     * If disabled, once the configured job stops running {@link
+     * Job#getMetrics()} will always return empty metrics for it, regardless of
+     * the settings for {@link MetricsConfig#setEnabled global metrics
+     * collection} or {@link JobConfig#isMetricsEnabled() per job metrics
+     * collection}.
      * <p>
      * It's disabled by default. Ignored for {@linkplain
      * JetService#newLightJob(Pipeline) light jobs}.

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -1295,7 +1295,7 @@ public class JobConfig implements IdentifiedDataSerializable {
 
     /**
      * Returns whether metrics should be stored in the cluster after the job
-     * completes. Needs both {@link MetricsConfig#isEnabled()} and
+     * completes successfully. Needs both {@link MetricsConfig#isEnabled()} and
      * {@link #isMetricsEnabled()} to be on in order to function.
      * <p>
      * If enabled, metrics can be retrieved by calling {@link Job#getMetrics()}.
@@ -1310,9 +1310,8 @@ public class JobConfig implements IdentifiedDataSerializable {
 
     /**
      * Sets whether metrics should be stored in the cluster after the job completes.
-     * If enabled, metrics can be retrieved for the configured job even if it's no
-     * longer running (has completed successfully, has failed, has been cancelled or
-     * suspended) by calling {@link Job#getMetrics()}.
+     * If enabled, metrics can be retrieved for the configured job after it has
+     * completed successfully and it is no longer running by calling {@link Job#getMetrics()}.
      * <p>
      * If disabled, once the configured job stops running {@link Job#getMetrics()}
      * will always return empty metrics for it, regardless of the settings for

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_MiscTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_MiscTest.java
@@ -36,13 +36,12 @@ import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Function;
 
@@ -50,17 +49,12 @@ import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
 import static com.hazelcast.jet.core.metrics.JobMetrics_BatchTest.JOB_CONFIG_WITH_METRICS;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class JobMetrics_MiscTest extends TestInClusterSupport {
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Before
     public void setup() {
@@ -148,7 +142,7 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
     @Test
     public void when_jobSuspended_andMetricsNotStored_then_onlyPeriodicMetricsReturned() throws Throwable {
         DAG dag = new DAG();
-        Vertex v1 = dag.newVertex("v1", TestProcessors.MockP::new);
+        Vertex v1 = dag.newVertex("v1", MockP::new);
         Vertex v2 = dag.newVertex("v2", (SupplierEx<Processor>) TestProcessors.NoOutputSourceP::new);
         dag.edge(between(v1, v2));
 
@@ -159,7 +153,7 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
         Job job = hz().getJet().newJob(dag, config);
 
         //when
-        TestProcessors.NoOutputSourceP.executionStarted.await();
+        NoOutputSourceP.executionStarted.await();
         //then
         assertJobStatusEventually(job, JobStatus.RUNNING);
         assertTrueEventually(() -> assertJobHasMetrics(job, false));
@@ -177,7 +171,7 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
         assertTrueEventually(() -> assertJobHasMetrics(job, false));
 
         //when
-        TestProcessors.NoOutputSourceP.proceedLatch.countDown();
+        NoOutputSourceP.proceedLatch.countDown();
         job.join();
         //then
         assertJobStatusEventually(job, JobStatus.COMPLETED);
@@ -185,24 +179,88 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
     }
 
     @Test
-    public void when_jobRestarted_then_metricsRepopulate() throws Throwable {
+    public void when_jobSuspended_andMetricsStored_then_onlyPeriodicAndFinalMetricsReturned() throws Throwable {
         DAG dag = new DAG();
-        Vertex v1 = dag.newVertex("v1", TestProcessors.MockP::new);
+        Vertex v1 = dag.newVertex("v1", MockP::new);
         Vertex v2 = dag.newVertex("v2", (SupplierEx<Processor>) TestProcessors.NoOutputSourceP::new);
         dag.edge(between(v1, v2));
 
+        //init
+        JobConfig config = new JobConfig()
+                .setMetricsEnabled(true) //enable metric collection
+                .setStoreMetricsAfterJobCompletion(true); //enable metric saving on completion
+        Job job = hz().getJet().newJob(dag, config);
+
+        //when
+        NoOutputSourceP.executionStarted.await();
+        //then
+        assertJobStatusEventually(job, JobStatus.RUNNING);
+        assertTrueEventually(() -> assertJobHasMetrics(job, false));
+
+        //when
+        job.suspend();
+        //then
+        assertJobStatusEventually(job, SUSPENDED);
+        assertTrueEventually(() -> assertEmptyJobMetrics(job, false));
+
+        //when
+        job.resume();
+        //then
+        assertJobStatusEventually(job, RUNNING);
+        assertTrueEventually(() -> assertJobHasMetrics(job, false));
+
+        //when
+        NoOutputSourceP.proceedLatch.countDown();
+        job.join();
+        //then
+        assertJobStatusEventually(job, JobStatus.COMPLETED);
+        assertTrueEventually(() -> assertJobHasMetrics(job, true));
+    }
+
+    @Test
+    public void when_jobRestarted_then_metricsRepopulate() throws Throwable {
+        DAG dag = new DAG();
+        Vertex v1 = dag.newVertex("v1", MockP::new);
+        Vertex v2 = dag.newVertex("v2", (SupplierEx<Processor>) NoOutputSourceP::new);
+        dag.edge(between(v1, v2));
+
         Job job = hz().getJet().newJob(dag, JOB_CONFIG_WITH_METRICS);
-        TestProcessors.NoOutputSourceP.executionStarted.await();
+        NoOutputSourceP.executionStarted.await();
         assertJobStatusEventually(job, JobStatus.RUNNING);
 
         job.restart();
         assertJobStatusEventually(job, JobStatus.RUNNING);
         assertTrueEventually(() -> assertJobHasMetrics(job, false));
 
-        TestProcessors.NoOutputSourceP.proceedLatch.countDown();
+        NoOutputSourceP.proceedLatch.countDown();
         job.join();
         assertJobStatusEventually(job, JobStatus.COMPLETED);
         assertJobHasMetrics(job, true);
+    }
+
+    @Test
+    public void when_jobCancelled_then_emptyMetrics() {
+        DAG dag = new DAG();
+        dag.newVertex("v1", () -> new MockP().streaming());
+
+        //init
+        JobConfig config = new JobConfig()
+                .setMetricsEnabled(true) //enable metric collection
+                .setStoreMetricsAfterJobCompletion(true); //enable metric saving on completion
+        Job job = hz().getJet().newJob(dag, config);
+
+        //when
+        assertJobStatusEventually(job, JobStatus.RUNNING);
+        //then
+        assertTrueEventually(() -> assertJobHasMetrics(job, false));
+
+        //when
+        job.cancel();
+        assertThrows(CancellationException.class, job::join);
+
+        //then
+        assertJobStatusEventually(job, JobStatus.FAILED);
+        assertTrueEventually(() -> assertEmptyJobMetrics(job, true));
     }
 
     @Test
@@ -228,19 +286,6 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
         assertJobStatusEventually(job, JobStatus.COMPLETED);
         //then
         assertEmptyJobMetrics(job, true);
-    }
-
-    private Job runJobExpectFailure(@Nonnull DAG dag, @Nonnull RuntimeException expectedException) {
-        Job job = null;
-        try {
-            job = hz().getJet().newJob(dag, JOB_CONFIG_WITH_METRICS);
-            job.join();
-            fail("Job execution should have failed");
-        } catch (Exception actual) {
-            Throwable cause = peel(actual);
-            assertContains(cause.getMessage(), expectedException.getMessage());
-        }
-        return job;
     }
 
     private void assertJobHasMetrics(Job job, boolean saved) {


### PR DESCRIPTION
When `storeMetricsAfterJobCompletion` is enabled, metrics are stored after job completion only in case of success.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
