### PR TITLE
Fix synchronization in TestAwareInstanceFactory [HZ-1855]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.config.Config.DEFAULT_CLUSTER_NAME;
@@ -166,7 +167,7 @@ public class TestAwareInstanceFactory {
 
     protected List<HazelcastInstance> getOrInitInstances(Map<String, List<HazelcastInstance>> map) {
         String methodName = getTestMethodName();
-        List<HazelcastInstance> list = map.computeIfAbsent(methodName, k -> new ArrayList<>());
+        List<HazelcastInstance> list = map.computeIfAbsent(methodName, k -> new CopyOnWriteArrayList<>());
         return list;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
@@ -30,7 +30,6 @@ import com.hazelcast.instance.impl.NodeContext;
 import com.hazelcast.internal.jmx.ManagementService;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;


### PR DESCRIPTION
Use a synchronized `List` instance to hold members/clients as it can be used from different threads.
Fixes hazelcast/hazelcast-enterprise#5439