### PR TITLE
Fix eventual consistency in WanPublisherMigrationTest.testMigration [HZ-1853] [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanPublisherMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanPublisherMigrationTest.java
@@ -50,6 +50,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -106,12 +107,10 @@ public class WanPublisherMigrationTest extends HazelcastTestSupport {
             map.put(i, i);
         }
 
-        int partitionsToMigrate = 0;
-        for (IPartition partition : getPartitionService(member1).getPartitions()) {
-            if (partition.isLocal()) {
-                partitionsToMigrate++;
-            }
-        }
+        //Find local partitions of this member
+        final long partitionsToMigrate = Arrays.stream(getPartitionService(member1).getPartitions())
+                .filter(IPartition::isLocal)
+                .count();
 
         member1.shutdown();
         assertClusterSizeEventually(1, member2);
@@ -125,8 +124,12 @@ public class WanPublisherMigrationTest extends HazelcastTestSupport {
             assertTrue("Expected at least " + partitionsToMigrate
                             + " migration operations to be processed but was " + publisher,
                     publisher.migrationProcess.intValue() >= partitionsToMigrate);
-            assertEquals(exceptionMsg("migrationCommit", publisher),
-                    partitionsToMigrate, publisher.migrationCommit.intValue());
+
+            //onMigrationCommit() method of the listener is called asynchronously. So assert eventually
+            assertTrueEventually(() -> assertEquals(exceptionMsg("migrationCommit", publisher),
+                    partitionsToMigrate,
+                    publisher.migrationCommit.intValue())
+            );
         } else {
             assertEquals(exceptionMsg("migrationStart", publisher),
                     partitionsToMigrate + 1, publisher.migrationStart.intValue());
@@ -135,10 +138,17 @@ public class WanPublisherMigrationTest extends HazelcastTestSupport {
             assertTrue("Expected at least " + partitionsToMigrate
                             + " migration operations to be processed but was " + publisher,
                     publisher.migrationProcess.intValue() >= partitionsToMigrate);
-            assertEquals(exceptionMsg("migrationCommit", publisher),
-                    partitionsToMigrate, publisher.migrationCommit.intValue());
-            assertEquals(exceptionMsg("migrationRollback", publisher),
-                    1, publisher.migrationRollback.intValue());
+
+            //onMigrationCommit() method of the listener is called asynchronously. So assert eventually
+            assertTrueEventually(() -> assertEquals(exceptionMsg("migrationCommit", publisher),
+                    partitionsToMigrate, publisher.migrationCommit.intValue())
+            );
+
+            //onMigrationRollback() method of the listener is called asynchronously. So assert eventually
+            assertTrueEventually(() -> assertEquals(exceptionMsg("migrationRollback", publisher),
+                    1,
+                    publisher.migrationRollback.intValue())
+            );
         }
     }
 


### PR DESCRIPTION
After replica performs MigrationCommitOperation(), it calls the listeners' onMigrationCommit() method asynchronously. The test was failing because it was not using eventual consistency to check for the migration commit counter. I have changed the test to assert the migration commit counter eventually.

Note : If you want to re-produce the failure before the fix, just add a sleep(1_000) ms statement to onMigrationCommit() method.

Fixes : https://github.com/hazelcast/hazelcast/issues/22434 (cherry picked from commit d706b81636caf4f8e86bf3dbe397f7b4b70d7024)

Backport : https://github.com/hazelcast/hazelcast/pull/23056
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible