### PR TITLE
Wide log level for PartitionAssignmentsCorrectnessTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionAssignmentsCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionAssignmentsCorrectnessTest.java
@@ -17,10 +17,12 @@
 package com.hazelcast.internal.partition;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -35,6 +37,8 @@ import static org.junit.runners.Parameterized.UseParametersRunnerFactory;
 @Category({QuickTest.class, ParallelJVMTest.class})
 // related issue https://github.com/hazelcast/hazelcast/issues/5444
 public class PartitionAssignmentsCorrectnessTest extends AbstractPartitionAssignmentsCorrectnessTest {
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-partition-service-debug.xml");
 
     @Parameterized.Parameters(name = "backups:{0},nodes:{1}")
     public static Collection<Object[]> parameters() {

--- a/hazelcast/src/test/resources/log4j2-partition-service-debug.xml
+++ b/hazelcast/src/test/resources/log4j2-partition-service-debug.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.hazelcast.internal.cluster" level="debug"/>
+        <Logger name="com.hazelcast.internal.partition" level="debug"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
After a careful logs review of the **only** test failure we may assume the failure was caused by some environmental reasons, not by the production code. On other hand, failure is pretty suspicious and we want to have more information if it fails again. This patch introduces widen logs for `PartitionAssignmentsCorrectnessTest`. 

Closes https://github.com/hazelcast/hazelcast/issues/22122