### PR TITLE
Add registration on the recordStore

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -355,16 +355,21 @@ class MapMigrationAwareService
             CacheDeserializedValues cacheDeserializedValues = mapContainer.getMapConfig().getCacheDeserializedValues();
             CachedQueryEntry<?, ?> cachedEntry = cacheDeserializedValues == NEVER ? new CachedQueryEntry<>(serializationService,
                     mapContainer.getExtractors()) : null;
-            recordStore.forEach((key, record) -> {
-                Object value = Records.getValueOrCachedValue(record, serializationService);
-                if (value != null) {
-                    QueryableEntry queryEntry = mapContainer.newQueryEntry(key, value);
-                    queryEntry.setRecord(record);
-                    CachedQueryEntry<?, ?> newEntry =
+            recordStore.beforeOperation();
+            try {
+                recordStore.forEach((key, record) -> {
+                    Object value = Records.getValueOrCachedValue(record, serializationService);
+                    if (value != null) {
+                        QueryableEntry queryEntry = mapContainer.newQueryEntry(key, value);
+                        queryEntry.setRecord(record);
+                        CachedQueryEntry<?, ?> newEntry =
                             cachedEntry == null ? (CachedQueryEntry<?, ?>) queryEntry : cachedEntry.init(key, value);
-                    indexes.putEntry(newEntry, null, queryEntry, Index.OperationSource.SYSTEM);
-                }
-            }, false);
+                        indexes.putEntry(newEntry, null, queryEntry, Index.OperationSource.SYSTEM);
+                    }
+                }, false);
+            } finally {
+                recordStore.afterOperation();
+            }
 
             Indexes.markPartitionAsIndexed(event.getPartitionId(), indexesSnapshot);
         }
@@ -397,11 +402,16 @@ class MapMigrationAwareService
             Indexes.beginPartitionUpdate(indexesSnapshot);
 
             CachedQueryEntry<?, ?> entry = new CachedQueryEntry<>(serializationService, mapContainer.getExtractors());
-            recordStore.forEach((key, record) -> {
-                Object value = Records.getValueOrCachedValue(record, serializationService);
-                entry.init(key, value);
-                indexes.removeEntry(entry, Index.OperationSource.SYSTEM);
-            }, false);
+            recordStore.beforeOperation();
+            try {
+                recordStore.forEach((key, record) -> {
+                    Object value = Records.getValueOrCachedValue(record, serializationService);
+                    entry.init(key, value);
+                    indexes.removeEntry(entry, Index.OperationSource.SYSTEM);
+                }, false);
+            } finally {
+                recordStore.afterOperation();
+            }
 
             Indexes.markPartitionAsUnindexed(event.getPartitionId(), indexesSnapshot);
         }


### PR DESCRIPTION
Add registration on the record store before populating/depopulating indexes on partition migration

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/5551

EE https://github.com/hazelcast/hazelcast-enterprise/pull/5552