### PR TITLE
Introduce RepeatOnNodeFailure annotation

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpSplitBrainDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpSplitBrainDiscoveryTest.java
@@ -83,12 +83,12 @@ public class TcpIpSplitBrainDiscoveryTest extends HazelcastTestSupport {
     public void testSplitBrainRecoveryFromInitialSplit() throws IOException {
         instances.add(Hazelcast.newHazelcastInstance(createConfigWithRestEnabled(5801, 5901)));
         instances.add(Hazelcast.newHazelcastInstance(createConfigWithRestEnabled(5901, 5801)));
-        assertClusterSizeEventually(2, Arrays.asList(instances.get(0), instances.get(1)), 10);
-
+        assertClusterSizeEventually(2, instances.subList(0, 2), 10);
 
         instances.add(Hazelcast.newHazelcastInstance(createConfigWithRestEnabled(6001, 6101)));
         instances.add(Hazelcast.newHazelcastInstance(createConfigWithRestEnabled(6101, 6001)));
-        assertClusterSizeEventually(2, Arrays.asList(instances.get(2), instances.get(3)), 10);
+        assertClusterSizeEventually(2, instances.subList(2, 4), 10);
+
         updateMemberList();
         assertClusterSizeEventually(4, instances, 10);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpSplitBrainDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpSplitBrainDiscoveryTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.RepeatOnNodeFailure;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -80,6 +81,7 @@ public class TcpIpSplitBrainDiscoveryTest extends HazelcastTestSupport {
     }
 
     @Test
+    @RepeatOnNodeFailure
     public void testSplitBrainRecoveryFromInitialSplit() throws IOException {
         instances.add(Hazelcast.newHazelcastInstance(createConfigWithRestEnabled(5801, 5901)));
         instances.add(Hazelcast.newHazelcastInstance(createConfigWithRestEnabled(5901, 5801)));

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/RepeatOnNodeFailure.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/RepeatOnNodeFailure.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.annotation;
+
+import com.hazelcast.test.HazelcastTestSupport;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The tests that are specifically about the cluster topology, e.g. split-brain
+ * tests, should be marked with this annotation, so that the test is repeated
+ * upon a node failure. A test is repeated at most 5 times and 10 seconds are
+ * waited before each repeat. The designated tests are not cancelled as soon as
+ * a node fails, which will cause unnecessary waiting when {@code
+ * assertXXXEventually()} methods are used. For early-exit, use {@link
+ * HazelcastTestSupport#assertNoFailedInstances}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface RepeatOnNodeFailure {
+
+}


### PR DESCRIPTION
The tests that are specifically about the cluster topology, e.g. split-brain tests, should be repeated upon node failure. I introduced a new annotation to mark such tests and also a new assertion to cancel the designated tests earlier when `assertXXXEventually` methods are used.

Some refactoring is done to get rid of IntelliJ warnings.

Fixes #23078

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
