### PR TITLE
Add debug logging for migrations & indexes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -34,6 +34,9 @@ import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.IndexAwarePredicate;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -57,6 +60,10 @@ public class Indexes {
      * The negative value means the check should be skipped.
      */
     public static final int SKIP_PARTITIONS_COUNT_CHECK = -1;
+
+    // internal property, only for tests
+    public static final String CUSTOM_INDEXES_CLASS_NAME = System.getProperty("hazelcast.internal.indexes.className");
+
     private static final InternalIndex[] EMPTY_INDEXES = {};
 
     private static final ThreadLocal<CachedQueryEntry[]> CACHED_ENTRIES =
@@ -85,8 +92,9 @@ public class Indexes {
     private volatile InternalIndex[] indexes = EMPTY_INDEXES;
     private volatile InternalIndex[] compositeIndexes = EMPTY_INDEXES;
 
+    // package-private for testing
     @SuppressWarnings("checkstyle:ParameterNumber")
-    private Indexes(Node node,
+    Indexes(Node node,
                     String mapName,
                     InternalSerializationService ss,
                     IndexCopyBehavior indexCopyBehavior,
@@ -677,9 +685,25 @@ public class Indexes {
          * @return a new instance of Indexes
          */
         public Indexes build() {
-            return new Indexes(node, mapName, serializationService, indexCopyBehavior, extractors,
-                    indexProvider, usesCachedQueryableEntries, statsEnabled, global,
-                    inMemoryFormat, partitionCount, resultFilterFactory);
+            if (CUSTOM_INDEXES_CLASS_NAME == null) {
+                return new Indexes(node, mapName, serializationService, indexCopyBehavior, extractors,
+                        indexProvider, usesCachedQueryableEntries, statsEnabled, global,
+                        inMemoryFormat, partitionCount, resultFilterFactory);
+            }
+            try {
+                Class<? extends Indexes> klass = (Class<? extends Indexes>)
+                        getClass().getClassLoader().loadClass(CUSTOM_INDEXES_CLASS_NAME);
+                MethodType ctor = MethodType.methodType(void.class, Node.class, String.class, InternalSerializationService.class,
+                        IndexCopyBehavior.class, Extractors.class, IndexProvider.class,
+                        boolean.class, boolean.class, boolean.class, InMemoryFormat.class, int.class,
+                        Supplier.class);
+                MethodHandle indexesCtor = MethodHandles.publicLookup().findConstructor(klass, ctor);
+                return (Indexes) indexesCtor.invoke(node, mapName, serializationService, indexCopyBehavior, extractors,
+                        indexProvider, usesCachedQueryableEntries, statsEnabled, global,
+                        inMemoryFormat, partitionCount, resultFilterFactory);
+            } catch (Throwable e) {
+                throw rethrow(e);
+            }
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -62,7 +62,7 @@ public class Indexes {
     public static final int SKIP_PARTITIONS_COUNT_CHECK = -1;
 
     // internal property, only for tests
-    public static final String CUSTOM_INDEXES_CLASS_NAME = System.getProperty("hazelcast.internal.indexes.className");
+    public static final String CUSTOM_INDEXES_CLASS_NAME = "hazelcast.internal.indexes.className";
 
     private static final InternalIndex[] EMPTY_INDEXES = {};
 
@@ -685,14 +685,15 @@ public class Indexes {
          * @return a new instance of Indexes
          */
         public Indexes build() {
-            if (CUSTOM_INDEXES_CLASS_NAME == null) {
+            String customClassName = System.getProperty(CUSTOM_INDEXES_CLASS_NAME);
+            if (customClassName == null) {
                 return new Indexes(node, mapName, serializationService, indexCopyBehavior, extractors,
                         indexProvider, usesCachedQueryableEntries, statsEnabled, global,
                         inMemoryFormat, partitionCount, resultFilterFactory);
             }
             try {
                 Class<? extends Indexes> klass = (Class<? extends Indexes>)
-                        getClass().getClassLoader().loadClass(CUSTOM_INDEXES_CLASS_NAME);
+                        getClass().getClassLoader().loadClass(customClassName);
                 MethodType ctor = MethodType.methodType(void.class, Node.class, String.class, InternalSerializationService.class,
                         IndexCopyBehavior.class, Extractors.class, IndexProvider.class,
                         boolean.class, boolean.class, boolean.class, InMemoryFormat.class, int.class,

--- a/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
@@ -19,14 +19,20 @@ package com.hazelcast.map;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.partition.PartitionTableView;
+import com.hazelcast.internal.partition.TestPartitionUtils;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.SampleTestObjects;
+import com.hazelcast.query.impl.LoggingIndexes;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
 import com.hazelcast.test.bounce.BounceTestConfiguration;
 import com.hazelcast.test.jitter.JitterRule;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -35,6 +41,8 @@ import org.junit.runner.RunWith;
 import java.util.Collection;
 import java.util.Random;
 
+import static com.hazelcast.query.impl.Indexes.CUSTOM_INDEXES_CLASS_NAME;
+import static com.hazelcast.test.Accessors.getPartitionService;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
@@ -49,6 +57,17 @@ public class QueryBounceTest {
     private static final String TEST_MAP_NAME = "employees";
     private static final int COUNT_ENTRIES = 10000;
     private static final int CONCURRENCY = 10;
+
+    // enable trace logging for migrations
+    // see
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-trace-migrations.xml");
+
+    // change Indexes implementation to LoggingIndexes class that decorates plain
+    // Indexes class with logging.
+    @Rule
+    public OverridePropertyRule customIndexImplProperty = OverridePropertyRule.set(CUSTOM_INDEXES_CLASS_NAME,
+            LoggingIndexes.class.getName());
 
     @Rule
     public BounceMemberRule bounceMemberRule =
@@ -69,7 +88,15 @@ public class QueryBounceTest {
 
     @Test
     public void testQueryWithIndexes() {
-        prepareAndRunQueryTasks(true);
+        try {
+            prepareAndRunQueryTasks(true);
+        } catch (AssertionError e) {
+            PartitionTableView partitionTableView = getPartitionService(bounceMemberRule.getSteadyMember())
+                    .createPartitionTableView();
+            System.out.println("Partition assignments at time of failure:\n"
+                    + TestPartitionUtils.dumpPartitionTable(partitionTableView));
+            throw e;
+        }
     }
 
     protected Config getConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
@@ -20,6 +20,8 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.partition.PartitionTableView;
+import com.hazelcast.internal.partition.TestPartitionUtils;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.IterableUtil;
 import com.hazelcast.map.IMap;
@@ -28,16 +30,21 @@ import com.hazelcast.query.Predicates;
 import com.hazelcast.query.SampleTestObjects.Employee;
 import com.hazelcast.query.SampleTestObjects.Value;
 import com.hazelcast.query.impl.IndexCopyBehavior;
+import com.hazelcast.query.impl.LoggingIndexes;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -58,6 +65,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.impl.Indexes.CUSTOM_INDEXES_CLASS_NAME;
+import static com.hazelcast.test.Accessors.getPartitionService;
 import static com.hazelcast.test.TimeConstants.MINUTE;
 import static java.lang.Thread.interrupted;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -69,6 +78,17 @@ import static org.junit.Assert.assertTrue;
 @UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({SlowTest.class, ParallelJVMTest.class})
 public class QueryIndexMigrationTest extends HazelcastTestSupport {
+
+    // enable trace logging for migrations
+    // see
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-trace-migrations.xml");
+
+    // change Indexes implementation to LoggingIndexes class that decorates plain
+    // Indexes class with logging.
+    @Rule
+    public OverridePropertyRule customIndexImplProperty = OverridePropertyRule.set(CUSTOM_INDEXES_CLASS_NAME,
+            LoggingIndexes.class.getName());
 
     private Random random = new Random();
 
@@ -163,23 +183,30 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
     @Test
     public void testQueryWithIndexesWhileMigrating() {
         HazelcastInstance instance = nodeFactory.newHazelcastInstance(getTestConfig());
-        IMap<String, Employee> map = instance.getMap("employees");
-        map.addIndex(IndexType.SORTED, "age");
-        map.addIndex(IndexType.HASH, "active");
+        try {
+            IMap<String, Employee> map = instance.getMap("employees");
+            map.addIndex(IndexType.SORTED, "age");
+            map.addIndex(IndexType.HASH, "active");
 
-        for (int i = 0; i < 500; i++) {
-            map.put("e" + i, new Employee("name" + i, i % 50, ((i & 1) == 1), (double) i));
-        }
-        assertEquals(500, map.size());
-        Set<Map.Entry<String, Employee>> entries = map.entrySet(Predicates.sql("active=true and age>44"));
-        assertEquals(30, entries.size());
-
-        nodeFactory.newInstances(getTestConfig(), 3);
-
-        long startNow = Clock.currentTimeMillis();
-        while ((Clock.currentTimeMillis() - startNow) < 10000) {
-            entries = map.entrySet(Predicates.sql("active=true and age>44"));
+            for (int i = 0; i < 500; i++) {
+                map.put("e" + i, new Employee("name" + i, i % 50, ((i & 1) == 1), (double) i));
+            }
+            assertEquals(500, map.size());
+            Set<Map.Entry<String, Employee>> entries = map.entrySet(Predicates.sql("active=true and age>44"));
             assertEquals(30, entries.size());
+
+            nodeFactory.newInstances(getTestConfig(), 3);
+
+            long startNow = Clock.currentTimeMillis();
+            while ((Clock.currentTimeMillis() - startNow) < 10000) {
+                entries = map.entrySet(Predicates.sql("active=true and age>44"));
+                assertEquals(30, entries.size());
+            }
+        } catch (AssertionError e) {
+            PartitionTableView partitionTableView = getPartitionService(instance).createPartitionTableView();
+            System.out.println("Partition assignments at time of failure:\n"
+                    + TestPartitionUtils.dumpPartitionTable(partitionTableView));
+            throw e;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/LoggingIndexes.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/LoggingIndexes.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.query.impl;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.IndexConfig;
+import com.hazelcast.core.TypeConverter;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.monitor.impl.PerIndexStats;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.query.impl.getters.Extractors;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+// decorates Indexes classes with logging
+public class LoggingIndexes extends Indexes {
+
+    private final ILogger logger;
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public LoggingIndexes(Node node,
+                    String mapName,
+                    InternalSerializationService ss,
+                    IndexCopyBehavior indexCopyBehavior,
+                    Extractors extractors,
+                    IndexProvider indexProvider,
+                    boolean usesCachedQueryableEntries,
+                    boolean statisticsEnabled,
+                    boolean global,
+                    InMemoryFormat inMemoryFormat,
+                    int partitionCount,
+                    Supplier<Predicate<QueryableEntry>> resultFilterFactory) {
+        super(node, mapName, ss, indexCopyBehavior, extractors, indexProvider,
+                usesCachedQueryableEntries, statisticsEnabled, global, inMemoryFormat,
+                partitionCount, resultFilterFactory);
+        logger = node.getLogger(LoggingIndexes.class);
+    }
+
+    @Override
+    public InternalIndex[] getIndexes() {
+        InternalIndex[] indexes = super.getIndexes();
+        return Arrays.stream(indexes).map(LoggingInternalIndex::new)
+                .collect(Collectors.toList()).toArray(new InternalIndex[0]);
+    }
+
+    private class LoggingInternalIndex implements InternalIndex {
+        private final InternalIndex delegate;
+
+        LoggingInternalIndex(InternalIndex delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String getName() {
+            return delegate.getName();
+        }
+
+        @Override
+        public String[] getComponents() {
+            return delegate.getComponents();
+        }
+
+        @Override
+        public IndexConfig getConfig() {
+            return delegate.getConfig();
+        }
+
+        @Override
+        public boolean isOrdered() {
+            return delegate.isOrdered();
+        }
+
+        @Override
+        public TypeConverter getConverter() {
+            return delegate.getConverter();
+        }
+
+        @Override
+        public void putEntry(CachedQueryEntry newEntry, CachedQueryEntry oldEntry, QueryableEntry entryToStore, OperationSource operationSource) {
+            delegate.putEntry(newEntry, oldEntry, entryToStore, operationSource);
+        }
+
+        @Override
+        public void removeEntry(CachedQueryEntry entry, OperationSource operationSource) {
+            delegate.removeEntry(entry, operationSource);
+        }
+
+        @Override
+        public boolean isEvaluateOnly() {
+            return delegate.isEvaluateOnly();
+        }
+
+        @Override
+        public boolean canEvaluate(Class<? extends com.hazelcast.query.Predicate> predicateClass) {
+            return delegate.canEvaluate(predicateClass);
+        }
+
+        @Override
+        public Set<QueryableEntry> evaluate(com.hazelcast.query.Predicate predicate) {
+            return delegate.evaluate(predicate);
+        }
+
+        @Override
+        public Iterator<QueryableEntry> getSqlRecordIterator(boolean descending) {
+            return delegate.getSqlRecordIterator(descending);
+        }
+
+        @Override
+        public Iterator<QueryableEntry> getSqlRecordIterator(Comparable value) {
+            return delegate.getSqlRecordIterator(value);
+        }
+
+        @Override
+        public Iterator<QueryableEntry> getSqlRecordIterator(Comparison comparison, Comparable value, boolean descending) {
+            return delegate.getSqlRecordIterator(comparison, value, descending);
+        }
+
+        @Override
+        public Iterator<QueryableEntry> getSqlRecordIterator(Comparable from, boolean fromInclusive, Comparable to, boolean toInclusive, boolean descending) {
+            return delegate.getSqlRecordIterator(from, fromInclusive, to, toInclusive, descending);
+        }
+
+        @Override
+        public Iterator<IndexKeyEntries> getSqlRecordIteratorBatch(Comparable value) {
+            return delegate.getSqlRecordIteratorBatch(value);
+        }
+
+        @Override
+        public Iterator<IndexKeyEntries> getSqlRecordIteratorBatch(boolean descending) {
+            return delegate.getSqlRecordIteratorBatch(descending);
+        }
+
+        @Override
+        public Iterator<IndexKeyEntries> getSqlRecordIteratorBatch(Comparison comparison, Comparable value, boolean descending) {
+            return delegate.getSqlRecordIteratorBatch(comparison, value, descending);
+        }
+
+        @Override
+        public Iterator<IndexKeyEntries> getSqlRecordIteratorBatch(Comparable from, boolean fromInclusive, Comparable to, boolean toInclusive, boolean descending) {
+            return delegate.getSqlRecordIteratorBatch(from, fromInclusive, to, toInclusive, descending);
+        }
+
+        @Override
+        public Set<QueryableEntry> getRecords(Comparable value) {
+            return delegate.getRecords(value);
+        }
+
+        @Override
+        public Set<QueryableEntry> getRecords(Comparable[] values) {
+            return delegate.getRecords(values);
+        }
+
+        @Override
+        public Set<QueryableEntry> getRecords(Comparable from, boolean fromInclusive, Comparable to, boolean toInclusive) {
+            return delegate.getRecords(from, fromInclusive, to, toInclusive);
+        }
+
+        @Override
+        public Set<QueryableEntry> getRecords(Comparison comparison, Comparable value) {
+            return delegate.getRecords(comparison, value);
+        }
+
+        @Override
+        public void clear() {
+            logger.info("Clear index " + delegate.getName());
+            delegate.clear();
+        }
+
+        @Override
+        public void destroy() {
+            logger.info("Destroy index " + delegate.getName());
+            delegate.destroy();
+        }
+
+        @Override
+        public Comparable canonicalizeQueryArgumentScalar(Comparable value) {
+            return delegate.canonicalizeQueryArgumentScalar(value);
+        }
+
+        @Override
+        public boolean hasPartitionIndexed(int partitionId) {
+            return delegate.hasPartitionIndexed(partitionId);
+        }
+
+        @Override
+        public boolean allPartitionsIndexed(int ownedPartitionCount) {
+            return delegate.allPartitionsIndexed(ownedPartitionCount);
+        }
+
+        @Override
+        public void beginPartitionUpdate() {
+            logger.info("beginPartitionUpdate for index " + delegate.getName());
+            delegate.beginPartitionUpdate();
+        }
+
+        @Override
+        public void markPartitionAsIndexed(int partitionId) {
+            logger.info("markPartitionAsIndexed for index " + delegate.getName()
+                            + ", partitionId: " + partitionId);
+            delegate.markPartitionAsIndexed(partitionId);
+        }
+
+        @Override
+        public void markPartitionAsUnindexed(int partitionId) {
+            logger.info("markPartitionAsUnindexed for index " + delegate.getName()
+                    + ", partitionId: " + partitionId);
+            delegate.markPartitionAsUnindexed(partitionId);
+        }
+
+        @Override
+        public PerIndexStats getPerIndexStats() {
+            return delegate.getPerIndexStats();
+        }
+
+        @Override
+        public GlobalIndexPartitionTracker.PartitionStamp getPartitionStamp() {
+            return delegate.getPartitionStamp();
+        }
+
+        @Override
+        public boolean validatePartitionStamp(long stamp) {
+            return delegate.validatePartitionStamp(stamp);
+        }
+    }
+}


### PR DESCRIPTION
Tests with indexes during migrations sporadically fail. There might be an issue with population of
indexes after migrations complete. This commit adds trace logging to migrations and index population.
Logging is implemented in a subclass of Indexes class in test classpath, as I wanted to avoid adding another implementation of Indexes class in the production classpath, because it might affect JIT compiler optimizations.

Adds logging in `master` branch for #21283, #22235 & #22090