### PR TITLE
Increase cluster merge timeout in TcpIpSplitBrainDiscoveryTest [HZ-1866]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpSplitBrainDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpSplitBrainDiscoveryTest.java
@@ -83,14 +83,14 @@ public class TcpIpSplitBrainDiscoveryTest extends HazelcastTestSupport {
     public void testSplitBrainRecoveryFromInitialSplit() throws IOException {
         instances.add(Hazelcast.newHazelcastInstance(createConfigWithRestEnabled(5801, 5901)));
         instances.add(Hazelcast.newHazelcastInstance(createConfigWithRestEnabled(5901, 5801)));
-        assertClusterSizeEventually(2, Arrays.asList(instances.get(0), instances.get(1)), 10);
+        assertClusterSizeEventually(2, Arrays.asList(instances.get(0), instances.get(1)));
 
 
         instances.add(Hazelcast.newHazelcastInstance(createConfigWithRestEnabled(6001, 6101)));
         instances.add(Hazelcast.newHazelcastInstance(createConfigWithRestEnabled(6101, 6001)));
-        assertClusterSizeEventually(2, Arrays.asList(instances.get(2), instances.get(3)), 10);
+        assertClusterSizeEventually(2, Arrays.asList(instances.get(2), instances.get(3)));
         updateMemberList();
-        assertClusterSizeEventually(4, instances, 10);
+        assertClusterSizeEventually(4, instances);
     }
 
     protected static Config createConfigWithRestEnabled(int port, int... otherMembersPorts) {


### PR DESCRIPTION
With bad timing, the response to `MergeClustersOp` can get lost, because the member that merges itself to the other cluster resets its state (which includes closing all connections and clearing the write queues).

The operation is retried, but the original 10 s timeout is too short for that. Increasing the timeout fixes the flaky test.

Fixes #23078

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
