### PR TITLE
Fix misleading exception message when reading JDBC table column metadata fails

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -166,7 +166,7 @@ public class JdbcSqlConnector implements SqlConnector {
             }
             return fields;
         } catch (Exception e) {
-            throw new HazelcastException("Could not read column metadata for table " + externalDataStoreRef, e);
+            throw new HazelcastException("Could not read column metadata for table " + externalTableName, e);
         } finally {
             closeDataSource(dataSource);
         }


### PR DESCRIPTION
Use table name instead of data source ref in exception message.

Backport of: #23122

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
