### PR TITLE
Use dedicated package for shaded dependencies

### DIFF
--- a/extensions/csv/pom.xml
+++ b/extensions/csv/pom.xml
@@ -70,15 +70,15 @@
                     <relocations>
                         <relocation>
                             <pattern>com.fasterxml.jackson.core</pattern>
-                            <shadedPattern>com.hazelcast.com.fasterxml.jackson.core</shadedPattern>
+                            <shadedPattern>${relocation.root}.com.fasterxml.jackson.core</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>com.fasterxml.jackson.databind</pattern>
-                            <shadedPattern>com.hazelcast.com.fasterxml.jackson.databind</shadedPattern>
+                            <shadedPattern>${relocation.root}.com.fasterxml.jackson.databind</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>com.fasterxml.jackson.dataformat</pattern>
-                            <shadedPattern>com.hazelcast.com.fasterxml.jackson.dataformat</shadedPattern>
+                            <shadedPattern>${relocation.root}.com.fasterxml.jackson.dataformat</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>

--- a/extensions/hadoop-dist/pom.xml
+++ b/extensions/hadoop-dist/pom.xml
@@ -58,19 +58,19 @@
                         <relocations>
                             <relocation>
                                 <pattern>com.fasterxml.jackson.jr</pattern>
-                                <shadedPattern>com.hazelcast.com.fasterxml.jackson.jr</shadedPattern>
+                                <shadedPattern>${relocation.root}.com.fasterxml.jackson.jr</shadedPattern>
                             </relocation>
                             <relocation>
                                 <pattern>com.fasterxml.jackson.core</pattern>
-                                <shadedPattern>com.hazelcast.com.fasterxml.jackson.core</shadedPattern>
+                                <shadedPattern>${relocation.root}.com.fasterxml.jackson.core</shadedPattern>
                             </relocation>
                             <relocation>
                                 <pattern>com.fasterxml.jackson.databind</pattern>
-                                <shadedPattern>com.hazelcast.com.fasterxml.jackson.databind</shadedPattern>
+                                <shadedPattern>${relocation.root}.com.fasterxml.jackson.databind</shadedPattern>
                             </relocation>
                             <relocation>
                                 <pattern>com.fasterxml.jackson.dataformat</pattern>
-                                <shadedPattern>com.hazelcast.com.fasterxml.jackson.dataformat</shadedPattern>
+                                <shadedPattern>${relocation.root}.com.fasterxml.jackson.dataformat</shadedPattern>
                             </relocation>
                         </relocations>
                     </configuration>

--- a/extensions/kinesis/pom.xml
+++ b/extensions/kinesis/pom.xml
@@ -52,7 +52,7 @@
                     <relocations>
                         <relocation>
                             <pattern>com.amazonaws</pattern>
-                            <shadedPattern>com.hazelcast.com.amazonaws</shadedPattern>
+                            <shadedPattern>${relocation.root}.com.amazonaws</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>

--- a/hazelcast-sql/src/main/resources/com.hazelcast.org.codehaus.commons.compiler.properties
+++ b/hazelcast-sql/src/main/resources/com.hazelcast.org.codehaus.commons.compiler.properties
@@ -1,1 +1,1 @@
-compilerFactory=com.hazelcast.org.codehaus.janino.CompilerFactory
+compilerFactory=com.hazelcast.shaded.org.codehaus.janino.CompilerFactory

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
         <!-- The path to relocated external dependencies. -->
-        <relocation.root>com.hazelcast</relocation.root>
+        <relocation.root>com.hazelcast.shaded</relocation.root>
 
         <!-- Additional JVM system arguments -->
         <extraVmArgs/>


### PR DESCRIPTION
Dedicated package for shaded dependencies makes it easier to ignore them in bulk to avoid problems in Serialization Conventions tests after adding new dependency (see for example https://github.com/hazelcast/hazelcast-enterprise/issues/5517).

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
