### PR TITLE
Fix migration failure in MigrationCommitTest.shouldCommitMigrationWhenSourceFailsDuringCommit [HZ-1881]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
@@ -296,9 +296,19 @@ public class MigrationCommitTest extends HazelcastTestSupport {
 
         masterListener.other = hz2;
 
+        // hz1 and hz3 know the cluster members
         assertClusterSize(3, hz1, hz3);
+
+        // hz2 also  knows the cluster members
         assertClusterSizeEventually(3, hz2);
 
+        // In some rare occasions clusters member list is processed before the master information.
+        // Assert that hz2 and hz3 know the master
+        assertMasterAddressEventually(getAddress(hz1), hz2);
+        assertMasterAddressEventually(getAddress(hz1), hz3);
+
+        // Migration thread of hz1 (the master) was blocked.
+        // Unblock it and allow it to migrate hz2 to hz3
         migrationStartLatch.countDown();
 
         waitAllForSafeState(hz1, hz3);


### PR DESCRIPTION
The problem is master response is processed after member list is processed. In that case we see exceptions like below. These exceptions mean that master is not known when an operation is received by a member.

- com.hazelcast.spi.exception.CallerNotMemberException
- java.lang.IllegalStateException: Migration initiator is not master node! => com.hazelcast.internal.partition.operation.MigrationRequestOperation

 I have added assertMasterAddressEventually() calls to make sure that the test waits for master response to be processed to improve the stability of the test.

Fixes : https://github.com/hazelcast/hazelcast/issues/21580


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
