### PR TITLE
Remove incorrect getName override in AbstractParameterizedHazelcastClassRunner

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractParameterizedHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractParameterizedHazelcastClassRunner.java
@@ -54,18 +54,9 @@ public abstract class AbstractParameterizedHazelcastClassRunner extends BlockJUn
     }
 
     @Override
-    protected String getName() {
-        if (isParameterized) {
-            return fName;
-        } else {
-            return super.getName();
-        }
-    }
-
-    @Override
     protected String testName(FrameworkMethod method) {
         if (isParameterized) {
-            return method.getName() + getName();
+            return method.getName() + fName;
         } else {
             return method.getName();
         }


### PR DESCRIPTION
The overridden name causes issues in surefire. When the name is not equal to the name of the class, JUnit creates a different `Description` here

https://github.com/junit-team/junit4/blob/r4.13.2/src/main/java/org/junit/runners/ParentRunner.java#L395

without a reference to the test class. Surefire then doesn't consider the class and the categories are incorrectly evaluated.

https://github.com/apache/maven-surefire/blob/surefire-3.0.0-M7/surefire-providers/common-junit48/src/main/java/org/apache/maven/surefire/common/junit48/GroupMatcherCategoryFilter.java#L73

This PR will be accompanied with cleanup in `@Category` annotations.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
