### PR TITLE
Add notes about SQL-only builder to README [HZ-1874]

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ see used in the comments on your PR:
   `extensions/cdc-postgres` module
 * `run-s3-tests` - run all tests in the `extensions/s3` module
 * *`run-nightly-tests` - run nightly (slow) tests. WARNING: Use with care as this is a resource consuming task.*
-* `run-sql-only` - run all tests in `hazelcast-sql`, `hazelcast-distribution`, and `extensions/mapstore` modules
+* `run-sql-only` - run default tests in `hazelcast-sql`, `hazelcast-distribution`, and `extensions/mapstore` modules
 
 Where not indicated, the builds run on a Linux machine with Oracle JDK 8.
 

--- a/README.md
+++ b/README.md
@@ -353,10 +353,17 @@ see used in the comments on your PR:
   `extensions/cdc-postgres` module
 * `run-s3-tests` - run all tests in the `extensions/s3` module
 * *`run-nightly-tests` - run nightly (slow) tests. WARNING: Use with care as this is a resource consuming task.*
+* `run-sql-only` - run all tests in `hazelcast-sql`, `hazelcast-distribution`, and `extensions/mapstore` modules
 
+Where not indicated, the builds run on a Linux machine with Oracle JDK 8.
 
-Where not indicated, the builds run on a Linux machine with Oracle JDK
-8.
+### Creating PRs for Hazelcast SQL
+
+When creating a PR with changes located in the `hazelcast-sql` module and nowhere else,
+you can label your PR with `SQL-only`. This will change the standard PR builder to one that
+will only run tests related to SQL (see `run-sql-only` above), which will significantly shorten
+the build time vs. the default PR builder. **NOTE**: this job will fail if you've made changes
+anywhere other than `hazelcast-sql`.
 
 ## License
 


### PR DESCRIPTION
Adds `run-sql-only` to the list of "Trigger Phrases" as well as a more complete description of the job and corresponding label.
