### PR TITLE
Moving queue statistic updates to run method [5.1.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
@@ -21,15 +21,15 @@ import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.internal.monitor.impl.LocalQueueStatsImpl;
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.operationservice.BlockingOperation;
+import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Notifier;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.WaitNotifyKey;
-import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
 import java.io.IOException;
 
@@ -53,22 +53,21 @@ public final class OfferOperation extends QueueBackupAwareOperation
     @Override
     public void run() {
         QueueContainer queueContainer = getContainer();
+        LocalQueueStatsImpl stats = getQueueService().getLocalQueueStatsImpl(name);
         if (queueContainer.hasEnoughCapacity()) {
             itemId = queueContainer.offer(data);
+            stats.incrementOffers();
             response = true;
         } else {
+            stats.incrementRejectedOffers();
             response = false;
         }
     }
 
     @Override
     public void afterRun() throws Exception {
-        LocalQueueStatsImpl stats = getQueueService().getLocalQueueStatsImpl(name);
         if (Boolean.TRUE.equals(response)) {
-            stats.incrementOffers();
             publishEvent(ItemEventType.ADDED, data);
-        } else {
-            stats.incrementRejectedOffers();
         }
     }
 


### PR DESCRIPTION
Fixes: #21696 
Moving queue statistic updates to run method

(cherry picked from commit 4fcbac164f071df226332366d6839b1232ed93e0)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
