### PR TITLE
Make AbstractListenersOnReconnectTest resilient to concurrent events [API-1656] [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -385,7 +385,7 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
         eventCount.set(0);
         eventsLatch = new CountDownLatch(1);
         for (int i = 0; i < EVENT_COUNT; i++) {
-            events.add(randomString());
+            events.add(i + randomString());
         }
 
         for (String event : events) {
@@ -430,8 +430,8 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     protected abstract void produceEvent(String event);
 
     void onEvent(String event) {
-        events.remove(event);
         eventCount.incrementAndGet();
+        events.remove(event);
         if (events.isEmpty()) {
             eventsLatch.countDown();
         }


### PR DESCRIPTION
The test's `onEvent` method is called when an event is received on any of the subclass tests.

However, it was problematic, when the client receives events more or less at the same time.

The client uses an event executor with 5 threads by default for all sorts of events. So, it is possible that the `onEvent` is called concurrently two or more times, for different events.

The structure of the `onEvent` was as follows:

```java
    void onEvent(String event) {
        events.remove(event);
        eventCount.incrementAndGet();
        if (events.isEmpty()) {
            eventsLatch.countDown();
        }
    }
```

Imagine there are two events for different `event` keys, that are being executed in different threads of the event executor at the same time. Let's call them thread-1 and 2.

In thread-1, we remove the `event` from the set, then stop for some time.

In thread-2, we also remove the other `event`, increment the counter, and if this is the last event to be removed from the set, see that the `events` is now empty and count down the latch. Note that, thread-1 didn't have the time to increment the counter yet.

Then, the `validateListenerFunctionality` continues execution after seeing that the latch is open. However, the assertion of the event count is no longer true, because thread-1 couldn't increment the counter yet. That causes the test to fail.

As a solution, I have moved the increment operation above the remove.

Also, I know that it is practically impossible, but the same test could fail if there were two identical random strings (UUID strings) added to the `events` set, in
`validateListenerFunctionality`. So, just to be on the safe side, I have also included the counter value in the random strings.

clean backport of https://github.com/hazelcast/hazelcast/pull/23114