### PR TITLE
Relax the ClientHazelcastRunningInForkJoinPoolTest [API-1667]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientHazelcastRunningInForkJoinPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientHazelcastRunningInForkJoinPoolTest.java
@@ -83,15 +83,17 @@ public class ClientHazelcastRunningInForkJoinPoolTest extends HazelcastTestSuppo
 
     @Test
     public void slow_data_loading_does_not_block_entry_listener_addition() {
-        // 1. Let's simulate 1000 parallel tasks
+        // 1. Let's simulate some parallel tasks
         // contend on loading 1 item from a database.
-        Collection<Future> tasks = new ArrayList<>();
-        for (int i = 0; i < 1000; i++) {
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        int count = availableProcessors + 1;
+        Collection<Future> tasks = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
             tasks.add(ForkJoinPool.commonPool().submit(() -> clientMap.get(1)));
         }
 
         // 2. In parallel, adding a listener to a different
-        // map must not affected by loading phase at step 1.
+        // map must not be affected by loading phase at step 1.
         serverMap.addEntryListener(new EntryAdapter<>(), true);
     }
 }


### PR DESCRIPTION
The test was submitting 1000 blocking requests to the common FJP.

That was problematic because after parallelism +
`java.util.concurrent.ForkJoinPool.common.maximumSpares` tasks, which is equal to available CPUs - 1 + 256 by default, the client requests were throwing
`RejectedExecutionException("Thread limit exceeded replacing blocked worker")`.

So, it was not useful to spawn that many tasks to test the validity of the ManagedBlocker implementation of the client futures.

Just like the `HazelcastRunningInForkJoinPoolTest`, I have relaxed the test by decreasing the amount of work submitted to FJP. After all, the test wouldn't pass when the number of blocking tasks is more than parallelism if we haven't implemented ManagedBlocker in the returned client futures.

I am not fully sure that this was the reason behind the test failure, but my gut feeling says it plays some part in it.

Also, I see that there will be some work in 5.3 to eliminate all internal usages of the FJP common pool, so that might be a better permanent solution to this problem.

Until then, I believe we can relax the test a bit and close the issue.

closes #22232 