### PR TITLE
Eliminate ProxyService and rely on EventService [HZ-1920]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapPartitionAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapPartitionAwareService.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.cluster.Address;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.internal.partition.PartitionAwareService;
 import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
@@ -37,13 +36,11 @@ class MapPartitionAwareService implements PartitionAwareService {
     private final MapServiceContext mapServiceContext;
     private final NodeEngine nodeEngine;
     private final EventServiceImpl eventService;
-    private final ILogger logger;
 
     MapPartitionAwareService(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
         this.nodeEngine = mapServiceContext.getNodeEngine();
         this.eventService = (EventServiceImpl) this.nodeEngine.getEventService();
-        this.logger = nodeEngine.getLogger(MapPartitionAwareService.class.getName());
     }
 
     @Override
@@ -53,7 +50,6 @@ class MapPartitionAwareService implements PartitionAwareService {
 
         EventServiceSegment eventServiceSegment = eventService.getSegment(MapService.SERVICE_NAME, false);
         if (eventServiceSegment == null) {
-            logger.warning("No service registration found for " + MapService.SERVICE_NAME);
             return;
         }
         Set<String> maps = eventServiceSegment.getRegistrations().keySet();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
@@ -148,7 +148,6 @@ public class EventServiceSegment<S> {
         return registrationIdMap;
     }
 
-    // this method is only used for testing purposes
     public ConcurrentMap<String, Collection<Registration>> getRegistrations() {
         return registrations;
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapPartitionLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapPartitionLostListenerTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.map;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
-import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.partition.PartitionLostEventImpl;
 import com.hazelcast.map.MapPartitionLostEvent;
@@ -29,7 +28,6 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.listener.MapPartitionLostListener;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
-import com.hazelcast.spi.impl.proxyservice.InternalProxyService;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -40,13 +38,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.test.Accessors.getNode;
-import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -129,9 +125,6 @@ public class ClientMapPartitionLostListenerTest extends HazelcastTestSupport {
         assertRegistrationEventually(instance1, mapName, true);
         assertRegistrationEventually(instance2, mapName, true);
 
-        assertProxyExistsEventually(instance1, mapName);
-        assertProxyExistsEventually(instance2, mapName);
-
         MapService mapService = getNode(instance2).getNodeEngine().getService(SERVICE_NAME);
         int partitionId = 5;
         mapService.onPartitionLost(new PartitionLostEventImpl(partitionId, 0, null));
@@ -154,22 +147,6 @@ public class ClientMapPartitionLostListenerTest extends HazelcastTestSupport {
                 assertFalse(events.isEmpty());
                 assertEquals(partitionId, events.get(0).getPartitionId());
 
-            }
-        });
-    }
-
-    private static void assertProxyExistsEventually(HazelcastInstance instance, final String proxyName) {
-        final InternalProxyService proxyService = getNodeEngineImpl(instance).getProxyService();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                Collection<DistributedObject> allDistributedObjects = proxyService.getAllDistributedObjects();
-                for (DistributedObject distributedObject : allDistributedObjects) {
-                    if (distributedObject.getName().equals(proxyName)) {
-                        return;
-                    }
-                }
-                fail("There is no proxy with name " + proxyName + " created (yet)");
             }
         });
     }


### PR DESCRIPTION
While registering listeners we don’t check proxy existence but rely on proxy existence during publishing.
The current fix removes this dependency and relies on `EventService`.

This PR is a separate fix for the https://github.com/hazelcast/hazelcast/issues/18381, but does not fix the problem with the "lost" proxy on another member.

Fixes #18381

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forward ports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
