### PR TITLE
Monitor left member invocations periodically [HZ-977] (#23005) [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -287,7 +287,7 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
                 // then it means a member left.
                 throw new MemberLeftException(previousTargetMember);
             }
-            if (!(isJoinOperation(op) || isWanReplicationOperation(op))) {
+            if (requiresTargetAsClusterMember()) {
                 throw new TargetNotMemberException(target, op.getPartitionId(), op.getClass().getName(), op.getServiceName());
             }
         }
@@ -295,6 +295,10 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
         if (op instanceof TargetAware) {
             ((TargetAware) op).setTarget(targetAddress);
         }
+    }
+
+    private boolean requiresTargetAsClusterMember() {
+        return !(isJoinOperation(op) || isWanReplicationOperation(op));
     }
 
     /**
@@ -447,6 +451,19 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
         } else {
             return false;
         }
+    }
+
+    boolean detectAndHandleLeftMember() {
+        if (requiresTargetAsClusterMember()
+                // if target member is null, error is already notified
+                && targetMember != null
+                && context.clusterService.getMember(targetAddress, targetMember.getUuid()) == null) {
+            notifyError(new MemberLeftException("Member: " + targetMember
+                    + " with address: " + targetAddress + " has left the cluster."));
+            return true;
+        }
+
+        return false;
     }
 
     boolean skipTimeoutDetection() {
@@ -763,7 +780,9 @@ public abstract class Invocation<T> extends BaseInvocation implements OperationR
                 + ", firstInvocationTime='" + timeToString(firstInvocationTimeMillis) + '\''
                 + ", lastHeartbeatMillis=" + lastHeartbeatMillis
                 + ", lastHeartbeatTime='" + timeToString(lastHeartbeatMillis) + '\''
-                + ", target=" + targetAddress
+                + ", targetAddress=" + targetAddress
+                + ", targetMember=" + targetMember
+                + ", memberListVersion=" + memberListVersion
                 + ", pendingResponse={" + pendingResponse + '}'
                 + ", backupsAcksExpected=" + backupsAcksExpected
                 + ", backupsAcksReceived=" + backupsAcksReceived

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -317,6 +317,7 @@ public class InvocationMonitor implements Consumer<Packet>, StaticMetricsProvide
 
             int backupTimeouts = 0;
             int normalTimeouts = 0;
+            int memberLeft = 0;
             int invocationCount = 0;
 
             for (Invocation inv : invocationRegistry) {
@@ -326,6 +327,8 @@ public class InvocationMonitor implements Consumer<Packet>, StaticMetricsProvide
                         normalTimeouts++;
                     } else if (inv.detectAndHandleBackupTimeout(backupTimeoutMillis)) {
                         backupTimeouts++;
+                    } else if (inv.detectAndHandleLeftMember()) {
+                        memberLeft++;
                     }
                 } catch (Throwable t) {
                     inspectOutOfMemoryError(t);
@@ -335,10 +338,10 @@ public class InvocationMonitor implements Consumer<Packet>, StaticMetricsProvide
 
             backupTimeoutsCount.inc(backupTimeouts);
             normalTimeoutsCount.inc(normalTimeouts);
-            log(invocationCount, backupTimeouts, normalTimeouts);
+            log(invocationCount, backupTimeouts, normalTimeouts, memberLeft);
         }
 
-        private void log(int invocationCount, int backupTimeouts, int invocationTimeouts) {
+        private void log(int invocationCount, int backupTimeouts, int invocationTimeouts, int memberLeft) {
             Level logLevel = null;
             if (backupTimeouts > 0 || invocationTimeouts > 0) {
                 logLevel = INFO;
@@ -349,7 +352,8 @@ public class InvocationMonitor implements Consumer<Packet>, StaticMetricsProvide
             if (logLevel != null) {
                 logger.log(logLevel, "Invocations:" + invocationCount
                         + " timeouts:" + invocationTimeouts
-                        + " backup-timeouts:" + backupTimeouts);
+                        + " backup-timeouts:" + backupTimeouts
+                        + " member-left: " + memberLeft);
             }
         }
     }


### PR DESCRIPTION
Previously, once a member leaves the cluster, `OnMemberLeftTask` was  responsible for notifying errors for invocations sent to the left  member. With this PR, we also check these invocations periodically in  `MonitorInvocationsTask`.

We need this because invocations are registered to the `invocationRegistry` after their targets are initialized. So, what could happen is:

  1. Invocation target is initialized to a member.
  2. This member leaves the cluster.
  3. `OnMemberLeftTask` is executed.
  4. Invocation is registered.

At this point, this invocation could only time out before. Now it will be cleaned by `MonitorInvocationsTask`.

Together with https://github.com/hazelcast/hazelcast/pull/22998 fixes  https://github.com/hazelcast/hazelcast/issues/1325

Backport of: https://github.com/hazelcast/hazelcast/pull/23005