### PR TITLE
Fixed NPE in MulticastConfig#hashcode due to loopbackModeEnabled as null

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
@@ -314,7 +314,7 @@ public class MulticastConfig implements TrustedInterfacesConfigurable<MulticastC
         result = 31 * result + multicastTimeoutSeconds;
         result = 31 * result + multicastTimeToLive;
         result = 31 * result + trustedInterfaces.hashCode();
-        result = 31 * result + (loopbackModeEnabled ? 1 : 0);
+        result = 31 * result + (Boolean.TRUE.equals(loopbackModeEnabled) ? 1 : 0);
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.hazelcast.internal.util.Preconditions.checkHasText;
@@ -314,7 +315,7 @@ public class MulticastConfig implements TrustedInterfacesConfigurable<MulticastC
         result = 31 * result + multicastTimeoutSeconds;
         result = 31 * result + multicastTimeToLive;
         result = 31 * result + trustedInterfaces.hashCode();
-        result = 31 * result + (Boolean.TRUE.equals(loopbackModeEnabled) ? 1 : 0);
+        result = 31 * result + Objects.hashCode(loopbackModeEnabled);
         return result;
     }
 


### PR DESCRIPTION
This fixes the NullPointerException that may arise in MulticastConfig#hashcode when the `loopbackModeEnabled` variable is null.

Fixes https://github.com/hazelcast/hazelcast/issues/23177



Breaking changes (list specific methods/types/messages):
None

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
