### PR TITLE
Wait for safe state in ClientMapLoadAllTest [API-1665]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapLoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapLoadAllTest.java
@@ -70,6 +70,8 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
 
+        waitForSafeState();
+
         try {
             final IMap<Object, Object> map = server.getMap(mapName);
             populateMap(map, itemCount);
@@ -85,12 +87,14 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void testLoadAll_givenKeys() throws Exception {
+    public void testLoadAll_givenKeys() {
         final String mapName = randomMapName();
         final Config config = createNewConfig(mapName);
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
+
+        waitForSafeState();
 
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(getClientConfig());
         final IMap<Object, Object> map = client.getMap(mapName);
@@ -138,6 +142,9 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
+
+        waitForSafeState();
+
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(getClientConfig());
         final IMap<Object, Object> map = client.getMap(mapName);
         populateMap(map, 1000);
@@ -145,6 +152,12 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
         map.loadAll(true);
 
         assertEquals(1000, map.size());
+    }
+
+    private void waitForSafeState() {
+        Collection<HazelcastInstance> instances = hazelcastFactory.getAllHazelcastInstances();
+        warmUpPartitions(instances);
+        waitAllForSafeState(instances);
     }
 
     protected ClientConfig getClientConfig() {


### PR DESCRIPTION
In the failing run, we can see the following lines in the log.

```
18:46:46,862  INFO |testLoadAll_givenKeys| - [MigrationManager] hz.youthful_diffie.migration - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT] Repartitioning cluster data. Migration tasks count: 11
18:46:46,877  INFO |testLoadAll_givenKeys| - [MigrationManager] hz.youthful_diffie.migration - [127.0.0.1]:5701 [dev] [5.2-SNAPSHOT] All migration tasks have been completed. (repartitionTime=Tue Aug 02 18:46:46 UTC 2022, plannedMigrations=11, completedMigrations=11, remainingMigrations=0, totalCompletedMigrations=11, elapsedMigrationOperationTime=88ms, totalElapsedMigrationOperationTime=88ms, elapsedDestinationCommitTime=7ms, totalElapsedDestinationCommitTime=7ms, elapsedMigrationTime=97ms, totalElapsedMigrationTime=97ms)
```

It is easy to see that the test can fail when faced with migrations. When the
`warmUpPartitions(hazelcastFactory.getAllHazelcastInstances());` line is added to the failing `testLoadAll_givenKeys` test, the local runs fail with similar exceptions and logs after some time.

The fix is to make sure that the cluster is safe and there won't be migrations while the test logic is running.

I have also added a similar logic to the other tests in this file where we use more than one instance.

closes https://github.com/hazelcast/hazelcast-enterprise/issues/5168