### PR TITLE
Fix building maven command for Windows OS [HZ-1925]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.util.OsHelper.isWindows;
 import static com.hazelcast.internal.util.Preconditions.checkState;
 import static com.hazelcast.test.JenkinsDetector.isOnJenkins;
 import static java.io.File.separator;
@@ -109,7 +110,8 @@ public class HazelcastVersionLocator {
     }
 
     private static String buildMavenCommand(Artifact artifact, String version) {
-        return "mvn dependency:get -Dartifact=com.hazelcast:"
+        String mvn = isWindows() ? "mvn.cmd" : "mvn";
+        return mvn + " dependency:get -Dartifact=com.hazelcast:"
                 + artifact.mavenProject + ":" + version
                 + (artifact.test ? ":jar:tests" : "")
                 + (artifact.enterprise ? " -DremoteRepositories=https://repository.hazelcast.com/release" : "");


### PR DESCRIPTION
For Windows OS we should use maven as `mvn.cmd` command instead of just `mvn` .

Fixes #23217

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible
- [X] Send backports/forwardports if fix needs to be applied to past/future releases
- [X] New public APIs have `@Nonnull/@Nullable` annotations
- [X] New public APIs have `@since` tags in Javadoc
