### PR TITLE
Add assumeDockerEnabled in AbstractMongoDBTest to ignore tests on Windows [HZ-1926]

### DIFF
--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/AbstractMongoDBTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/AbstractMongoDBTest.java
@@ -27,9 +27,12 @@ import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.utility.DockerImageName;
+
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 
 public abstract class AbstractMongoDBTest extends JetTestSupport {
 
@@ -45,6 +48,11 @@ public abstract class AbstractMongoDBTest extends JetTestSupport {
 
     @Rule
     public MongoDBContainer mongoContainer = new MongoDBContainer(DOCKER_IMAGE_NAME);
+
+    @BeforeClass
+    public static void beforeClass() {
+        assumeDockerEnabled();
+    }
 
     @Before
     public void setUp() {


### PR DESCRIPTION
…dows machine

Fixes #23219

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible
- [X] Send backports/forwardports if fix needs to be applied to past/future releases
- [X] New public APIs have `@Nonnull/@Nullable` annotations
- [X] New public APIs have `@since` tags in Javadoc
