### PR TITLE
Fix cancel-with-snapshot with suspend-on-failure

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -695,7 +695,11 @@ public class MasterJobContext {
                     mc.setJobStatus(SUSPENDED);
                     mc.jobExecutionRecord().setSuspended(null);
                     nonSynchronizedAction = () -> mc.writeJobExecutionRecord(false);
-                } else if (failure != null && !isCancelled() && mc.jobConfig().isSuspendOnFailure()) {
+                } else if (failure != null
+                        && !isCancelled()
+                        && requestedTerminationMode != CANCEL_GRACEFUL
+                        && mc.jobConfig().isSuspendOnFailure()
+                ) {
                     mc.setJobStatus(SUSPENDED);
                     mc.jobExecutionRecord().setSuspended("Execution failure:\n" +
                             ExceptionUtil.stackTraceToString(failure));


### PR DESCRIPTION
Fix the combination of `Job.cancelAndExportSnapshot()` and `JobConfig.setSuspendOnFailure(true)`. Before, a job cancelled with snapshot was suspended instead of cancelled, because the `CANCEL_GRACEFUL` mode was treated as a failure.

Fixes hazelcast/hazelcast-enterprise#4071
