### PR TITLE
Backport: Stabilize TenantControl test (#22694) - 5.2.z branch

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/tenantcontrol/TenantControlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/tenantcontrol/TenantControlTest.java
@@ -143,7 +143,7 @@ public class TenantControlTest extends TenantControlTestSupport {
         // AddCacheConfigOperation
         // TenantControlReplicationOperation
         assertEquals(4, setTenantCount.get());
-        assertEquals(4, closeTenantCount.get());
+        assertEqualsEventually(4, closeTenantCount);
         assertEquals(1, registerTenantCount.get());
         assertEqualsEventually(1, unregisterTenantCount);
         // thread context should be cleared at least twice.


### PR DESCRIPTION
Assertion on closeTenantCount should be eventual.
Reasoning: operations notify responses before executing their afterRun & closing the tenant context, so it is possible their futures are completed (so get/put are done) before tenant context is closed.

fixes #17990

<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

INSERT_PR_DESCRIPTION_HERE

Fixes INSERT_LINK_TO_THE_ISSUE_HERE

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
