### PR TITLE
Fix auto force start [HZ-1768] [5.0.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -665,7 +665,9 @@ public class ClusterJoinManager {
                 }
 
                 // send members update back to node trying to join again...
-                boolean deferPartitionProcessing = isMemberRestartingWithPersistence(member.getAttributes());
+                MemberMap memberMap = clusterService.getMembershipManager().getMemberMap();
+                boolean deferPartitionProcessing = isMemberRestartingWithPersistence(member.getAttributes())
+                        && isMemberRejoining(memberMap, member.getAddress(), member.getUuid());
                 OnJoinOp preJoinOp = preparePreJoinOps();
                 OnJoinOp postJoinOp = preparePostJoinOp();
                 PartitionRuntimeState partitionRuntimeState = node.getPartitionService().createPartitionState();


### PR DESCRIPTION
Align the deferPartitionProcessing value evaluation to have a consistent value for the FinalizeJoinOp operation instances. This should fix an issue when FinalizeJoinOp-s operations are processed in a different order.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/4375

Backport of: https://github.com/hazelcast/hazelcast/pull/23195

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
