### PR TITLE
Add more logging to kinesis tests and upgrade toxiproxy [HZ-1093] #21140

### DIFF
--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
@@ -32,11 +32,13 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.ToxiproxyContainer.ContainerProxy;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 import java.util.List;
 import java.util.Map;
@@ -58,7 +60,6 @@ public class KinesisFailureTest extends AbstractKinesisTest {
 
     @ClassRule
     public static final Network NETWORK = Network.newNetwork();
-
     public static LocalStackContainer localStack;
 
     public static ToxiproxyContainer toxiProxy;
@@ -67,6 +68,8 @@ public class KinesisFailureTest extends AbstractKinesisTest {
     private static AmazonKinesisAsync KINESIS;
     private static ContainerProxy PROXY;
     private static KinesisTestHelper HELPER;
+
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(KinesisFailureTest.class);
 
     public KinesisFailureTest() {
         super(AWS_CONFIG, KINESIS, HELPER);
@@ -79,12 +82,14 @@ public class KinesisFailureTest extends AbstractKinesisTest {
         localStack = new LocalStackContainer(parse("localstack/localstack")
                 .withTag("0.12.3"))
                 .withNetwork(NETWORK)
-                .withServices(Service.KINESIS);
+                .withServices(Service.KINESIS)
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER));
         localStack.start();
-        toxiProxy = new ToxiproxyContainer(parse("shopify/toxiproxy")
-                .withTag("2.1.0"))
+        toxiProxy = new ToxiproxyContainer(parse("ghcr.io/shopify/toxiproxy")
+                .withTag("2.5.0"))
                 .withNetwork(NETWORK)
-                .withNetworkAliases("toxiproxy");
+                .withNetworkAliases("toxiproxy")
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER));
         toxiProxy.start();
 
         System.setProperty(SDKGlobalConfiguration.AWS_CBOR_DISABLE_SYSTEM_PROPERTY, "true");


### PR DESCRIPTION
Looks like a problem with LocalStack/ToxiProxy container being down or maybe docker runtime itself on CI. 
- Added logging to the docker containers for further investigation
- Upgraded ToxiProxy

Fixes to https://github.com/hazelcast/hazelcast/issues/21140
