### PR TITLE
Fix SQL catalog default async backup count [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
@@ -170,6 +170,7 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
         return config
                 .setName(SQL_CATALOG_MAP_NAME)
                 .setBackupCount(MapConfig.MAX_BACKUP_COUNT)
+                .setAsyncBackupCount(0)
                 .setTimeToLiveSeconds(DISABLED_TTL_SECONDS)
                 .setReadBackupData(true)
                 .setMergePolicyConfig(new MergePolicyConfig().setPolicy(LatestUpdateMergePolicy.class.getName()))

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
@@ -170,7 +170,7 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
         return config
                 .setName(SQL_CATALOG_MAP_NAME)
                 .setBackupCount(MapConfig.MAX_BACKUP_COUNT)
-                .setAsyncBackupCount(0)
+                .setAsyncBackupCount(MapConfig.MIN_BACKUP_COUNT)
                 .setTimeToLiveSeconds(DISABLED_TTL_SECONDS)
                 .setReadBackupData(true)
                 .setMergePolicyConfig(new MergePolicyConfig().setPolicy(LatestUpdateMergePolicy.class.getName()))


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/23232

We configure the backup count to maximum for SQL catalog map, but we leave the async backup count untouched. The async backup count is 0 by default, but if the user changes it to >0, the member fails to start with:
```
java.lang.IllegalArgumentException: the sum of backup-count and async-backup-count can't be larger than than 6
	at com.hazelcast.internal.util.Preconditions.checkBackupCount(Preconditions.java:226)
	at com.hazelcast.config.MapConfig.setBackupCount(MapConfig.java:271)
	at com.hazelcast.jet.impl.JetServiceBackend.initializeSqlCatalog(JetServiceBackend.java:167)
	at com.hazelcast.jet.impl.JetServiceBackend.configureJetInternalObjects(JetServiceBackend.java:161)
	at com.hazelcast.jet.impl.EnterpriseJetServiceBackend.configureJetInternalObjects(EnterpriseJetServiceBackend.java:63)
	at com.hazelcast.instance.impl.DefaultNodeExtension.beforeStart(DefaultNodeExtension.java:245)
	at com.hazelcast.instance.impl.EnterpriseNodeExtension.beforeStart(EnterpriseNodeExtension.java:288)
	at com.hazelcast.instance.impl.Node.<init>(Node.java:253)
	at com.hazelcast.instance.impl.HazelcastInstanceImpl.createNode(HazelcastInstanceImpl.java:149)
	at com.hazelcast.instance.impl.HazelcastInstanceImpl.<init>(HazelcastInstanceImpl.java:118)
	at com.hazelcast.instance.impl.HazelcastInstanceFactory.constructHazelcastInstance(HazelcastInstanceFactory.java:217)
	at com.hazelcast.instance.impl.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:196)
	at com.hazelcast.instance.impl.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:134)
	at com.hazelcast.core.Hazelcast.newHazelcastInstance(Hazelcast.java:95)
```
The fix is to explicitly configure the async-backup-count to 0.