### PR TITLE
Use Elasticsearch docker images from their official repository

### DIFF
--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
@@ -30,8 +30,8 @@ import static com.hazelcast.jet.elastic.ElasticClients.client;
 
 public final class ElasticSupport {
 
-    public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName.parse("elasticsearch:6.8.23")
-            .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch");
+    public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName
+            .parse("docker.elastic.co/elasticsearch/elasticsearch:6.8.23");
     public static final int PORT = 9200;
 
     // Elastic container takes long time to start up, reusing the container for speedup

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
@@ -32,6 +32,7 @@ public final class ElasticSupport {
 
     public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName
             .parse("docker.elastic.co/elasticsearch/elasticsearch:6.8.23");
+
     public static final int PORT = 9200;
 
     // Elastic container takes long time to start up, reusing the container for speedup

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
@@ -32,9 +32,7 @@ public final class ElasticSupport {
     public static final String TEST_ELASTIC_VERSION = System.getProperty("test.elastic.version", "7.17.7");
 
     public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName
-            .parse("elasticsearch:" + TEST_ELASTIC_VERSION)
-            .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch");
-
+            .parse("docker.elastic.co/elasticsearch/elasticsearch:" + TEST_ELASTIC_VERSION);
     public static final int PORT = 9200;
 
     // Elastic container takes long time to start up, reusing the container for speedup

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticSupport.java
@@ -33,6 +33,7 @@ public final class ElasticSupport {
 
     public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName
             .parse("docker.elastic.co/elasticsearch/elasticsearch:" + TEST_ELASTIC_VERSION);
+
     public static final int PORT = 9200;
 
     // Elastic container takes long time to start up, reusing the container for speedup


### PR DESCRIPTION
It fixes problems when some of Elasticsearch versions, like 7.15.X are not available in their official docker hub

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible
- [X] Send backports/forwardports if fix needs to be applied to past/future releases
- [X] New public APIs have `@Nonnull/@Nullable` annotations
- [X] New public APIs have `@since` tags in Javadoc
