### PR TITLE
Fix broken watermark counters in unordered mapUsingServiceAsync [HZ-1928]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
@@ -967,9 +967,9 @@ public final class TestSupport {
                         elapsed < MILLISECONDS.toNanos(cooperativeTimeout));
             }
             // print warning
-            if (elapsed > MILLISECONDS.toNanos(cooperativeTimeout)) {
+            if (elapsed > MILLISECONDS.toNanos(COOPERATIVE_TIME_LIMIT_MS_WARN)) {
                 System.out.printf("Warning: call to %s() took %.2fms, it should be <%dms normally%n",
-                        methodName, toMillis(elapsed), cooperativeTimeout);
+                        methodName, toMillis(elapsed), COOPERATIVE_TIME_LIMIT_MS_WARN);
             }
         } else {
             if (elapsed > MILLISECONDS.toNanos(BLOCKING_TIME_LIMIT_MS_WARN)) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
@@ -963,13 +963,13 @@ public final class TestSupport {
         if (isCooperative) {
             if (cooperativeTimeout > 0) {
                 assertTrue(String.format("call to %s() took %.1fms, it should be <%dms", methodName,
-                                toMillis(elapsed), COOPERATIVE_TIME_LIMIT_MS_FAIL),
-                        elapsed < MILLISECONDS.toNanos(COOPERATIVE_TIME_LIMIT_MS_FAIL));
+                                toMillis(elapsed), cooperativeTimeout),
+                        elapsed < MILLISECONDS.toNanos(cooperativeTimeout));
             }
             // print warning
-            if (elapsed > MILLISECONDS.toNanos(COOPERATIVE_TIME_LIMIT_MS_WARN)) {
+            if (elapsed > MILLISECONDS.toNanos(cooperativeTimeout)) {
                 System.out.printf("Warning: call to %s() took %.2fms, it should be <%dms normally%n",
-                        methodName, toMillis(elapsed), COOPERATIVE_TIME_LIMIT_MS_WARN);
+                        methodName, toMillis(elapsed), cooperativeTimeout);
             }
         } else {
             if (elapsed > MILLISECONDS.toNanos(BLOCKING_TIME_LIMIT_MS_WARN)) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
@@ -88,7 +88,7 @@ public final class AsyncTransformUsingServiceUnorderedP<C, S, T, K, R> extends A
     for events received before it were already sent.
 
     Snapshot contains in-flight elements at the time of taking the snapshot.
-    They are replayed when state is restored from the snapshot, so we get only at-least-once guarantee.
+    They are replayed when state is restored from the snapshot.
      */
 
     private final BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>> callAsyncFn;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
@@ -247,7 +247,7 @@ public class AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport 
                 2, (ctx, item) -> new CompletableFuture<>()).get(1).iterator().next();
         processor.init(new TestOutbox(128), new TestProcessorContext());
         TestInbox inbox = new TestInbox();
-        // i have to add an item first because otherwise the WMs are forwarded right away
+        // I have to add an item first because otherwise the WMs are forwarded right away
         inbox.add("foo");
         processor.process(0, inbox);
         assertTrue("inbox not empty", inbox.isEmpty());
@@ -258,7 +258,7 @@ public class AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport 
 
     @Test
     public void test_allItemsProcessed_withoutWatermarks() throws Exception {
-        CompletableFuture processFuture = new CompletableFuture();
+        CompletableFuture<Traverser<String>> processFuture = new CompletableFuture<>();
         Processor processor = getSupplier(2, (ctx, item) -> processFuture)
                 .get(1).iterator().next();
         TestOutbox outbox = new TestOutbox(128);
@@ -275,7 +275,7 @@ public class AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport 
     @Test
     public void test_firstWatermarkIsForwardedAfterPreviousItemsComplete() throws Exception {
         // edge case test for first watermark
-        CompletableFuture processFuture = new CompletableFuture();
+        CompletableFuture<Traverser<String>> processFuture = new CompletableFuture<>();
         Processor processor = getSupplier(2, (ctx, item) -> processFuture)
                 .get(1).iterator().next();
 
@@ -311,12 +311,12 @@ public class AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport 
                                                                                                         int third)
             throws Exception {
         // futures can be completed in arbitrary order
-        List<CompletableFuture> futureList = new ArrayList<>(3);
+        List<CompletableFuture<String>> futureList = new ArrayList<>(3);
 
         Processor processor = getSupplier(
                 10,
                 (ctx, item) -> {
-                    CompletableFuture f = new CompletableFuture();
+                    CompletableFuture<String> f = new CompletableFuture<>();
                     futureList.add(f);
                     return f.thenApply(Traversers::singleton);
                 }).get(1).iterator().next();

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
@@ -194,10 +194,10 @@ public class AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport 
                 .input(asList("a", "a", wm(10), "a"))
                 .outputChecker((expected, actual) ->
                         actual.equals(asList("a-1", "a-1", wm(10), "a-1"))
-                        // last item may be reordered with watermark in current implementation
-                        // but this is not required.
+                        // this is possible if restoring the processor after every snapshot
                         || (!ordered && actual.equals(asList("a-1", "a-1", "a-1", wm(10))))
-                        // after snapshot restore watermark may be duplicated
+                        // this is possible if restoring the processor after every other snapshot. The
+                        // WM isn't actually duplicated, but is emitted again after a restart
                         || (!ordered && actual.equals(asList("a-1", "a-1", wm(10), "a-1", wm(10))))
                 )
                 .disableProgressAssertion()


### PR DESCRIPTION
mapUsingServiceAsync in unordered mode used wrong condition to check if the processing is complete and wrong number of currently processed items to propagate watermarks. This could lead to lost items when the pipeline was completed and to crashes during processing of streams containing the same item multiple times.

Fixes #23245

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases