### PR TITLE
Do not process JoinMessages from left members [HZ-1713]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -705,9 +705,10 @@ public class ClusterJoinManager {
         // If I am the master, I will just suspect from the target. If it sends a new join request, it will be processed.
         // If I am not the current master, I can turn into the new master and start the claim process
         // after I suspect from the target.
-        if (clusterService.isMaster() || targetAddress.equals(clusterService.getMasterAddress())) {
+        if (!hasMemberLeft(joinMessage.getUuid())
+                && (clusterService.isMaster() || targetAddress.equals(clusterService.getMasterAddress()))) {
             String msg = format("New join request has been received from an existing endpoint %s."
-                    + " Removing old member and processing join request...", member);
+                    + " Removing old member and processing join request with UUID %s", member, joinMessage.getUuid());
             logger.warning(msg);
 
             clusterService.suspectMember(member, msg, false);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -355,6 +355,7 @@ public class MembershipManager {
         }
 
         for (MemberImpl member : removedMembers) {
+            clusterService.getClusterJoinManager().addLeftMember(member);
             closeConnections(member.getAddress(), "Member left event received from master");
             handleMemberRemove(memberMapRef.get(), member);
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -30,6 +30,8 @@ import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.operations.MembersUpdateOp;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionListener;
+import com.hazelcast.internal.server.FirewallingServer;
+import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.services.PostJoinAwareService;
 import com.hazelcast.internal.services.PreJoinAwareService;
@@ -64,6 +66,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.LockSupport;
 
+import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static com.hazelcast.instance.impl.HazelcastInstanceFactory.newHazelcastInstance;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.FINALIZE_JOIN;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.F_ID;
@@ -663,6 +666,59 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
             assertClusterSize(1, hz2);
         }, 3);
     }
+
+    @Test
+    public void shouldNotProcessStaleJoinRequest_afterSplitBrainMerges() {
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
+        assertClusterSizeEventually(3, hz1, hz2, hz3);
+
+        JoinRequest staleJoinReq = getNode(hz3).createJoinRequest(getNode(hz1).address);
+
+        closeConnectionBetween(hz1, hz3);
+        closeConnectionBetween(hz2, hz3);
+        assertClusterSizeEventually(2, hz1, hz2);
+        assertClusterSizeEventually(1, hz3);
+
+        getNode(hz3).getClusterService().merge(getAddress(hz1));
+
+        FirewallingServer server = (FirewallingServer) getNode(hz1).getServer();
+        ServerConnection serverConnection = server.delegate.getConnectionManager(MEMBER).get(getAddress(hz3));
+        ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz1);
+
+        clusterService.getClusterJoinManager().handleJoinRequest(staleJoinReq, serverConnection);
+
+        assertClusterSizeEventually(3, hz1, hz2, hz3);
+    }
+
+    @Test
+    public void shouldNotProcessStaleJoinRequest_afterSplitBrainMerges_whenMasterChanges() {
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
+        assertClusterSizeEventually(3, hz1, hz2, hz3);
+
+        JoinRequest staleJoinReq = getNode(hz3).createJoinRequest(getNode(hz1).address);
+
+        closeConnectionBetween(hz1, hz3);
+        closeConnectionBetween(hz2, hz3);
+        assertClusterSizeEventually(2, hz1, hz2);
+        assertClusterSizeEventually(1, hz3);
+
+        getNode(hz3).getClusterService().merge(getAddress(hz1));
+
+        hz1.shutdown();
+
+        FirewallingServer server = (FirewallingServer) getNode(hz2).getServer();
+        ServerConnection serverConnection = server.delegate.getConnectionManager(MEMBER).get(getAddress(hz3));
+        ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz2);
+
+        clusterService.getClusterJoinManager().handleJoinRequest(staleJoinReq, serverConnection);
+
+        assertClusterSizeEventually(2, hz2, hz3);
+    }
+
 
     @Test
     public void memberJoinsEventually_whenMemberRestartedWithSameUuid_butMasterDoesNotNoticeItsLeave() throws Exception {


### PR DESCRIPTION
In the case of temporary cluster splitting, just after discovery is finished, the `JoinMessage` from the split member can be stuck and reach other members when this member has changed their UUID. This leads to that old `JoinMessage` (with the outdated member UUID) considering as a new join request from the new member and splitting the cluster again.

Fixes https://github.com/hazelcast/hazelcast/issues/22713

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
