### PR TITLE
Change default cloud coordinator url to viridian API-1796

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudDiscovery.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudDiscovery.java
@@ -43,7 +43,7 @@ import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 
 /**
  * Discovery service that discover nodes via hazelcast.cloud
- * https://coordinator.hazelcast.cloud/cluster/discovery?token=<TOKEN>
+ * https://api.viridian.hazelcast.com/cluster/discovery?token=<TOKEN>
  */
 public class HazelcastCloudDiscovery {
 
@@ -52,7 +52,7 @@ public class HazelcastCloudDiscovery {
      * Used for testing cloud discovery.
      */
     public static final HazelcastProperty CLOUD_URL_BASE_PROPERTY =
-            new HazelcastProperty("hazelcast.client.cloud.url", "https://coordinator.hazelcast.cloud");
+            new HazelcastProperty("hazelcast.client.cloud.url", "https://api.viridian.hazelcast.com");
     private static final String CLOUD_URL_PATH = "/cluster/discovery?token=";
     private static final String PRIVATE_ADDRESS_PROPERTY = "private-address";
     private static final String PUBLIC_ADDRESS_PROPERTY = "public-address";

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudConfigTest.java
@@ -54,7 +54,7 @@ public class HazelcastCloudConfigTest extends ClientTestSupport {
         HazelcastProperties hazelcastProperties = new HazelcastProperties(config.getProperties());
         String cloudUrlBase = hazelcastProperties.getString(HazelcastCloudDiscovery.CLOUD_URL_BASE_PROPERTY);
         String urlEndpoint = HazelcastCloudDiscovery.createUrlEndpoint(cloudUrlBase, token);
-        assertEquals("https://coordinator.hazelcast.cloud/cluster/discovery?token=TOKEN", urlEndpoint);
+        assertEquals("https://api.viridian.hazelcast.com/cluster/discovery?token=TOKEN", urlEndpoint);
     }
 
 }


### PR DESCRIPTION
Changes the default cloud coordinator URL to viridian.

Breaking changes (list specific methods/types/messages):
* Users who use the default configuration now will connect to viridian instead of hazelcast cloud. Potentially leading them to not being able to connect to the cloud cluster.

I have tried to connect to viridian manually using the following code:

```java
import com.hazelcast.client.HazelcastClient;
import com.hazelcast.client.config.ClientConfig;
import com.hazelcast.config.SSLConfig;
import com.hazelcast.core.HazelcastInstance;
import com.hazelcast.map.IMap;

import java.net.URISyntaxException;
import java.util.Properties;

class MainXX {
    public static void main(String[] args) throws URISyntaxException {
        ClassLoader classLoader = MainXX.class.getClassLoader();
        Properties props = new Properties();
        props.setProperty("javax.net.ssl.keyStore", classLoader.getResource("client.keystore").toURI().getPath());
        props.setProperty("javax.net.ssl.keyStorePassword", "----");
        props.setProperty("javax.net.ssl.trustStore",
                classLoader.getResource("client.truststore").toURI().getPath());
        props.setProperty("javax.net.ssl.trustStorePassword", "-----");
        ClientConfig config = new ClientConfig();
        config.getNetworkConfig().setSSLConfig(new SSLConfig().setEnabled(true).setProperties(props));
        config.getNetworkConfig().getCloudConfig()
                .setDiscoveryToken("-----")
                .setEnabled(true);
        config.setClusterName("----");

        HazelcastInstance client = HazelcastClient.newHazelcastClient(config);

        System.out.println("Connection Successful!");

        IMap<String, String> map = client.getMap("map");
        map.put("key", "value");
        System.out.println(map.get("key"));
    }
}
```

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc

This won't be backported. 