### PR TITLE
Make sure that the spare threads are not terminated in ClientHazelcastRunningInForkJoinPoolTest [API-1667]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientHazelcastRunningInForkJoinPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/ClientHazelcastRunningInForkJoinPoolTest.java
@@ -36,8 +36,13 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -82,18 +87,52 @@ public class ClientHazelcastRunningInForkJoinPoolTest extends HazelcastTestSuppo
     }
 
     @Test
-    public void slow_data_loading_does_not_block_entry_listener_addition() {
+    public void slow_data_loading_does_not_block_entry_listener_addition() throws ExecutionException, InterruptedException {
+        CountDownLatch tasksSubmitted = new CountDownLatch(1);
+        ForkJoinPool commonPool = ForkJoinPool.commonPool();
+
         // 1. Let's simulate some parallel tasks
         // contend on loading 1 item from a database.
-        int availableProcessors = Runtime.getRuntime().availableProcessors();
-        int count = availableProcessors + 1;
+        int count = 2 * Runtime.getRuntime().availableProcessors();
         Collection<Future> tasks = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
-            tasks.add(ForkJoinPool.commonPool().submit(() -> clientMap.get(1)));
+            tasks.add(commonPool.submit(() -> {
+                // Before calling map#get and expand the pool
+                // we need to wait for all tasks to be submitted
+                // because if there is a delay between running
+                // task-X and submission of task-X+1, in Java-8
+                // the FJP could try to terminate the spare thread
+                // created while running task-X, thinking that the
+                // pool is now quiescent. It might cause task-X+1
+                // and any further submissions to FJP not run because
+                // there is now no spare threads.
+                assertOpenEventually(tasksSubmitted);
+                clientMap.get(1);
+            }));
         }
 
-        // 2. In parallel, adding a listener to a different
-        // map must not be affected by loading phase at step 1.
-        serverMap.addEntryListener(new EntryAdapter<>(), true);
+        // Wait until all the initial FJP threads got a map#get task,
+        // and the rest of the tasks are waiting in the queue, so that
+        // the assertions below make sense.
+        assertTrueEventually(() -> assertEquals(count - commonPool.getParallelism(), commonPool.getQueuedSubmissionCount()));
+
+        Future addListenerFuture = spawn(() -> {
+            // 2. In parallel, adding a listener to a different
+            // map must not be affected by loading phase at step 1.
+            serverMap.addEntryListener(new EntryAdapter<>(), true);
+        });
+
+        // The task for add listener call above would eventually be
+        // queued and that would guarantee that the spare FJP thread
+        // created for the last map#get call above wouldn't terminate
+        // before completing it.
+        assertTrueEventually(() -> assertTrue(commonPool.getQueuedSubmissionCount() > count - commonPool.getParallelism()));
+
+        // All tasks are submitted, if the ManagedBlocker is implemented
+        // properly for the client futures, the FJP would expand and run
+        // the task for listener addition as well.
+        tasksSubmitted.countDown();
+
+        addListenerFuture.get();
     }
 }


### PR DESCRIPTION
This test failed again after my initial attempt to fix it.

Upon further investigation, I saw that the FJP would terminate
the last spare thread, if it thinks that the pool is now quiescent,
in Java 8.

From Zulu JDK 8 comments
```
     * Trimming workers. To release resources after periods of lack of
     * use, a worker starting to wait when the pool is quiescent will
     * time out and terminate (see awaitWork) if the pool has remained
     * quiescent for period IDLE_TIMEOUT, increasing the period as the
     * number of threads decreases, eventually removing all workers.
     * Also, when more than two spare threads exist, excess threads
     * are immediately terminated at the next quiescent point.
     * (Padding by two avoids hysteresis.)
```

The last sentence is the one causing problems in our case.

If submitting a task to FJP is delayed for a reason(like
overloaded test runner), it can cause the last spare thread
to terminate, and the test would hang waiting on addListener
call to finish, because all FJP threads are blocked on map#get
calls and there is no spare thread left to run further tasks.

This has been fixed (or let's say the policy about terminating
workers is changed) in JDK 9 and onwards. So, I believe if
we add a simple Java version check to the test, it would
solve the problem. However, since most of our tests are
run on JDK-8, I didn't want to do that.

Instead, I have changed the test so that task to `addListener`
call is queued in the FJP before FJP starts expanding its
pool to accommodate blocking map#get calls, thanks to our
ManagedBlocker implementation.

Closes #22232