### PR TITLE
[TPC] JCTools shading

### DIFF
--- a/hazelcast-tpc-engine/pom.xml
+++ b/hazelcast-tpc-engine/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <!-- Needed for CheckStyle -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <jctools.version>3.3.0</jctools.version>
+        <jctools.version>4.0.1</jctools.version>
     </properties>
 
     <build>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -177,6 +177,10 @@
                                     <shadedPattern>${relocation.root}.org.snakeyaml</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>org.jctools</pattern>
+                                    <shadedPattern>${relocation.root}.org.jctools</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>io.github.classgraph</pattern>
                                     <shadedPattern>${relocation.root}.io.github.classgraph</shadedPattern>
                                 </relocation>
@@ -205,9 +209,16 @@
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                        implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                             </transformers>
                             <filters>
+                                <filter>
+                                    <artifact>org.jctools:jctools-core</artifact>
+                                    <includes>
+                                        <include>org/jctools/queues/*</include>
+                                        <include>org/jctools/util/*</include>
+                                    </includes>
+                                </filter>
                                 <filter>
                                     <artifact>com.fasterxml.jackson.core:*</artifact>
                                     <excludes>


### PR DESCRIPTION
So JCTools is properly shaded/relocated in the final Hazelcast jar.

It is moved under com.hazelcast.org.jctools.

All non-relevant packages have been removed to reduce bloat.

The final build has been verified on Simulator.

