### PR TITLE
Prefix dependabot's PRs and do not include the scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "thursday"
       time: "02:00"
     labels:
       - "Source: Internal"
@@ -18,5 +19,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "thursday"
       time: "02:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     open-pull-requests-limit: 100
     commit-message:
       prefix: ""
+    ignore:
+      # it's our supported version, no need to upgrade
+      - dependency-name: "org.springframework.version"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       - "dependencies"
     open-pull-requests-limit: 100
     commit-message:
-      prefix: "[dependency]"
+      prefix: ""
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       - "Source: Internal"
       - "dependencies"
     open-pull-requests-limit: 100
+    commit-message:
+      prefix: "[dependency]"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Prefix all PRs with "[dependency]" for easy filtering on the list.
The `include: scope` is not present, meaning it should not include the scope of PR by default.