### PR TITLE
Bump Netty to 4.1.86.Final [5.0.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <log4j.version>1.2.17.redhat-00008</log4j.version>
         <log4j2.version>2.17.1</log4j2.version>
         <mysql.connector.version>8.0.20</mysql.connector.version>
-        <netty.version>4.1.75.Final</netty.version>
+        <netty.version>4.1.86.Final</netty.version>
         <osgi.version>4.2.0</osgi.version>
         <parquet.version>1.12.3</parquet.version>
         <picocli.version>4.4.0</picocli.version>


### PR DESCRIPTION
Bumps netty to 4.1.86.Final in order to avoid CVE.

Fixes #23301

Backport of #23350 for 5.0

EE PR: [#23351](https://github.com/hazelcast/hazelcast-enterprise/pull/23351)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases