### PR TITLE
Remove JRuby from dependencies

### DIFF
--- a/hazelcast-build-utils/src/test/resources/manifest.mf
+++ b/hazelcast-build-utils/src/test/resources/manifest.mf
@@ -23,7 +23,7 @@ Import-Package: javax.annotation,javax.cache;version="[1.0,2)";resolut
  on:=optional,org.apache.logging.log4j;version="[2.0,3)";resolution:=o
  ptional,org.apache.logging.log4j.spi;version="[2.0,3)";resolution:=op
  tional,org.codehaus.groovy.jsr223;resolution:=optional;version="[2.1,
- 3)",org.jruby.embed.jsr223;resolution:=optional;version="[1.7,2)",org
+ 3)",org
  .osgi.framework;version="[1.5,2)";resolution:=optional,org.slf4j;vers
  ion="[1.6,2)";resolution:=optional,org.w3c.dom,org.xml.sax,sun.misc;r
  esolution:=optional

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -281,7 +281,6 @@
                                     org.apache.logging.log4j.spi;resolution:=optional,
                                     org.slf4j;resolution:=optional,
                                     org.codehaus.groovy.jsr223;resolution:=optional,
-                                    org.jruby.embed.jsr223;resolution:=optional,
                                     com.damnhandy.uri.template;resolution:=optional,
                                     org.apache.commons.validator.routines;resolution:=optional,
                                     com.google.re2j;resolution:=optional,
@@ -624,13 +623,6 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.4.21</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jruby</groupId>
-            <artifactId>jruby-complete</artifactId>
-            <version>1.7.22</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
INSERT_PR_DESCRIPTION_HERE

Fixes INSERT_LINK_TO_THE_ISSUE_HERE

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
