### PR TITLE
[HZ-1877] NoMigrationClusterStateTest.promotions_shouldHappen_whenMemberLeaves asserts fix

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
@@ -100,8 +100,10 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
         assertClusterSizeEventually(2, instances[2]);
         assertAllPartitionsAreAssigned(instances[2], 1);
 
-        assertEquals(getPartitionService(instances[1]).getPartitionStateStamp(),
-                getPartitionService(instances[2]).getPartitionStateStamp());
+        assertTrueEventually(() -> {
+            assertEquals(getPartitionService(instances[1]).getPartitionStateStamp(),
+                    getPartitionService(instances[2]).getPartitionStateStamp());
+        });
     }
 
     @Test


### PR DESCRIPTION
Potentially fixes #19917

Asserts currently do not account for further changes to the partition table post assignment of replicas/pruning of invalid replicas.