### PR TITLE
Do not try to send statistics on cluster changes if it is disabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
@@ -107,6 +107,10 @@ public class ClientStatisticsService {
     }
 
     public void collectAndSendStatsNow() {
+        if (!enabled) {
+            return;
+        }
+
         client.getTaskScheduler().schedule(this::collectAndSendStats, 0, SECONDS);
     }
 


### PR DESCRIPTION
It seems there is a missing check before trying to send the client statistics in case the cluster is changed.

With this change, we won't schedule a task to send the statistics after cluster changes, when the statistics is disabled.

closes https://github.com/hazelcast/hazelcast/issues/23229