### PR TITLE
Replicate lastUpdateTime from expiryMetadata [HZ-1138] [HZ-1669] (#23279) [4.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -67,10 +67,6 @@ public final class EntryViews {
     }
 
     private static <V> long calculateLastUpdateTime(Record<V> record, ExpiryMetadata expiryMetadata) {
-        if (record.getLastUpdateTime() != Record.UNSET) {
-            return record.getLastUpdateTime();
-        }
-
         if (expiryMetadata != ExpiryMetadata.NULL) {
             return expiryMetadata.getLastUpdateTime();
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -35,14 +35,14 @@ public final class EntryViews {
         return new SimpleEntryView<>();
     }
 
-    public static <K, V> EntryView<K, V> createSimpleEntryView(K key, V value, Record record,
+    public static <K, V> EntryView<K, V> createSimpleEntryView(K key, V value, Record<V> record,
                                                                ExpiryMetadata expiryMetadata) {
         return new SimpleEntryView<>(key, value)
                 .withCost(record.getCost())
                 .withVersion(record.getVersion())
                 .withHits(record.getHits())
                 .withLastAccessTime(record.getLastAccessTime())
-                .withLastUpdateTime(record.getLastUpdateTime())
+                .withLastUpdateTime(calculateLastUpdateTime(record, expiryMetadata))
                 .withCreationTime(record.getCreationTime())
                 .withLastStoredTime(record.getLastStoredTime())
                 .withTtl(expiryMetadata.getTtl())
@@ -58,11 +58,23 @@ public final class EntryViews {
                 .withVersion(record.getVersion())
                 .withHits(record.getHits())
                 .withLastAccessTime(record.getLastAccessTime())
-                .withLastUpdateTime(record.getLastUpdateTime())
+                .withLastUpdateTime(calculateLastUpdateTime(record, expiryMetadata))
                 .withCreationTime(record.getCreationTime())
                 .withLastStoredTime(record.getLastStoredTime())
                 .withTtl(expiryMetadata.getTtl())
                 .withMaxIdle(expiryMetadata.getMaxIdle())
                 .withExpirationTime(expiryMetadata.getExpirationTime());
+    }
+
+    private static <V> long calculateLastUpdateTime(Record<V> record, ExpiryMetadata expiryMetadata) {
+        if (record.getLastUpdateTime() != Record.UNSET) {
+            return record.getLastUpdateTime();
+        }
+
+        if (expiryMetadata != ExpiryMetadata.NULL) {
+            return expiryMetadata.getLastUpdateTime();
+        }
+
+        return Record.UNSET;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -71,6 +71,6 @@ public final class EntryViews {
             return expiryMetadata.getLastUpdateTime();
         }
 
-        return Record.UNSET;
+        return record.getLastUpdateTime();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.query.PagingPredicate;
@@ -89,6 +90,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -871,6 +873,56 @@ public class BasicMapTest extends HazelcastTestSupport {
                 MILLISECONDS.toSeconds(time3));
         assertBetween("entryView3.getLastUpdateTime()", MILLISECONDS.toSeconds(entryView3.getLastUpdateTime()),
                 MILLISECONDS.toSeconds(time1), MILLISECONDS.toSeconds(time2));
+    }
+
+    @Test
+    public void testEntryViewLastUpdateTimeSet_whenEntryIsExpirable() {
+        // statisticsEnabled shouldn't change anything, no need to test same scenario twice
+        assumeThat(statisticsEnabled, is(false));
+
+        HazelcastInstance instance = getInstance();
+        IMap<Integer, Integer> map = instance.getMap("testEntryViewLastUpdateTimeSet_whenEntryIsExpirable");
+
+        map.put(1, 1, 10_000, MILLISECONDS);
+        EntryView<Integer, Integer> entryView1 = map.getEntryView(1);
+
+        assertNotEquals(Record.UNSET, entryView1.getLastUpdateTime());
+    }
+
+    @Test
+    public void testEntryViewLastUpdateTimeSet_whenEntryIsNotExpirable_butPerEntryStatsEnabled() {
+        // statisticsEnabled shouldn't change anything, no need to test same scenario twice
+        assumeThat(statisticsEnabled, is(false));
+
+        // test condition
+        assumeThat(perEntryStatsEnabled, is(true));
+
+        HazelcastInstance instance = getInstance();
+        IMap<Integer, Integer> map = instance.getMap(
+                "testEntryViewLastUpdateTimeSet_whenEntryIsNotExpirable_butPerEntryStatsEnabled");
+
+        map.put(1, 1, 0, MILLISECONDS);
+        EntryView<Integer, Integer> entryView1 = map.getEntryView(1);
+
+        assertNotEquals(Record.UNSET, entryView1.getLastUpdateTime());
+    }
+
+    @Test
+    public void testEntryViewLastUpdateTimeIsNotSet_whenEntryIsNotExpirable_andPerEntryStatsDisabled() {
+        // statisticsEnabled shouldn't change anything, no need to test same scenario twice
+        assumeThat(statisticsEnabled, is(false));
+
+        // test condition
+        assumeThat(perEntryStatsEnabled, is(false));
+
+        HazelcastInstance instance = getInstance();
+        IMap<Integer, Integer> map = instance.getMap(
+                "testEntryViewLastUpdateTimeIsNotSet_whenEntryIsNotExpirable_andPerEntryStatsDisabled");
+
+        map.put(1, 1, 0, MILLISECONDS);
+        EntryView<Integer, Integer> entryView1 = map.getEntryView(1);
+
+        assertEquals(Record.UNSET, entryView1.getLastUpdateTime());
     }
 
     @Test


### PR DESCRIPTION
If per entry stats are disabled then lastUpdateTime is replicated as -1. 
This causes an issue when expiryTime is recalculated without a put 
event. This PR enhances this logic so if stats are disabled, we use 
expiryMetadata to replicate lastUpdateTime.

Backport of: https://github.com/hazelcast/hazelcast/pull/23279
