### PR TITLE
Add support for java.time.Instant

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -55,6 +55,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -229,6 +230,19 @@ public final class IOUtil {
         int zoneTotalSeconds = in.readInt();
         ZoneOffset zoneOffset = ZoneOffset.ofTotalSeconds(zoneTotalSeconds);
         return OffsetDateTime.of(year, month, dayOfMonth, hour, minute, second, nano, zoneOffset);
+    }
+
+    public static void writeInstant(ObjectDataOutput out, Instant value) throws IOException {
+        long epochSeconds = value.getEpochSecond();
+        int nanos = value.getNano();
+        out.writeLong(epochSeconds);
+        out.writeInt(nanos);
+    }
+
+    public static Instant readInstant(ObjectDataInput in) throws IOException {
+        long epochSeconds = in.readLong();
+        int nanos = in.readInt();
+        return Instant.ofEpochSecond(epochSeconds, nanos);
     }
 
     public static void writeData(ObjectDataOutput out, Data data) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldOperations.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldOperations.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.serialization.FieldKind;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecord;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -715,6 +716,55 @@ public final class FieldOperations {
             @Override
             public void writeJsonFormattedField(StringBuilder stringBuilder, AbstractGenericRecord record, String fieldName) {
                 Object[] objects = record.getArrayOfTimestampWithTimezone(fieldName);
+                writeArrayJsonFormatted(stringBuilder, objects,
+                        (builder, o) -> builder.append("\"").append(o).append("\""));
+            }
+        };
+        ALL[FieldKind.INSTANT.getId()] = new FieldKindBasedOperations() {
+            @Override
+            public Object readGenericRecordOrPrimitive(GenericRecord genericRecord, String fieldName) {
+                return genericRecord.getInstant(fieldName);
+            }
+
+            @Override
+            public void writeFieldFromRecordToWriter(DefaultCompactWriter writer, GenericRecord genericRecord, String fieldName) {
+                writer.writeInstant(fieldName, genericRecord.getInstant(fieldName));
+            }
+
+            @Override
+            public void writeJsonFormattedField(StringBuilder stringBuilder, AbstractGenericRecord record, String fieldName) {
+                Instant value = record.getInstant(fieldName);
+                if (value == null) {
+                    stringBuilder.append("null");
+                    return;
+                }
+                stringBuilder.append('"').append(value).append('"');
+            }
+        };
+        ALL[FieldKind.ARRAY_OF_INSTANT.getId()] = new FieldKindBasedOperations() {
+            @Override
+            public Object readGenericRecordOrPrimitive(GenericRecord genericRecord, String fieldName) {
+                return genericRecord.getArrayOfInstant(fieldName);
+            }
+
+            @Override
+            public Object readIndexed(InternalGenericRecord record, String fieldName, int index) {
+                return record.getInstantFromArray(fieldName, index);
+            }
+
+            @Override
+            public int hashCode(GenericRecord record, String fieldName) {
+                return Arrays.hashCode(record.getArrayOfInstant(fieldName));
+            }
+
+            @Override
+            public void writeFieldFromRecordToWriter(DefaultCompactWriter writer, GenericRecord record, String fieldName) {
+                writer.writeArrayOfInstant(fieldName, record.getArrayOfInstant(fieldName));
+            }
+
+            @Override
+            public void writeJsonFormattedField(StringBuilder stringBuilder, AbstractGenericRecord record, String fieldName) {
+                Object[] objects = record.getArrayOfInstant(fieldName);
                 writeArrayJsonFormatted(stringBuilder, objects,
                         (builder, o) -> builder.append("\"").append(o).append("\""));
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/InternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/InternalGenericRecord.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.serialization.compact.CompactReader;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -285,6 +286,16 @@ public interface InternalGenericRecord extends GenericRecord {
      */
     @Nullable
     OffsetDateTime getTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index);
+
+    /**
+     * @param fieldName the name of the field
+     * @return the value from the given index, returns null if index is larger than the array size or if array itself
+     * is null
+     * @throws HazelcastSerializationException if the field name does not exist in the class definition/schema or
+     *                                         the type of the field does not match the one in the class definition/schema.
+     */
+    @Nullable
+    Instant getInstantFromArray(@Nonnull String fieldName, int index);
 
     /**
      * @param fieldName the name of the field

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -57,6 +58,7 @@ import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATE;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMAL;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT32;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT64;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INSTANT;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT16;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT32;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT64;
@@ -76,6 +78,7 @@ import static com.hazelcast.nio.serialization.FieldKind.BOOLEAN;
 import static com.hazelcast.nio.serialization.FieldKind.COMPACT;
 import static com.hazelcast.nio.serialization.FieldKind.DATE;
 import static com.hazelcast.nio.serialization.FieldKind.DECIMAL;
+import static com.hazelcast.nio.serialization.FieldKind.INSTANT;
 import static com.hazelcast.nio.serialization.FieldKind.STRING;
 import static com.hazelcast.nio.serialization.FieldKind.TIME;
 import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP;
@@ -401,6 +404,11 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
         return getVariableSize(fieldName, TIMESTAMP_WITH_TIMEZONE, IOUtil::readOffsetDateTime);
     }
 
+    @Override
+    @Nullable
+    public Instant getInstant(@Nonnull String fieldName) {
+        return getVariableSize(fieldName, INSTANT, IOUtil::readInstant);
+    }
 
     @Override
     @Nullable
@@ -518,6 +526,13 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     public OffsetDateTime[] getArrayOfTimestampWithTimezone(@Nonnull String fieldName) {
         return getArrayOfVariableSize(fieldName, ARRAY_OF_TIMESTAMP_WITH_TIMEZONE,
                 OffsetDateTime[]::new, IOUtil::readOffsetDateTime);
+    }
+
+    @Override
+    @Nullable
+    public Instant[] getArrayOfInstant(@Nonnull String fieldName) {
+        return getArrayOfVariableSize(fieldName, ARRAY_OF_INSTANT,
+                Instant[]::new, IOUtil::readInstant);
     }
 
     @Override
@@ -1017,6 +1032,12 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     @Override
     public OffsetDateTime getTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index) {
         return getVariableSizeFromArray(fieldName, ARRAY_OF_TIMESTAMP_WITH_TIMEZONE, IOUtil::readOffsetDateTime, index);
+    }
+
+    @Nullable
+    @Override
+    public Instant getInstantFromArray(@Nonnull String fieldName, int index) {
+        return getVariableSizeFromArray(fieldName, ARRAY_OF_INSTANT, IOUtil::readInstant, index);
     }
 
     @Nullable

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactReader.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.compact.CompactReader;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -115,6 +116,12 @@ public class DefaultCompactReader extends CompactInternalGenericRecord implement
         return getTimestampWithTimezone(fieldName);
     }
 
+    @Nullable
+    @Override
+    public Instant readInstant(@Nonnull String fieldName) {
+        return getInstant(fieldName);
+    }
+
     @Override
     public <T> T readCompact(@Nonnull String fieldName) {
         return getObject(fieldName);
@@ -183,6 +190,11 @@ public class DefaultCompactReader extends CompactInternalGenericRecord implement
     @Override
     public OffsetDateTime[] readArrayOfTimestampWithTimezone(@Nonnull String fieldName) {
         return getArrayOfTimestampWithTimezone(fieldName);
+    }
+
+    @Override
+    public Instant[] readArrayOfInstant(@Nonnull String fieldName) {
+        return getArrayOfInstant(fieldName);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DefaultCompactWriter.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -74,11 +75,13 @@ import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT16;
 import static com.hazelcast.nio.serialization.FieldKind.STRING;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_STRING;
 import static com.hazelcast.nio.serialization.FieldKind.TIME;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIME;
 import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP;
 import static com.hazelcast.nio.serialization.FieldKind.TIMESTAMP_WITH_TIMEZONE;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIMESTAMP_WITH_TIMEZONE;
-import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_TIME;
+import static com.hazelcast.nio.serialization.FieldKind.INSTANT;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INSTANT;
 
 /**
  * Default implementation of the {@link CompactWriter} that writes the
@@ -293,6 +296,11 @@ public class DefaultCompactWriter implements CompactWriter {
     }
 
     @Override
+    public void writeInstant(@Nonnull String fieldName, @Nullable Instant value) {
+        writeVariableSizeField(fieldName, INSTANT, value, IOUtil::writeInstant);
+    }
+
+    @Override
     public void writeArrayOfInt8(@Nonnull String fieldName, @Nullable byte[] values) {
         writeVariableSizeField(fieldName, ARRAY_OF_INT8, values, ObjectDataOutput::writeByteArray);
     }
@@ -386,6 +394,11 @@ public class DefaultCompactWriter implements CompactWriter {
     @Override
     public void writeArrayOfTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime[] value) {
         writeArrayOfVariableSize(fieldName, ARRAY_OF_TIMESTAMP_WITH_TIMEZONE, value, IOUtil::writeOffsetDateTime);
+    }
+
+    @Override
+    public void writeArrayOfInstant(@Nonnull String fieldName, @Nullable Instant[] value) {
+        writeArrayOfVariableSize(fieldName, ARRAY_OF_INSTANT, value, IOUtil::writeInstant);
     }
 
     protected void setPositionAsNull(@Nonnull String fieldName, @Nonnull FieldKind fieldKind) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -41,6 +42,7 @@ import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATE;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMAL;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT32;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT64;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INSTANT;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT16;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT32;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT64;
@@ -62,6 +64,7 @@ import static com.hazelcast.nio.serialization.FieldKind.DATE;
 import static com.hazelcast.nio.serialization.FieldKind.DECIMAL;
 import static com.hazelcast.nio.serialization.FieldKind.FLOAT32;
 import static com.hazelcast.nio.serialization.FieldKind.FLOAT64;
+import static com.hazelcast.nio.serialization.FieldKind.INSTANT;
 import static com.hazelcast.nio.serialization.FieldKind.INT16;
 import static com.hazelcast.nio.serialization.FieldKind.INT32;
 import static com.hazelcast.nio.serialization.FieldKind.INT64;
@@ -205,6 +208,12 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
     @Override
     public OffsetDateTime getTimestampWithTimezone(@Nonnull String fieldName) {
         return get(fieldName, TIMESTAMP_WITH_TIMEZONE);
+    }
+
+    @Nullable
+    @Override
+    public Instant getInstant(@Nonnull String fieldName) {
+        return get(fieldName, INSTANT);
     }
 
     @Nullable
@@ -379,6 +388,12 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
     @Nullable
     public OffsetDateTime[] getArrayOfTimestampWithTimezone(@Nonnull String fieldName) {
         return get(fieldName, ARRAY_OF_TIMESTAMP_WITH_TIMEZONE);
+    }
+
+    @Nullable
+    @Override
+    public Instant[] getArrayOfInstant(@Nonnull String fieldName) {
+        return get(fieldName, ARRAY_OF_INSTANT);
     }
 
     @Nullable
@@ -715,6 +730,12 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
     @Override
     public OffsetDateTime getTimestampWithTimezoneFromArray(@Nonnull String fieldName, int index) {
         return getFromArray(getArrayOfTimestampWithTimezone(fieldName), index);
+    }
+
+    @Nullable
+    @Override
+    public Instant getInstantFromArray(@Nonnull String fieldName, int index) {
+        return getFromArray(getArrayOfInstant(fieldName), index);
     }
 
     @Nullable

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriter.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.compact.CompactWriter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -135,6 +136,11 @@ public final class SchemaWriter implements CompactWriter {
     }
 
     @Override
+    public void writeInstant(@Nonnull String fieldName, @Nullable Instant value) {
+        addField(new FieldDescriptor(fieldName, FieldKind.INSTANT));
+    }
+
+    @Override
     public void writeArrayOfInt8(@Nonnull String fieldName, @Nullable byte[] values) {
         addField(new FieldDescriptor(fieldName, FieldKind.ARRAY_OF_INT8));
     }
@@ -197,6 +203,11 @@ public final class SchemaWriter implements CompactWriter {
     @Override
     public void writeArrayOfTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime[] values) {
         addField(new FieldDescriptor(fieldName, FieldKind.ARRAY_OF_TIMESTAMP_WITH_TIMEZONE));
+    }
+
+    @Override
+    public void writeArrayOfInstant(@Nonnull String fieldName, @Nullable Instant[] value) {
+        addField(new FieldDescriptor(fieldName, FieldKind.ARRAY_OF_INSTANT));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -59,6 +60,7 @@ import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DATE;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_DECIMAL;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT32;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_FLOAT64;
+import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INSTANT;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT16;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT32;
 import static com.hazelcast.nio.serialization.FieldKind.ARRAY_OF_INT64;
@@ -80,6 +82,7 @@ import static com.hazelcast.nio.serialization.FieldKind.DATE;
 import static com.hazelcast.nio.serialization.FieldKind.DECIMAL;
 import static com.hazelcast.nio.serialization.FieldKind.FLOAT32;
 import static com.hazelcast.nio.serialization.FieldKind.FLOAT64;
+import static com.hazelcast.nio.serialization.FieldKind.INSTANT;
 import static com.hazelcast.nio.serialization.FieldKind.INT16;
 import static com.hazelcast.nio.serialization.FieldKind.INT32;
 import static com.hazelcast.nio.serialization.FieldKind.INT64;
@@ -123,6 +126,9 @@ public final class ValueReaderWriters {
 
         CONSTRUCTORS.put(OffsetDateTime.class, OffsetDateTimeReaderWriter::new);
         ARRAY_CONSTRUCTORS.put(OffsetDateTime.class, OffsetDateTimeArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(Instant.class, InstantReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(Instant.class, InstantArrayReaderWriter::new);
 
         CONSTRUCTORS.put(Boolean.class, NullableBooleanReaderWriter::new);
         CONSTRUCTORS.put(Boolean.TYPE, BooleanReaderWriter::new);
@@ -534,6 +540,46 @@ public final class ValueReaderWriters {
         @Override
         public void write(CompactWriter writer, OffsetDateTime[] value) {
             writer.writeArrayOfTimestampWithTimezone(fieldName, value);
+        }
+    }
+
+    private static final class InstantReaderWriter extends ValueReaderWriter<Instant> {
+
+        private InstantReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Instant read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, INSTANT)) {
+                return null;
+            }
+            return reader.readInstant(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Instant value) {
+            writer.writeInstant(fieldName, value);
+        }
+    }
+
+    private static final class InstantArrayReaderWriter extends ValueReaderWriter<Instant[]> {
+
+        private InstantArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public Instant[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_INSTANT)) {
+                return null;
+            }
+            return reader.readArrayOfInstant(fieldName);
+        }
+
+        @Override
+        public void write(CompactWriter writer, Instant[] value) {
+            writer.writeArrayOfInstant(fieldName, value);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecord.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.serialization.ClassDefinition;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.time.Instant;
 
 /**
  * See the javadoc of {@link InternalGenericRecord} for GenericRecord class hierarchy.
@@ -86,6 +87,12 @@ public abstract class PortableGenericRecord extends AbstractGenericRecord {
 
     @Nullable
     @Override
+    public Instant getInstant(@Nonnull String fieldName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Nullable
+    @Override
     public Boolean[] getArrayOfNullableBoolean(@Nonnull String fieldName) {
         throw new UnsupportedOperationException();
     }
@@ -123,6 +130,18 @@ public abstract class PortableGenericRecord extends AbstractGenericRecord {
     @Nullable
     @Override
     public Short[] getArrayOfNullableInt16(@Nonnull String fieldName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Nullable
+    @Override
+    public Instant[] getArrayOfInstant(@Nonnull String fieldName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Nullable
+    @Override
+    public Instant getInstantFromArray(@Nonnull String fieldName, int index) {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/FieldKind.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/FieldKind.java
@@ -159,7 +159,17 @@ public enum FieldKind {
     /**
      * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
      */
-    ARRAY_OF_NULLABLE_FLOAT64(46);
+    ARRAY_OF_NULLABLE_FLOAT64(46),
+
+    /**
+     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     */
+    INSTANT(47),
+
+    /**
+     * Supported only for {@link com.hazelcast.config.CompactSerializationConfig Compact}. Not applicable to {@link Portable}.
+     */
+    ARRAY_OF_INSTANT(48);
 
     private static final FieldKind[] ALL = FieldKind.values();
     private final int id;

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactReader.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -272,6 +273,18 @@ public interface CompactReader {
     @Nullable
     OffsetDateTime readTimestampWithTimezone(@Nonnull String fieldName);
 
+    /**
+     * Reads an instant consisting of epoch seconds and nanos.
+     *
+     * @param fieldName name of the field.
+     * @return the value of the field.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
+     */
+    @Nullable
+    Instant readInstant(@Nonnull String fieldName);
 
     /**
      * Reads a compact object
@@ -501,6 +514,18 @@ public interface CompactReader {
     @Nullable
     OffsetDateTime[] readArrayOfTimestampWithTimezone(@Nonnull String fieldName);
 
+    /**
+     * Reads an array of instants consisting of epoch seconds and nanos.
+     *
+     * @param fieldName name of the field.
+     * @return the value of the field. The items in the array cannot be null.
+     * @throws HazelcastSerializationException if the field does not exist in
+     *                                         the schema or the type of the
+     *                                         field does not match with the one
+     *                                         defined in the schema.
+     */
+    @Nullable
+    Instant[] readArrayOfInstant(@Nonnull String fieldName);
 
     /**
      * Reads an array of compact objects.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/compact/CompactWriter.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -138,6 +139,14 @@ public interface CompactWriter {
     void writeTimestampWithTimezone(@Nonnull String fieldName, @Nonnull OffsetDateTime value);
 
     /**
+     * Writes an instant consisting of epoch seconds and nanos.
+     *
+     * @param fieldName name of the field.
+     * @param value     to be written.
+     */
+    void writeInstant(@Nonnull String fieldName, @Nonnull Instant value);
+
+    /**
      * Writes a nested compact object.
      *
      * @param fieldName name of the field.
@@ -248,6 +257,14 @@ public interface CompactWriter {
      * @param value     to be written.
      */
     void writeArrayOfTimestampWithTimezone(@Nonnull String fieldName, @Nullable OffsetDateTime[] value);
+
+    /**
+     * Writes an array of instants consisting of epoch seconds and nanos.
+     *
+     * @param fieldName name of the field.
+     * @param value     to be written.
+     */
+    void writeArrayOfInstant(@Nonnull String fieldName, @Nullable Instant[] value);
 
     /**
      * Writes an array of nested compact objects.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/genericrecord/GenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/genericrecord/GenericRecord.java
@@ -27,6 +27,7 @@ import com.hazelcast.nio.serialization.PortableFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -323,6 +324,19 @@ public interface GenericRecord {
 
     /**
      * @param fieldName the name of the field
+     * @return instant consisting of epoch seconds and nanos parts as
+     * {@link Instant}
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
+     */
+    @Nullable
+    Instant getInstant(@Nonnull String fieldName);
+
+    /**
+     * @param fieldName the name of the field
      * @return the value of the field
      * @throws HazelcastSerializationException if the field name does not exist
      *                                         in the schema/class definition or
@@ -507,6 +521,19 @@ public interface GenericRecord {
      */
     @Nullable
     OffsetDateTime[] getArrayOfTimestampWithTimezone(@Nonnull String fieldName);
+
+    /**
+     * @param fieldName the name of the field
+     * @return the value of the field
+     * @throws HazelcastSerializationException if the field name does not exist
+     *                                         in the schema/class definition or
+     *                                         the type of the field does not
+     *                                         match the one in the schema/class
+     *                                         definition.
+     * @see #getTimestampWithTimezone(String)
+     */
+    @Nullable
+    Instant[] getArrayOfInstant(@Nonnull String fieldName);
 
     /**
      * @param fieldName the name of the field

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/EnumCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/EnumCompatibilityTest.java
@@ -185,6 +185,8 @@ public class EnumCompatibilityTest {
         mappings.put(FieldKind.ARRAY_OF_NULLABLE_FLOAT32, 44);
         mappings.put(FieldKind.NULLABLE_FLOAT64, 45);
         mappings.put(FieldKind.ARRAY_OF_NULLABLE_FLOAT64, 46);
+        mappings.put(FieldKind.INSTANT, 47);
+        mappings.put(FieldKind.ARRAY_OF_INSTANT, 48);
         verifyCompatibility(FieldKind.values(), FieldKind::getId, mappings);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
@@ -36,6 +36,7 @@ import example.serialization.SerializableEmployeeDTO;
 
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -169,7 +170,7 @@ public final class CompactTestUtil {
                 OffsetDateTime.of(-999999999, 3, 31, 1, 2, 3, 999999999, ZoneOffset.UTC), true,
                 (byte) 113, (short) -500, 56789, -50992225L, 900.5678f, -897543.3678909d,
                 new boolean[]{true, false}, new byte[]{0, 1, 2}, new short[]{3, 4, 5},
-                 new int[]{9, 8, 7, 6}, new long[]{0, 1, 5, 7, 9, 11},
+                new int[]{9, 8, 7, 6}, new long[]{0, 1, 5, 7, 9, 11},
                 new float[]{0.6543f, -3.56f, 45.67f}, new double[]{456.456, 789.789, 321.321},
                 new String[]{"test", null}, new BigDecimal[]{new BigDecimal("12345"), new BigDecimal("123456")},
                 new LocalTime[]{LocalTime.of(22, 13, 15, 123123), null, LocalTime.of(1, 2, 3, 999_999_999)},
@@ -193,13 +194,13 @@ public final class CompactTestUtil {
                 new String[]{"test", null}, new BigDecimal("12345"),
                 new BigDecimal[]{new BigDecimal("12345.123123123"), null},
                 null, new LocalTime[]{LocalTime.now(), null, LocalTime.now()},
-                LocalDate.now(),  new LocalDate[]{LocalDate.now(), null, LocalDate.now()},
+                LocalDate.now(), new LocalDate[]{LocalDate.now(), null, LocalDate.now()},
                 LocalDateTime.now(), new LocalDateTime[]{LocalDateTime.now(), null},
-                OffsetDateTime.now(), null, inner, new InnerDTO[]{createInnerDTO(), null},
-                null, new Boolean[]{true, false, null}, (byte) 123, new Byte[]{0, 1, 2, null},
-                (short) 1232, new Short[]{3, 4, 5, null}, null, new Integer[]{9, 8, 7, 6, null},
-                12323121331L, new Long[]{0L, 1L, 5L, 7L, 9L, 12323121331L}, 0.6543f,
-                new Float[]{0.6543f, -3.56f, 45.67f}, 456.4123156,
+                OffsetDateTime.now(), null, Instant.now(), new Instant[]{Instant.now(), null}, inner,
+                new InnerDTO[]{createInnerDTO(), null}, null, new Boolean[]{true, false, null}, (byte) 123,
+                new Byte[]{0, 1, 2, null}, (short) 1232, new Short[]{3, 4, 5, null}, null,
+                new Integer[]{9, 8, 7, 6, null}, 12323121331L, new Long[]{0L, 1L, 5L, 7L, 9L, 12323121331L},
+                0.6543f, new Float[]{0.6543f, -3.56f, 45.67f}, 456.4123156,
                 new Double[]{456.4123156, 789.789, 321.321});
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/SchemaWriterTest.java
@@ -76,6 +76,9 @@ public class SchemaWriterTest {
         writer.writeTimestampWithTimezone(FieldKind.TIMESTAMP_WITH_TIMEZONE.name(), null);
         writer.writeArrayOfTimestampWithTimezone(FieldKind.ARRAY_OF_TIMESTAMP_WITH_TIMEZONE.name(), null);
 
+        writer.writeInstant(FieldKind.INSTANT.name(), null);
+        writer.writeArrayOfInstant(FieldKind.ARRAY_OF_INSTANT.name(), null);
+
         writer.writeCompact(FieldKind.COMPACT.name(), null);
         writer.writeArrayOfCompact(FieldKind.ARRAY_OF_COMPACT.name(), null);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/VarSizedFieldsDTO.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/VarSizedFieldsDTO.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.serialization.impl.compact;
 import example.serialization.InnerDTO;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -47,6 +48,8 @@ public class VarSizedFieldsDTO {
     public LocalDateTime[] arrayOfLocalDateTime;
     public OffsetDateTime offsetDateTime;
     public OffsetDateTime[] arrayOfOffsetDateTime;
+    public Instant instant;
+    public Instant[] arrayOfInstant;
     public InnerDTO compact;
     public InnerDTO[] arrayOfCompact;
     public Boolean nullableBool;
@@ -73,8 +76,9 @@ public class VarSizedFieldsDTO {
                              LocalTime localTime, LocalTime[] arrayOfLocalTime, LocalDate localDate,
                              LocalDate[] arrayOfLocalDate, LocalDateTime localDateTime,
                              LocalDateTime[] arrayOfLocalDateTime, OffsetDateTime offsetDateTime,
-                             OffsetDateTime[] arrayOfOffsetDateTime, InnerDTO compact, InnerDTO[] arrayOfCompact,
-                             Boolean nullableBool, Boolean[] arrayOfNullableBool, Byte nullableB, Byte[] arrayOfNullableB,
+                             OffsetDateTime[] arrayOfOffsetDateTime, Instant instant, Instant[] arrayOfInstant,
+                             InnerDTO compact,  InnerDTO[] arrayOfCompact, Boolean nullableBool,
+                             Boolean[] arrayOfNullableBool, Byte nullableB, Byte[] arrayOfNullableB,
                              Short nullableS, Short[] arrayOfNullableS, Integer nullableI, Integer[] arrayOfNullableI,
                              Long nullableL, Long[] arrayOfNullableL, Float nullableF, Float[] arrayOfNullableF,
                              Double nullableD, Double[] arrayOfNullableD) {
@@ -97,6 +101,8 @@ public class VarSizedFieldsDTO {
         this.arrayOfLocalDateTime = arrayOfLocalDateTime;
         this.offsetDateTime = offsetDateTime;
         this.arrayOfOffsetDateTime = arrayOfOffsetDateTime;
+        this.instant = instant;
+        this.arrayOfInstant = arrayOfInstant;
         this.compact = compact;
         this.arrayOfCompact = arrayOfCompact;
         this.nullableBool = nullableBool;
@@ -136,6 +142,8 @@ public class VarSizedFieldsDTO {
                 && Arrays.equals(arrayOfLocalDateTime, that.arrayOfLocalDateTime)
                 && Objects.equals(offsetDateTime, that.offsetDateTime)
                 && Arrays.equals(arrayOfOffsetDateTime, that.arrayOfOffsetDateTime)
+                && Objects.equals(instant, that.instant)
+                && Arrays.equals(arrayOfInstant, that.arrayOfInstant)
                 && Objects.equals(compact, that.compact) && Arrays.equals(arrayOfCompact, that.arrayOfCompact)
                 && Objects.equals(nullableBool, that.nullableBool)
                 && Arrays.equals(arrayOfNullableBool, that.arrayOfNullableBool)
@@ -149,8 +157,8 @@ public class VarSizedFieldsDTO {
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(str, bigDecimal, localTime, localDate, localDateTime, offsetDateTime, compact,
-                nullableBool, nullableB, nullableS, nullableI, nullableL, nullableF, nullableD);
+        int result = Objects.hash(str, bigDecimal, localTime, localDate, localDateTime, offsetDateTime, instant,
+                compact, nullableBool, nullableB, nullableS, nullableI, nullableL, nullableF, nullableD);
         result = 31 * result + Arrays.hashCode(arrayOfBoolean);
         result = 31 * result + Arrays.hashCode(arrayOfInt8);
         result = 31 * result + Arrays.hashCode(arrayOfInt16);
@@ -164,6 +172,7 @@ public class VarSizedFieldsDTO {
         result = 31 * result + Arrays.hashCode(arrayOfLocalDate);
         result = 31 * result + Arrays.hashCode(arrayOfLocalDateTime);
         result = 31 * result + Arrays.hashCode(arrayOfOffsetDateTime);
+        result = 31 * result + Arrays.hashCode(arrayOfInstant);
         result = 31 * result + Arrays.hashCode(arrayOfCompact);
         result = 31 * result + Arrays.hashCode(arrayOfNullableBool);
         result = 31 * result + Arrays.hashCode(arrayOfNullableB);
@@ -196,6 +205,8 @@ public class VarSizedFieldsDTO {
                 + ", arrayOfLocalDateTime=" + Arrays.toString(arrayOfLocalDateTime)
                 + ", offsetDateTime=" + offsetDateTime
                 + ", arrayOfOffsetDateTime=" + Arrays.toString(arrayOfOffsetDateTime)
+                + ", instant=" + instant
+                + ", arrayOfInstant=" + Arrays.toString(arrayOfInstant)
                 + ", compact=" + compact
                 + ", arrayOfCompact=" + Arrays.toString(arrayOfCompact)
                 + ", nullableBool=" + nullableBool

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/VarSizedFieldsDTOSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/VarSizedFieldsDTOSerializer.java
@@ -22,6 +22,7 @@ import example.serialization.InnerDTO;
 
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -50,6 +51,8 @@ public class VarSizedFieldsDTOSerializer implements CompactSerializer<VarSizedFi
         LocalDateTime[] arrayOfLocalDateTime = reader.readArrayOfTimestamp("arrayOfLocalDateTime");
         OffsetDateTime offsetDateTime = reader.readTimestampWithTimezone("offsetDateTime");
         OffsetDateTime[] arrayOfOffsetDateTime = reader.readArrayOfTimestampWithTimezone("arrayOfOffsetDateTime");
+        Instant instant = reader.readInstant("instant");
+        Instant[] arrayOfInstant = reader.readArrayOfInstant("arrayOfInstant");
         InnerDTO compact = reader.readCompact("compact");
         InnerDTO[] arrayOfCompact = reader.readArrayOfCompact("arrayOfCompact", InnerDTO.class);
         Boolean nullableBool = reader.readNullableBoolean("nullableBool");
@@ -70,9 +73,9 @@ public class VarSizedFieldsDTOSerializer implements CompactSerializer<VarSizedFi
         return new VarSizedFieldsDTO(arrayOfBoolean, arrayOfInt8, arrayOfInt16, arrayOfInt32, arrayOfInt64, arrayOfFloat32,
                 arrayOfFloat64, str, arrayOfString, bigDecimal, arrayOfBigDecimal, localTime, arrayOfLocalTime,
                 localDate, arrayOfLocalDate, localDateTime, arrayOfLocalDateTime, offsetDateTime,
-                arrayOfOffsetDateTime, compact, arrayOfCompact, nullableBool, arrayOfNullableBool, nullableB,
-                arrayOfNullableB, nullableS, arrayOfNullableS, nullableI, arrayOfNullableI, nullableL,
-                arrayOfNullableL, nullableF, arrayOfNullableF, nullableD, arrayOfNullableD
+                arrayOfOffsetDateTime, instant, arrayOfInstant, compact, arrayOfCompact, nullableBool,
+                arrayOfNullableBool, nullableB, arrayOfNullableB, nullableS, arrayOfNullableS, nullableI,
+                arrayOfNullableI, nullableL, arrayOfNullableL, nullableF, arrayOfNullableF, nullableD, arrayOfNullableD
         );
     }
 
@@ -97,6 +100,8 @@ public class VarSizedFieldsDTOSerializer implements CompactSerializer<VarSizedFi
         out.writeArrayOfTimestamp("arrayOfLocalDateTime", object.arrayOfLocalDateTime);
         out.writeTimestampWithTimezone("offsetDateTime", object.offsetDateTime);
         out.writeArrayOfTimestampWithTimezone("arrayOfOffsetDateTime", object.arrayOfOffsetDateTime);
+        out.writeInstant("instant", object.instant);
+        out.writeArrayOfInstant("arrayOfInstant", object.arrayOfInstant);
         out.writeCompact("compact", object.compact);
         out.writeArrayOfCompact("arrayOfCompact", object.arrayOfCompact);
         out.writeNullableBoolean("nullableBool", object.nullableBool);


### PR DESCRIPTION
Adds support for Compact serialization of java.time.Instant.
This is serialized as an int64 for epoch seconds and an int32 for nanos within the second.


Breaking changes (list specific methods/types/messages):
New FieldKinds specified for INSTANT and ARRAY_OF_INSTANT (ids 47 and 48)

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
