### PR TITLE
Move describedAs method before assertion [HZ-1911]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLAllTypesInsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLAllTypesInsertJdbcSqlConnectorTest.java
@@ -35,8 +35,9 @@ public class MySQLAllTypesInsertJdbcSqlConnectorTest extends AllTypesInsertJdbcS
 
     @Before
     public void setUp() throws Exception {
-        assumeThat(type).isNotEqualTo("TIMESTAMP WITH TIME ZONE")
-                        .describedAs("TIMESTAMP WITH TIME ZONE not supported on MySQL");
+        assumeThat(type).describedAs("TIMESTAMP WITH TIME ZONE not supported on MySQL")
+                .isNotEqualTo("TIMESTAMP WITH TIME ZONE");
+
     }
 
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLAllTypesSelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLAllTypesSelectJdbcSqlConnectorTest.java
@@ -40,7 +40,8 @@ public class MySQLAllTypesSelectJdbcSqlConnectorTest extends AllTypesSelectJdbcS
 
     @Before
     public void setUp() throws Exception {
-        assumeThat(type).isNotEqualTo("TIMESTAMP WITH TIME ZONE")
-                .describedAs("TIMESTAMP WITH TIME ZONE not supported on MySQL");
+        assumeThat(type).describedAs("TIMESTAMP WITH TIME ZONE not supported on MySQL")
+        .isNotEqualTo("TIMESTAMP WITH TIME ZONE");
+
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLAllTypesSelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLAllTypesSelectJdbcSqlConnectorTest.java
@@ -41,7 +41,7 @@ public class MySQLAllTypesSelectJdbcSqlConnectorTest extends AllTypesSelectJdbcS
     @Before
     public void setUp() throws Exception {
         assumeThat(type).describedAs("TIMESTAMP WITH TIME ZONE not supported on MySQL")
-        .isNotEqualTo("TIMESTAMP WITH TIME ZONE");
+                .isNotEqualTo("TIMESTAMP WITH TIME ZONE");
 
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresAllTypesInsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresAllTypesInsertJdbcSqlConnectorTest.java
@@ -35,10 +35,12 @@ public class PostgresAllTypesInsertJdbcSqlConnectorTest extends AllTypesInsertJd
 
     @Before
     public void setUp() throws Exception {
-        assumeThat(type).isNotEqualTo("TINYINT")
-                        .describedAs("TINYINT not supported on Postgres");
-        assumeThat(type).isNotEqualTo("TIMESTAMP WITH TIME ZONE")
-                        .describedAs("TIMESTAMP WITH TIME ZONE not supported on Postgres");
+        assumeThat(type).describedAs("TINYINT not supported on Postgres")
+                .isNotEqualTo("TINYINT");
+
+        assumeThat(type).describedAs("TIMESTAMP WITH TIME ZONE not supported on Postgres")
+                .isNotEqualTo("TIMESTAMP WITH TIME ZONE");
+
 
         if (type.equals("DOUBLE")) {
             type = "DOUBLE PRECISION";

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresAllTypesSelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresAllTypesSelectJdbcSqlConnectorTest.java
@@ -35,10 +35,12 @@ public class PostgresAllTypesSelectJdbcSqlConnectorTest extends AllTypesSelectJd
 
     @Before
     public void setUp() throws Exception {
-        assumeThat(type).isNotEqualTo("TINYINT")
-                        .describedAs("TINYINT not supported on Postgres");
-        assumeThat(type).isNotEqualTo("TIMESTAMP WITH TIME ZONE")
-                        .describedAs("TIMESTAMP WITH TIME ZONE not supported on Postgres");
+        assumeThat(type).describedAs("TINYINT not supported on Postgres")
+                .isNotEqualTo("TINYINT");
+
+        assumeThat(type).describedAs("TIMESTAMP WITH TIME ZONE not supported on Postgres")
+                .isNotEqualTo("TIMESTAMP WITH TIME ZONE");
+
 
         if (type.equals("DOUBLE")) {
             type = "DOUBLE PRECISION";

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/test/TestSourcesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/test/TestSourcesTest.java
@@ -173,12 +173,13 @@ public class TestSourcesTest extends PipelineTestSupport {
                     // Ignore if a long pause was recorded
                     if (pauses < (windowSize / 2)) {
                         assertThat(windowResult.result())
-                                .isGreaterThan(itemsPerSecond / 2)
-                                .describedAs("emitted items is more than twice lower then expected itemsPerSecond");
+                                .describedAs("emitted items is more than twice lower then expected itemsPerSecond")
+                                .isGreaterThan(itemsPerSecond / 2);
 
                         assertThat(windowResult.result())
-                                .isLessThan(itemsPerSecond * 2)
-                                .describedAs("emitted items is more than twice higher then expected itemsPerSecond");
+                                .describedAs("emitted items is more than twice higher then expected itemsPerSecond")
+                                .isLessThan(itemsPerSecond * 2);
+
                     }
                 }));
 


### PR DESCRIPTION
AssertJ methods setting the assertion context should come before an assertion [java:S5833](https://sonarcloud.io/organizations/devopshazelcast-github/rules?open=java%3AS5833&rule_key=java%3AS5833)

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible
- [X] Send backports/forwardports if fix needs to be applied to past/future releases
- [X] New public APIs have `@Nonnull/@Nullable` annotations
- [X] New public APIs have `@since` tags in Javadoc
