### PR TITLE
Fix broken watermark counters in unordered mapUsingServiceAsync [HZ-1928] (backport of #23271)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
@@ -963,8 +963,8 @@ public final class TestSupport {
         if (isCooperative) {
             if (cooperativeTimeout > 0) {
                 assertTrue(String.format("call to %s() took %.1fms, it should be <%dms", methodName,
-                                toMillis(elapsed), COOPERATIVE_TIME_LIMIT_MS_FAIL),
-                        elapsed < MILLISECONDS.toNanos(COOPERATIVE_TIME_LIMIT_MS_FAIL));
+                                toMillis(elapsed), cooperativeTimeout),
+                        elapsed < MILLISECONDS.toNanos(cooperativeTimeout));
             }
             // print warning
             if (elapsed > MILLISECONDS.toNanos(COOPERATIVE_TIME_LIMIT_MS_WARN)) {

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.Traverser;
+import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Watermark;
@@ -44,9 +45,12 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import static com.hazelcast.jet.Traversers.singleton;
 import static com.hazelcast.jet.Traversers.traverseItems;
 import static com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture;
 import static com.hazelcast.jet.pipeline.GeneralStage.DEFAULT_MAX_CONCURRENT_OPS;
@@ -54,12 +58,15 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParametrizedRunner.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class  AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport {
+public class AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -160,9 +167,6 @@ public class  AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport
 
     @Test
     public void test_forwardMultipleWatermarksWithoutItems() {
-        if (ordered) {
-            return;
-        }
         TestSupport
                 .verifyProcessor(getSupplier((ctx, item) -> {
                     throw new UnsupportedOperationException();
@@ -170,6 +174,34 @@ public class  AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport
                 .hazelcastInstance(instance())
                 .input(asList(wm(10, (byte) 0), wm(5, (byte) 1), wm(0, (byte) 2)))
                 .expectOutput(asList(wm(10, (byte) 0), wm(5, (byte) 1), wm(0, (byte) 2)));
+    }
+
+    @Test
+    public void test_completedFutures_sameElement() {
+        TestSupport
+                .verifyProcessor(getSupplier((ctx, item) ->  completedFuture(singleton(item + "-1"))))
+                .hazelcastInstance(instance())
+                .input(asList("a", "a", "a"))
+                .disableProgressAssertion()
+                .expectOutput(asList("a-1", "a-1", "a-1"));
+    }
+
+    @Test
+    public void test_completedFutures_sameElementInterleavedWithWatermark() {
+        TestSupport
+                .verifyProcessor(getSupplier((ctx, item) ->  completedFuture(singleton(item + "-1"))))
+                .hazelcastInstance(instance())
+                .input(asList("a", "a", wm(10), "a"))
+                .outputChecker((expected, actual) ->
+                        actual.equals(asList("a-1", "a-1", wm(10), "a-1"))
+                        // this is possible if restoring the processor after every snapshot
+                        || (!ordered && actual.equals(asList("a-1", "a-1", "a-1", wm(10))))
+                        // this is possible if restoring the processor after every other snapshot. The
+                        // WM isn't actually duplicated, but is emitted again after a restart
+                        || (!ordered && actual.equals(asList("a-1", "a-1", wm(10), "a-1", wm(10))))
+                )
+                .disableProgressAssertion()
+                .expectOutput(singletonList("<see code>"));
     }
 
     @Test
@@ -214,7 +246,7 @@ public class  AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport
         assertTrue("wm rejected", processor.tryProcessWatermark(wm(0)));
         inbox.add("bar");
         processor.process(0, inbox);
-        assertTrue("2nd item rejected even though max parallel ops is 1", inbox.isEmpty());
+        assertTrue("2nd item rejected even though max parallel ops is 2", inbox.isEmpty());
     }
 
     @Test
@@ -223,12 +255,114 @@ public class  AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport
                 2, (ctx, item) -> new CompletableFuture<>()).get(1).iterator().next();
         processor.init(new TestOutbox(128), new TestProcessorContext());
         TestInbox inbox = new TestInbox();
-        // i have to add an item first because otherwise the WMs are forwarded right away
+        // I have to add an item first because otherwise the WMs are forwarded right away
         inbox.add("foo");
         processor.process(0, inbox);
         assertTrue("inbox not empty", inbox.isEmpty());
         assertTrue("wm rejected", processor.tryProcessWatermark(wm(0)));
         assertTrue("wm rejected", processor.tryProcessWatermark(wm(1)));
         assertTrue("wm rejected", processor.tryProcessWatermark(wm(2)));
+    }
+
+    @Test
+    public void test_allItemsProcessed_withoutWatermarks() throws Exception {
+        CompletableFuture<Traverser<String>> processFuture = new CompletableFuture<>();
+        Processor processor = getSupplier(2, (ctx, item) -> processFuture)
+                .get(1).iterator().next();
+        TestOutbox outbox = new TestOutbox(128);
+        processor.init(outbox, new TestProcessorContext());
+        TestInbox inbox = new TestInbox(singletonList("foo"));
+        processor.process(0, inbox);
+        assertFalse("Should not complete when items are being processed", processor.complete());
+        processFuture.complete(Traversers.singleton("foo-processed"));
+        assertTrueEventually(() -> assertTrue("Should complete after all items are processed",
+                processor.complete()));
+        assertThat(outbox.queue(0)).containsExactly("foo-processed");
+    }
+
+    @Test
+    public void test_firstWatermarkIsForwardedAfterPreviousItemsComplete() throws Exception {
+        // edge case test for first watermark
+        CompletableFuture<Traverser<String>> processFuture = new CompletableFuture<>();
+        Processor processor = getSupplier(2, (ctx, item) -> processFuture)
+                .get(1).iterator().next();
+
+        TestOutbox outbox = new TestOutbox(128);
+        processor.init(outbox, new TestProcessorContext());
+        TestInbox inbox = new TestInbox(singletonList("foo"));
+        processor.process(0, inbox);
+        assertTrue(processor.tryProcessWatermark(wm(10)));
+        assertEquals("Should not forward watermark until previous elements are processed",
+                Long.MIN_VALUE, outbox.lastForwardedWm((byte) 0));
+        assertThat(outbox.queue(0)).isEmpty();
+
+        processFuture.complete(Traversers.singleton("foo-processed"));
+
+        assertTrueEventually(() -> assertTrue("Should complete after all items are processed",
+                processor.complete()));
+        assertThat(outbox.queue(0)).containsExactly("foo-processed", wm(10));
+        assertEquals(10, outbox.lastForwardedWm((byte) 0));
+    }
+
+    @Test
+    public void test_firstWatermarkIsForwardedAfterPreviousItemsComplete_whenTheSameElementIsProcessed_inOrder() throws Exception {
+        test_firstWatermarkIsForwardedAfterPreviousItemsComplete_whenTheSameElementIsProcessed(0, 1, 2);
+    }
+
+    @Test
+    public void test_firstWatermarkIsForwardedAfterPreviousItemsComplete_whenTheSameElementIsProcessed_inReverseOrder() throws Exception {
+        test_firstWatermarkIsForwardedAfterPreviousItemsComplete_whenTheSameElementIsProcessed(2, 1, 0);
+    }
+
+    private void test_firstWatermarkIsForwardedAfterPreviousItemsComplete_whenTheSameElementIsProcessed(int first,
+                                                                                                        int second,
+                                                                                                        int third)
+            throws Exception {
+        // futures can be completed in arbitrary order
+        List<CompletableFuture<String>> futureList = new ArrayList<>(3);
+
+        Processor processor = getSupplier(
+                10,
+                (ctx, item) -> {
+                    CompletableFuture<String> f = new CompletableFuture<>();
+                    futureList.add(f);
+                    return f.thenApply(Traversers::singleton);
+                }).get(1).iterator().next();
+        TestOutbox outbox = new TestOutbox(128);
+        processor.init(outbox, new TestProcessorContext());
+        TestInbox inbox = new TestInbox(asList("foo", "foo"));
+        processor.process(0, inbox);
+        assertTrue(processor.tryProcessWatermark(wm(10)));
+        assertEquals("Should not forward watermark until previous elements are processed",
+                Long.MIN_VALUE, outbox.lastForwardedWm((byte) 0));
+        assertThat(outbox.queue(0)).isEmpty();
+
+        TestInbox inbox2 = new TestInbox(singletonList("foo"));
+        processor.process(0, inbox2);
+        assertEquals("Should not forward watermark until previous elements are processed",
+                Long.MIN_VALUE, outbox.lastForwardedWm((byte) 0));
+        assertThat(outbox.queue(0)).isEmpty();
+
+        assertThat(futureList).hasSize(3);
+        futureList.get(first).complete("foo-" + first);
+        futureList.get(second).complete("foo-" + second);
+        futureList.get(third).complete("foo-" + third);
+
+        assertTrueEventually(null, () -> assertTrue("Should complete after all items are processed",
+                processor.complete()), 10);
+        if (ordered) {
+            assertThat(outbox.queue(0))
+                    .as("Items should be emitted in submission order")
+                    .containsExactly("foo-0", "foo-1", wm(10), "foo-2");
+        } else {
+            assertThat(outbox.queue(0))
+                    .as("All items should be emitted")
+                    .containsExactlyInAnyOrder("foo-0", "foo-1", "foo-2", wm(10))
+                    // note that foo-2 can be reordered with watermark but this way it is fine
+                    .as("Items should be emitted in correct order relative to watermark")
+                    .containsSubsequence("foo-0", wm(10))
+                    .containsSubsequence("foo-1", wm(10));
+        }
+        assertEquals(10, outbox.lastForwardedWm((byte) 0));
     }
 }


### PR DESCRIPTION
mapUsingServiceAsync in unordered mode used wrong condition to check if the processing is complete and wrong number of currently processed items to propagate watermarks. This could lead to lost items when the pipeline was completed and to crashes during processing of streams containing the same item multiple times.

Fixes #23245

Co-authored-by: Krzysztof Jamróz <krzysztof.jamroz@hazelcast.com>
(cherry picked from commit 2bec37220f2086afacb471ade9ca50d5bc1baea0)