### PR TITLE
[TPC] Socket improvements

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncServerSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncServerSocket.java
@@ -16,41 +16,25 @@
 
 package com.hazelcast.internal.tpc;
 
-import com.hazelcast.internal.tpc.logging.TpcLogger;
-import com.hazelcast.internal.tpc.logging.TpcLoggerLocator;
-import com.hazelcast.internal.tpc.nio.NioAsyncSocket;
 import com.hazelcast.internal.tpc.util.ProgressIndicator;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.SocketAddress;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
  * A server socket that is asynchronous. So accepting incoming connections does not block,
  * but are executed on an {@link Eventloop}.
  */
-public abstract class AsyncServerSocket implements Closeable {
-
-    /**
-     * Allows for objects to be bound to this AsyncServerSocket. Useful for the lookup of services and other dependencies.
-     */
-    @SuppressWarnings("checkstyle:VisibilityModifier")
-    public final ConcurrentMap<?, ?> context = new ConcurrentHashMap<>();
-
-    protected final TpcLogger logger = TpcLoggerLocator.getLogger(getClass());
-    protected final AtomicBoolean closed = new AtomicBoolean(false);
+public abstract class AsyncServerSocket extends Socket {
     protected final ProgressIndicator accepted = new ProgressIndicator();
 
     protected AsyncServerSocket() {
     }
 
     /**
-     * Returns the number of socks that have been accepted by the AsyncServerSocket.
+     * Returns the number of sockets that have been accepted.
      *
      * @return the number of accepted sockets.
      */
@@ -59,7 +43,7 @@ public abstract class AsyncServerSocket implements Closeable {
     }
 
     /**
-     * Gets the local address of this ServerSocketChannel.
+     * Gets the local address: the socket address that this channel's socket is bound to.
      *
      * @return the local address.
      */
@@ -86,6 +70,8 @@ public abstract class AsyncServerSocket implements Closeable {
 
     /**
      * Gets the local port of the ServerSocketChannel.
+     * <p/>
+     * If {@link #bind(SocketAddress)} has not been called, then 0 is returned.
      *
      * @return the local port.
      * @throws UncheckedIOException if something failed while obtaining the local port.
@@ -129,16 +115,16 @@ public abstract class AsyncServerSocket implements Closeable {
     public abstract void setReuseAddress(boolean reuseAddress);
 
     /**
-     * Sets the receivebuffer size in bytes.
+     * Sets the receive buffer size in bytes.
      *
-     * @param size the receivebuffer size in bytes.
+     * @param size the receive buffer size in bytes.
      * @throws IllegalArgumentException when the size isn't positive.
      * @throws UncheckedIOException     if something failed with configuring the socket
      */
     public abstract void setReceiveBufferSize(int size);
 
     /**
-     * Gets the receivebuffer size in bytes.
+     * Gets the receive buffer size in bytes.
      *
      * @return the size of the receive buffer.
      * @throws UncheckedIOException if something failed with configuring the socket
@@ -146,73 +132,58 @@ public abstract class AsyncServerSocket implements Closeable {
     public abstract int getReceiveBufferSize();
 
     /**
-     * Binds this AsyncServerSocket to the local.
+     * Binds this AsyncServerSocket to the localAddress address. This method is equivalent to calling
+     * {@link #bind(SocketAddress, int)} with an Integer.MAX_VALUE backlog.
      *
-     * @param local the local SocketAddress.
-     * @throws UncheckedIOException if something failed with configuring the socket
+     * @param localAddress the local address.
+     * @throws UncheckedIOException if something failed while binding.
+     * @throws NullPointerException if localAddress is null.
      */
-    public abstract void bind(SocketAddress local);
-
-    public abstract void listen(int backlog);
+    public void bind(SocketAddress localAddress) {
+        bind(localAddress, Integer.MAX_VALUE);
+    }
 
     /**
-     * Accept incoming AsyncSocket.
+     * Binds this AsyncServerSocket to the localAddress address by assigning the local address to it.
+     * <p/>
+     * At a socket level, this method does 2 things:
+     * <ol>
+     *     <li>bind: assigning an address to the socket</li>
+     *     <li>listen: marks the socket as a passive socket that waits for incoming connections.
+     *     Because every AsyncServerSocket is such a passive socket, there is no point in adding a
+     *     listen method to the AsyncServerSocket.</li>
+     * </ol>
+     * <p>
+     * This call needs to be made before {@link #accept(Consumer)}.
+     * <p/>
+     * Bind should only be called once, otherwise an UncheckedIOException is thrown.
+     *
+     * @param localAddress the local address.
+     * @param backlog      the maximum number of pending connections. The backlog argument doesn't need
+     *                     to be respected by the socket implementation.
+     * @throws UncheckedIOException     if something failed while binding.
+     * @throws NullPointerException     if localAddress is null.
+     * @throws IllegalArgumentException if backlog smaller than 0.
+     */
+    public abstract void bind(SocketAddress localAddress, int backlog);
+
+    /**
+     * Start accept incoming sockets asynchronously This call should only be made once.
      * <p/>
      * This call can be made from any thread, but the actual processing will happen on the eventloop-thread.
+     * <p/>
+     * Before accept is called, bind needs to be called.
      *
      * @param consumer a function that is called when a socket has connected.
+     * @return a CompletableFuture that contains the result of the AsyncServerSocket managed
+     * to start with accepting successfully.
      * @throws NullPointerException if consumer is null.
      */
-    public abstract void accept(Consumer<AsyncSocket> consumer);
-
-    /**
-     * Closes the AsyncServerSocket.
-     * <p/>
-     * If the AsyncServerSocket is already closed, it is ignored.
-     * <p/>
-     * This method is thread-safe.
-     * <p/>
-     * This method doesn't throw an exception.
-     */
-    @Override
-    public final void close() {
-        if (!closed.compareAndSet(false, true)) {
-            return;
-        }
-
-        if (logger.isInfoEnabled()) {
-            logger.info("Closing  " + this);
-        }
-
-        try {
-            close0();
-        } catch (Exception e) {
-            logger.warning(e);
-        }
-    }
-
-    /**
-     * Does the actual closing. No guarantee is made on which thread this is called.
-     * <p/>
-     * Is guaranteed to be called at most once.
-     *
-     * @throws IOException
-     */
-    protected abstract void close0() throws IOException;
-
-    /**
-     * Checks if the AsyncServerSocket is closed.
-     *
-     * This method is thread-safe.
-     *
-     * @return true if closed, false otherwise.
-     */
-    public final boolean isClosed() {
-        return closed.get();
-    }
+    public abstract CompletableFuture<Void> accept(Consumer<AsyncSocket> consumer);
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + "[" + getLocalAddress() + "]";
     }
+
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncServerSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncServerSocket.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
  * but are executed on an {@link Eventloop}.
  */
 public abstract class AsyncServerSocket extends Socket {
+
     protected final ProgressIndicator accepted = new ProgressIndicator();
 
     protected AsyncServerSocket() {
@@ -71,7 +72,7 @@ public abstract class AsyncServerSocket extends Socket {
     /**
      * Gets the local port of the ServerSocketChannel.
      * <p/>
-     * If {@link #bind(SocketAddress)} has not been called, then 0 is returned.
+     * If {@link #bind(SocketAddress)} has not been called, then -1 is returned.
      *
      * @return the local port.
      * @throws UncheckedIOException if something failed while obtaining the local port.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncSocket.java
@@ -17,38 +17,22 @@
 package com.hazelcast.internal.tpc;
 
 import com.hazelcast.internal.tpc.iobuffer.IOBuffer;
-import com.hazelcast.internal.tpc.logging.TpcLogger;
-import com.hazelcast.internal.tpc.logging.TpcLoggerLocator;
 import com.hazelcast.internal.tpc.util.ProgressIndicator;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.internal.tpc.util.Preconditions.checkNotNull;
 
 /**
- * A Socket that is asynchronous. So reads and writes do not block,
+ * A 'client' Socket that is asynchronous. So reads and writes do not block,
  * but are executed on an {@link Eventloop}.
  */
 @SuppressWarnings({"checkstyle:MethodCount", "checkstyle:VisibilityModifier"})
-public abstract class AsyncSocket implements Closeable {
-
-    /**
-     * Allows for objects to be bound to this AsyncSocket. Useful for the lookup of services and other dependencies.
-     */
-    @SuppressWarnings("")
-    public final ConcurrentMap<?, ?> context = new ConcurrentHashMap<>();
-
-    protected final TpcLogger logger = TpcLoggerLocator.getLogger(getClass());
-    protected final AtomicBoolean closed = new AtomicBoolean();
+public abstract class AsyncSocket extends Socket {
 
     protected volatile SocketAddress remoteAddress;
     protected volatile SocketAddress localAddress;
@@ -61,10 +45,7 @@ public abstract class AsyncSocket implements Closeable {
     protected final ProgressIndicator writeEvents = new ProgressIndicator();
     protected final ProgressIndicator readEvents = new ProgressIndicator();
 
-    private CloseListener closeListener;
-    private Executor closeExecutor;
     protected ReadHandler readHandler;
-
 
     /**
      * Gets the number of bytes read.
@@ -154,11 +135,6 @@ public abstract class AsyncSocket implements Closeable {
         return localAddress;
     }
 
-    // TODO: This option only makes sense for blocking sockets according to StandardSocketOptions.SO_LINGER
-    public abstract void setSoLinger(int soLinger);
-
-    public abstract int getSoLinger();
-
     /**
      * Set the SO_KEEPALIVE option.
      *
@@ -176,22 +152,22 @@ public abstract class AsyncSocket implements Closeable {
     public abstract boolean isKeepAlive();
 
     /**
-     * Sets the interval in seconds between the last data packet sent (simple ACKs are not considered data) and
-     * the first keepalive probe; after the connection is marked to need keepalive, this counter is not used
-     * any further.
+     * Sets the interval in seconds between the last data packet sent (simple ACKs are
+     * not considered data) and the first keepalive probe; after the connection is marked
+     * to need keepalive, this counter is not used any further.
      * <p/>
      * If the setting isn't supported, the call is ignored.
      *
      * @param keepAliveTime the keep alive time.
      * @throws IllegalArgumentException if keepAliveIntvl is smaller than 0.
-     * @throws UncheckedIOException if something failed with configuring the socket
+     * @throws UncheckedIOException     if something failed with configuring the socket
      */
     public abstract void setTcpKeepAliveTime(int keepAliveTime);
 
     /**
-     * Gets the interval in seconds between the last data packet sent (simple ACKs are not considered data) and
-     * the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any
-     * further.
+     * Gets the interval in seconds between the last data packet sent (simple ACKs are not
+     * considered data) and the first keepalive probe; after the connection is marked to need
+     * keepalive, this counter is not used any further.
      * <p/>
      * If the setting isn't supported, 0 is returned.
      *
@@ -201,20 +177,20 @@ public abstract class AsyncSocket implements Closeable {
     public abstract int getTcpKeepAliveTime();
 
     /**
-     * Sets the interval in seconds between subsequent keepalive probes, regardless of what the connection
-     * has exchanged in the meantime.
+     * Sets the interval in seconds between subsequent keepalive probes, regardless of what the
+     * connection has exchanged in the meantime.
      * <p/>
      * If the setting isn't supported, the call is ignored.
      *
      * @param keepaliveIntvl the interval in seconds.
      * @throws IllegalArgumentException if keepAliveIntvl is smaller than 0.
-     * @throws UncheckedIOException if something failed with configuring the socket
+     * @throws UncheckedIOException     if something failed with configuring the socket
      */
     public abstract void setTcpKeepaliveIntvl(int keepaliveIntvl);
 
     /**
-     * Gets the interval in seconds between subsequent keepalive probes, regardless of what the connection
-     * has exchanged in the meantime
+     * Gets the interval in seconds between subsequent keepalive probes, regardless of what
+     * the connection has exchanged in the meantime
      * <p/>
      * If the setting isn't supported, 0 is returned.
      *
@@ -224,8 +200,8 @@ public abstract class AsyncSocket implements Closeable {
     public abstract int getTcpKeepaliveIntvl();
 
     /**
-     * Sets the number of unacknowledged probes to send before considering the connection dead and notifying the
-     * application layer.
+     * Sets the number of unacknowledged probes to send before considering the connection
+     * dead and notifying the application layer.
      * <p/>
      * If the setting isn't supported, the call is ignored.
      *
@@ -235,8 +211,8 @@ public abstract class AsyncSocket implements Closeable {
     public abstract void setTcpKeepAliveProbes(int keepAliveProbes);
 
     /**
-     * Gets the number of unacknowledged probes to send before considering the connection dead and notifying the
-     * application layer.
+     * Gets the number of unacknowledged probes to send before considering the connection
+     * dead and notifying the application layer.
      * <p/>
      * If the setting isn't supported, 0 is returned.
      *
@@ -262,16 +238,16 @@ public abstract class AsyncSocket implements Closeable {
     public abstract boolean isTcpNoDelay();
 
     /**
-     * Sets the receivebuffer size in bytes.
+     * Sets the receive buffer size in bytes.
      *
-     * @param size the receivebuffer size in bytes.
+     * @param size the receive buffer size in bytes.
      * @throws IllegalArgumentException when the size isn't positive.
      * @throws UncheckedIOException     if something failed with configuring the socket
      */
     public abstract void setReceiveBufferSize(int size);
 
     /**
-     * Gets the receivebuffer size in bytes.
+     * Gets the receive buffer size in bytes.
      *
      * @return the size of the receive buffer.
      * @throws UncheckedIOException if something failed with configuring the socket
@@ -279,16 +255,16 @@ public abstract class AsyncSocket implements Closeable {
     public abstract int getReceiveBufferSize();
 
     /**
-     * Sets the sendbuffer size in bytes.
+     * Sets the send buffer size in bytes.
      *
-     * @param size the sendbuffer size in bytes.
+     * @param size the send buffer size in bytes.
      * @throws IllegalArgumentException when the size isn't positive.
      * @throws UncheckedIOException     if something failed with configuring the socket
      */
     public abstract void setSendBufferSize(int size);
 
     /**
-     * Gets the sendbuffer size in bytes.
+     * Gets the send buffer size in bytes.
      *
      * @return the size of the send buffer.
      * @throws UncheckedIOException if something failed with configuring the socket
@@ -296,7 +272,7 @@ public abstract class AsyncSocket implements Closeable {
     public abstract int getSendBufferSize();
 
     /**
-     * Sets the ReadHandler. Should be called before this AsyncSocket is activated.
+     * Sets the read handler. Should be called before this AsyncSocket is activated.
      *
      * @param readHandler the ReadHandler
      * @throws NullPointerException if readHandler is null.
@@ -304,21 +280,6 @@ public abstract class AsyncSocket implements Closeable {
     public final void setReadHandler(ReadHandler readHandler) {
         this.readHandler = checkNotNull(readHandler);
         this.readHandler.init(this);
-    }
-
-    /**
-     * Configures the CloseListener.
-     * <p>
-     * Call should be made before {@link #activate(Eventloop)} is called. This method is not
-     * threadsafe.
-     *
-     * @param listener the CloseListener
-     * @param executor the executor used to execute the {@link CloseListener#close()} method.
-     * @throws NullPointerException if listener or executor is null.
-     */
-    public final void setCloseListener(CloseListener listener, Executor executor) {
-        this.closeListener = checkNotNull(listener, "listener");
-        this.closeExecutor = checkNotNull(executor, "executor");
     }
 
     /**
@@ -394,78 +355,16 @@ public abstract class AsyncSocket implements Closeable {
      * @param address the address to connect to.
      * @return a {@link CompletableFuture}
      */
-    public abstract CompletableFuture<AsyncSocket> connect(SocketAddress address);
+    public abstract CompletableFuture<Void> connect(SocketAddress address);
 
-    /**
-     * Closes this {@link AsyncSocket}.
-     * <p>
-     * This method is thread-safe.
-     * <p>
-     * If the AsyncSocket is already closed, the call is ignored.
-     */
-    public final void close() {
-        if (!closed.compareAndSet(false, true)) {
-            return;
-        }
-
-        if (logger.isInfoEnabled()) {
-            logger.info("Closing  " + this);
-        }
-
-        try {
-            close0();
-        } catch (Exception e) {
-            logger.warning(e);
-        }
-
+    @Override
+    protected void close0() throws IOException {
         localAddress = null;
         remoteAddress = null;
-
-        if (closeListener != null) {
-            try {
-                closeExecutor.execute(() -> {
-                    try {
-                        closeListener.onClose(AsyncSocket.this);
-                    } catch (Throwable e) {
-                        logger.warning(e);
-                    }
-                });
-            } catch (Throwable e) {
-                logger.warning(e);
-            }
-        }
-    }
-
-    /**
-     * Does the actual closing. No guarantee is made on which thread this is called.
-     * <p/>
-     * Is guaranteed to be called at most once.
-     *
-     * @throws IOException
-     */
-    protected abstract void close0() throws IOException;
-
-    /**
-     * Checks if this AsyncSocket is closed.
-     * <p>
-     * This method is thread-safe.
-     *
-     * @return true if closed, false otherwise.
-     */
-    public final boolean isClosed() {
-        return closed.get();
-    }
-
-    interface CloseListener {
-        void onClose(AsyncSocket socket);
     }
 
     @Override
     public final String toString() {
-        if (clientSide) {
-            return getClass().getSimpleName() + "[" + localAddress + "->" + remoteAddress + "]";
-        } else {
-            return getClass().getSimpleName() + "[" + remoteAddress + "->" + localAddress + "]";
-        }
+        return getClass().getSimpleName() + "[" + localAddress + "->" + remoteAddress + "]";
     }
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncSocket.java
@@ -39,9 +39,9 @@ public abstract class AsyncSocket extends Socket {
     protected boolean clientSide;
 
     protected final ProgressIndicator ioBuffersWritten = new ProgressIndicator();
+    protected final ProgressIndicator ioBuffersRead = new ProgressIndicator();
     protected final ProgressIndicator bytesRead = new ProgressIndicator();
     protected final ProgressIndicator bytesWritten = new ProgressIndicator();
-    protected final ProgressIndicator ioBuffersRead = new ProgressIndicator();
     protected final ProgressIndicator writeEvents = new ProgressIndicator();
     protected final ProgressIndicator readEvents = new ProgressIndicator();
 

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Eventloop.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Eventloop.java
@@ -194,7 +194,7 @@ public abstract class Eventloop implements Executor {
      * Opens TCP/IP (stream) based async socket. The returned socket assumes IPv4. When support for
      * IPv6 is added, a boolean 'ipv4' flag needs to be added.
      * <p/>
-     * This AsyncSocket isn't tied to this Eventloop. After it is opened, it needs to be assigned
+     * The opened AsyncSocket isn't tied to this Eventloop. After it is opened, it needs to be assigned
      * to a particular eventloop by calling {@link AsyncSocket#activate(Eventloop)}. The reason why
      * this isn't done in 1 go, is that it could be that when the AsyncServerSocket accepts an
      * AsyncSocket, we want to assign that AsyncSocket to a different Eventloop. Otherwise if there

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Socket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Socket.java
@@ -1,0 +1,214 @@
+package com.hazelcast.internal.tpc;
+
+import com.hazelcast.internal.tpc.logging.TpcLogger;
+import com.hazelcast.internal.tpc.logging.TpcLoggerLocator;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.internal.tpc.util.Preconditions.checkNotNull;
+
+/**
+ * The socket for TPC engine.
+ */
+public abstract class Socket implements Closeable {
+
+    /**
+     * Allows for objects to be bound to this socket. Useful for the lookup of services and other dependencies.
+     */
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public final ConcurrentMap<?, ?> context = new ConcurrentHashMap<>();
+
+    protected final TpcLogger logger = TpcLoggerLocator.getLogger(getClass());
+    protected final AtomicReference<State> state = new AtomicReference<>(State.OPEN);
+    private volatile String closeReason;
+    private volatile Throwable closeCause;
+    private CloseListener closeListener;
+    private Executor closeExecutor;
+
+    /**
+     * Configures the close listener.
+     * <p/>
+     * Can only be configured once.
+     * <p/>
+     * Is threadsafe.
+     * <p/>
+     * If the method is called when the socket already is closed, the close listener
+     * is called.
+     *
+     * @param listener the CloseListener
+     * @param executor the executor used to execute the {@link CloseListener#close()} method.
+     * @throws NullPointerException  if listener or executor is null.
+     * @throws IllegalStateException if already set.
+     */
+    public final void setCloseListener(CloseListener listener, Executor executor) {
+        checkNotNull(executor, "executor");
+        checkNotNull(listener, "listener");
+
+        // Using lock to make sure that there is a matching listener/executor.
+        synchronized (this) {
+            if (closeExecutor != null) {
+                throw new IllegalStateException("Can't reset the closeListener");
+            }
+            this.closeExecutor = executor;
+            this.closeListener = listener;
+        }
+
+        // if the socket is already closed, we need to notify.
+        if (state.get() == State.CLOSED) {
+            notifyCloseListener(listener, executor);
+        }
+    }
+
+    /**
+     * Checks if the socket is closed.
+     * <p/>
+     * This method is thread-safe.
+     *
+     * @return true if closed, false otherwise.
+     */
+    public final boolean isClosed() {
+        return state.get() == State.CLOSED;
+    }
+
+    /**
+     * Closes the socket with a null reason and cause.
+     * <p/>
+     * If the socket is already closed, it is ignored.
+     * <p/>
+     * This method is thread-safe.
+     * <p/>
+     * This method doesn't throw an exception.
+     */
+    @Override
+    public final void close() {
+        close(null, null);
+    }
+
+    /**
+     * Closes the socket.
+     * <p/>
+     * If the socket is already closed, the call is ignored.
+     * <p/>
+     * This method is thread-safe.
+     *
+     * @param reason the reason this socket is going to be closed.
+     *               Is allowed to be null.
+     * @param cause  the Throwable that caused this socket to be closed.
+     *               Is allowed to be null.
+     */
+    public final void close(String reason, Throwable cause) {
+        if (!state.compareAndSet(State.OPEN, State.CLOSING)) {
+            return;
+        }
+
+        this.closeReason = reason;
+        this.closeCause = cause;
+
+        if (cause == null) {
+            if (logger.isInfoEnabled()) {
+                if (reason == null) {
+                    logger.info("Closing  " + this);
+                } else {
+                    logger.info("Closing " + this + " due to " + reason);
+                }
+            }
+        } else {
+            if (logger.isWarningEnabled()) {
+                if (reason == null) {
+                    logger.warning("Closing  " + this, cause);
+                } else {
+                    logger.warning("Closing " + this + " due to " + reason, cause);
+                }
+            }
+        }
+
+        try {
+            close0();
+        } catch (Exception e) {
+            logger.warning(e);
+        } finally {
+            state.set(State.CLOSED);
+        }
+
+        CloseListener closeListener;
+        Executor closeExecutor;
+        synchronized (this) {
+            closeListener = this.closeListener;
+            closeExecutor = this.closeExecutor;
+        }
+
+        if (closeListener != null) {
+            notifyCloseListener(closeListener, closeExecutor);
+        }
+    }
+
+    private void notifyCloseListener(CloseListener closeListener, Executor closeExecutor) {
+        closeExecutor.execute(() -> {
+            try {
+                closeListener.onClose(Socket.this);
+            } catch (Exception e) {
+                logger.warning(e);
+            }
+        });
+    }
+
+    /**
+     * Does the actual closing. No guarantee is made on which thread this is called.
+     * <p/>
+     * Is guaranteed to be called at most once.
+     *
+     * @throws IOException if something goes wrong while closing the socket.
+     */
+    protected abstract void close0() throws IOException;
+
+    /**
+     * Gets the reason this socket was closed. Can be null if no reason was given or if
+     * the socket is still active. It is purely meant for debugging to shed some light on
+     * why sockets are closed.
+     * <p>
+     * This method is thread-safe and can be called at any moment.
+     * <p>
+     * If the socket is closed and no reason is available, it is very likely that the
+     * close cause does contain the reason of closing.
+     *
+     * @return the reason this socket was closed.
+     * @see #getCloseCause()
+     * @see #close(String, Throwable)
+     */
+    public String getCloseReason() {
+        return closeReason;
+    }
+
+    /**
+     * Gets the cause this socket was closed. Can be null if no cause was given or if the
+     * socket is still active. It is purely meant for debugging to shed some light on why
+     * sockets are closed.
+     * <p>
+     * This method is thread-safe.
+     *
+     * @return the cause of closing this socket.
+     * @see #getCloseReason() ()
+     * @see #close(String, Throwable)
+     */
+    public Throwable getCloseCause() {
+        return closeCause;
+    }
+
+    protected enum State {
+        OPEN,
+        CLOSING,
+        CLOSED
+    }
+
+    /**
+     * A Listener that allows you to listen to the socket closing.
+     */
+    public interface CloseListener {
+        void onClose(Socket socket);
+    }
+}

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Socket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Socket.java
@@ -18,7 +18,8 @@ import static com.hazelcast.internal.tpc.util.Preconditions.checkNotNull;
 public abstract class Socket implements Closeable {
 
     /**
-     * Allows for objects to be bound to this socket. Useful for the lookup of services and other dependencies.
+     * Allows for objects to be bound to this socket. Useful for the lookup of
+     * services and other dependencies.
      */
     @SuppressWarnings("checkstyle:VisibilityModifier")
     public final ConcurrentMap<?, ?> context = new ConcurrentHashMap<>();
@@ -29,37 +30,44 @@ public abstract class Socket implements Closeable {
     private volatile Throwable closeCause;
     private CloseListener closeListener;
     private Executor closeExecutor;
+    private boolean closeListenerChecked;
 
     /**
      * Configures the close listener.
      * <p/>
      * Can only be configured once.
      * <p/>
-     * Is threadsafe.
+     * This call is threadsafe.
      * <p/>
      * If the method is called when the socket already is closed, the close listener
-     * is called.
+     * is notified.
      *
-     * @param listener the CloseListener
-     * @param executor the executor used to execute the {@link CloseListener#close()} method.
+     * @param listener the close listener to set.
+     * @param executor the executor used to execute the close listener.
      * @throws NullPointerException  if listener or executor is null.
-     * @throws IllegalStateException if already set.
+     * @throws IllegalStateException if a close listener is already set.
      */
     public final void setCloseListener(CloseListener listener, Executor executor) {
         checkNotNull(executor, "executor");
         checkNotNull(listener, "listener");
 
         // Using lock to make sure that there is a matching listener/executor.
+        boolean closeListenerChecked;
         synchronized (this) {
-            if (closeExecutor != null) {
+            if (closeListener != null) {
                 throw new IllegalStateException("Can't reset the closeListener");
             }
+
             this.closeExecutor = executor;
             this.closeListener = listener;
+            closeListenerChecked = this.closeListenerChecked;
         }
 
-        // if the socket is already closed, we need to notify.
-        if (state.get() == State.CLOSED) {
+        if (closeListenerChecked) {
+            // the closing thread already checked the closeListener and therefor
+            // it hasn't seen the close listener that is now being set. So we need
+            // to notify the close listener ourselves to prevent omitting the
+            // notification.
             notifyCloseListener(listener, executor);
         }
     }
@@ -138,8 +146,12 @@ public abstract class Socket implements Closeable {
         CloseListener closeListener;
         Executor closeExecutor;
         synchronized (this) {
+            this.closeListenerChecked = true;
             closeListener = this.closeListener;
             closeExecutor = this.closeExecutor;
+            // this will signal to a different thread calling the setCloseListener that
+            // the socket is closed but the thread calling the close will not check any
+            // change to the closeListener after this point.
         }
 
         if (closeListener != null) {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocket.java
@@ -94,8 +94,7 @@ public final class NioAsyncServerSocket extends AsyncServerSocket {
 
     @Override
     public int getLocalPort() {
-        int localPort = serverSocketChannel.socket().getLocalPort();
-        return localPort == -1 ? 0 : localPort;
+        return serverSocketChannel.socket().getLocalPort();
     }
 
     @Override

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/SelectionKeyListener.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/SelectionKeyListener.java
@@ -16,21 +16,27 @@
 
 package com.hazelcast.internal.tpc.nio;
 
-import com.hazelcast.internal.tpc.Eventloop;
-import com.hazelcast.internal.tpc.EventloopTest;
-import com.hazelcast.internal.tpc.EventloopType;
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
 
-public class NioEventloopTest extends EventloopTest {
+/**
+ * A callback interface when something interesting happened on a {@link SelectionKey}.
+ */
+public interface SelectionKeyListener {
 
-    @Override
-    public EventloopType getType() {
-        return EventloopType.NIO;
-    }
+    /**
+     * Signals the listener that socket should be closed.
+     *
+     * @param reason the reason (can be null).
+     * @param cause the cause (can be null).
+     */
+    void close(String reason, Exception cause);
 
-    @Override
-    public Eventloop createEventloop() {
-        NioEventloop eventloop = new NioEventloop();
-        loops.add(eventloop);
-        return eventloop;
-    }
+    /**
+     * Signals that something interesting happened on a SelectionKey.
+     *
+     * @param key the SelectionKey
+     * @throws IOException if handling lead to problems.
+     */
+    void handle(SelectionKey key) throws IOException;
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/SelectorOptimizer.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/SelectorOptimizer.java
@@ -50,7 +50,6 @@ public final class SelectorOptimizer {
     /**
      * Creates a new Selector and will optimize it if possible.
      *
-     * @param logger the logger used for the optimization process.
      * @return the created Selector.
      * @throws NullPointerException if logger is null.
      */
@@ -97,7 +96,6 @@ public final class SelectorOptimizer {
             selectedKeysField.set(selector, set);
             publicSelectedKeysField.set(selector, set);
 
-            //System.out.println("Optimized Selector: " + selector.getClass().getName());
             logger.finest("Optimized Selector: " + selector.getClass().getName());
             return set;
         } catch (Throwable t) {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/OS.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/OS.java
@@ -26,7 +26,7 @@ public class OS {
     private static final boolean IS_LINUX = isLinux0(OS_NAME);
     private static final int LINUX_KERNEL_MAJOR_VERSION = linuxMajorVersion0(OS_VERSION);
     private static final int LINUX_KERNEL_MINOR_VERSION = linuxMinorVersion0(OS_VERSION);
-    private static final int PAGE_SIZE = UnsafeUtil.UNSAFE.pageSize();
+    private static final int PAGE_SIZE = UnsafeLocator.UNSAFE.pageSize();
     private static final String OS_ARCH = System.getProperty("os.arch", "?");
     private static final boolean IS_64BIT = is64bit0(OS_ARCH);
     private static final boolean IS_X86_64 = OS_ARCH.equals("amd64");

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/ProgressIndicator.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/ProgressIndicator.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Field;
  */
 public class ProgressIndicator {
 
-    private static final Unsafe UNSAFE = UnsafeUtil.UNSAFE;
+    private static final Unsafe UNSAFE = UnsafeLocator.UNSAFE;
     private static final long OFFSET;
 
     static {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/UnsafeLocator.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/UnsafeLocator.java
@@ -20,21 +20,26 @@ import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
 
-public final class UnsafeUtil {
+public final class UnsafeLocator {
 
     public static final Unsafe UNSAFE;
 
     static {
+        Unsafe unsafe;
         try {
-            Field theUnsafeField = Unsafe.class.getDeclaredField("theUnsafe");
-            theUnsafeField.setAccessible(true);
-            UNSAFE = (Unsafe) theUnsafeField.get(null);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
+            unsafe = Unsafe.getUnsafe();
+        } catch (SecurityException e) {
+            try {
+                Field theUnsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+                theUnsafeField.setAccessible(true);
+                unsafe = (Unsafe) theUnsafeField.get(null);
+            } catch (Exception e2) {
+                throw new RuntimeException(e2);
+            }
         }
+        UNSAFE = unsafe;
     }
 
-    private UnsafeUtil() {
+    private UnsafeLocator() {
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncServerSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncServerSocketTest.java
@@ -31,6 +31,7 @@ import static com.hazelcast.internal.tpc.TpcTestSupport.terminate;
 import static com.hazelcast.internal.tpc.TpcTestSupport.terminateAll;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -153,7 +154,7 @@ public abstract class AsyncServerSocketTest {
         AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
 
         int localPort = socket.getLocalPort();
-        assertEquals(0, localPort);
+        assertEquals(-1, localPort);
     }
 
     @Test
@@ -169,7 +170,7 @@ public abstract class AsyncServerSocketTest {
     public void test_getLocalAddress_whenNotBound() {
         Eventloop eventloop = createEventloop();
         AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
-        System.out.println(socket.getLocalAddress());
+        assertNull(socket.getLocalAddress());
     }
 
     @Test

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncServerSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncServerSocketTest.java
@@ -20,15 +20,16 @@ import com.hazelcast.internal.tpc.nio.NioAsyncServerSocketTest;
 import com.hazelcast.internal.tpc.util.JVM;
 import org.junit.After;
 import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
 
-import java.io.Closeable;
 import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.internal.tpc.util.CloseUtil.closeAllQuietly;
+import static com.hazelcast.internal.tpc.TpcTestSupport.terminate;
+import static com.hazelcast.internal.tpc.TpcTestSupport.terminateAll;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
@@ -36,34 +37,27 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 public abstract class AsyncServerSocketTest {
-    public List<Closeable> closeables = new ArrayList<>();
+
     public List<Eventloop> loops = new ArrayList<>();
 
     public abstract Eventloop createEventloop();
 
-    public abstract AsyncServerSocket createAsyncServerSocket(Eventloop eventloop);
-
     @After
     public void after() throws InterruptedException {
-        closeAllQuietly(closeables);
-
-        for (Eventloop eventloop : loops) {
-            eventloop.shutdown();
-            eventloop.awaitTermination(5, TimeUnit.SECONDS);
-        }
+        terminateAll(loops);
     }
 
     @Test
     public void test_construction() {
         Eventloop eventloop = createEventloop();
-        AsyncServerSocket socket = createAsyncServerSocket(eventloop);
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
         assertSame(eventloop, socket.getEventloop());
     }
 
     @Test
     public void test_receiveBufferSize() {
         Eventloop eventloop = createEventloop();
-        AsyncServerSocket socket = createAsyncServerSocket(eventloop);
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
         int size = 64 * 1024;
         socket.setReceiveBufferSize(size);
         assertTrue(socket.getReceiveBufferSize() >= size);
@@ -72,15 +66,15 @@ public abstract class AsyncServerSocketTest {
     @Test
     public void test_setReceiveBufferSize_whenIOException() {
         Eventloop eventloop = createEventloop();
-        AsyncServerSocket socket = createAsyncServerSocket(eventloop);
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
         socket.close();
-        assertThrows(UncheckedIOException.class, () -> socket.setReceiveBufferSize(64*1024));
+        assertThrows(UncheckedIOException.class, () -> socket.setReceiveBufferSize(64 * 1024));
     }
 
     @Test
     public void test_getReceiveBufferSize_whenIOException() {
         Eventloop eventloop = createEventloop();
-        AsyncServerSocket socket = createAsyncServerSocket(eventloop);
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
         socket.close();
         assertThrows(UncheckedIOException.class, socket::getReceiveBufferSize);
     }
@@ -88,7 +82,7 @@ public abstract class AsyncServerSocketTest {
     @Test
     public void test_reuseAddress() {
         Eventloop eventloop = createEventloop();
-        AsyncServerSocket socket = createAsyncServerSocket(eventloop);
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
         socket.setReuseAddress(true);
         assertTrue(socket.isReuseAddress());
 
@@ -99,7 +93,7 @@ public abstract class AsyncServerSocketTest {
     @Test
     public void test_setReuseAddress_whenIOException() {
         Eventloop eventloop = createEventloop();
-        AsyncServerSocket socket = createAsyncServerSocket(eventloop);
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
         socket.close();
         assertThrows(UncheckedIOException.class, () -> socket.setReuseAddress(true));
     }
@@ -107,7 +101,7 @@ public abstract class AsyncServerSocketTest {
     @Test
     public void test_isReuseAddress_whenIOException() {
         Eventloop eventloop = createEventloop();
-        AsyncServerSocket socket = createAsyncServerSocket(eventloop);
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
         socket.close();
         assertThrows(UncheckedIOException.class, socket::isReuseAddress);
     }
@@ -123,7 +117,7 @@ public abstract class AsyncServerSocketTest {
         assumeIfNioThenJava11Plus();
 
         Eventloop eventloop = createEventloop();
-        AsyncServerSocket socket = createAsyncServerSocket(eventloop);
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
         socket.setReusePort(true);
         assertTrue(socket.isReusePort());
 
@@ -136,7 +130,7 @@ public abstract class AsyncServerSocketTest {
         assumeIfNioThenJava11Plus();
 
         Eventloop eventloop = createEventloop();
-        AsyncServerSocket socket = createAsyncServerSocket(eventloop);
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
         socket.close();
 
         assertThrows(UncheckedIOException.class, () -> socket.setReusePort(true));
@@ -147,9 +141,126 @@ public abstract class AsyncServerSocketTest {
         assumeIfNioThenJava11Plus();
 
         Eventloop eventloop = createEventloop();
-        AsyncServerSocket socket = createAsyncServerSocket(eventloop);
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
         socket.close();
 
         assertThrows(UncheckedIOException.class, socket::isReusePort);
+    }
+
+    @Test
+    public void test_getLocalPort_whenNotYetBound() {
+        Eventloop eventloop = createEventloop();
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
+
+        int localPort = socket.getLocalPort();
+        assertEquals(0, localPort);
+    }
+
+    @Test
+    public void test_bind_whenLocalAddressNull() {
+        Eventloop eventloop = createEventloop();
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
+
+        System.out.println(socket.getLocalPort());
+        assertThrows(NullPointerException.class, () -> socket.bind(null));
+    }
+
+    @Test
+    public void test_getLocalAddress_whenNotBound() {
+        Eventloop eventloop = createEventloop();
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
+        System.out.println(socket.getLocalAddress());
+    }
+
+    @Test
+    public void test_accept_andNoBind() {
+        Eventloop eventloop = createEventloop();
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
+
+        socket.accept(socket1 -> {
+
+        }).join();
+    }
+
+    @Test
+    public void test_bind_whenBacklogNegative() {
+        Eventloop eventloop = createEventloop();
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
+
+        SocketAddress local = new InetSocketAddress("127.0.0.1", 5000);
+
+        assertThrows(IllegalArgumentException.class, () -> socket.bind(local, -1));
+    }
+
+    @Test
+    public void test_bind() {
+        Eventloop eventloop = createEventloop();
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
+
+        SocketAddress local = new InetSocketAddress("127.0.0.1", 5000);
+        socket.bind(local);
+
+        assertEquals(local, socket.getLocalAddress());
+        assertEquals(5000, socket.getLocalPort());
+
+        // we need to close the socket manually only when accept is called, the AsyncSocket is part
+        // of the eventloop
+        socket.close();
+    }
+
+    @Test
+    public void test_bind_whenAlreadyBound() {
+        Eventloop eventloop = createEventloop();
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
+
+        SocketAddress local = new InetSocketAddress("127.0.0.1", 5000);
+        socket.bind(local);
+        assertThrows(UncheckedIOException.class, () -> socket.bind(local));
+
+        socket.close();
+    }
+
+    @Test
+    public void test_accept_whenConsumerNull() {
+        Eventloop eventloop = createEventloop();
+        AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
+
+        SocketAddress local = new InetSocketAddress("127.0.0.1", 5000);
+        socket.bind(local);
+
+        assertThrows(NullPointerException.class, () -> socket.accept(null));
+
+        socket.close();
+    }
+
+    @Test
+    public void test_createCloseLoop_withSameEventloop() {
+        SocketAddress local = new InetSocketAddress("127.0.0.1", 5000);
+        Eventloop eventloop = createEventloop();
+        for (int k = 0; k < 1000; k++) {
+            System.out.println("at:" + k);
+            AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
+            socket.setReusePort(true);
+            socket.bind(local);
+            socket.accept(socket1 -> {
+            }).join();
+            socket.close();
+        }
+    }
+
+    @Test
+    public void test_createCloseLoop_withNewEventloop() {
+        SocketAddress local = new InetSocketAddress("127.0.0.1", 5000);
+        for (int k = 0; k < 1000; k++) {
+            System.out.println("at:" + k);
+            Eventloop eventloop = createEventloop();
+            loops.remove(eventloop);
+            AsyncServerSocket socket = eventloop.openTcpAsyncServerSocket();
+            socket.setReusePort(true);
+            socket.bind(local);
+            socket.accept(socket1 -> {
+            }).join();
+            terminate(eventloop);
+        }
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocketTest.java
@@ -60,6 +60,19 @@ public abstract class AsyncSocketTest {
         assertNull(remoteAddress);
     }
 
+
+    @Test
+    public void test_localAddress_whenNotConnected() {
+        Eventloop eventloop = createEventloop();
+        AsyncSocket socket = eventloop.openTcpAsyncSocket();
+        socket.setReadHandler(mock(ReadHandler.class));
+        socket.activate(eventloop);
+
+        SocketAddress localAddress = socket.getLocalAddress();
+        System.out.println(localAddress);
+        assertNull(localAddress);
+    }
+
     @Test
     public void test_receiveBufferSize() {
         Eventloop eventloop = createEventloop();

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_RpcTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_RpcTest.java
@@ -33,11 +33,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.internal.tpc.TpcTestSupport.terminate;
 import static com.hazelcast.internal.tpc.util.BitUtil.SIZEOF_INT;
 import static com.hazelcast.internal.tpc.util.BitUtil.SIZEOF_LONG;
 import static com.hazelcast.internal.tpc.util.BufferUtil.put;
-import static com.hazelcast.internal.tpc.util.CloseUtil.closeQuietly;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Mimics an RPC call. So there are worker threads that send request with a call id and a payload. This request is
@@ -49,12 +48,12 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public abstract class AsyncSocket_RpcTest {
     // use small buffers to cause a lot of network scheduling overhead (and shake down problems)
     public static final int SOCKET_BUFFER_SIZE = 16 * 1024;
-    public static int requestTotal = 20000;
+    //todo: needs to be restored to 20000 for nightly tests
+    public static int requestTotal = 200;
     public final ConcurrentMap<Long, CompletableFuture> futures = new ConcurrentHashMap<>();
+
     private Eventloop clientEventloop;
     private Eventloop serverEventloop;
-    private AsyncSocket clientSocket;
-    private AsyncServerSocket serverSocket;
 
     public abstract Eventloop createEventloop();
 
@@ -66,18 +65,8 @@ public abstract class AsyncSocket_RpcTest {
 
     @After
     public void after() throws InterruptedException {
-        closeQuietly(clientSocket);
-        closeQuietly(serverSocket);
-
-        if (clientEventloop != null) {
-            clientEventloop.shutdown();
-            clientEventloop.awaitTermination(10, SECONDS);
-        }
-
-        if (serverEventloop != null) {
-            serverEventloop.shutdown();
-            serverEventloop.awaitTermination(10, SECONDS);
-        }
+        terminate(clientEventloop);
+        terminate(serverEventloop);
     }
 
     @Test
@@ -242,13 +231,11 @@ public abstract class AsyncSocket_RpcTest {
 
         AsyncSocket clientSocket = newClient(serverAddress);
 
-        System.out.println("Starting");
-
         AtomicLong callIdGenerator = new AtomicLong();
         List<WorkerThread> threads = new ArrayList<>();
         int requestPerThread = requestTotal / concurrency;
         for (int k = 0; k < concurrency; k++) {
-            WorkerThread thread = new WorkerThread(requestPerThread, payloadSize, callIdGenerator);
+            WorkerThread thread = new WorkerThread(requestPerThread, payloadSize, callIdGenerator, clientSocket);
             threads.add(thread);
             thread.start();
         }
@@ -262,11 +249,13 @@ public abstract class AsyncSocket_RpcTest {
         private final int requests;
         private final byte[] payload;
         private final AtomicLong callIdGenerator;
+        private final AsyncSocket clientSocket;
 
-        public WorkerThread(int requests, int payloadSize, AtomicLong callIdGenerator) {
+        public WorkerThread(int requests, int payloadSize, AtomicLong callIdGenerator, AsyncSocket clientSocket) {
             this.requests = requests;
             this.payload = new byte[payloadSize];
             this.callIdGenerator = callIdGenerator;
+            this.clientSocket = clientSocket;
         }
 
         @Override
@@ -292,23 +281,17 @@ public abstract class AsyncSocket_RpcTest {
     }
 
     private AsyncSocket newClient(SocketAddress serverAddress) {
-        clientSocket = clientEventloop.openAsyncTcpSocket();
+        AsyncSocket clientSocket = clientEventloop.openTcpAsyncSocket();
         clientSocket.setTcpNoDelay(true);
-        clientSocket.setSoLinger(0);
         clientSocket.setSendBufferSize(SOCKET_BUFFER_SIZE);
         clientSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
         clientSocket.setReadHandler(new ReadHandler() {
-            private boolean firstTime = true;
             private ByteBuffer payloadBuffer;
             private long callId;
             private int payloadSize = -1;
 
             @Override
             public void onRead(ByteBuffer receiveBuffer) {
-                if (firstTime) {
-                    firstTime = false;
-                }
-
                 for (; ; ) {
                     if (payloadSize == -1) {
                         if (receiveBuffer.remaining() < SIZEOF_INT + SIZEOF_LONG) {
@@ -342,18 +325,15 @@ public abstract class AsyncSocket_RpcTest {
     }
 
     private AsyncServerSocket newServer(SocketAddress serverAddress) {
-        serverSocket = serverEventloop.openTcpServerSocket();
+        AsyncServerSocket serverSocket = serverEventloop.openTcpAsyncServerSocket();
         serverSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
         serverSocket.bind(serverAddress);
-        serverSocket.listen(10);
 
         serverSocket.accept(socket -> {
-            socket.setSoLinger(-1);
             socket.setTcpNoDelay(true);
             socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
             socket.setReceiveBufferSize(serverSocket.getReceiveBufferSize());
             socket.setReadHandler(new ReadHandler() {
-                private boolean firstTime;
                 private ByteBuffer payloadBuffer;
                 private long callId;
                 private int payloadSize = -1;
@@ -361,10 +341,6 @@ public abstract class AsyncSocket_RpcTest {
 
                 @Override
                 public void onRead(ByteBuffer receiveBuffer) {
-                    if (firstTime) {
-                        firstTime = false;
-                    }
-
                     for (; ; ) {
                         if (payloadSize == -1) {
                             if (receiveBuffer.remaining() < SIZEOF_INT + SIZEOF_LONG) {
@@ -381,7 +357,6 @@ public abstract class AsyncSocket_RpcTest {
                             break;
                         }
 
-
                         payloadBuffer.flip();
                         IOBuffer responseBuf = responseAllocator.allocate(SIZEOF_INT + SIZEOF_LONG + payloadSize);
                         responseBuf.writeInt(payloadSize);
@@ -396,7 +371,6 @@ public abstract class AsyncSocket_RpcTest {
                     }
                 }
             });
-            System.out.println("Activating server side socket");
             socket.activate(serverEventloop);
         });
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/EventloopBuilderTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/EventloopBuilderTest.java
@@ -16,12 +16,16 @@
 
 package com.hazelcast.internal.tpc;
 
+import com.hazelcast.internal.util.ThreadAffinity;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class EventloopBuilderTest {
 
@@ -121,5 +125,31 @@ public abstract class EventloopBuilderTest {
     public void test_setSchedulerSupplier_whenNull() {
         EventloopBuilder builder = newBuilder();
         assertThrows(NullPointerException.class, () -> builder.setSchedulerSupplier(null));
+    }
+
+    @Test
+    public void test_setThreadAffinity_nullAffinityIsAllowed(){
+        EventloopBuilder builder = newBuilder();
+        builder.setThreadAffinity(null);
+
+        assertNull(builder.threadAffinity);
+    }
+
+
+    @Test
+    public void test_setThreadAffinity(){
+        EventloopBuilder builder = newBuilder();
+        ThreadAffinity affinity = new ThreadAffinity("1-5");
+        builder.setThreadAffinity(affinity);
+
+        assertSame(affinity, builder.threadAffinity);
+    }
+
+    @Test
+    public void test_setSpin(){
+        EventloopBuilder builder = newBuilder();
+        builder.setSpin(true);
+
+        assertTrue(builder.spin);
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/FutTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/FutTest.java
@@ -123,6 +123,7 @@ public class FutTest {
         fut.completeExceptionally(exception);
 
         assertOpenEventually(executed);
+        assertTrue(fut.isCompletedExceptionally());
         assertNull(valueRef.get());
         assertSame(exception, throwableRef.get());
     }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/NopSchedulerTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/NopSchedulerTest.java
@@ -14,14 +14,24 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.tpc.nio;
+package com.hazelcast.internal.tpc;
 
-import java.io.IOException;
-import java.nio.channels.SelectionKey;
+import com.hazelcast.internal.tpc.iobuffer.IOBuffer;
+import org.junit.Test;
 
-public interface NioSelectedKeyListener {
+import static org.junit.Assert.assertFalse;
 
-    void handleException(Exception e);
+public class NopSchedulerTest {
 
-    void handle(SelectionKey key) throws IOException;
+    @Test
+    public void test(){
+        NopScheduler scheduler = new NopScheduler();
+        scheduler.schedule(new IOBuffer(64));
+    }
+
+    @Test
+    public void test_tick(){
+        NopScheduler scheduler = new NopScheduler();
+        assertFalse(scheduler.tick());
+    }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/SocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/SocketTest.java
@@ -1,0 +1,184 @@
+package com.hazelcast.internal.tpc;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class SocketTest {
+
+    @Test
+    public void test_construction() {
+        MockSocket socket = new MockSocket();
+
+        assertNull(socket.getCloseCause());
+        assertNull(socket.getCloseCause());
+        assertFalse(socket.isClosed());
+    }
+
+    @Test
+    public void test_setCloseListener_whenAlreadySet() {
+        MockSocket socket = new MockSocket();
+        Socket.CloseListener oldCloseListener = mock(Socket.CloseListener.class);
+        Executor oldExecutor = mock(Executor.class);
+        socket.setCloseListener(oldCloseListener, oldExecutor);
+
+        assertThrows(IllegalStateException.class, () -> socket.setCloseListener(mock(Socket.CloseListener.class), mock(Executor.class)));
+    }
+
+    @Test
+    public void test_setCloseListener_whenListenerNull() {
+        MockSocket socket = new MockSocket();
+
+        assertThrows(NullPointerException.class, () -> socket.setCloseListener(null, mock(Executor.class)));
+    }
+
+    @Test
+    public void test_setCloseListener_whenExecutorNull() {
+        MockSocket socket = new MockSocket();
+
+        assertThrows(NullPointerException.class, () -> socket.setCloseListener(mock(Socket.CloseListener.class), null));
+    }
+
+    @Test
+    public void test_close_whenCloseListenerConfigured() {
+        MockSocket socket = new MockSocket();
+        Executor executor = command -> {
+            command.run();
+        };
+        Socket.CloseListener listener = mock(Socket.CloseListener.class);
+        socket.setCloseListener(listener, executor);
+
+        socket.close();
+
+        verify(listener).onClose(socket);
+    }
+
+    @Test
+    public void test_close_whenCloseListenerConfiguredAndSocketAlreadyClosed() {
+        MockSocket socket = new MockSocket();
+        socket.close();
+
+        Executor executor = command -> {
+            command.run();
+        };
+        Socket.CloseListener listener = mock(Socket.CloseListener.class);
+        socket.setCloseListener(listener, executor);
+
+        verify(listener).onClose(socket);
+    }
+
+    @Test
+    public void test_close_whenCloseListenerThrowsException_thenIgnore() {
+        MockSocket socket = new MockSocket();
+        Executor executor = command -> {
+            command.run();
+        };
+        Socket.CloseListener listener = mock(Socket.CloseListener.class);
+        socket.setCloseListener(listener, executor);
+
+        doThrow(new RuntimeException()).when(listener).onClose(socket);
+        socket.close();
+
+        socket.close();
+        assertTrue(socket.isClosed());
+    }
+
+    @Test
+    public void test_close_whenClose0ThrowsException_thenIgnore() throws IOException {
+        MockSocket socket = new MockSocket();
+        socket.exceptionToThrow = new IOException();
+
+        socket.close();
+
+        assertTrue(socket.isClosed());
+    }
+
+    @Test
+    public void test_close() {
+        MockSocket socket = new MockSocket();
+        socket.close();
+
+        assertTrue(socket.isClosed());
+        assertNull(socket.getCloseCause());
+        assertNull(socket.getCloseReason());
+        assertEquals(1, socket.closeCalls);
+    }
+
+    @Test
+    public void test_close_withReasonAndCause() {
+        MockSocket socket = new MockSocket();
+        String reason = "foo";
+        Throwable cause = new Exception();
+        socket.close(reason, cause);
+
+        assertTrue(socket.isClosed());
+        assertSame(cause, socket.getCloseCause());
+        assertSame(reason, socket.getCloseReason());
+        assertEquals(1, socket.closeCalls);
+    }
+
+    @Test
+    public void test_close_withReasonOnly() {
+        MockSocket socket = new MockSocket();
+        String reason = "foo";
+        socket.close(reason, null);
+
+        assertTrue(socket.isClosed());
+        assertNull(socket.getCloseCause());
+        assertSame(reason, socket.getCloseReason());
+        assertEquals(1, socket.closeCalls);
+    }
+
+    @Test
+    public void test_close_withCauseOnly() {
+        MockSocket socket = new MockSocket();
+        Throwable cause = new Exception();
+        socket.close(null, cause);
+
+        assertTrue(socket.isClosed());
+        assertNull(socket.getCloseReason());
+        assertSame(cause, socket.getCloseCause());
+        assertEquals(1, socket.closeCalls);
+    }
+
+
+    @Test
+    public void test_close_whenAlreadyClosed() {
+        MockSocket socket = new MockSocket();
+        String reason = "foo";
+        Throwable cause = new Exception();
+        socket.close(reason, cause);
+
+        socket.close();
+
+        assertTrue(socket.isClosed());
+        assertSame(cause, socket.getCloseCause());
+        assertSame(reason, socket.getCloseReason());
+        assertEquals(1, socket.closeCalls);
+    }
+
+
+    public static class MockSocket extends Socket {
+        int closeCalls;
+        IOException exceptionToThrow;
+
+        @Override
+        protected void close0() throws IOException {
+            closeCalls++;
+            if (exceptionToThrow != null) {
+                throw exceptionToThrow;
+            }
+        }
+    }
+}

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/TpcEngineTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/TpcEngineTest.java
@@ -35,9 +35,12 @@ public class TpcEngineTest {
     private TpcEngine engine;
 
     @After
-    public void after() {
+    public void after() throws InterruptedException {
         if (engine != null) {
             engine.shutdown();
+            if(!engine.awaitTermination(10, TimeUnit.SECONDS)){
+                throw new RuntimeException("Failed to await termination due to timeout");
+            }
         }
     }
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/TpcTestSupport.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/TpcTestSupport.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.internal.tpc;
 
+import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.Integer.getInteger;
@@ -31,6 +33,52 @@ import static org.junit.Assert.fail;
 public class TpcTestSupport {
 
     public static final int ASSERT_TRUE_EVENTUALLY_TIMEOUT = getInteger("hazelcast.assertTrueEventually.timeout", 120);
+    public static final int TERMINATION_TIMEOUT_SECONDS = 30;
+
+    public static void assertCompletesEventually(final Future future) {
+        assertTrueEventually(() -> assertTrue("Future has not completed", future.isDone()));
+    }
+
+    public static void terminateAll(Collection<? extends Eventloop> eventloops)  {
+        if(eventloops==null){
+            return;
+        }
+
+        for (Eventloop eventloop : eventloops) {
+            if (eventloop == null) {
+                continue;
+            }
+            eventloop.shutdown();
+        }
+
+        for (Eventloop eventloop : eventloops) {
+            if (eventloop == null) {
+                continue;
+            }
+            try {
+                if (!eventloop.awaitTermination(TERMINATION_TIMEOUT_SECONDS, SECONDS)) {
+                    throw new RuntimeException("Eventloop failed to terminate within timeout.");
+                }
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static void terminate(Eventloop eventloop)  {
+        if (eventloop == null) {
+            return;
+        }
+
+        eventloop.shutdown();
+        try {
+            if (!eventloop.awaitTermination(TERMINATION_TIMEOUT_SECONDS, SECONDS)) {
+                throw new RuntimeException("Eventloop failed to terminate within timeout.");
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public static void sleepMillis(int millis) {
         try {
@@ -110,7 +158,6 @@ public class TpcTestSupport {
 
         throw new RuntimeException(t);
     }
-
 
     public static void assertTrueEventually(AssertTask task, long timeoutSeconds) {
         assertTrueEventually(null, task, timeoutSeconds);

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocketTest.java
@@ -16,24 +16,17 @@
 
 package com.hazelcast.internal.tpc.nio;
 
-import com.hazelcast.internal.tpc.AsyncServerSocket;
 import com.hazelcast.internal.tpc.AsyncServerSocketTest;
 import com.hazelcast.internal.tpc.Eventloop;
 
 
 public class NioAsyncServerSocketTest extends AsyncServerSocketTest {
+
     @Override
     public Eventloop createEventloop() {
         NioEventloop eventloop = new NioEventloop();
         loops.add(eventloop);
         eventloop.start();
         return eventloop;
-    }
-
-    @Override
-    public AsyncServerSocket createAsyncServerSocket(Eventloop eventloop) {
-        NioAsyncServerSocket socket = NioAsyncServerSocket.openTcpServerSocket((NioEventloop) eventloop);
-        closeables.add(socket);
-        return socket;
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncSocketTest.java
@@ -24,6 +24,7 @@ public class NioAsyncSocketTest extends AsyncSocketTest {
     @Override
     public Eventloop createEventloop() {
         NioEventloop eventloop = new NioEventloop();
+        eventloops.add(eventloop);
         eventloop.start();
         return eventloop;
     }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/util/OSTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/util/OSTest.java
@@ -26,7 +26,7 @@ public class OSTest {
 
     @Test
     public void test_pageSize(){
-        assertEquals(UnsafeUtil.UNSAFE.pageSize(), OS.pageSize());
+        assertEquals(UnsafeLocator.UNSAFE.pageSize(), OS.pageSize());
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/internal/bootstrap/TpcServerBootstrap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/bootstrap/TpcServerBootstrap.java
@@ -132,7 +132,7 @@ public class TpcServerBootstrap {
                     () -> new ClientAsyncReadHandler(nodeEngine.getNode().clientEngine);
             readHandlerSuppliers.put(eventloop, readHandlerSupplier);
 
-            AsyncServerSocket serverSocket = eventloop.openTcpServerSocket();
+            AsyncServerSocket serverSocket = eventloop.openTcpAsyncServerSocket();
             serverSockets.add(serverSocket);
             int receiveBufferSize = clientSocketConfig.getReceiveBufferSize();
             int sendBufferSize = clientSocketConfig.getSendBufferSize();


### PR DESCRIPTION
List of improvements:

- The biggest improvement is the close functionality of the eventloop and socket/server sockets. There is no more need for the closeableList for now since the appropriate resources can be acquired from the SelectionKey. Also, the Selector is now properly closed. So you can just close the eventloops and the sockets get closed properly without running into a port that doesn't get released.

- More testing has been added.

- Socket superclass has been pulled out containing the close functionality

- Socket tracks close cause and reason (like the HZ connections) which helps with debugging.

- Unit tests run a lot faster. The RPC and large payload test do a much smaller number of iterations. We do need some nightly tests that run with a high number of iterations.

- AsyncServerSocket.listen is not needed any longer. AsyncServerSocket is a passive socket by nature, so it implies that listen needs to be called. This is now done directly after binding, similar to the java.nio.ServerSocket. It implies the API and makes it less error-prone.

- AsyncSocket SO_LINGER functionality removed. Its behavior with non-blocking sockets either is undefined or problematic (on Linux it can lead to blocking).
