### PR TITLE
Skip address resolution in a case of exception for CPMemberInfo [HZ-1943]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/CPMemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/CPMemberInfo.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.net.UnknownHostException;
 import java.util.UUID;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -86,7 +87,11 @@ public class CPMemberInfo implements CPMember, Serializable, IdentifiedDataSeria
         endpoint = new RaftEndpointImpl(uuid);
         String host = in.readUTF();
         int port = in.readInt();
-        address = new Address(host, port);
+        try {
+            address = new Address(host, port);
+        } catch (UnknownHostException ex) {
+            address = Address.createUnresolvedAddress(host, port);
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberInfoTest.java
@@ -52,7 +52,7 @@ public class CPMemberInfoTest {
 
         // need a list of CPMemberInfo to trigger the default java serializer
         Data data = SERIALIZATION_SERVICE.toData(Arrays.asList(cpMemberInfo));
-        List<CPMemberInfo> cpMemberInfoList =  SERIALIZATION_SERVICE.toObject(data);
+        List<CPMemberInfo> cpMemberInfoList = SERIALIZATION_SERVICE.toObject(data);
         CPMemberInfo restoredCPMemberInfo = cpMemberInfoList.get(0);
         Address memberInfoAddress = restoredCPMemberInfo.getAddress();
 
@@ -67,7 +67,7 @@ public class CPMemberInfoTest {
 
         // need a list of CPMemberInfo to trigger the default java serializer
         Data data = SERIALIZATION_SERVICE.toData(Arrays.asList(cpMemberInfo));
-        List<CPMemberInfo> cpMemberInfoList =  SERIALIZATION_SERVICE.toObject(data);
+        List<CPMemberInfo> cpMemberInfoList = SERIALIZATION_SERVICE.toObject(data);
         CPMemberInfo restoredCPMemberInfo = cpMemberInfoList.get(0);
         Address memberInfoAddress = restoredCPMemberInfo.getAddress();
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPMemberInfoTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class CPMemberInfoTest {
+
+    private static final InternalSerializationService SERIALIZATION_SERVICE =
+            new DefaultSerializationServiceBuilder().build();
+
+    @Test
+    public void testDeserialization() throws UnknownHostException {
+        InetAddress localHost = InetAddress.getLocalHost();
+        Address address = new Address(localHost.getHostName(), 0);
+        CPMemberInfo cpMemberInfo = new CPMemberInfo(UUID.randomUUID(), address);
+
+        // need a list of CPMemberInfo to trigger the default java serializer
+        Data data = SERIALIZATION_SERVICE.toData(Arrays.asList(cpMemberInfo));
+        List<CPMemberInfo> cpMemberInfoList =  SERIALIZATION_SERVICE.toObject(data);
+        CPMemberInfo restoredCPMemberInfo = cpMemberInfoList.get(0);
+        Address memberInfoAddress = restoredCPMemberInfo.getAddress();
+
+        assertEquals(cpMemberInfo, restoredCPMemberInfo);
+        assertTrue(memberInfoAddress.isIPv4() ||  memberInfoAddress.isIPv6());
+    }
+
+    @Test
+    public void testDeserializationWithUnresolvableHost() {
+        Address unresolvedAddress = Address.createUnresolvedAddress("unresolved-host", 0);
+        CPMemberInfo cpMemberInfo = new CPMemberInfo(UUID.randomUUID(), unresolvedAddress);
+
+        // need a list of CPMemberInfo to trigger the default java serializer
+        Data data = SERIALIZATION_SERVICE.toData(Arrays.asList(cpMemberInfo));
+        List<CPMemberInfo> cpMemberInfoList =  SERIALIZATION_SERVICE.toObject(data);
+        CPMemberInfo restoredCPMemberInfo = cpMemberInfoList.get(0);
+        Address memberInfoAddress = restoredCPMemberInfo.getAddress();
+
+        assertEquals(cpMemberInfo, restoredCPMemberInfo);
+        assertFalse(memberInfoAddress.isIPv4() ||  memberInfoAddress.isIPv6());
+    }
+}


### PR DESCRIPTION
If members are using internal hostnames that are not known to the client, then deserialization of `Collection<CPMember>` can fail on the client side since the hostname is unknown. 
In that case, we can skip hostname resolution and create the unresolved `Address`.

Fix https://github.com/hazelcast/hazelcast/issues/23311

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
