### PR TITLE
[TPC] Make it explicit that TCP sockets are opened.

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Eventloop.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Eventloop.java
@@ -185,28 +185,32 @@ public abstract class Eventloop implements Executor {
     }
 
     /**
-     * Opens an AsyncServerSocket and ties that socket to the this Eventloop instance.
+     * Opens an TCP/IP (stream) async server socket and ties that socket to the this Eventloop
+     * instance. The returned socket assumes IPv4. When support for IPv6 is added, a boolean
+     * 'ipv4' flag needs to be added.
      * <p>
      * This method is thread-safe.
      *
      * @return the opened AsyncServerSocket.
      */
-    public abstract AsyncServerSocket openAsyncServerSocket();
+    public abstract AsyncServerSocket openTcpServerSocket();
 
     /**
-     * Opens an AsyncSocket.
+     * Opens TCP/IP (stream) based async socket. The returned socket assumes IPv4. When support for
+     * IPv6 is added, a boolean 'ipv4' flag needs to be added.
      * <p/>
-     * This AsyncSocket isn't tied to this Eventloop. After it is opened, it needs to be assigned to a particular
-     * eventloop by calling {@link AsyncSocket#activate(Eventloop)}. The reason why this isn't done in 1 go, is
-     * that it could be that when the AsyncServerSocket accepts an AsyncSocket, we want to assign that AsyncSocket
-     * to a different Eventloop. Otherwise if there would be 1 AsyncServerSocket, connected AsyncSockets can only
-     * run on top of the Eventloop of the AsyncServerSocket instead of being distributed over multiple eventloops.
+     * This AsyncSocket isn't tied to this Eventloop. After it is opened, it needs to be assigned
+     * to a particular eventloop by calling {@link AsyncSocket#activate(Eventloop)}. The reason why
+     * this isn't done in 1 go, is that it could be that when the AsyncServerSocket accepts an
+     * AsyncSocket, we want to assign that AsyncSocket to a different Eventloop. Otherwise if there
+     * would be 1 AsyncServerSocket, connected AsyncSockets can only run on top of the Eventloop of
+     * the AsyncServerSocket instead of being distributed over multiple eventloops.
      * <p>
      * This method is thread-safe.
      *
      * @return the opened AsyncSocket.
      */
-    public abstract AsyncSocket openAsyncSocket();
+    public abstract AsyncSocket openAsyncTcpSocket();
 
     /**
      * Creates the Eventloop specific Unsafe instance.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocket.java
@@ -72,14 +72,14 @@ public final class NioAsyncServerSocket extends AsyncServerSocket {
     }
 
     /**
-     * Opens a NioAsyncServerSocket.
+     * Opens a TCP/IP (stream) based IPv4 NioAsyncServerSocket.
      * <p/>
-     * To prevent coupling to Nio, it is better to use the {@link Eventloop#openAsyncServerSocket()}.
+     * To prevent coupling to Nio, it is better to use the {@link Eventloop#openTcpServerSocket()}.
      *
      * @param eventloop the eventloop the opened socket will be processed by.
      * @return the opened NioAsyncServerSocket.
      */
-    public static NioAsyncServerSocket open(NioEventloop eventloop) {
+    public static NioAsyncServerSocket openTcpServerSocket(NioEventloop eventloop) {
         return new NioAsyncServerSocket(eventloop);
     }
 

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocket.java
@@ -71,13 +71,13 @@ public final class NioAsyncSocket extends AsyncSocket {
     private static final AtomicBoolean TCP_KEEPINTERVAL_PRINTED = new AtomicBoolean();
 
     /**
-     * Opens a NioAsyncSocket.
+     * Opens a stream based IPv4 NioAsyncSocket.
      * <p/>
-     * To prevent coupling, it is better to use the {@link Eventloop#openAsyncSocket()}.
+     * To prevent coupling, it is better to use the {@link Eventloop#openAsyncTcpSocket()}.
      *
      * @return the opened NioAsyncSocket.
      */
-    public static NioAsyncSocket open() {
+    public static NioAsyncSocket openTcpSocket() {
         return new NioAsyncSocket();
     }
 

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioEventloop.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioEventloop.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.tpc.nio;
 import com.hazelcast.internal.tpc.AsyncServerSocket;
 import com.hazelcast.internal.tpc.AsyncSocket;
 import com.hazelcast.internal.tpc.Eventloop;
-import com.hazelcast.internal.tpc.EventloopType;
 import com.hazelcast.internal.tpc.util.NanoClock;
 
 import java.io.IOException;
@@ -33,7 +32,8 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * Nio implementation of the {@link Eventloop}.
  */
 public final class NioEventloop extends Eventloop {
-    final Selector selector;
+
+    final Selector selector = SelectorOptimizer.newSelector();
 
     public NioEventloop() {
         this(new NioEventloopBuilder());
@@ -41,17 +41,16 @@ public final class NioEventloop extends Eventloop {
 
     public NioEventloop(NioEventloopBuilder eventloopBuilder) {
         super(eventloopBuilder);
-        this.selector = SelectorOptimizer.newSelector();
     }
 
     @Override
-    public AsyncServerSocket openAsyncServerSocket() {
-        return NioAsyncServerSocket.open(this);
+    public AsyncServerSocket openTcpServerSocket() {
+        return NioAsyncServerSocket.openTcpServerSocket(this);
     }
 
     @Override
-    public AsyncSocket openAsyncSocket() {
-        return NioAsyncSocket.open();
+    public AsyncSocket openAsyncTcpSocket() {
+        return NioAsyncSocket.openTcpSocket();
     }
 
     @Override

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocketTest.java
@@ -53,7 +53,7 @@ public abstract class AsyncSocketTest {
     @Test
     public void test_remoteAddress_whenNotConnected() {
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
         socket.setReadHandler(mock(ReadHandler.class));
         socket.activate(eventloop);
 
@@ -64,7 +64,7 @@ public abstract class AsyncSocketTest {
     @Test
     public void test_receiveBufferSize() {
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
 
         int size = 64 * 1024;
         socket.setReceiveBufferSize(size);
@@ -74,7 +74,7 @@ public abstract class AsyncSocketTest {
     @Test
     public void test_sendBufferSize() {
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
 
         int size = 64 * 1024;
         socket.setSendBufferSize(size);
@@ -84,7 +84,7 @@ public abstract class AsyncSocketTest {
     @Test
     public void test_tcpNoDelay() {
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
 
         socket.setTcpNoDelay(false);
         assertFalse(socket.isTcpNoDelay());
@@ -96,7 +96,7 @@ public abstract class AsyncSocketTest {
     @Test
     public void test_soLinger() {
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
 
         socket.setSoLinger(10);
         assertEquals(10, socket.getSoLinger());
@@ -114,18 +114,18 @@ public abstract class AsyncSocketTest {
 
         Eventloop eventloop = createEventloop();
 
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
 
         socket.setTcpKeepAliveTime(100);
         assertEquals(100, socket.getTcpKeepAliveTime());
     }
 
     @Test
-    public void test_sTcpKeepaliveIntvl() {
+    public void test_TcpKeepaliveIntvl() {
         assumeIfNioThenJava11Plus();
 
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
 
         socket.setTcpKeepaliveIntvl(100);
         assertEquals(100, socket.getTcpKeepaliveIntvl());
@@ -136,7 +136,7 @@ public abstract class AsyncSocketTest {
         assumeIfNioThenJava11Plus();
 
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
 
         socket.setTcpKeepAliveProbes(5);
         assertEquals(5, socket.getTcpKeepaliveProbes());
@@ -174,7 +174,7 @@ public abstract class AsyncSocketTest {
     @Test
     public void test_connect_whenNotActivated() {
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
         socket.setReadHandler(mock(ReadHandler.class));
         try {
             socket.connect(new InetSocketAddress(5000));
@@ -196,7 +196,7 @@ public abstract class AsyncSocketTest {
     @Test
     public void test_close_whenNotActivated() {
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
         socket.close();
         assertTrue(socket.isClosed());
     }
@@ -204,7 +204,7 @@ public abstract class AsyncSocketTest {
     @Test
     public void test_close_whenNotActivated_andAlreadyClosed() {
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
         socket.close();
         socket.close();
         assertTrue(socket.isClosed());
@@ -213,7 +213,7 @@ public abstract class AsyncSocketTest {
     @Test
     public void test_activate_whenNull() {
         Eventloop eventloop = createEventloop();
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
         socket.setReadHandler(mock(ReadHandler.class));
 
         assertThrows(NullPointerException.class, ()->socket.activate(null));
@@ -224,7 +224,7 @@ public abstract class AsyncSocketTest {
         Eventloop eventloop1 = createEventloop();
         Eventloop eventloop2 = createEventloop();
 
-        AsyncSocket socket = eventloop1.openAsyncSocket();
+        AsyncSocket socket = eventloop1.openAsyncTcpSocket();
         socket.setReadHandler(mock(ReadHandler.class));
 
         socket.activate(eventloop1);
@@ -235,7 +235,7 @@ public abstract class AsyncSocketTest {
     public void test_activate_whenReadHandlerNotConfigured() {
         Eventloop eventloop = createEventloop();
 
-        AsyncSocket socket = eventloop.openAsyncSocket();
+        AsyncSocket socket = eventloop.openAsyncTcpSocket();
         assertThrows(IllegalStateException.class, ()->socket.activate(eventloop));
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_LargePayloadTest.java
@@ -227,7 +227,7 @@ public abstract class AsyncSocket_LargePayloadTest {
     }
 
     private AsyncSocket newClient(SocketAddress serverAddress, CountDownLatch latch) {
-        clientSocket = clientEventloop.openAsyncSocket();
+        clientSocket = clientEventloop.openAsyncTcpSocket();
         clientSocket.setTcpNoDelay(true);
         clientSocket.setSoLinger(0);
         clientSocket.setSendBufferSize(SOCKET_BUFFER_SIZE);
@@ -289,7 +289,7 @@ public abstract class AsyncSocket_LargePayloadTest {
     }
 
     private AsyncServerSocket newServer(SocketAddress serverAddress) {
-        serverSocket = serverEventloop.openAsyncServerSocket();
+        serverSocket = serverEventloop.openTcpServerSocket();
         serverSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
         serverSocket.bind(serverAddress);
         serverSocket.listen(10);

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_RpcTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_RpcTest.java
@@ -292,7 +292,7 @@ public abstract class AsyncSocket_RpcTest {
     }
 
     private AsyncSocket newClient(SocketAddress serverAddress) {
-        clientSocket = clientEventloop.openAsyncSocket();
+        clientSocket = clientEventloop.openAsyncTcpSocket();
         clientSocket.setTcpNoDelay(true);
         clientSocket.setSoLinger(0);
         clientSocket.setSendBufferSize(SOCKET_BUFFER_SIZE);
@@ -342,7 +342,7 @@ public abstract class AsyncSocket_RpcTest {
     }
 
     private AsyncServerSocket newServer(SocketAddress serverAddress) {
-        serverSocket = serverEventloop.openAsyncServerSocket();
+        serverSocket = serverEventloop.openTcpServerSocket();
         serverSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
         serverSocket.bind(serverAddress);
         serverSocket.listen(10);

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocketTest.java
@@ -32,7 +32,7 @@ public class NioAsyncServerSocketTest extends AsyncServerSocketTest {
 
     @Override
     public AsyncServerSocket createAsyncServerSocket(Eventloop eventloop) {
-        NioAsyncServerSocket socket = NioAsyncServerSocket.open((NioEventloop) eventloop);
+        NioAsyncServerSocket socket = NioAsyncServerSocket.openTcpServerSocket((NioEventloop) eventloop);
         closeables.add(socket);
         return socket;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/bootstrap/TpcServerBootstrap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/bootstrap/TpcServerBootstrap.java
@@ -132,7 +132,7 @@ public class TpcServerBootstrap {
                     () -> new ClientAsyncReadHandler(nodeEngine.getNode().clientEngine);
             readHandlerSuppliers.put(eventloop, readHandlerSupplier);
 
-            AsyncServerSocket serverSocket = eventloop.openAsyncServerSocket();
+            AsyncServerSocket serverSocket = eventloop.openTcpServerSocket();
             serverSockets.add(serverSocket);
             int receiveBufferSize = clientSocketConfig.getReceiveBufferSize();
             int sendBufferSize = clientSocketConfig.getSendBufferSize();


### PR DESCRIPTION
A socket can have different types like stream (TCP), datagram (UDP) or UNIX domain sockets. Currently from the name 'open' this is completely unclear that it is a TCP socket.