### PR TITLE
Add testConnection method to ExternalDataStoreService [MC-1883]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
@@ -42,7 +42,9 @@ public interface ExternalDataStoreFactory<DS> extends AutoCloseable {
     void init(ExternalDataStoreConfig config);
 
     /**
-     * Test data store connection.
+     * Test connection of previously initialized data store.
+     *
+     * @since 5.3
      */
     boolean testConnection() throws Exception;
 

--- a/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreFactory.java
@@ -22,7 +22,7 @@ import com.hazelcast.spi.annotation.Beta;
 /**
  * Creates external datastore. Configuration is provided by {@link #init(ExternalDataStoreConfig)}.
  *
- * @param <DS> - type of the data store
+ * @param <DS> type of the data store
  * @since 5.2
  */
 @Beta
@@ -40,6 +40,11 @@ public interface ExternalDataStoreFactory<DS> extends AutoCloseable {
      * @param config configuration of the given datastore
      */
     void init(ExternalDataStoreConfig config);
+
+    /**
+     * Test data store connection.
+     */
+    boolean testConnection() throws Exception;
 
     /**
      * Closes underlying resources

--- a/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreService.java
@@ -34,6 +34,7 @@ public interface ExternalDataStoreService extends AutoCloseable {
      * @param config name of the data store factory
      * @return {@code true} if test was successful
      * @throws Exception if the test operation fails
+     * @since 5.3
      */
     boolean testConnection(ExternalDataStoreConfig config) throws Exception;
 

--- a/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/ExternalDataStoreService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.datastore;
 
+import com.hazelcast.config.ExternalDataStoreConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.spi.annotation.Beta;
 
@@ -26,6 +27,16 @@ import com.hazelcast.spi.annotation.Beta;
  */
 @Beta
 public interface ExternalDataStoreService extends AutoCloseable {
+
+    /**
+     * Tests external data store configuration.
+     *
+     * @param config name of the data store factory
+     * @return {@code true} if test was successful
+     * @throws Exception if the test operation fails
+     */
+    boolean testConnection(ExternalDataStoreConfig config) throws Exception;
+
     /**
      * Returns external data store factory with given name.
      *

--- a/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
@@ -24,6 +24,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -40,6 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Beta
 public class JdbcDataStoreFactory implements ExternalDataStoreFactory<DataSource> {
 
+    private static final int JDBC_TEST_CONNECTION_TIMEOUT_SECONDS = 1;
     private static final AtomicInteger DATA_SOURCE_COUNTER = new AtomicInteger();
 
     protected HikariDataSource sharedDataSource;
@@ -58,6 +60,14 @@ public class JdbcDataStoreFactory implements ExternalDataStoreFactory<DataSource
     @Override
     public DataSource getDataStore() {
         return config.isShared() ? sharedCloseableDataSource : CloseableDataSource.closing(doCreateDataSource());
+    }
+
+    @Override
+    public boolean testConnection() throws Exception {
+        try (CloseableDataSource dataStore = ((CloseableDataSource) getDataStore());
+             Connection connection = dataStore.getConnection()) {
+            return connection.isValid(JDBC_TEST_CONNECTION_TIMEOUT_SECONDS);
+        }
     }
 
     protected HikariDataSource doCreateDataSource() {

--- a/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/JdbcDataStoreFactory.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Beta
 public class JdbcDataStoreFactory implements ExternalDataStoreFactory<DataSource> {
 
-    private static final int JDBC_TEST_CONNECTION_TIMEOUT_SECONDS = 1;
+    private static final int JDBC_TEST_CONNECTION_TIMEOUT_SECONDS = 5;
     private static final AtomicInteger DATA_SOURCE_COUNTER = new AtomicInteger();
 
     protected HikariDataSource sharedDataSource;

--- a/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImpl.java
@@ -65,6 +65,13 @@ public class ExternalDataStoreServiceImpl implements ExternalDataStoreService {
     }
 
     @Override
+    public boolean testConnection(ExternalDataStoreConfig config) throws Exception {
+        try (ExternalDataStoreFactory<Object> factory = createFactory(config)) {
+            return factory.testConnection();
+        }
+    }
+
+    @Override
     public <DS> ExternalDataStoreFactory<DS> getExternalDataStoreFactory(String name) {
         ExternalDataStoreConfig externalDataStoreConfig = node.getConfig().getExternalDataStoreConfigs().get(name);
         if (externalDataStoreConfig == null) {

--- a/hazelcast/src/test/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datastore/impl/ExternalDataStoreServiceImplTest.java
@@ -37,7 +37,6 @@ import org.junit.runner.RunWith;
 import javax.sql.DataSource;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Properties;
 
 import static com.hazelcast.datastore.impl.HikariTestUtil.assertDataSourceClosed;
 import static com.hazelcast.datastore.impl.HikariTestUtil.assertEventuallyNoHikariThreads;
@@ -56,12 +55,10 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
 
     @Before
     public void configure() {
-        Properties properties = new Properties();
-        properties.put("jdbcUrl", "jdbc:h2:mem:" + ExternalDataStoreServiceImplTest.class.getSimpleName());
         ExternalDataStoreConfig externalDataStoreConfig = new ExternalDataStoreConfig()
                 .setName(TEST_CONFIG_NAME)
                 .setClassName("com.hazelcast.datastore.JdbcDataStoreFactory")
-                .setProperties(properties);
+                .setProperty("jdbcUrl", "jdbc:h2:mem:" + ExternalDataStoreServiceImplTest.class.getSimpleName());
         config.addExternalDataStoreConfig(externalDataStoreConfig);
         externalDataStoreService = getExternalDataStoreService();
     }
@@ -70,6 +67,38 @@ public class ExternalDataStoreServiceImplTest extends HazelcastTestSupport {
     public void tearDown() throws Exception {
         hazelcastInstanceFactory.shutdownAll();
         assertEventuallyNoHikariThreads(TEST_CONFIG_NAME);
+    }
+
+    @Test
+    public void test_connection_should_return_TRUE_when_datastore_exists() throws Exception {
+        ExternalDataStoreConfig externalDSConfig = config.getExternalDataStoreConfig(TEST_CONFIG_NAME);
+
+        assertThat(externalDataStoreService.testConnection(externalDSConfig)).isTrue();
+    }
+
+    @Test
+    public void test_connection_should_throw_when_no_db_is_present() {
+        ExternalDataStoreConfig externalDSConfig = new ExternalDataStoreConfig()
+                .setName(TEST_CONFIG_NAME)
+                .setClassName("com.hazelcast.datastore.JdbcDataStoreFactory")
+                .setProperty("jdbcUrl", "jdbc:h2:file:/random/path;IFEXISTS=TRUE");
+
+        assertThatThrownBy(() -> externalDataStoreService.testConnection(externalDSConfig))
+                .hasMessageContaining("Database \"/random/path\" not found");
+    }
+
+    @Test
+    public void test_connection_should_throw_when_no_suitable_driver_is_present() {
+        ExternalDataStoreConfig externalDSConfig = new ExternalDataStoreConfig()
+                .setName(TEST_CONFIG_NAME)
+                .setClassName("com.hazelcast.datastore.JdbcDataStoreFactory")
+                .setProperty("jdbcUrl", "jdbc:mysql:localhost:3306/random_db");
+
+
+        assertThatThrownBy(() -> externalDataStoreService.testConnection(externalDSConfig))
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(SQLException.class)
+                .hasRootCauseMessage("No suitable driver");
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ExternalDataStoreTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ExternalDataStoreTestUtil.java
@@ -61,6 +61,11 @@ final class ExternalDataStoreTestUtil {
     private static class DummyDataStoreFactory implements ExternalDataStoreFactory<Object> {
 
         @Override
+        public boolean testConnection() {
+            return true;
+        }
+
+        @Override
         public Object getDataStore() {
             return new Object();
         }


### PR DESCRIPTION
Add `testConnection` implementation for `JdbcDataStoreFactory`.
It uses [Connection#isValid(int)](https://docs.oracle.com/javase/6/docs/api/java/sql/Connection.html#isValid%28int%29) for the connection testing.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
