### PR TITLE
Add a tag with client name to the CP session metric [HZ-1942] [5.1.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
@@ -525,6 +525,8 @@ public class RaftSessionService extends AbstractCPMigrationAwareService
                 context.collect(desc.copy().withTag("endpoint", session.endpoint().toString()).withMetric("endpoint"), 0);
                 context.collect(desc.copy().withTag("endpointType", session.endpointType().toString())
                         .withMetric("endpointType"), 0);
+                context.collect(desc.copy().withTag("endpointName", session.endpointName())
+                        .withMetric("endpointName"), 0);
 
                 context.collect(desc.copy().withMetric("version"), session.version());
                 context.collect(desc.copy().withUnit(ProbeUnit.MS).withMetric("creationTime"), session.creationTime());


### PR DESCRIPTION
CP Dashboard in MC should display client names for CP sessions. For this reason, a new `endpointName` tag has been added to the CP session metric.

Backport of:  https://github.com/hazelcast/hazelcast/pull/23387

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
