### PR TITLE
Renamed GroupPropertyTest to ClusterPropertyTest.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/properties/ClusterPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/properties/ClusterPropertyTest.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class GroupPropertyTest extends HazelcastTestSupport {
+public class ClusterPropertyTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor() {


### PR DESCRIPTION
The GroupProperty was renamed to ClusterProperty, but the (useless) test wasn't renamed.
