### PR TITLE
[TPC] Duplicate nightly annotation

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/NightlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/NightlyTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.annotation;
+
+/**
+ * Annotates tests which are too slow for the PR builder and have no relevance for code coverage.
+ * <p>
+ * Will be executed in nightly builds, but are not used for code coverage measurements.
+ */
+public final class NightlyTest {
+}


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast/pull/23413 moved NightlyTest 
which in turn failed compilation of other nightly tests. This PR 
duplicates this class.

Maybe we can add dependencies between tests as an alternative.
