### PR TITLE
Refactor SqlConnector API

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/HazelcastPhysicalScan.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/HazelcastPhysicalScan.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl;
 
 import com.hazelcast.jet.sql.impl.opt.physical.PhysicalRel;
-import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
 import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
@@ -26,6 +25,4 @@ public interface HazelcastPhysicalScan extends PhysicalRel {
 
     RexNode filter();
     List<RexNode> projection();
-
-    PlanNodeSchema tableSchema();
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/HazelcastPhysicalScan.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/HazelcastPhysicalScan.java
@@ -17,13 +17,15 @@
 package com.hazelcast.jet.sql.impl;
 
 import com.hazelcast.jet.sql.impl.opt.physical.PhysicalRel;
-import com.hazelcast.sql.impl.QueryParameterMetadata;
-import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
+import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
 
 public interface HazelcastPhysicalScan extends PhysicalRel {
 
-    Expression<Boolean> filter(QueryParameterMetadata parameterMetadata);
-    List<Expression<?>> projection(QueryParameterMetadata parameterMetadata);
+    RexNode filter();
+    List<RexNode> projection();
+
+    PlanNodeSchema tableSchema();
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -397,6 +397,7 @@ public interface SqlConnector {
         /**
          * Returns the {@link DAG} that's being created.
          */
+        @Nonnull
         DAG getDag();
 
         /**
@@ -406,6 +407,7 @@ public interface SqlConnector {
          *     <li>for nested loop reader, it's the table read in the inner loop (the right join input)
          * </ul>
          */
+        @Nullable
         Table getTable();
 
         /**
@@ -416,13 +418,15 @@ public interface SqlConnector {
          *     <li>Otherwise the conversion of an input ref will fail.
          * </ul>
          */
-        Expression<Boolean> convertFilter(RexNode node);
+        @Nullable
+        Expression<Boolean> convertFilter(@Nullable RexNode node);
 
         /**
          * Converts a list of RexNodes. See also {@link #convertFilter(RexNode)}
          * for information about {@link RexInputRef} conversion.
          */
-        List<Expression<?>> convertProjection(List<RexNode> nodes);
+        @Nonnull
+        List<Expression<?>> convertProjection(@Nonnull List<RexNode> nodes);
     }
 
     /**

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -406,8 +406,10 @@ public interface SqlConnector {
          *     <li>for DML, it's the target table
          *     <li>for nested loop reader, it's the table read in the inner loop (the right join input)
          * </ul>
+         *
+         * @throws IllegalStateException if the table doesn't apply in the current context
          */
-        @Nullable
+        @Nonnull
         Table getTable();
 
         /**

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -23,13 +23,13 @@ import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.sql.impl.ExpressionUtil;
 import com.hazelcast.jet.sql.impl.JetJoinInfo;
-import com.hazelcast.jet.sql.impl.schema.HazelcastTable;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.schema.Table;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nonnull;
@@ -261,7 +261,6 @@ public interface SqlConnector {
      * {@code eventTimePolicyProvider} is not null. Streaming sources should
      * support it, batch sources don't have to.
      *
-     * @param table                   the table object
      * @param predicate               SQL expression to filter the rows
      * @param projection              the list of field names to return
      * @param eventTimePolicyProvider {@link EventTimePolicy}
@@ -269,30 +268,12 @@ public interface SqlConnector {
      */
     @Nonnull
     default Vertex fullScanReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projection,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode predicate,
+            @Nonnull List<RexNode> projection,
             @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
     ) {
         throw new UnsupportedOperationException("Full scan not supported for " + typeName());
-    }
-
-    /**
-     * Variant of {@link #fullScanReader(DAG, Table, Expression, List, FunctionEx)} that provides
-     * {@link HazelcastTable}. It is useful to get filter and projection as RexNode instead of Expression.
-     *
-     * You should override only one of the {@code fullScanReader} methods.
-     */
-    default Vertex fullScanReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table,
-            @Nonnull HazelcastTable hzTable,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projection,
-            @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
-    ) {
-        return fullScanReader(dag, table, predicate, projection, eventTimePolicyProvider);
     }
 
     /**
@@ -331,7 +312,6 @@ public interface SqlConnector {
      *         null}s and returned
      * </ul>
      *
-     * @param table      the table object
      * @param predicate  SQL expression to filter the rows
      * @param projection the list of fields to return
      * @param joinInfo   {@link JetJoinInfo}
@@ -339,10 +319,9 @@ public interface SqlConnector {
      */
     @Nonnull
     default VertexWithInputConfig nestedLoopReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projection,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode predicate,
+            @Nonnull List<RexNode> projection,
             @Nonnull JetJoinInfo joinInfo
     ) {
         throw new UnsupportedOperationException("Nested-loop join not supported for " + typeName());
@@ -351,7 +330,7 @@ public interface SqlConnector {
     default boolean isNestedLoopReaderSupported() {
         try {
             // nestedLoopReader() is supported, if the class overrides the default method in this class
-            Method m = getClass().getMethod("nestedLoopReader", DAG.class, Table.class, Expression.class, List.class,
+            Method m = getClass().getMethod("nestedLoopReader", DagBuildContext.class, RexNode.class, List.class,
                     JetJoinInfo.class);
             return m.getDeclaringClass() != SqlConnector.class;
         } catch (NoSuchMethodException e) {
@@ -363,7 +342,7 @@ public interface SqlConnector {
      * Returns the supplier for the insert processor.
      */
     @Nonnull
-    default VertexWithInputConfig insertProcessor(@Nonnull DAG dag, @Nonnull Table table) {
+    default VertexWithInputConfig insertProcessor(@Nonnull DagBuildContext context) {
         throw new UnsupportedOperationException("INSERT INTO not supported for " + typeName());
     }
 
@@ -371,7 +350,7 @@ public interface SqlConnector {
      * Returns the supplier for the sink processor.
      */
     @Nonnull
-    default Vertex sinkProcessor(@Nonnull DAG dag, @Nonnull Table table) {
+    default Vertex sinkProcessor(@Nonnull DagBuildContext context) {
         throw new UnsupportedOperationException("SINK INTO not supported for " + typeName());
     }
 
@@ -382,21 +361,11 @@ public interface SqlConnector {
      */
     @Nonnull
     default Vertex updateProcessor(
-            @Nonnull DAG dag,
-            @Nonnull Table table,
-            @Nonnull Map<String, Expression<?>> updatesByFieldNames
+            @Nonnull DagBuildContext context,
+            @Nonnull List<String> fieldNames,
+            @Nonnull List<RexNode> expressions
     ) {
         throw new UnsupportedOperationException("UPDATE not supported for " + typeName());
-    }
-
-    @Nonnull
-    default Vertex updateProcessor(
-            @Nonnull DAG dag,
-            @Nonnull Table table,
-            @Nonnull Map<String, RexNode> updates,
-            @Nonnull Map<String, Expression<?>> updatesByFieldNames
-    ) {
-        return updateProcessor(dag, table, updatesByFieldNames);
     }
 
     /**
@@ -405,7 +374,7 @@ public interface SqlConnector {
      * returned by {@link #getPrimaryKey(Table)}.
      */
     @Nonnull
-    default Vertex deleteProcessor(@Nonnull DAG dag, @Nonnull Table table) {
+    default Vertex deleteProcessor(@Nonnull DagBuildContext context) {
         throw new UnsupportedOperationException("DELETE not supported for " + typeName());
     }
 
@@ -422,6 +391,38 @@ public interface SqlConnector {
     @Nonnull
     default List<String> getPrimaryKey(Table table) {
         throw new UnsupportedOperationException("PRIMARY KEY not supported by connector: " + typeName());
+    }
+
+    interface DagBuildContext {
+        /**
+         * Returns the {@link DAG} that's being created.
+         */
+        DAG getDag();
+
+        /**
+         * Returns the context table. It is:<ul>
+         *     <li>for scans, it's the scanned table
+         *     <li>for DML, it's the target table
+         *     <li>for nested loop reader, it's the table read in the inner loop (the right join input)
+         * </ul>
+         */
+        Table getTable();
+
+        /**
+         * Converts a boolean RexNode. When evaluating a {@link RexInputRef},
+         * this context is assumed:<ul>
+         *     <li>If a table is set (see {@link #getTable()}), then it's assumed that it's that table's fields
+         *     <li>If it's a single-input rel, then it's then input
+         *     <li>Otherwise the conversion of an input ref will fail.
+         * </ul>
+         */
+        Expression<Boolean> convertFilter(RexNode node);
+
+        /**
+         * Converts a list of RexNodes. See also {@link #convertFilter(RexNode)}
+         * for information about {@link RexInputRef} conversion.
+         */
+        List<Expression<?>> convertProjection(List<RexNode> nodes);
     }
 
     /**

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/file/FileSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/file/FileSqlConnector.java
@@ -17,18 +17,17 @@
 package com.hazelcast.jet.sql.impl.connector.file;
 
 import com.hazelcast.function.FunctionEx;
-import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.jet.sql.impl.connector.SqlProcessors;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.QueryException;
-import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.schema.Table;
+import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -130,32 +129,31 @@ public class FileSqlConnector implements SqlConnector {
     @Nonnull
     @Override
     public Vertex fullScanReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table0,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projections,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode predicate,
+            @Nonnull List<RexNode> projection,
             @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
     ) {
         if (eventTimePolicyProvider != null) {
             throw QueryException.error("Ordering functions are not supported on top of " + TYPE_NAME + " mappings");
         }
 
-        FileTable table = (FileTable) table0;
+        FileTable table = (FileTable) context.getTable();
 
-        Vertex vStart = dag.newUniqueVertex(table.toString(), table.processorMetaSupplier());
+        Vertex vStart = context.getDag().newUniqueVertex(table.toString(), table.processorMetaSupplier());
 
-        Vertex vEnd = dag.newUniqueVertex(
+        Vertex vEnd = context.getDag().newUniqueVertex(
                 "Project(" + table + ")",
                 SqlProcessors.rowProjector(
                         table.paths(),
                         table.types(),
                         table.queryTargetSupplier(),
-                        predicate,
-                        projections
+                        context.convertFilter(predicate),
+                        context.convertProjection(projection)
                 )
         );
 
-        dag.edge(between(vStart, vEnd).isolated());
+        context.getDag().edge(between(vStart, vEnd).isolated());
         return vEnd;
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl.connector.generator;
 
 import com.hazelcast.function.FunctionEx;
-import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.Vertex;
@@ -33,6 +32,7 @@ import com.hazelcast.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.schema.Table;
 import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -91,19 +91,18 @@ class SeriesSqlConnector implements SqlConnector {
     @Nonnull
     @Override
     public Vertex fullScanReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table0,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projections,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode predicate,
+            @Nonnull List<RexNode> projection,
             @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
     ) {
         if (eventTimePolicyProvider != null) {
             throw QueryException.error("Ordering functions are not supported on top of " + TYPE_NAME + " mappings");
         }
 
-        SeriesTable table = (SeriesTable) table0;
-        BatchSource<JetSqlRow> source = table.items(predicate, projections);
+        SeriesTable table = (SeriesTable) context.getTable();
+        BatchSource<JetSqlRow> source = table.items(context.convertFilter(predicate), context.convertProjection(projection));
         ProcessorMetaSupplier pms = ((BatchSourceTransform<JetSqlRow>) source).metaSupplier;
-        return dag.newUniqueVertex(table.toString(), pms);
+        return context.getDag().newUniqueVertex(table.toString(), pms);
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl.connector.generator;
 
 import com.hazelcast.function.FunctionEx;
-import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.Vertex;
@@ -32,6 +31,7 @@ import com.hazelcast.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.schema.Table;
 import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -90,19 +90,18 @@ public class StreamSqlConnector implements SqlConnector {
     @Nonnull
     @Override
     public Vertex fullScanReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table0,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projections,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode predicate,
+            @Nonnull List<RexNode> projection,
             @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
     ) {
         if (eventTimePolicyProvider != null) {
             throw QueryException.error("Ordering functions are not supported on top of " + TYPE_NAME + " mappings");
         }
 
-        StreamTable table = (StreamTable) table0;
-        StreamSourceTransform<JetSqlRow> source = (StreamSourceTransform<JetSqlRow>) table.items(predicate, projections);
+        StreamTable table = (StreamTable) context.getTable();
+        StreamSourceTransform<JetSqlRow> source = (StreamSourceTransform<JetSqlRow>) table.items(context.convertFilter(predicate), context.convertProjection(projection));
         ProcessorMetaSupplier pms = source.metaSupplierFn.apply(EventTimePolicy.noEventTime());
-        return dag.newUniqueVertex(table.toString(), pms);
+        return context.getDag().newUniqueVertex(table.toString(), pms);
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
@@ -100,7 +100,8 @@ public class StreamSqlConnector implements SqlConnector {
         }
 
         StreamTable table = (StreamTable) context.getTable();
-        StreamSourceTransform<JetSqlRow> source = (StreamSourceTransform<JetSqlRow>) table.items(context.convertFilter(predicate), context.convertProjection(projection));
+        StreamSourceTransform<JetSqlRow> source = (StreamSourceTransform<JetSqlRow>) table.items(
+                context.convertFilter(predicate), context.convertProjection(projection));
         ProcessorMetaSupplier pms = source.metaSupplierFn.apply(EventTimePolicy.noEventTime());
         return context.getDag().newUniqueVertex(table.toString(), pms);
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
@@ -102,7 +102,8 @@ final class InfoSchemaConnector implements SqlConnector {
         List<Expression<?>> convertedProjection = context.convertProjection(projection);
         return context.getDag().newUniqueVertex(
                 table.toString(),
-                forceTotalParallelismOne(ProcessorSupplier.of(() -> new StaticSourceP(convertedPredicate, convertedProjection, rows)))
+                forceTotalParallelismOne(ProcessorSupplier.of(() ->
+                        new StaticSourceP(convertedPredicate, convertedProjection, rows)))
         );
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
@@ -20,7 +20,6 @@ import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.core.AbstractProcessor;
-import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Vertex;
@@ -33,6 +32,7 @@ import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.schema.Table;
+import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -87,21 +87,22 @@ final class InfoSchemaConnector implements SqlConnector {
 
     @Nonnull @Override
     public Vertex fullScanReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table0,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projection,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode predicate,
+            @Nonnull List<RexNode> projection,
             @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
     ) {
         if (eventTimePolicyProvider != null) {
             throw QueryException.error("Ordering functions are not supported on top of " + TYPE_NAME + " mappings");
         }
 
-        InfoSchemaTable table = (InfoSchemaTable) table0;
+        InfoSchemaTable table = (InfoSchemaTable) context.getTable();
         List<Object[]> rows = table.rows();
-        return dag.newUniqueVertex(
+        Expression<Boolean> convertedPredicate = context.convertFilter(predicate);
+        List<Expression<?>> convertedProjection = context.convertProjection(projection);
+        return context.getDag().newUniqueVertex(
                 table.toString(),
-                forceTotalParallelismOne(ProcessorSupplier.of(() -> new StaticSourceP(predicate, projection, rows)))
+                forceTotalParallelismOne(ProcessorSupplier.of(() -> new StaticSourceP(convertedPredicate, convertedProjection, rows)))
         );
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectQueryBuilder.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectQueryBuilder.java
@@ -34,7 +34,7 @@ class SelectQueryBuilder {
     private final ParamCollectingVisitor paramCollectingVisitor = new ParamCollectingVisitor();
 
     @SuppressWarnings("ExecutableStatementCount")
-    public SelectQueryBuilder(Table table0, RexNode filter, List<RexNode> projects) {
+    SelectQueryBuilder(Table table0, RexNode filter, List<RexNode> projects) {
         JdbcTable table = (JdbcTable) table0;
         SqlDialect dialect = table.sqlDialect();
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectQueryBuilder.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectQueryBuilder.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.jet.sql.impl.connector.jdbc;
 
-import com.hazelcast.jet.sql.impl.schema.HazelcastTable;
+import com.hazelcast.sql.impl.schema.Table;
 import org.apache.calcite.rel.rel2sql.SqlImplementor.SimpleContext;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlDialect;
@@ -34,8 +34,8 @@ class SelectQueryBuilder {
     private final ParamCollectingVisitor paramCollectingVisitor = new ParamCollectingVisitor();
 
     @SuppressWarnings("ExecutableStatementCount")
-    SelectQueryBuilder(HazelcastTable hzTable) {
-        JdbcTable table = hzTable.getTarget();
+    public SelectQueryBuilder(Table table0, RexNode filter, List<RexNode> projects) {
+        JdbcTable table = (JdbcTable) table0;
         SqlDialect dialect = table.sqlDialect();
 
         SimpleContext simpleContext = new SimpleContext(dialect, value -> {
@@ -43,7 +43,6 @@ class SelectQueryBuilder {
             return new SqlIdentifier(field.externalName(), SqlParserPos.ZERO);
         });
 
-        RexNode filter = hzTable.getFilter();
         String predicateFragment = null;
         if (filter != null) {
             SqlNode sqlNode = simpleContext.toSql(null, filter);
@@ -52,7 +51,6 @@ class SelectQueryBuilder {
         }
 
         String projectionFragment = null;
-        List<RexNode> projects = hzTable.getProjects();
         if (!projects.isEmpty()) {
             projectionFragment = projects.stream()
                                          .map(proj -> simpleContext.toSql(null, proj).toSqlString(dialect).toString())

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.sql.impl.connector.kafka;
 
 import com.hazelcast.function.FunctionEx;
-import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.Vertex;
@@ -33,13 +32,13 @@ import com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolver;
 import com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolvers;
 import com.hazelcast.jet.sql.impl.connector.keyvalue.KvProcessors;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.sql.impl.schema.ConstantTableStatistics;
 import com.hazelcast.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.schema.Table;
 import com.hazelcast.sql.impl.schema.TableField;
+import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -120,15 +119,14 @@ public class KafkaSqlConnector implements SqlConnector {
 
     @Nonnull @Override
     public Vertex fullScanReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table0,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projections,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode predicate,
+            @Nonnull List<RexNode> projection,
             @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
     ) {
-        KafkaTable table = (KafkaTable) table0;
+        KafkaTable table = (KafkaTable) context.getTable();
 
-        return dag.newUniqueVertex(
+        return context.getDag().newUniqueVertex(
                 table.toString(),
                 ProcessorMetaSupplier.of(
                         StreamKafkaP.PREFERRED_LOCAL_PARALLELISM,
@@ -140,28 +138,28 @@ public class KafkaSqlConnector implements SqlConnector {
                                 table.types(),
                                 table.keyQueryDescriptor(),
                                 table.valueQueryDescriptor(),
-                                predicate,
-                                projections
+                                context.convertFilter(predicate),
+                                context.convertProjection(projection)
                         )
                 )
         );
     }
 
     @Nonnull @Override
-    public VertexWithInputConfig insertProcessor(@Nonnull DAG dag, @Nonnull Table table) {
-        return new VertexWithInputConfig(writeProcessor(dag, table));
+    public VertexWithInputConfig insertProcessor(@Nonnull DagBuildContext context) {
+        return new VertexWithInputConfig(writeProcessor(context));
     }
 
     @Nonnull @Override
-    public Vertex sinkProcessor(@Nonnull DAG dag, @Nonnull Table table) {
-        return writeProcessor(dag, table);
+    public Vertex sinkProcessor(@Nonnull DagBuildContext context) {
+        return writeProcessor(context);
     }
 
     @Nonnull
-    private Vertex writeProcessor(DAG dag, Table table0) {
-        KafkaTable table = (KafkaTable) table0;
+    private Vertex writeProcessor(@Nonnull DagBuildContext context) {
+        KafkaTable table = (KafkaTable) context.getTable();
 
-        Vertex vStart = dag.newUniqueVertex(
+        Vertex vStart = context.getDag().newUniqueVertex(
                 "Project(" + table + ")",
                 KvProcessors.entryProjector(
                         table.paths(),
@@ -175,7 +173,7 @@ public class KafkaSqlConnector implements SqlConnector {
         // TODO: eliminate the project vertex altogether and do the projecting in the sink directly
         vStart.localParallelism(1);
 
-        Vertex vEnd = dag.newUniqueVertex(
+        Vertex vEnd = context.getDag().newUniqueVertex(
                 table.toString(),
                 KafkaProcessors.<Entry<Object, Object>, Object, Object>writeKafkaP(
                         table.kafkaProducerProperties(),
@@ -186,7 +184,7 @@ public class KafkaSqlConnector implements SqlConnector {
                 )
         );
 
-        dag.edge(between(vStart, vEnd));
+        context.getDag().edge(between(vStart, vEnd));
         return vStart;
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -22,7 +22,6 @@ import com.hazelcast.config.IndexType;
 import com.hazelcast.function.ComparatorEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.Edge;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
@@ -45,7 +44,6 @@ import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.exec.scan.MapIndexScanMetadata;
 import com.hazelcast.sql.impl.exec.scan.index.IndexFilter;
-import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.row.JetSqlRow;
@@ -56,6 +54,7 @@ import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.schema.map.MapTableIndex;
 import com.hazelcast.sql.impl.schema.map.MapTableUtils;
 import com.hazelcast.sql.impl.schema.map.PartitionedMapTable;
+import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -165,53 +164,51 @@ public class IMapSqlConnector implements SqlConnector {
     @Nonnull
     @Override
     public Vertex fullScanReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table0,
-            @Nullable Expression<Boolean> filter,
-            @Nonnull List<Expression<?>> projection,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode filter,
+            @Nonnull List<RexNode> projection,
             @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
     ) {
         if (eventTimePolicyProvider != null) {
             throw QueryException.error("Ordering functions are not supported on top of " + TYPE_NAME + " mappings");
         }
 
-        PartitionedMapTable table = (PartitionedMapTable) table0;
+        PartitionedMapTable table = (PartitionedMapTable) context.getTable();
 
-        Vertex vStart = dag.newUniqueVertex(
+        Vertex vStart = context.getDag().newUniqueVertex(
                 toString(table),
                 SourceProcessors.readMapP(table.getMapName())
         );
 
-        Vertex vEnd = dag.newUniqueVertex(
+        Vertex vEnd = context.getDag().newUniqueVertex(
                 "Project(" + toString(table) + ")",
                 rowProjector(
                         table.paths(),
                         table.types(),
                         table.getKeyDescriptor(),
                         table.getValueDescriptor(),
-                        filter,
-                        projection
+                        context.convertFilter(filter),
+                        context.convertProjection(projection)
                 )
         );
 
-        dag.edge(Edge.from(vStart).to(vEnd).isolated());
+        context.getDag().edge(Edge.from(vStart).to(vEnd).isolated());
         return vEnd;
     }
 
     @Nonnull
     @SuppressWarnings("checkstyle:ParameterNumber")
     public Vertex indexScanReader(
-            @Nonnull DAG dag,
+            @Nonnull DagBuildContext context,
             @Nonnull Address localMemberAddress,
-            @Nonnull Table table0,
             @Nonnull MapTableIndex tableIndex,
-            @Nullable Expression<Boolean> remainingFilter,
-            @Nonnull List<Expression<?>> projection,
+            @Nullable RexNode remainingFilter,
+            @Nonnull List<RexNode> projection,
             @Nullable IndexFilter indexFilter,
             @Nullable ComparatorEx<JetSqlRow> comparator,
             boolean descending
     ) {
-        PartitionedMapTable table = (PartitionedMapTable) table0;
+        PartitionedMapTable table = (PartitionedMapTable) context.getTable();
         MapIndexScanMetadata indexScanMetadata = new MapIndexScanMetadata(
                 table.getMapName(),
                 tableIndex.getName(),
@@ -220,13 +217,13 @@ public class IMapSqlConnector implements SqlConnector {
                 Arrays.asList(table.paths()),
                 Arrays.asList(table.types()),
                 indexFilter,
-                projection,
-                remainingFilter,
+                context.convertProjection(projection),
+                context.convertFilter(remainingFilter),
                 comparator,
                 descending
         );
 
-        Vertex scanner = dag.newUniqueVertex(
+        Vertex scanner = context.getDag().newUniqueVertex(
                 "Index(" + toString(table) + ")",
                 readMapIndexSupplier(indexScanMetadata)
         );
@@ -235,7 +232,7 @@ public class IMapSqlConnector implements SqlConnector {
         scanner.localParallelism(1);
 
         if (tableIndex.getType() == IndexType.SORTED) {
-            Vertex sorter = dag.newUniqueVertex(
+            Vertex sorter = context.getDag().newUniqueVertex(
                     "SortCombine",
                     ProcessorMetaSupplier.forceTotalParallelismOne(
                             ProcessorSupplier.of(mapP(FunctionEx.identity())),
@@ -244,7 +241,7 @@ public class IMapSqlConnector implements SqlConnector {
             );
 
             assert comparator != null;
-            dag.edge(between(scanner, sorter)
+            context.getDag().edge(between(scanner, sorter)
                     .ordered(comparator)
                     .distributeTo(localMemberAddress)
                     .allToOne("")
@@ -257,35 +254,31 @@ public class IMapSqlConnector implements SqlConnector {
     @Nonnull
     @Override
     public VertexWithInputConfig nestedLoopReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table0,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projections,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode predicate,
+            @Nonnull List<RexNode> projections,
             @Nonnull JetJoinInfo joinInfo
     ) {
-        PartitionedMapTable table = (PartitionedMapTable) table0;
+        PartitionedMapTable table = (PartitionedMapTable) context.getTable();
 
         KvRowProjector.Supplier rightRowProjectorSupplier = KvRowProjector.supplier(
                 table.paths(),
                 table.types(),
                 table.getKeyDescriptor(),
                 table.getValueDescriptor(),
-                predicate,
-                projections
+                context.convertFilter(predicate),
+                context.convertProjection(projections)
         );
 
-        return Joiner.join(dag, table.getMapName(), toString(table), joinInfo, rightRowProjectorSupplier);
+        return Joiner.join(context.getDag(), table.getMapName(), toString(table), joinInfo, rightRowProjectorSupplier);
     }
 
     @Nonnull
     @Override
-    public VertexWithInputConfig insertProcessor(
-            @Nonnull DAG dag,
-            @Nonnull Table table0
-    ) {
-        PartitionedMapTable table = (PartitionedMapTable) table0;
+    public VertexWithInputConfig insertProcessor(@Nonnull DagBuildContext context) {
+        PartitionedMapTable table = (PartitionedMapTable) context.getTable();
 
-        Vertex vertex = dag.newUniqueVertex(
+        Vertex vertex = context.getDag().newUniqueVertex(
                 toString(table),
                 new InsertProcessorSupplier(
                         table.getMapName(),
@@ -303,13 +296,10 @@ public class IMapSqlConnector implements SqlConnector {
 
     @Nonnull
     @Override
-    public Vertex sinkProcessor(
-            @Nonnull DAG dag,
-            @Nonnull Table table0
-    ) {
-        PartitionedMapTable table = (PartitionedMapTable) table0;
+    public Vertex sinkProcessor(@Nonnull DagBuildContext context) {
+        PartitionedMapTable table = (PartitionedMapTable) context.getTable();
 
-        Vertex vStart = dag.newUniqueVertex(
+        Vertex vStart = context.getDag().newUniqueVertex(
                 "Project(" + toString(table) + ")",
                 KvProcessors.entryProjector(
                         table.paths(),
@@ -320,39 +310,39 @@ public class IMapSqlConnector implements SqlConnector {
                 )
         );
 
-        Vertex vEnd = dag.newUniqueVertex(
+        Vertex vEnd = context.getDag().newUniqueVertex(
                 toString(table),
                 writeMapP(table.getMapName())
         );
 
-        dag.edge(between(vStart, vEnd));
+        context.getDag().edge(between(vStart, vEnd));
         return vStart;
     }
 
     @Nonnull
     @Override
     public Vertex updateProcessor(
-            @Nonnull DAG dag,
-            @Nonnull Table table0,
-            @Nonnull Map<String, Expression<?>> updatesByFieldNames
+            @Nonnull DagBuildContext context,
+            @Nonnull List<String> fieldNames,
+            @Nonnull List<RexNode> expressions
     ) {
-        PartitionedMapTable table = (PartitionedMapTable) table0;
+        PartitionedMapTable table = (PartitionedMapTable) context.getTable();
 
-        return dag.newUniqueVertex(
+        return context.getDag().newUniqueVertex(
                 "Update(" + toString(table) + ")",
                 new UpdateProcessorSupplier(
                         table.getMapName(),
-                        UpdatingEntryProcessor.supplier(table, updatesByFieldNames)
+                        UpdatingEntryProcessor.supplier(table, fieldNames, context.convertProjection(expressions))
                 )
         );
     }
 
     @Nonnull
     @Override
-    public Vertex deleteProcessor(@Nonnull DAG dag, @Nonnull Table table0) {
-        PartitionedMapTable table = (PartitionedMapTable) table0;
+    public Vertex deleteProcessor(@Nonnull DagBuildContext context) {
+        PartitionedMapTable table = (PartitionedMapTable) context.getTable();
 
-        return dag.newUniqueVertex(
+        return context.getDag().newUniqueVertex(
                 toString(table),
                 // TODO do a simpler, specialized deleting-only processor
                 updateMapP(table.getMapName(), (FunctionEx<JetSqlRow, Object>) row -> {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CalcPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CalcPhysicalRel.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.jet.sql.impl.opt.physical;
 
+import com.hazelcast.jet.sql.impl.validate.types.HazelcastTypeUtils;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
-import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import org.apache.calcite.plan.RelOptCluster;
@@ -43,20 +43,17 @@ public class CalcPhysicalRel extends Calc implements PhysicalRel {
         super(cluster, traits, input, program);
     }
 
-    public Expression<Boolean> filter(QueryParameterMetadata parameterMetadata) {
-        PlanNodeSchema schema = ((PhysicalRel) getInput()).schema(parameterMetadata);
-        return filter(schema, program.expandLocalRef(program.getCondition()), parameterMetadata);
+    public RexNode filter() {
+        return program.expandLocalRef(program.getCondition());
     }
 
-    public List<Expression<?>> projection(QueryParameterMetadata parameterMetadata) {
-        PlanNodeSchema inputSchema = ((PhysicalRel) getInput()).schema(parameterMetadata);
-        List<RexNode> projectList = program.expandList(program.getProjectList());
-        return project(inputSchema, projectList, parameterMetadata);
+    public List<RexNode> projection() {
+        return program.expandList(program.getProjectList());
     }
 
     @Override
     public PlanNodeSchema schema(QueryParameterMetadata parameterMetadata) {
-        List<QueryDataType> fieldTypes = toList(projection(parameterMetadata), Expression::getType);
+        List<QueryDataType> fieldTypes = toList(projection(), n -> HazelcastTypeUtils.toHazelcastType(n.getType()));
         return new PlanNodeSchema(fieldTypes);
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateTopLevelDagVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateTopLevelDagVisitor.java
@@ -183,7 +183,8 @@ public class CreateTopLevelDagVisitor extends CreateDagVisitorBase<Vertex> {
 
         dagBuildContext.setTable(table);
         dagBuildContext.setRel(rel);
-        Vertex vertex = getJetSqlConnector(table).updateProcessor(dagBuildContext, rel.getUpdateColumnList(), rel.getSourceExpressionList());
+        Vertex vertex = getJetSqlConnector(table).updateProcessor(
+                dagBuildContext, rel.getUpdateColumnList(), rel.getSourceExpressionList());
         connectInput(rel.getInput(), vertex, null);
         return vertex;
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateTopLevelDagVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateTopLevelDagVisitor.java
@@ -490,8 +490,6 @@ public class CreateTopLevelDagVisitor extends CreateDagVisitorBase<Vertex> {
 
     @Override
     public Vertex onHashJoin(JoinHashPhysicalRel rel) {
-        dagBuildContext.setTable(null);
-        dagBuildContext.setRel(rel);
         JetJoinInfo joinInfo = rel.joinInfo(dagBuildContext.getParameterMetadata());
 
         Vertex joinVertex = dag.newUniqueVertex(
@@ -507,8 +505,6 @@ public class CreateTopLevelDagVisitor extends CreateDagVisitorBase<Vertex> {
 
     @Override
     public Vertex onStreamToStreamJoin(StreamToStreamJoinPhysicalRel rel) {
-        dagBuildContext.setTable(null);
-        dagBuildContext.setRel(rel);
         JetJoinInfo joinInfo = rel.joinInfo(dagBuildContext.getParameterMetadata());
 
         Map<Byte, ToLongFunctionEx<JetSqlRow>> leftExtractors = new HashMap<>();
@@ -594,8 +590,6 @@ public class CreateTopLevelDagVisitor extends CreateDagVisitorBase<Vertex> {
 
         Expression<?> fetch = ConstantExpression.create(Long.MAX_VALUE, QueryDataType.BIGINT);
         Expression<?> offset = ConstantExpression.create(0L, QueryDataType.BIGINT);
-        dagBuildContext.setTable(null);
-        dagBuildContext.setRel(rootRel);
 
         // We support only top-level LIMIT ... OFFSET.
         if (input instanceof LimitPhysicalRel) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DagBuildContextImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DagBuildContextImpl.java
@@ -48,9 +48,12 @@ public class DagBuildContextImpl implements DagBuildContext {
         return dag;
     }
 
-    @Nullable
+    @Nonnull
     @Override
     public Table getTable() {
+        if (table == null) {
+            throw new IllegalArgumentException("table not available");
+        }
         return table;
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DagBuildContextImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DagBuildContextImpl.java
@@ -42,11 +42,13 @@ public class DagBuildContextImpl implements DagBuildContext {
         this.parameterMetadata = parameterMetadata;
     }
 
+    @Nonnull
     @Override
     public DAG getDag() {
         return dag;
     }
 
+    @Nullable
     @Override
     public Table getTable() {
         return table;
@@ -60,17 +62,19 @@ public class DagBuildContextImpl implements DagBuildContext {
         this.table = table;
     }
 
+    @Nullable
     @SuppressWarnings("unchecked")
     @Override
-    public Expression<Boolean> convertFilter(RexNode node) {
+    public Expression<Boolean> convertFilter(@Nullable RexNode node) {
         if (node == null) {
             return null;
         }
         return (Expression<Boolean>) node.accept(createVisitor());
     }
 
+    @Nonnull
     @Override
-    public List<Expression<?>> convertProjection(List<RexNode> nodes) {
+    public List<Expression<?>> convertProjection(@Nonnull List<RexNode> nodes) {
         RexVisitor<Expression<?>> visitor = createVisitor();
         return Util.toList(nodes, node -> node.accept(visitor));
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DagBuildContextImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DagBuildContextImpl.java
@@ -52,7 +52,7 @@ public class DagBuildContextImpl implements DagBuildContext {
     @Override
     public Table getTable() {
         if (table == null) {
-            throw new IllegalArgumentException("table not available");
+            throw new IllegalStateException("table not available");
         }
         return table;
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DagBuildContextImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/DagBuildContextImpl.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.opt.physical;
+
+import com.hazelcast.jet.core.DAG;
+import com.hazelcast.jet.impl.util.Util;
+import com.hazelcast.jet.sql.impl.connector.SqlConnector.DagBuildContext;
+import com.hazelcast.jet.sql.impl.opt.OptUtils;
+import com.hazelcast.sql.impl.QueryParameterMetadata;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.plan.node.PlanNodeFieldTypeProvider;
+import com.hazelcast.sql.impl.schema.Table;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexVisitor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class DagBuildContextImpl implements DagBuildContext {
+    private final DAG dag;
+    private final QueryParameterMetadata parameterMetadata;
+    private Table table;
+    private PhysicalRel rel;
+
+    public DagBuildContextImpl(DAG dag, QueryParameterMetadata parameterMetadata) {
+        this.dag = dag;
+        this.parameterMetadata = parameterMetadata;
+    }
+
+    @Override
+    public DAG getDag() {
+        return dag;
+    }
+
+    @Override
+    public Table getTable() {
+        return table;
+    }
+
+    public void setRel(@Nullable PhysicalRel rel) {
+        this.rel = rel;
+    }
+
+    public void setTable(Table table) {
+        this.table = table;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Expression<Boolean> convertFilter(RexNode node) {
+        if (node == null) {
+            return null;
+        }
+        return (Expression<Boolean>) node.accept(createVisitor());
+    }
+
+    @Override
+    public List<Expression<?>> convertProjection(List<RexNode> nodes) {
+        RexVisitor<Expression<?>> visitor = createVisitor();
+        return Util.toList(nodes, node -> node.accept(visitor));
+    }
+
+    @Nonnull
+    private RexVisitor<Expression<?>> createVisitor() {
+        PlanNodeFieldTypeProvider schema;
+        if (table != null) {
+            schema = OptUtils.schema(table);
+        } else if (rel.getInputs().size() != 1) {
+            schema = PlanNodeFieldTypeProvider.FAILING_FIELD_TYPE_PROVIDER;
+        } else {
+            schema = ((PhysicalRel) rel.getInput(0)).schema(parameterMetadata);
+        }
+        return OptUtils.createRexToExpressionVisitor(schema, parameterMetadata);
+    }
+
+    public QueryParameterMetadata getParameterMetadata() {
+        return parameterMetadata;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/FullScanPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/FullScanPhysicalRel.java
@@ -26,6 +26,7 @@ import com.hazelcast.jet.sql.impl.opt.FullScan;
 import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.jet.sql.impl.opt.cost.CostUtils;
 import com.hazelcast.jet.sql.impl.schema.HazelcastTable;
+import com.hazelcast.jet.sql.impl.validate.types.HazelcastTypeUtils;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
@@ -52,6 +53,7 @@ import static com.hazelcast.jet.sql.impl.opt.cost.CostUtils.TABLE_SCAN_CPU_MULTI
 public class FullScanPhysicalRel extends FullScan implements HazelcastPhysicalScan {
 
     /**
+     * TODO [viliam] fix
      * See {@link CalciteSqlOptimizer#uniquifyScans}.
      */
     private final int discriminator;
@@ -69,26 +71,23 @@ public class FullScanPhysicalRel extends FullScan implements HazelcastPhysicalSc
     }
 
     @Override
-    public Expression<Boolean> filter(QueryParameterMetadata parameterMetadata) {
-        PlanNodeSchema schema = OptUtils.schema(getTable());
-
-        RexNode filter = getTable().unwrap(HazelcastTable.class).getFilter();
-
-        return filter(schema, filter, parameterMetadata);
+    public RexNode filter() {
+        return getTable().unwrap(HazelcastTable.class).getFilter();
     }
 
     @Override
-    public List<Expression<?>> projection(QueryParameterMetadata parameterMetadata) {
-        PlanNodeSchema schema = OptUtils.schema(getTable());
+    public List<RexNode> projection() {
+        return getTable().unwrap(HazelcastTable.class).getProjects();
+    }
 
-        HazelcastTable table = getTable().unwrap(HazelcastTable.class);
-
-        return project(schema, table.getProjects(), parameterMetadata);
+    @Override
+    public PlanNodeSchema tableSchema() {
+        return OptUtils.schema(getTable());
     }
 
     @Override
     public PlanNodeSchema schema(QueryParameterMetadata parameterMetadata) {
-        List<QueryDataType> fieldTypes = toList(projection(parameterMetadata), Expression::getType);
+        List<QueryDataType> fieldTypes = toList(projection(), rexNode -> HazelcastTypeUtils.toHazelcastType(rexNode.getType()));
         return new PlanNodeSchema(fieldTypes);
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/FullScanPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/FullScanPhysicalRel.java
@@ -23,7 +23,6 @@ import com.hazelcast.jet.sql.impl.CalciteSqlOptimizer;
 import com.hazelcast.jet.sql.impl.HazelcastPhysicalScan;
 import com.hazelcast.jet.sql.impl.aggregate.WindowUtils;
 import com.hazelcast.jet.sql.impl.opt.FullScan;
-import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.jet.sql.impl.opt.cost.CostUtils;
 import com.hazelcast.jet.sql.impl.schema.HazelcastTable;
 import com.hazelcast.jet.sql.impl.validate.types.HazelcastTypeUtils;
@@ -53,8 +52,7 @@ import static com.hazelcast.jet.sql.impl.opt.cost.CostUtils.TABLE_SCAN_CPU_MULTI
 public class FullScanPhysicalRel extends FullScan implements HazelcastPhysicalScan {
 
     /**
-     * TODO [viliam] fix
-     * See {@link CalciteSqlOptimizer#uniquifyScans}.
+     * See {@link CalciteSqlOptimizer#postOptimizationRewrites(PhysicalRel)}.
      */
     private final int discriminator;
 
@@ -78,11 +76,6 @@ public class FullScanPhysicalRel extends FullScan implements HazelcastPhysicalSc
     @Override
     public List<RexNode> projection() {
         return getTable().unwrap(HazelcastTable.class).getProjects();
-    }
-
-    @Override
-    public PlanNodeSchema tableSchema() {
-        return OptUtils.schema(getTable());
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
@@ -24,9 +24,9 @@ import com.hazelcast.jet.sql.impl.opt.FieldCollation;
 import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.jet.sql.impl.opt.cost.CostUtils;
 import com.hazelcast.jet.sql.impl.schema.HazelcastTable;
+import com.hazelcast.jet.sql.impl.validate.types.HazelcastTypeUtils;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.exec.scan.index.IndexFilter;
-import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
 import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.sql.impl.schema.map.MapTableIndex;
@@ -89,6 +89,11 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
         return remainderExp;
     }
 
+    @Override
+    public PlanNodeSchema tableSchema() {
+        return OptUtils.schema(getTable());
+    }
+
     public ComparatorEx<JetSqlRow> getComparator() {
         if (index.getType() == IndexType.SORTED) {
             RelCollation relCollation = getTraitSet().getTrait(RelCollationTraitDef.INSTANCE);
@@ -115,17 +120,13 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
     }
 
     @Override
-    public Expression<Boolean> filter(QueryParameterMetadata parameterMetadata) {
-        PlanNodeSchema schema = OptUtils.schema(getTable());
-        return filter(schema, remainderExp, parameterMetadata);
+    public RexNode filter() {
+        return remainderExp;
     }
 
     @Override
-    public List<Expression<?>> projection(QueryParameterMetadata parameterMetadata) {
-        PlanNodeSchema schema = OptUtils.schema(getTable());
-
-        HazelcastTable table = getTable().unwrap(HazelcastTable.class);
-        return project(schema, table.getProjects(), parameterMetadata);
+    public List<RexNode> projection() {
+        return getTable().unwrap(HazelcastTable.class).getProjects();
     }
 
     public HazelcastTable getTableUnwrapped() {
@@ -134,7 +135,7 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
 
     @Override
     public PlanNodeSchema schema(QueryParameterMetadata parameterMetadata) {
-        List<QueryDataType> fieldTypes = toList(projection(parameterMetadata), Expression::getType);
+        List<QueryDataType> fieldTypes = toList(projection(), rexNode -> HazelcastTypeUtils.toHazelcastType(rexNode.getType()));
         return new PlanNodeSchema(fieldTypes);
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
@@ -21,7 +21,6 @@ import com.hazelcast.function.ComparatorEx;
 import com.hazelcast.jet.sql.impl.ExpressionUtil;
 import com.hazelcast.jet.sql.impl.HazelcastPhysicalScan;
 import com.hazelcast.jet.sql.impl.opt.FieldCollation;
-import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.jet.sql.impl.opt.cost.CostUtils;
 import com.hazelcast.jet.sql.impl.schema.HazelcastTable;
 import com.hazelcast.jet.sql.impl.validate.types.HazelcastTypeUtils;
@@ -87,11 +86,6 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
 
     public RexNode getRemainderExp() {
         return remainderExp;
-    }
-
-    @Override
-    public PlanNodeSchema tableSchema() {
-        return OptUtils.schema(getTable());
     }
 
     public ComparatorEx<JetSqlRow> getComparator() {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/JoinNestedLoopPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/JoinNestedLoopPhysicalRel.java
@@ -53,12 +53,12 @@ public class JoinNestedLoopPhysicalRel extends JoinPhysicalRel {
         super(cluster, traitSet, left, right, condition, joinType);
     }
 
-    public Expression<Boolean> rightFilter(QueryParameterMetadata parameterMetadata) {
-        return ((HazelcastPhysicalScan) getRight()).filter(parameterMetadata);
+    public RexNode rightFilter() {
+        return ((HazelcastPhysicalScan) getRight()).filter();
     }
 
-    public List<Expression<?>> rightProjection(QueryParameterMetadata parameterMetadata) {
-        return ((HazelcastPhysicalScan) getRight()).projection(parameterMetadata);
+    public List<RexNode> rightProjection() {
+        return ((HazelcastPhysicalScan) getRight()).projection();
     }
 
     public JetJoinInfo joinInfo(QueryParameterMetadata parameterMetadata) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/PhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/PhysicalRel.java
@@ -37,7 +37,6 @@ public interface PhysicalRel extends RelNode {
 
     PlanNodeSchema schema(QueryParameterMetadata parameterMetadata);
 
-    // TODO [viliam] do we need this?
     @SuppressWarnings("unchecked")
     default Expression<Boolean> filter(
             PlanNodeFieldTypeProvider schema,
@@ -51,7 +50,6 @@ public interface PhysicalRel extends RelNode {
         return (Expression<Boolean>) node.accept(visitor);
     }
 
-    // TODO [viliam] do we need this?
     default List<Expression<?>> project(
             PlanNodeFieldTypeProvider schema,
             List<? extends RexNode> nodes,

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/PhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/PhysicalRel.java
@@ -37,6 +37,7 @@ public interface PhysicalRel extends RelNode {
 
     PlanNodeSchema schema(QueryParameterMetadata parameterMetadata);
 
+    // TODO [viliam] do we need this?
     @SuppressWarnings("unchecked")
     default Expression<Boolean> filter(
             PlanNodeFieldTypeProvider schema,
@@ -50,6 +51,7 @@ public interface PhysicalRel extends RelNode {
         return (Expression<Boolean>) node.accept(visitor);
     }
 
+    // TODO [viliam] do we need this?
     default List<Expression<?>> project(
             PlanNodeFieldTypeProvider schema,
             List<? extends RexNode> nodes,

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdateByKeyMapPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdateByKeyMapPhysicalRel.java
@@ -37,11 +37,8 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.IntStream;
 
 import static com.hazelcast.sql.impl.plan.node.PlanNodeFieldTypeProvider.FAILING_FIELD_TYPE_PROVIDER;
-import static java.util.stream.Collectors.toMap;
 
 public class UpdateByKeyMapPhysicalRel extends AbstractRelNode implements PhysicalRel {
 
@@ -83,10 +80,7 @@ public class UpdateByKeyMapPhysicalRel extends AbstractRelNode implements Physic
 
     public UpdatingEntryProcessor.Supplier updaterSupplier(QueryParameterMetadata parameterMetadata) {
         List<Expression<?>> projects = project(OptUtils.schema(table), sourceExpressions, parameterMetadata);
-        Map<String, Expression<?>> updates = IntStream.range(0, projects.size())
-                .boxed()
-                .collect(toMap(updatedColumns::get, projects::get));
-        return UpdatingEntryProcessor.supplier(table(), updates);
+        return UpdatingEntryProcessor.supplier(table(), updatedColumns, projects);
     }
 
     private PartitionedMapTable table() {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdatePhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdatePhysicalRel.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.sql.impl.opt.physical;
 
-import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
 import org.apache.calcite.plan.RelOptCluster;
@@ -44,10 +43,6 @@ public class UpdatePhysicalRel extends TableModify implements PhysicalRel {
             boolean flattened
     ) {
         super(cluster, traitSet, table, catalogReader, input, UPDATE, updateColumnList, sourceExpressionList, flattened);
-    }
-
-    public PlanNodeSchema tableSchema() {
-        return OptUtils.schema(getTable());
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdatePhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/UpdatePhysicalRel.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.sql.impl.opt.physical;
 
 import com.hazelcast.jet.sql.impl.opt.OptUtils;
 import com.hazelcast.sql.impl.QueryParameterMetadata;
-import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.plan.node.PlanNodeSchema;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
@@ -29,10 +28,7 @@ import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rex.RexNode;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.IntStream;
 
-import static java.util.stream.Collectors.toMap;
 import static org.apache.calcite.rel.core.TableModify.Operation.UPDATE;
 
 public class UpdatePhysicalRel extends TableModify implements PhysicalRel {
@@ -50,18 +46,8 @@ public class UpdatePhysicalRel extends TableModify implements PhysicalRel {
         super(cluster, traitSet, table, catalogReader, input, UPDATE, updateColumnList, sourceExpressionList, flattened);
     }
 
-    public Map<String, Expression<?>> updates(QueryParameterMetadata parameterMetadata) {
-        List<Expression<?>> projects = project(OptUtils.schema(getTable()), getSourceExpressionList(), parameterMetadata);
-        return IntStream.range(0, projects.size())
-                .boxed()
-                .collect(toMap(i -> getUpdateColumnList().get(i), projects::get));
-    }
-
-    public Map<String, RexNode> updatesAsRex() {
-        List<RexNode> updates = getSourceExpressionList();
-        return IntStream.range(0, updates.size())
-                        .boxed()
-                        .collect(toMap(i -> getUpdateColumnList().get(i), updates::get));
+    public PlanNodeSchema tableSchema() {
+        return OptUtils.schema(getTable());
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/visitor/RexToExpressionVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/visitor/RexToExpressionVisitor.java
@@ -41,7 +41,7 @@ import org.apache.calcite.rex.RexVisitor;
 import java.util.List;
 
 /**
- * Visitor that converts REX nodes to Hazelcast expressions.
+ * Visitor that converts a {@link RexNode} to Hazelcast's {@link Expression}.
  */
 public final class RexToExpressionVisitor implements RexVisitor<Expression<?>> {
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorTest.java
@@ -49,7 +49,6 @@ import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class UpdateProcessorTest extends SqlTestSupport {
@@ -74,7 +73,8 @@ public class UpdateProcessorTest extends SqlTestSupport {
                 1,
                 1,
                 partitionedTable(INT),
-                singletonMap(VALUE, PlusFunction.create(ColumnExpression.create(1, INT), ConstantExpression.create(1, INT), INT)),
+                singletonList(VALUE),
+                singletonList(PlusFunction.create(ColumnExpression.create(1, INT), ConstantExpression.create(1, INT), INT)),
                 emptyList()
         );
         assertThat(updated).isEqualTo(2);
@@ -86,7 +86,8 @@ public class UpdateProcessorTest extends SqlTestSupport {
                 2L,
                 1,
                 partitionedTable(BIGINT),
-                singletonMap(VALUE, PlusFunction.create(ColumnExpression.create(1, BIGINT), ParameterExpression.create(0, BIGINT), BIGINT)),
+                singletonList(VALUE),
+                singletonList(PlusFunction.create(ColumnExpression.create(1, BIGINT), ParameterExpression.create(0, BIGINT), BIGINT)),
                 singletonList(2L)
         );
         assertThat(updated).isEqualTo(4L);
@@ -98,7 +99,8 @@ public class UpdateProcessorTest extends SqlTestSupport {
                 1,
                 0,
                 partitionedTable(INT),
-                singletonMap(VALUE, PlusFunction.create(ColumnExpression.create(1, INT), ConstantExpression.create(1, INT), INT)),
+                singletonList(VALUE),
+                singletonList(PlusFunction.create(ColumnExpression.create(1, INT), ConstantExpression.create(1, INT), INT)),
                 emptyList()
         );
         assertThat(updated).isEqualTo(1);
@@ -128,11 +130,12 @@ public class UpdateProcessorTest extends SqlTestSupport {
             Object initialValue,
             int inputValue,
             PartitionedMapTable table,
-            Map<String, Expression<?>> updatesByFieldNames,
+            List<String> fieldNames,
+            List<Expression<?>> expressions,
             List<Object> arguments
     ) {
         UpdateProcessorSupplier processor = new UpdateProcessorSupplier(
-                MAP_NAME, UpdatingEntryProcessor.supplier(table, updatesByFieldNames)
+                MAP_NAME, UpdatingEntryProcessor.supplier(table, fieldNames, expressions)
         );
 
         TestSupport

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAbstractSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAbstractSqlConnector.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.sql.impl.connector.test;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.Traversers;
-import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimeMapper;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.Processor.Context;
@@ -41,6 +40,7 @@ import com.hazelcast.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.schema.Table;
 import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.type.QueryDataTypeFamily;
+import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -182,26 +182,27 @@ public abstract class TestAbstractSqlConnector implements SqlConnector {
     @Nonnull
     @Override
     public Vertex fullScanReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table_,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projection,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode predicate,
+            @Nonnull List<RexNode> projection,
             @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
     ) {
-        TestTable table = (TestTable) table_;
+        TestTable table = (TestTable) context.getTable();
         List<Object[]> rows = table.rows;
         boolean streaming = table.streaming;
+        Expression<Boolean> convertedPredicate = context.convertFilter(predicate);
+        List<Expression<?>> convertedProjection = context.convertProjection(projection);
 
         FunctionEx<Context, TestDataGenerator> createContextFn = ctx -> {
             ExpressionEvalContext evalContext = ExpressionEvalContext.from(ctx);
             EventTimePolicy<JetSqlRow> eventTimePolicy = eventTimePolicyProvider == null
                     ? EventTimePolicy.noEventTime()
                     : eventTimePolicyProvider.apply(evalContext);
-            return new TestDataGenerator(rows, predicate, projection, evalContext, eventTimePolicy, streaming);
+            return new TestDataGenerator(rows, convertedPredicate, convertedProjection, evalContext, eventTimePolicy, streaming);
         };
 
         ProcessorMetaSupplier pms = createProcessorSupplier(createContextFn);
-        return dag.newUniqueVertex(table.toString(), pms);
+        return context.getDag().newUniqueVertex(table.toString(), pms);
     }
 
     protected abstract ProcessorMetaSupplier createProcessorSupplier(FunctionEx<Context, TestDataGenerator> createContextFn);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestFailingSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestFailingSqlConnector.java
@@ -18,14 +18,12 @@ package com.hazelcast.jet.sql.impl.connector.test;
 
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.AbstractProcessor;
-import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.jet.sql.impl.schema.JetTable;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.QueryException;
-import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.optimizer.PlanObjectKey;
 import com.hazelcast.sql.impl.row.JetSqlRow;
@@ -34,6 +32,7 @@ import com.hazelcast.sql.impl.schema.MappingField;
 import com.hazelcast.sql.impl.schema.Table;
 import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.type.QueryDataType;
+import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -95,18 +94,17 @@ public class TestFailingSqlConnector implements SqlConnector {
 
     @Nonnull @Override
     public Vertex fullScanReader(
-            @Nonnull DAG dag,
-            @Nonnull Table table,
-            @Nullable Expression<Boolean> predicate,
-            @Nonnull List<Expression<?>> projection,
+            @Nonnull DagBuildContext context,
+            @Nullable RexNode predicate,
+            @Nonnull List<RexNode> projection,
             @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
     ) {
         if (eventTimePolicyProvider != null) {
             throw QueryException.error("Ordering functions are not supported on top of " + TYPE_NAME + " mappings");
         }
 
-        return dag.newUniqueVertex(
-                "FailingSource[" + table.getSchemaName() + "." + table.getSqlName() + ']',
+        return context.getDag().newUniqueVertex(
+                "FailingSource[" + context.getTable().getSchemaName() + "." + context.getTable().getSqlName() + ']',
                 FailingP::new
         );
     }


### PR DESCRIPTION
In preparation for https://hazelcast.atlassian.net/browse/HZ-1526

Some connectors needed `Expression` and some `RexNode`. For this we had two overloads, one with both types of objects, and one with just `Expression`, for b-w compatibility. 

This PR uses just `RexNode`, and provides a `context` object the connector can use to convert `RexNode` to `Expression`. We also moved the `DAG` and `Table` objects to the context, to reduce the number of parameters. In the future we can add more context objects without breaking the compatibility.

Breaking the compatibility now is allowed because the `SqlConnector` is still not a public API.