### PR TITLE
Handle null entry (#23439)[5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/MergeOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/MergeOpSteps.java
@@ -180,7 +180,9 @@ public enum MergeOpSteps implements IMapOpStep {
                     // if same values, merge expiry and continue with next entry
                     if (recordStore.getValueComparator().isEqual(newValue, oldValue, serializationService)) {
                         Record record = recordStore.getRecord((Data) key);
-                        recordStore.mergeRecordExpiration((Data) key, record, mergingEntry, state.getNow());
+                        if (record != null) {
+                            recordStore.mergeRecordExpiration((Data) key, record, mergingEntry, state.getNow());
+                        }
                         continue;
                     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutAllOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutAllOpSteps.java
@@ -191,6 +191,11 @@ public enum PutAllOpSteps implements IMapOpStep {
 
             List<Map.Entry<Data, Data>> entries = state.getMapEntries().entries();
             for (Map.Entry<Data, Data> entry : entries) {
+                // it is possible that forced-eviction can delete some
+                // entries, and we find some entries are missing.
+                if (recordStore.getRecord(entry.getKey()) == null) {
+                    continue;
+                }
 
                 Data dataKey = entry.getKey();
                 Object newValue = entry.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.internal.iteration.IterationPointer;
@@ -156,7 +157,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     @Override
     public long getMapStoreOffloadedOperationsCount() {
-
         return mapStoreOffloadedOperationsCount.get();
     }
 
@@ -198,6 +198,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     @Override
     public JsonMetadataStore getOrCreateMetadataStore() {
+        if (mapContainer.getMapConfig().getMetadataPolicy() == MetadataPolicy.OFF) {
+            return JsonMetadataStore.NULL;
+        }
         if (metadataStore == null) {
             metadataStore = createMetadataStore();
         }


### PR DESCRIPTION
backport of https://github.com/hazelcast/hazelcast/pull/23439

Modifications:
- Some stepped-operations were not handling forced-eviction correctly. Forced eviction can remove some entries and we can have missing entries in a later step. This was causing NPE in the test linked #5652
- Returning NULL JsonMetadataStore when MetadataPolicy is OFF. Not returning NULL-meta-data-store was  causing unexpected HD memory usage hence was breaking the linked test's assumptions:  com.hazelcast.map.HDMapMemoryLeakStressTest.test_MapOperations hazelcast-enterprise#5652

