### PR TITLE
Fix JSON parsing in predicate query [HZ-1959] [5.1.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractJsonGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractJsonGetter.java
@@ -221,12 +221,10 @@ public abstract class AbstractJsonGetter extends Getter {
                 return false;
             }
             if (pathCursor.getCurrent().equals(parser.getCurrentName())) {
+                // current token matched, advance to next token before returning
                 parser.nextToken();
                 return true;
-            } else if (multiValue) {
-                parser.nextToken();
-            } else {
-                parser.nextToken();
+            } else if (!multiValue) {
                 parser.skipChildren();
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
@@ -496,6 +496,26 @@ public class MapPredicateJsonTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testMatches_whenAnyAndAttributeName_withInnerArray() {
+        JsonArray innerArray = Json.array("one", "two");
+        JsonArray outerArray = Json.array()
+                .add(Json.object().add("one", 1))
+                .add(Json.object().add("innerArray", innerArray))
+                .add(Json.object().add("two", 2))
+                .add(Json.object().add("three", 3));
+
+        JsonValue object = Json.object().add("outerArray", outerArray)
+                .add("id", 171);
+
+        IMap<String, HazelcastJsonValue> map = instance.getMap(randomMapName());
+        HazelcastJsonValue p1 = putJsonString(map, "one", object);
+
+        Collection<HazelcastJsonValue> vals = map.values(Predicates.equal("outerArray[any].one", 1));
+        assertEquals(1, vals.size());
+        assertTrue(vals.contains(p1));
+    }
+
+    @Test
     public void testJsonValueIsJustANumber() {
         IMap<Integer, HazelcastJsonValue> map = instance.getMap(randomMapName());
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
When trying to match attribute name, do not skip tokens assuming "fieldName":"value" structure in json array. Previous logic breaks when inner arrays are present and may result in queries that return wrong results or queries that do not complete.

The added test hangs with the current state of `master` branch. See also [HZ-1959].

(cherry picked from commit 210c9f58f007518d44436ed0d7da1e0ab73bedbd)

Backport of #23421 to 5.1.z

[HZ-1959]: https://hazelcast.atlassian.net/browse/HZ-1959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ