### PR TITLE
Extract major Java version from java.version property [HZ-1995]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaMajorVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaMajorVersion.java
@@ -16,17 +16,17 @@
 
 package com.hazelcast.internal.util;
 
+import com.hazelcast.internal.util.JavaVersion.FutureJavaVersion;
+import com.hazelcast.internal.util.JavaVersion.UnknownVersion;
+
 /**
- * Interface used by {@link JavaVersion} and
- * {@link JavaVersion.FutureJavaVersion}. This interface is needed only
- * to do version comparison safely on runtime environments with versions
- * not listed in {@link JavaVersion}.
+ * Interface used by {@link JavaVersion}, {@link UnknownVersion} and {@link
+ * FutureJavaVersion}. This interface is needed only to do version comparison
+ * safely on runtime environments with versions not listed in {@link JavaVersion}.
  */
 public interface JavaMajorVersion {
     /**
-     * Returns the major version.
-     *
-     * @return the major version
+     * Returns the major version or null if the version is unknown.
      */
-    int getMajorVersion();
+    Integer getMajorVersion();
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
@@ -17,21 +17,29 @@
 package com.hazelcast.internal.util;
 
 import com.hazelcast.internal.util.JavaVersion.FutureJavaVersion;
-import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.hazelcast.internal.util.JavaVersion.UNKNOWN_VERSION;
+import static com.hazelcast.test.OverridePropertyRule.clear;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class JavaVersionTest extends HazelcastTestSupport {
+    @Rule
+    public final OverridePropertyRule overrideJavaVersion = clear("java.version");
 
     @Test
     public void testIsAtLeast() {
@@ -63,5 +71,35 @@ public class JavaVersionTest extends HazelcastTestSupport {
             assertFalse(JavaVersion.isAtMost(thisVersion, new FutureJavaVersion(thisVersion.getMajorVersion() - 1)));
             assertTrue(JavaVersion.isAtMost(thisVersion, new FutureJavaVersion(thisVersion.getMajorVersion())));
         }
+    }
+
+    @Test
+    public void testVersionDetection() {
+        // java.version is empty
+        assertEquals(UNKNOWN_VERSION, JavaVersion.detectCurrentVersion());
+
+        overrideJavaVersion.setOrClearProperty("ea-99");
+        assertEquals(UNKNOWN_VERSION, JavaVersion.detectCurrentVersion());
+
+        overrideJavaVersion.setOrClearProperty("99-ea");
+        assertThat(JavaVersion.detectCurrentVersion())
+                .isInstanceOf(FutureJavaVersion.class)
+                .matches(v -> v.getMajorVersion() == 99);
+    }
+
+    @Test
+    public void testUnknownVersion() {
+        List<JavaMajorVersion> versions = new ArrayList<>(Arrays.<JavaMajorVersion>asList(JavaVersion.values()));
+        versions.add(new FutureJavaVersion(99));
+        for (JavaMajorVersion version : versions) {
+            assertFalse(JavaVersion.isAtLeast(UNKNOWN_VERSION, version));
+            assertFalse(JavaVersion.isAtLeast(version, UNKNOWN_VERSION));
+
+            assertFalse(JavaVersion.isAtMost(UNKNOWN_VERSION, version));
+            assertFalse(JavaVersion.isAtMost(version, UNKNOWN_VERSION));
+        }
+
+        assertFalse(JavaVersion.isAtLeast(UNKNOWN_VERSION, UNKNOWN_VERSION));
+        assertFalse(JavaVersion.isAtMost(UNKNOWN_VERSION, UNKNOWN_VERSION));
     }
 }


### PR DESCRIPTION
Parses system property `java.version` to get major Java version instead of calling `Runtime.version()` via reflection.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
