### PR TITLE
Use assertTrueEventually in PartitionIndexingTest API-1666 [4.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/query/impl/PartitionIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/PartitionIndexingTest.java
@@ -59,6 +59,7 @@ import static org.junit.Assert.assertTrue;
 public class PartitionIndexingTest extends HazelcastTestSupport {
 
     private static final int ENTRIES = 10000;
+    private static final int ASSERT_TRUE_EVENTUALLY_TIMEOUT = 10;
     private static final String MAP_NAME = "map";
 
     @Parameterized.Parameters(name = "format:{0}")
@@ -113,33 +114,33 @@ public class PartitionIndexingTest extends HazelcastTestSupport {
         int expectedPartitions = getPartitionService(instance1).getPartitionCount();
 
         IMap<Integer, Integer> map1 = instance1.getMap(MAP_NAME);
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1);
 
         IMap<Integer, Integer> client1 = createClientFor(map1);
         for (int i = 0; i < ENTRIES; ++i) {
             client1.put(i, i);
         }
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1);
 
         HazelcastInstance instance2 = factory.newHazelcastInstance(config);
         IMap<Integer, Integer> map2 = instance2.getMap(MAP_NAME);
         waitAllForSafeState(instance1, instance2);
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map2);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1, map2);
 
         HazelcastInstance instance3 = factory.newHazelcastInstance(config);
         IMap<Integer, Integer> map3 = instance3.getMap(MAP_NAME);
         waitAllForSafeState(instance1, instance2, instance3);
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map2, map3);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1, map2, map3);
 
         instance2.shutdown();
         waitAllForSafeState(instance1, instance3);
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map3);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1, map3);
 
         migrationFailingService.fail = true;
         HazelcastInstance instance4 = factory.newHazelcastInstance(config);
         IMap<Integer, Integer> map4 = instance4.getMap(MAP_NAME);
         waitAllForSafeState(instance1, instance3, instance4);
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map3, map4);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1, map3, map4);
         assertTrue(migrationFailingService.rolledBack);
     }
 
@@ -151,39 +152,47 @@ public class PartitionIndexingTest extends HazelcastTestSupport {
         int expectedPartitions = getPartitionService(instance1).getPartitionCount();
 
         IMap<Integer, Integer> map1 = instance1.getMap(MAP_NAME);
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1);
 
         IMap<Integer, Integer> client1 = createClientFor(map1);
         for (int i = 0; i < ENTRIES; ++i) {
             client1.put(i, i);
         }
         client1.addIndex(IndexType.HASH, "this");
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1);
 
         HazelcastInstance instance2 = factory.newHazelcastInstance(config);
         IMap<Integer, Integer> map2 = instance2.getMap(MAP_NAME);
         waitAllForSafeState(instance1, instance2);
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map2);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1, map2);
 
         HazelcastInstance instance3 = factory.newHazelcastInstance(config);
         IMap<Integer, Integer> map3 = instance3.getMap(MAP_NAME);
         waitAllForSafeState(instance1, instance2, instance3);
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map2, map3);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1, map2, map3);
 
         instance2.shutdown();
         waitAllForSafeState(instance1, instance3);
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map3);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1, map3);
 
         IMap<Integer, Integer> client3 = createClientFor(map3);
         client3.addIndex(IndexType.HASH, "__key");
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map3);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1, map3);
 
         migrationFailingService.fail = true;
         HazelcastInstance instance4 = factory.newHazelcastInstance(config);
         IMap<Integer, Integer> map4 = instance4.getMap(MAP_NAME);
         waitAllForSafeState(instance1, instance3, instance4);
-        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map3, map4);
+        assertPartitionsIndexedCorrectlyEventually(expectedPartitions, map1, map3, map4);
         assertTrue(migrationFailingService.rolledBack);
+    }
+
+    /**
+     * We assert eventually because waiting for safe state does not mean all partition migration events are received
+     * and processed. We should give MapMigrationAwareService some time to process all partition migration events.
+     */
+    private static void assertPartitionsIndexedCorrectlyEventually(int expectedPartitions, IMap... maps) {
+        assertTrueEventually(() -> assertPartitionsIndexedCorrectly(expectedPartitions, maps), ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }
 
     private static void assertPartitionsIndexedCorrectly(int expectedPartitions, IMap... maps) {


### PR DESCRIPTION
Backport of: #23179

Breaking changes (list specific methods/types/messages):
- None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
