### PR TITLE
Fixing HazelcastTransactionManager timeout

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
@@ -26,6 +26,7 @@ public class ServiceBeanWithTransactionalContext {
 
     TransactionalTaskContext transactionalContext;
     OtherServiceBeanWithTransactionalContext otherService;
+    static final int TIMEOUT = 1;
 
     public ServiceBeanWithTransactionalContext(TransactionalTaskContext transactionalContext,
                                                OtherServiceBeanWithTransactionalContext otherService) {
@@ -62,5 +63,25 @@ public class ServiceBeanWithTransactionalContext {
     public void putUsingOtherBean_thenSameBeanThrowingException_sameTransaction(DummyObject object, DummyObject otherObject) {
         otherService.put(otherObject);
         putWithException(object);
+    }
+
+    @Transactional
+    public void putWithDelay(DummyObject object, int delay) {
+        try {
+            Thread.sleep(delay * 1000);
+            put(object);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Transactional(timeout = TIMEOUT)
+    public void putWithDelay_transactionTimeoutValue(DummyObject object, int delay) {
+        try {
+            Thread.sleep(delay * 1000);
+            put(object);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -120,7 +120,7 @@ public class TestSpringManagedHazelcastTransaction {
      * Tests that transaction times out when its duration exceeds the value configured for the transaction
      */
     @Test
-    public void TransactionTimedOutExceptionWhenTimeoutValueIsSetForTransaction() {
+    public void transactionTimedOutExceptionWhenTimeoutValueIsSetForTransaction() {
         // given
         expectedException.expect(TransactionSystemException.class);
         expectedException.expectMessage("Transaction is timed-out!");

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -135,7 +135,7 @@ public class TestSpringManagedHazelcastTransaction {
      */
     @Test
     @DirtiesContext(methodMode = AFTER_METHOD)
-    public void TransactionTimedOutExceptionWhenTimeoutValueIsSetInTransactionManager() {
+    public void transactionTimedOutExceptionWhenTimeoutValueIsSetInTransactionManager() {
         // given
         transactionManager.setDefaultTimeout(TIMEOUT);
         expectedException.expect(TransactionSystemException.class);

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -32,18 +32,23 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.NoTransactionException;
 import org.springframework.transaction.TransactionSuspensionNotSupportedException;
+import org.springframework.transaction.TransactionSystemException;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.hazelcast.spring.transaction.ServiceBeanWithTransactionalContext.TIMEOUT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.annotation.DirtiesContext.MethodMode.AFTER_METHOD;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"transaction-applicationContext-hazelcast.xml"})
 @Category(QuickTest.class)
 public class TestSpringManagedHazelcastTransaction {
+
 
     @BeforeClass
     @AfterClass
@@ -70,6 +75,9 @@ public class TestSpringManagedHazelcastTransaction {
     @Autowired
     HazelcastInstance instance;
 
+    @Autowired
+    HazelcastTransactionManager transactionManager;
+
     /**
      * Tests that transactionalContext cannot be accessed when there is no transaction.
      */
@@ -93,6 +101,63 @@ public class TestSpringManagedHazelcastTransaction {
 
         // then
         assertNotNull(magic);
+    }
+
+    /**
+     * Tests that slow transaction will commit when no timeout value is set
+     * neither for the transaction nor in the transaction manager
+     */
+    @Test
+    public void noExceptionWithoutTimeoutValue() {
+        // when
+        service.putWithDelay(new DummyObject(1L, "magic"), TIMEOUT + 1);
+
+        // then
+        assertEquals(1L, instance.getMap("dummyObjectMap").size());
+    }
+
+    /**
+     * Tests that transaction times out when its duration exceeds the value configured for the transaction
+     */
+    @Test
+    public void TransactionTimedOutExceptionWhenTimeoutValueIsSetForTransaction() {
+        // given
+        expectedException.expect(TransactionSystemException.class);
+        expectedException.expectMessage("Transaction is timed-out!");
+
+        // when
+        service.putWithDelay_transactionTimeoutValue(new DummyObject(1L, "magic"), TIMEOUT + 1);
+    }
+
+    /**
+     * Tests that transaction times out when its duration exceeds the default value
+     * configured in the transaction manager AND no value is configured for the transaction
+     */
+    @Test
+    @DirtiesContext(methodMode = AFTER_METHOD)
+    public void TransactionTimedOutExceptionWhenTimeoutValueIsSetInTransactionManager() {
+        // given
+        transactionManager.setDefaultTimeout(TIMEOUT);
+        expectedException.expect(TransactionSystemException.class);
+        expectedException.expectMessage("Transaction is timed-out!");
+
+        // when
+        service.putWithDelay(new DummyObject(1L, "magic"), TIMEOUT + 1);
+    }
+
+    /**
+     * Tests that timeout value of the transaction takes precedence over the default value in the transaction manager
+     */
+    @Test
+    @DirtiesContext(methodMode = AFTER_METHOD)
+    public void TransactionTimeoutTakesPrecedenceOverTransactionManagerDefaultTimeout() {
+        // given
+        transactionManager.setDefaultTimeout(TIMEOUT + 2);
+        expectedException.expect(TransactionSystemException.class);
+        expectedException.expectMessage("Transaction is timed-out!");
+
+        // when
+        service.putWithDelay_transactionTimeoutValue(new DummyObject(1L, "magic"), TIMEOUT + 1);
     }
 
     /**

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -150,7 +150,7 @@ public class TestSpringManagedHazelcastTransaction {
      */
     @Test
     @DirtiesContext(methodMode = AFTER_METHOD)
-    public void TransactionTimeoutTakesPrecedenceOverTransactionManagerDefaultTimeout() {
+    public void transactionTimeoutTakesPrecedenceOverTransactionManagerDefaultTimeout() {
         // given
         transactionManager.setDefaultTimeout(TIMEOUT + 2);
         expectedException.expect(TransactionSystemException.class);

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -49,7 +49,6 @@ import static org.springframework.test.annotation.DirtiesContext.MethodMode.AFTE
 @Category(QuickTest.class)
 public class TestSpringManagedHazelcastTransaction {
 
-
     @BeforeClass
     @AfterClass
     public static void cleanup() {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
@@ -122,19 +122,13 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
     }
 
     private TransactionContext getTransactionContext(TransactionDefinition definition) {
-        TransactionContext transactionContext;
-        if (definition.getTimeout() == TransactionDefinition.TIMEOUT_DEFAULT
-            && this.getDefaultTimeout() == TransactionDefinition.TIMEOUT_DEFAULT) {
-                transactionContext = hazelcastInstance.newTransactionContext();
-        } else {
-            TransactionOptions options = new TransactionOptions();
-            if (definition.getTimeout() != TransactionDefinition.TIMEOUT_DEFAULT) {
-                options.setTimeout(definition.getTimeout(), TimeUnit.SECONDS);
-            } else {
-                options.setTimeout(this.getDefaultTimeout(), TimeUnit.SECONDS);
-            }
-            transactionContext = hazelcastInstance.newTransactionContext(options);
+        TransactionOptions options = TransactionOptions.getDefault();
+        if (definition.getTimeout() != TransactionDefinition.TIMEOUT_DEFAULT) {
+            options.setTimeout(definition.getTimeout(), TimeUnit.SECONDS);
+        } else if (getDefaultTimeout() != TransactionDefinition.TIMEOUT_DEFAULT) {
+            options.setTimeout(getDefaultTimeout(), TimeUnit.SECONDS);
         }
+        TransactionContext transactionContext = hazelcastInstance.newTransactionContext(options);
         if (logger.isDebugEnabled()) {
             logger.debug("Opened new TransactionContext [" + transactionContext + "]");
         }

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
@@ -123,15 +123,14 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
 
     private TransactionContext getTransactionContext(TransactionDefinition definition) {
         TransactionContext transactionContext;
-        if (definition.getTimeout() == TransactionDefinition.TIMEOUT_DEFAULT && this.getDefaultTimeout() == TransactionDefinition.TIMEOUT_DEFAULT) {
-            transactionContext = hazelcastInstance.newTransactionContext();
-        }
-        else {
+        if (definition.getTimeout() == TransactionDefinition.TIMEOUT_DEFAULT
+            && this.getDefaultTimeout() == TransactionDefinition.TIMEOUT_DEFAULT) {
+                transactionContext = hazelcastInstance.newTransactionContext();
+        } else {
             TransactionOptions options = new TransactionOptions();
             if (definition.getTimeout() != TransactionDefinition.TIMEOUT_DEFAULT) {
                 options.setTimeout(definition.getTimeout(), TimeUnit.SECONDS);
-            }
-            else {
+            } else {
                 options.setTimeout(this.getDefaultTimeout(), TimeUnit.SECONDS);
             }
             transactionContext = hazelcastInstance.newTransactionContext(options);

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
@@ -106,23 +106,7 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
 
         try {
             if (txObject.getTransactionContextHolder() == null) {
-                TransactionContext transactionContext = null;
-                if (definition.getTimeout() == TransactionDefinition.TIMEOUT_DEFAULT && this.getDefaultTimeout() == TransactionDefinition.TIMEOUT_DEFAULT) {
-                    transactionContext = hazelcastInstance.newTransactionContext();
-                }
-                else {
-                    TransactionOptions options = new TransactionOptions();
-                    if (definition.getTimeout() != TransactionDefinition.TIMEOUT_DEFAULT) {
-                        options.setTimeout(definition.getTimeout(), TimeUnit.SECONDS);
-                    }
-                    else {
-                        options.setTimeout(this.getDefaultTimeout(), TimeUnit.SECONDS);
-                    }
-                    transactionContext = hazelcastInstance.newTransactionContext(options);
-                }
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Opened new TransactionContext [" + transactionContext + "]");
-                }
+                TransactionContext transactionContext = getTransactionContext(definition);
                 txObject.setTransactionContextHolder(new TransactionContextHolder(transactionContext), true);
             }
 
@@ -135,6 +119,27 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
             closeTransactionContextAfterFailedBegin(txObject);
             throw new CannotCreateTransactionException("Could not begin Hazelcast transaction", ex);
         }
+    }
+
+    private TransactionContext getTransactionContext(TransactionDefinition definition) {
+        TransactionContext transactionContext;
+        if (definition.getTimeout() == TransactionDefinition.TIMEOUT_DEFAULT && this.getDefaultTimeout() == TransactionDefinition.TIMEOUT_DEFAULT) {
+            transactionContext = hazelcastInstance.newTransactionContext();
+        }
+        else {
+            TransactionOptions options = new TransactionOptions();
+            if (definition.getTimeout() != TransactionDefinition.TIMEOUT_DEFAULT) {
+                options.setTimeout(definition.getTimeout(), TimeUnit.SECONDS);
+            }
+            else {
+                options.setTimeout(this.getDefaultTimeout(), TimeUnit.SECONDS);
+            }
+            transactionContext = hazelcastInstance.newTransactionContext(options);
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("Opened new TransactionContext [" + transactionContext + "]");
+        }
+        return transactionContext;
     }
 
     private void closeTransactionContextAfterFailedBegin(HazelcastTransactionObject txObject) {


### PR DESCRIPTION
HazelcastTransactionManager doesn't use timeout values set either for the transaction or as default value in the transaction manager

Fixes https://github.com/hazelcast/hazelcast/issues/23460

Backport: 
[v5.3.0-DEVEL-5](https://github.com/hazelcast/hazelcast/releases/tag/v5.3.0-DEVEL-5)
[v5.2.1](https://github.com/hazelcast/hazelcast/releases/tag/v5.2.1)
[v5.0.4](https://github.com/hazelcast/hazelcast/releases/tag/v5.0.4)
[v4.2.6](https://github.com/hazelcast/hazelcast/releases/tag/v4.2.6)
[v4.1.10](https://github.com/hazelcast/hazelcast/releases/tag/v4.1.10)

Breaking changes (list specific methods/types/messages):
* None

Checklist:
- [ x ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ x ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ x ] Send backports/forwardports if fix needs to be applied to past/future releases

