### PR TITLE
Fix sending non-root-cause when serialization problem happens

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
@@ -99,7 +99,7 @@ public abstract class AsyncOperation extends Operation implements IdentifiedData
                     // the response will not be sent and the operation will hang.
                     // To prevent this from happening, replace the exception with
                     // another exception that can be serialized.
-                    sendResponse(new JetException(stackTraceToString(ex)));
+                    sendResponse(new JetException(stackTraceToString((Throwable) value)));
                 } else {
                     throw e;
                 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.MembersView;
+import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.config.JobConfig;
@@ -881,6 +882,40 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
         }
         TestProcessors.assertNoErrorsInProcessors();
     }
+
+    @Test
+    public void when_processorThrowsNonSerializable_thenItsWrapped() {
+        // Given
+        SupplierEx<ProcessorSupplier> supplier = PSThrowingNonSerializable::new;
+        DAG dag = new DAG().vertex(new Vertex("test", new MockPMS(supplier)));
+
+        // When
+        try {
+            Job job = newJob(dag);
+            job.join();
+            fail("Job execution should have failed");
+        } catch (Throwable e) {
+            assertContains(e.getMessage(), "bum!");
+        }
+    }
+
+    public static class PSThrowingNonSerializable implements ProcessorSupplier {
+
+        public static class NonSerializableException extends RuntimeException {
+            @SuppressWarnings("unused")
+            private final Object nonSerializableField = new Object();
+
+            public NonSerializableException(String message) {
+                super(message);
+            }
+        }
+
+        @Nonnull @Override
+        public List<Processor> get(int count) {
+            throw new JetException(new NonSerializableException("bum!"));
+        }
+    }
+
 
     public static class NotSerializable_DataSerializable_ProcessorSupplier implements ProcessorSupplier, DataSerializable {
         @Nonnull @Override

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -895,7 +895,7 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
             job.join();
             fail("Job execution should have failed");
         } catch (Throwable e) {
-            assertContains(e.getMessage(), "bum!");
+            assertContains(e.getMessage(), "boom!");
         }
     }
 
@@ -912,7 +912,7 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
 
         @Nonnull @Override
         public List<Processor> get(int count) {
-            throw new JetException(new NonSerializableException("bum!"));
+            throw new JetException(new NonSerializableException("boom!"));
         }
     }
 


### PR DESCRIPTION
Fixes the issue when original exception cannot be serialised; we were sending HazelcastSerializationException instead of root cause, which makes debugging harder.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible