### PR TITLE
Do not mock classloaders [HZ-1975]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheUtilTest.java
@@ -37,8 +37,6 @@ import static com.hazelcast.cache.HazelcastCacheManager.CACHE_MANAGER_PREFIX;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.runners.Parameterized.UseParametersRunnerFactory;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParametrizedRunner.class)
 @UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
@@ -69,8 +67,12 @@ public class CacheUtilTest extends HazelcastTestSupport {
     @Parameters(name = "{index}: uri={0}, classLoader={1}")
     public static Collection<Object[]> parameters() throws URISyntaxException {
         final URI uri = new URI(URI_SCOPE);
-        final ClassLoader classLoader = mock(ClassLoader.class);
-        when(classLoader.toString()).thenReturn(CLASSLOADER_SCOPE);
+        final ClassLoader classLoader = new ClassLoader() {
+            @Override
+            public String toString() {
+                return CLASSLOADER_SCOPE;
+            }
+        };
         return asList(
                 new Object[]{
                         null, null, null, CACHE_NAME, CACHE_MANAGER_PREFIX + CACHE_NAME,

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperationTest.java
@@ -55,7 +55,6 @@ public class OnJoinCacheOperationTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     private NodeEngine nodeEngine = mock(NodeEngine.class);
-    private ClassLoader classLoader = mock(ClassLoader.class);
     private ILogger logger = mock(ILogger.class);
 
     @BeforeClass
@@ -70,14 +69,15 @@ public class OnJoinCacheOperationTest {
 
     @Before
     public void setUp() {
-        when(nodeEngine.getConfigClassLoader()).thenReturn(classLoader);
+        when(nodeEngine.getConfigClassLoader()).thenReturn(getClass().getClassLoader());
         when(nodeEngine.getLogger(any(Class.class))).thenReturn(logger);
     }
 
     @Test
     public void test_cachePostJoinOperationSucceeds_whenJCacheAvailable_noWarningIsLogged() throws Exception {
         // JCacheDetector finds JCache in classpath
-        when(JCacheDetector.isJCacheAvailable(classLoader)).thenReturn(true);
+
+        mockedStatic.when(() -> JCacheDetector.isJCacheAvailable(any(ClassLoader.class))).thenReturn(true);
         // node engine returns mock CacheService
         when(nodeEngine.getService(CacheService.SERVICE_NAME)).thenReturn(mock(ICacheService.class));
 
@@ -90,11 +90,12 @@ public class OnJoinCacheOperationTest {
         verify(nodeEngine).getService(CacheService.SERVICE_NAME);
         // verify logger was not invoked
         verify(logger, never()).warning(anyString());
+
     }
 
     @Test
     public void test_cachePostJoinOperationSucceeds_whenJCacheNotAvailable_noCacheConfigs() throws Exception {
-        when(JCacheDetector.isJCacheAvailable(classLoader)).thenReturn(false);
+        mockedStatic.when(() -> JCacheDetector.isJCacheAvailable(any())).thenReturn(false);
 
         OnJoinCacheOperation onJoinCacheOperation = new OnJoinCacheOperation();
         onJoinCacheOperation.setNodeEngine(nodeEngine);
@@ -111,7 +112,7 @@ public class OnJoinCacheOperationTest {
     @Test
     public void test_cachePostJoinOperationFails_whenJCacheNotAvailable_withCacheConfigs() throws Exception {
         // JCache is not available in classpath
-        when(JCacheDetector.isJCacheAvailable(classLoader)).thenReturn(false);
+        mockedStatic.when(() -> JCacheDetector.isJCacheAvailable(any())).thenReturn(false);
         // node engine throws HazelcastException due to missing CacheService
         when(nodeEngine.getService(CacheService.SERVICE_NAME)).thenThrow(new HazelcastException("CacheService not found"));
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
@@ -84,7 +84,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
 
     private TaskletExecutionService tes;
     private ExecutorService executor;
-    private ClassLoader classLoaderMock;
+    private final ClassLoader classLoader = getClass().getClassLoader();
 
     @Before
     public void before() {
@@ -110,7 +110,6 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
 
         HazelcastProperties properties = new HazelcastProperties(new Properties());
         tes = new TaskletExecutionService(neMock, THREAD_COUNT, properties);
-        classLoaderMock = mock(ClassLoader.class);
     }
 
     @After
@@ -240,7 +239,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
                       .limit(100).collect(toList());
 
         // When
-        CompletableFuture<Void> f = tes.beginExecute(tasklets, cancellationFuture, classLoaderMock);
+        CompletableFuture<Void> f = tes.beginExecute(tasklets, cancellationFuture, classLoader);
         cancellationFuture.cancel(true);
 
         // Then
@@ -258,7 +257,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
                       .limit(100).collect(toList());
 
         // When
-        CompletableFuture<Void> f = tes.beginExecute(tasklets, cancellationFuture, classLoaderMock);
+        CompletableFuture<Void> f = tes.beginExecute(tasklets, cancellationFuture, classLoader);
         cancellationFuture.cancel(true);
 
         // Then
@@ -276,7 +275,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
                       .limit(100).collect(toList());
 
         // When
-        CompletableFuture<Void> f = tes.beginExecute(tasklets, cancellationFuture, classLoaderMock);
+        CompletableFuture<Void> f = tes.beginExecute(tasklets, cancellationFuture, classLoader);
         cancellationFuture.cancel(true);
 
         // Then
@@ -296,7 +295,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
                       .limit(100).collect(toList());
 
         // When
-        CompletableFuture<Void> f = tes.beginExecute(tasklets, cancellationFuture, classLoaderMock);
+        CompletableFuture<Void> f = tes.beginExecute(tasklets, cancellationFuture, classLoader);
 
         cancellationFuture.cancel(true);
 
@@ -321,8 +320,8 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
         assertTrue(t1.isCooperative());
 
         // When
-        CompletableFuture<Void> f1 = tes.beginExecute(singletonList(t1), new CompletableFuture<>(), classLoaderMock);
-        CompletableFuture<Void> f2 = tes.beginExecute(singletonList(t2), new CompletableFuture<>(), classLoaderMock);
+        CompletableFuture<Void> f1 = tes.beginExecute(singletonList(t1), new CompletableFuture<>(), classLoader);
+        CompletableFuture<Void> f2 = tes.beginExecute(singletonList(t2), new CompletableFuture<>(), classLoader);
         f1.join();
         f2.join();
 
@@ -334,7 +333,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     public void when_tryCompleteOnReturnedFuture_then_fails() {
         // Given
         final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
-        CompletableFuture<Void> f = tes.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);
+        CompletableFuture<Void> f = tes.beginExecute(singletonList(t), cancellationFuture, classLoader);
 
         // When - Then
         exceptionRule.expect(UnsupportedOperationException.class);
@@ -345,7 +344,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     public void when_tryCompleteExceptionallyOnReturnedFuture_then_fails() {
         // Given
         final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
-        CompletableFuture<Void> f = tes.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);
+        CompletableFuture<Void> f = tes.beginExecute(singletonList(t), cancellationFuture, classLoader);
 
         // When - Then
         exceptionRule.expect(UnsupportedOperationException.class);
@@ -356,7 +355,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     public void when_tryCancelOnReturnedFuture_then_fails() {
         // Given
         final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
-        CompletableFuture<Void> f = tes.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);
+        CompletableFuture<Void> f = tes.beginExecute(singletonList(t), cancellationFuture, classLoader);
 
         // When - Then
         exceptionRule.expect(UnsupportedOperationException.class);
@@ -367,7 +366,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     public void when_cancellationFutureCompleted_then_fails() throws Throwable {
         // Given
         final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
-        CompletableFuture<Void> f = tes.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);
+        CompletableFuture<Void> f = tes.beginExecute(singletonList(t), cancellationFuture, classLoader);
 
         // When
         cancellationFuture.complete(null);
@@ -382,7 +381,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     }
 
     private void executeAndJoin(List<MockTasklet> tasklets) {
-        CompletableFuture<Void> f = tes.beginExecute(tasklets, cancellationFuture, classLoaderMock);
+        CompletableFuture<Void> f = tes.beginExecute(tasklets, cancellationFuture, classLoader);
         f.join();
     }
 


### PR DESCRIPTION
It seems that with the newer Mockito the mocked classloaders can crash JVM:

```
05:32:34 # A fatal error has been detected by the Java Runtime Environment:
05:32:34 #
05:32:34 #  Internal Error (moduleEntry.cpp:263), pid=563, tid=126741
05:32:34 #  guarantee(java_lang_Module::is_instance(module)) failed: The unnamed module for ClassLoader jdk.internal.reflect.DelegatingClassLoader, is null or not an instance of java.lang.Module. The class loader has not been initialized correctly.
05:32:34 #
05:32:34 # JRE version: OpenJDK Runtime Environment Corretto-11.0.17.8.1 (11.0.17+8) (build 11.0.17+8-LTS)
05:32:34 # Java VM: OpenJDK 64-Bit Server VM Corretto-11.0.17.8.1 (11.0.17+8-LTS, mixed mode, tiered, compressed oops, g1 gc, linux-amd64)
05:32:34 # Core dump will be written. Default location: Core dumps may be processed with "/usr/share/apport/apport -p%p -s%s -c%c -d%d -P%P -u%u -g%g -- %E" (or dumping to /home/jenkins/jenkins_slave/workspace/Hazelcast-master-CorrettoJDK11/hazelcast/core.563)
05:32:34 #
05:32:34 # An error report file with more information is saved as:
05:32:34 # /home/jenkins/jenkins_slave/workspace/Hazelcast-master-CorrettoJDK11/hazelcast/hs_err_pid563.log
05:32:35 #
05:32:35 # If you would like to submit a bug report, please visit:
05:32:35 #   https://github.com/corretto/corretto-11/issues/
05:32:35 #
05:32:35 hazelcast[default] > Aborted (core dumped)
```
Fixes https://hazelcast.atlassian.net/browse/HZ-1975
