### PR TITLE
Remove unused SQL catalog migration code

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
@@ -181,10 +181,6 @@ public class TableResolverImpl implements TableResolver {
         }
     }
 
-    public View getView(String name) {
-        return tableStorage.getView(name);
-    }
-
     public void removeView(String name, boolean ifExists) {
         if (tableStorage.removeView(name) == null && !ifExists) {
             throw QueryException.error("View does not exist: " + name);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TablesStorage.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TablesStorage.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapEvent;
-import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.schema.Mapping;
 import com.hazelcast.sql.impl.schema.type.Type;
@@ -121,13 +120,6 @@ public class TablesStorage {
         if (!nodeEngine.getLocalMember().isLiteMember()) {
             storage().addEntryListener(listener, false);
         }
-    }
-
-    ReplicatedMap<String, Object> oldStorage() {
-        // To remove in 5.3. We are using the old storage if the cluster version is lower than 5.2. We destroy the old catalog
-        // during the first read after the cluster version is upgraded to > =5.2. We do not synchronize put operations to the old
-        // catalog, so it is possible that destroy happens before put, and we end up with a leaked ReplicatedMap.
-        return nodeEngine.getHazelcastInstance().getReplicatedMap(SQL_CATALOG_MAP_NAME);
     }
 
     IMap<String, Object> storage() {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TablesStorage.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TablesStorage.java
@@ -16,123 +16,65 @@
 
 package com.hazelcast.jet.sql.impl.schema;
 
-import com.hazelcast.cluster.Address;
-import com.hazelcast.cluster.Member;
-import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
-import com.hazelcast.internal.cluster.Versions;
-import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapEvent;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.ReplicatedMap;
-import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
-import com.hazelcast.replicatedmap.impl.operation.GetOperation;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.spi.impl.operationservice.Operation;
-import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.sql.impl.schema.Mapping;
 import com.hazelcast.sql.impl.schema.type.Type;
 import com.hazelcast.sql.impl.schema.view.View;
 
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.impl.JetServiceBackend.SQL_CATALOG_MAP_NAME;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 
 public class TablesStorage {
-    private static final int MAX_CHECK_ATTEMPTS = 5;
-    private static final long SLEEP_MILLIS = 100;
-
     private final NodeEngine nodeEngine;
-    private final Object mergingMutex = new Object();
-    private final ILogger logger;
-
-    private volatile boolean storageMovedToNew;
 
     public TablesStorage(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
-        this.logger = nodeEngine.getLogger(getClass());
     }
 
     void put(String name, Mapping mapping) {
-        newStorage().put(name, mapping);
-        if (useOldStorage()) {
-            oldStorage().put(name, mapping);
-            awaitMappingOnAllMembers(name, mapping);
-        }
+        storage().put(name, mapping);
     }
 
     void put(String name, View view) {
-        newStorage().put(name, view);
-        if (useOldStorage()) {
-            oldStorage().put(name, view);
-            awaitMappingOnAllMembers(name, view);
-        }
+        storage().put(name, view);
     }
 
     void put(String name, Type type) {
-        newStorage().put(name, type);
-        if (useOldStorage()) {
-            oldStorage().put(name, type);
-            awaitMappingOnAllMembers(name, type);
-        }
+        storage().put(name, type);
     }
 
     boolean putIfAbsent(String name, Mapping mapping) {
-        Object previousNew = newStorage().putIfAbsent(name, mapping);
-        Object previousOld = null;
-        if (useOldStorage()) {
-            previousOld = oldStorage().putIfAbsent(name, mapping);
-        }
-        return previousNew == null && previousOld == null;
+        return storage().putIfAbsent(name, mapping) == null;
     }
 
     boolean putIfAbsent(String name, View view) {
-        Object previousNew = newStorage().putIfAbsent(name, view);
-        Object previousOld = null;
-        if (useOldStorage()) {
-            previousOld = oldStorage().putIfAbsent(name, view);
-        }
-        return previousNew == null && previousOld == null;
+        return storage().putIfAbsent(name, view) == null;
     }
 
     boolean putIfAbsent(String name, Type type) {
-        Object previousNew = newStorage().putIfAbsent(name, type);
-        Object previousOld = null;
-        if (useOldStorage()) {
-            previousOld = oldStorage().putIfAbsent(name, type);
-        }
-        return previousNew == null && previousOld == null;
+        return storage().putIfAbsent(name, type) == null;
     }
 
     Mapping removeMapping(String name) {
-        Mapping removedNew = (Mapping) newStorage().remove(name);
-        Mapping removedOld = null;
-        if (useOldStorage()) {
-            removedOld = (Mapping) oldStorage().remove(name);
-        }
-        return removedNew == null ? removedOld : removedNew;
+        return (Mapping) storage().remove(name);
     }
 
     public Collection<Type> getAllTypes() {
-        return mergedStorage().values().stream()
+        return storage().values().stream()
                 .filter(o -> o instanceof Type)
                 .map(o -> (Type) o)
                 .collect(Collectors.toList());
     }
 
     public Type getType(final String name) {
-        Object obj = mergedStorage().get(name);
+        Object obj = storage().get(name);
         if (obj instanceof Type) {
             return (Type) obj;
         }
@@ -140,37 +82,19 @@ public class TablesStorage {
     }
 
     public Type removeType(String name) {
-        Type removedNew = (Type) newStorage().remove(name);
-        Type removedOld = null;
-        if (useOldStorage()) {
-            removedOld = (Type) oldStorage().remove(name);
-        }
-        return removedNew == null ? removedOld : removedNew;
-    }
-
-    View getView(String name) {
-        Object obj = mergedStorage().get(name);
-        if (obj instanceof View) {
-            return (View) obj;
-        }
-        return null;
+        return (Type) storage().remove(name);
     }
 
     View removeView(String name) {
-        View removedNew = (View) newStorage().remove(name);
-        View removedOld = null;
-        if (useOldStorage()) {
-            removedOld = (View) oldStorage().remove(name);
-        }
-        return removedNew == null ? removedOld : removedNew;
+        return (View) storage().remove(name);
     }
 
     Collection<Object> allObjects() {
-        return mergedStorage().values();
+        return storage().values();
     }
 
     Collection<String> mappingNames() {
-        return mergedStorage().values()
+        return storage().values()
                 .stream()
                 .filter(m -> m instanceof Mapping)
                 .map(m -> ((Mapping) m).name())
@@ -178,7 +102,7 @@ public class TablesStorage {
     }
 
     Collection<String> viewNames() {
-        return mergedStorage().values()
+        return storage().values()
                 .stream()
                 .filter(v -> v instanceof View)
                 .map(v -> ((View) v).name())
@@ -186,7 +110,7 @@ public class TablesStorage {
     }
 
     Collection<String> typeNames() {
-        return mergedStorage().values()
+        return storage().values()
                 .stream()
                 .filter(t -> t instanceof Type)
                 .map(t -> ((Type) t).getName())
@@ -194,17 +118,8 @@ public class TablesStorage {
     }
 
     void initializeWithListener(EntryListener<String, Object> listener) {
-        boolean useOldStorage = useOldStorage();
-
-        if (!useOldStorage) {
-            storageMovedToNew = true;
-        }
-
         if (!nodeEngine.getLocalMember().isLiteMember()) {
-            newStorage().addEntryListener(listener, false);
-            if (useOldStorage) {
-                oldStorage().addEntryListener(listener);
-            }
+            storage().addEntryListener(listener, false);
         }
     }
 
@@ -215,81 +130,8 @@ public class TablesStorage {
         return nodeEngine.getHazelcastInstance().getReplicatedMap(SQL_CATALOG_MAP_NAME);
     }
 
-    IMap<String, Object> newStorage() {
+    IMap<String, Object> storage() {
         return nodeEngine.getHazelcastInstance().getMap(SQL_CATALOG_MAP_NAME);
-    }
-
-    private Map<String, Object> mergedStorage() {
-        IMap<String, Object> newStorage = newStorage();
-        if (useOldStorage()) {
-            Map<String, Object> mergedCatalog = new HashMap<>();
-            mergedCatalog.putAll(newStorage);
-            mergedCatalog.putAll(oldStorage());
-            return mergedCatalog;
-        } else {
-            if (!storageMovedToNew) {
-                synchronized (mergingMutex) {
-                    if (!storageMovedToNew) {
-                        ReplicatedMap<String, Object> oldStorage = oldStorage();
-                        oldStorage.forEach(newStorage::putIfAbsent);
-                        oldStorage.destroy();
-                        storageMovedToNew = true;
-                    }
-                }
-            }
-            return newStorage;
-        }
-    }
-
-    private boolean useOldStorage() {
-        return !nodeEngine.getClusterService().getClusterVersion().isGreaterOrEqual(Versions.V5_2);
-    }
-
-    private Collection<Address> getMemberAddresses() {
-        return nodeEngine.getClusterService().getMembers(MemberSelectors.DATA_MEMBER_SELECTOR).stream()
-                .filter(member -> !member.localMember() && !member.isLiteMember())
-                .map(Member::getAddress)
-                .collect(toSet());
-    }
-
-    /**
-     * Temporary measure to ensure schema is propagated to all the members.
-     */
-    @SuppressWarnings("BusyWait")
-    private void awaitMappingOnAllMembers(String name, IdentifiedDataSerializable metadata) {
-        Data keyData = nodeEngine.getSerializationService().toData(name);
-        int keyPartitionId = nodeEngine.getPartitionService().getPartitionId(keyData);
-        OperationService operationService = nodeEngine.getOperationService();
-
-        Collection<Address> memberAddresses = getMemberAddresses();
-        for (int i = 0; i < MAX_CHECK_ATTEMPTS && !memberAddresses.isEmpty(); i++) {
-            List<CompletableFuture<Address>> futures = memberAddresses.stream()
-                    .map(memberAddress -> {
-                        Operation operation = new GetOperation(SQL_CATALOG_MAP_NAME, keyData)
-                                .setPartitionId(keyPartitionId)
-                                .setValidateTarget(false);
-                        return operationService
-                                .createInvocationBuilder(ReplicatedMapService.SERVICE_NAME, operation, memberAddress)
-                                .setTryCount(1)
-                                .invoke()
-                                .toCompletableFuture()
-                                .thenApply(result -> Objects.equals(metadata, result) ? memberAddress : null);
-                    }).collect(toList());
-            for (CompletableFuture<Address> future : futures) {
-                try {
-                    memberAddresses.remove(future.join());
-                } catch (Exception e) {
-                    logger.warning("Error occurred while trying to fetch mapping: " + e.getMessage(), e);
-                }
-            }
-            if (!memberAddresses.isEmpty()) {
-                try {
-                    Thread.sleep(SLEEP_MILLIS);
-                } catch (InterruptedException e) {
-                    break;
-                }
-            }
-        }
     }
 
     abstract static class EntryListenerAdapter implements EntryListener<String, Object> {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TablesStorageTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TablesStorageTest.java
@@ -16,10 +16,7 @@
 
 package com.hazelcast.jet.sql.impl.schema;
 
-import com.hazelcast.core.EntryEvent;
-import com.hazelcast.core.EntryListener;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
-import com.hazelcast.map.MapEvent;
 import com.hazelcast.sql.impl.schema.Mapping;
 import com.hazelcast.sql.impl.schema.view.View;
 import com.hazelcast.test.Accessors;
@@ -30,13 +27,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -110,116 +103,11 @@ public class TablesStorageTest extends SimpleTestInClusterSupport {
         assertThat(storage.removeView("non-existing")).isNull();
     }
 
-    @Test
-    public void when_clusterVersionIs5dot2_then_onlyNewCatalogIsUsed() {
-        String name = randomName();
-        storage.put(name, mapping(name, "type"));
-
-        assertEquals(1, storage.storage().size());
-        assertEquals(0, storage.oldStorage().size());
-    }
-
-    @Test
-    public void when_clusterVersionIs5dot2_then_oldCatalogIsMigratedOnFirstReadBeforeInitialization() {
-        String name = randomName();
-        storage.oldStorage().put(name, mapping(name, "type"));
-
-        assertEquals(1, storage.allObjects().size());
-        assertEquals(1, storage.storage().size());
-        assertEquals(0, storage.oldStorage().size());
-    }
-
-    @Test
-    public void when_clusterVersionIs5dot2_then_oldCatalogIsNotMigratedOnFirstReadAfterInitialization() {
-        storage.initializeWithListener(new TablesStorage.EntryListenerAdapter() {
-            @Override
-            public void entryUpdated(EntryEvent<String, Object> event) {
-            }
-
-            @Override
-            public void entryRemoved(EntryEvent<String, Object> event) {
-            }
-        });
-        String name = randomName();
-        storage.oldStorage().put(name, mapping(name, "type"));
-
-        assertEquals(0, storage.allObjects().size());
-        assertEquals(1, storage.oldStorage().size());
-    }
-
-    @Test
-    public void when_clusterVersionIs5dot2_then_listenerIsAppliedOnNewCatalogOnly() throws InterruptedException {
-        AtomicInteger clearCounter = new AtomicInteger();
-        storage.initializeWithListener(getCountingOnClearEntryListener(clearCounter));
-
-        String name = randomName();
-        storage.storage().put(name, mapping(name, "type"));
-        storage.oldStorage().put(name, mapping(name, "type"));
-        storage.oldStorage().clear();
-        storage.storage().clear();
-
-        assertTrueEventually(() -> {
-            assertEquals(1, clearCounter.get());
-        });
-        MILLISECONDS.sleep(100);
-        assertEquals(1, clearCounter.get());
-    }
-
     private static Mapping mapping(String name, String type) {
         return new Mapping(name, name, type, emptyList(), emptyMap());
     }
 
     private static View view(String name, String query) {
         return new View(name, query, emptyList(), emptyList());
-    }
-
-    private EntryListener<String, Object> getCountingOnClearEntryListener(AtomicInteger clearCounter) {
-        return new EntryListener<String, Object>() {
-            @Override
-            public void mapCleared(MapEvent event) {
-                clearCounter.incrementAndGet();
-            }
-
-            @Override
-            public void entryAdded(EntryEvent<String, Object> event) { }
-
-            @Override
-            public void entryEvicted(EntryEvent<String, Object> event) { }
-
-            @Override
-            public void entryExpired(EntryEvent<String, Object> event) { }
-
-            @Override
-            public void entryRemoved(EntryEvent<String, Object> event) { }
-
-            @Override
-            public void entryUpdated(EntryEvent<String, Object> event) { }
-
-            @Override
-            public void mapEvicted(MapEvent event) { }
-        };
-    }
-
-    private static class EmptyEntryListener implements EntryListener<String, Object> {
-        @Override
-        public void entryAdded(EntryEvent<String, Object> event) { }
-
-        @Override
-        public void entryRemoved(EntryEvent<String, Object> event) { }
-
-        @Override
-        public void entryUpdated(EntryEvent<String, Object> event) { }
-
-        @Override
-        public void entryEvicted(EntryEvent<String, Object> event) { }
-
-        @Override
-        public void mapEvicted(MapEvent event) { }
-
-        @Override
-        public void mapCleared(MapEvent event) { }
-
-        @Override
-        public void entryExpired(EntryEvent<String, Object> event) { }
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TablesStorageTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TablesStorageTest.java
@@ -115,7 +115,7 @@ public class TablesStorageTest extends SimpleTestInClusterSupport {
         String name = randomName();
         storage.put(name, mapping(name, "type"));
 
-        assertEquals(1, storage.newStorage().size());
+        assertEquals(1, storage.storage().size());
         assertEquals(0, storage.oldStorage().size());
     }
 
@@ -125,7 +125,7 @@ public class TablesStorageTest extends SimpleTestInClusterSupport {
         storage.oldStorage().put(name, mapping(name, "type"));
 
         assertEquals(1, storage.allObjects().size());
-        assertEquals(1, storage.newStorage().size());
+        assertEquals(1, storage.storage().size());
         assertEquals(0, storage.oldStorage().size());
     }
 
@@ -153,10 +153,10 @@ public class TablesStorageTest extends SimpleTestInClusterSupport {
         storage.initializeWithListener(getCountingOnClearEntryListener(clearCounter));
 
         String name = randomName();
-        storage.newStorage().put(name, mapping(name, "type"));
+        storage.storage().put(name, mapping(name, "type"));
         storage.oldStorage().put(name, mapping(name, "type"));
         storage.oldStorage().clear();
-        storage.newStorage().clear();
+        storage.storage().clear();
 
         assertTrueEventually(() -> {
             assertEquals(1, clearCounter.get());


### PR DESCRIPTION
The code was used in 5.1 to 5.2 upgrade and is now unused.