### PR TITLE
[TPC] Pulled out Unsafe/ScheduledTask.

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Eventloop.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Eventloop.java
@@ -21,10 +21,7 @@ import com.hazelcast.internal.tpc.iobuffer.IOBuffer;
 import com.hazelcast.internal.tpc.logging.TpcLogger;
 import com.hazelcast.internal.tpc.logging.TpcLoggerLocator;
 import com.hazelcast.internal.tpc.util.BoundPriorityQueue;
-import com.hazelcast.internal.tpc.util.CachedNanoClock;
 import com.hazelcast.internal.tpc.util.CircularQueue;
-import com.hazelcast.internal.tpc.util.NanoClock;
-import com.hazelcast.internal.tpc.util.StandardNanoClock;
 import com.hazelcast.internal.util.ThreadAffinityHelper;
 import org.jctools.queues.MpmcArrayQueue;
 
@@ -43,8 +40,6 @@ import static com.hazelcast.internal.tpc.Eventloop.State.NEW;
 import static com.hazelcast.internal.tpc.Eventloop.State.RUNNING;
 import static com.hazelcast.internal.tpc.Eventloop.State.SHUTDOWN;
 import static com.hazelcast.internal.tpc.Eventloop.State.TERMINATED;
-import static com.hazelcast.internal.tpc.util.Preconditions.checkNotNegative;
-import static com.hazelcast.internal.tpc.util.Preconditions.checkNotNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 /**
@@ -84,7 +79,7 @@ public abstract class Eventloop implements Executor {
 
     protected final Scheduler scheduler;
     protected final boolean spin;
-    private final int clockRefreshInterval;
+    final int clockRefreshInterval;
 
     protected Unsafe unsafe;
     protected final Thread eventloopThread;
@@ -93,7 +88,7 @@ public abstract class Eventloop implements Executor {
 
     TpcEngine engine;
 
-    private final FutAllocator futAllocator;
+    final FutAllocator futAllocator;
     private final EventloopType type;
     private final BitSet allowedCpus;
     private final CountDownLatch terminationLatch = new CountDownLatch(1);
@@ -418,62 +413,6 @@ public abstract class Eventloop implements Executor {
         return !concurrentTaskQueue.isEmpty();
     }
 
-    protected final class ScheduledTask implements Runnable, Comparable<ScheduledTask> {
-
-        private Fut fut;
-        private long deadlineNanos;
-        private Runnable task;
-        private long periodNanos = -1;
-        private long delayNanos = -1;
-
-        @Override
-        public void run() {
-            if (task != null) {
-                task.run();
-            }
-
-            if (periodNanos != -1 || delayNanos != -1) {
-                if (periodNanos != -1) {
-                    deadlineNanos += periodNanos;
-                } else {
-                    deadlineNanos = unsafe.nanoClock.nanoTime() + delayNanos;
-                }
-
-                if (deadlineNanos < 0) {
-                    deadlineNanos = Long.MAX_VALUE;
-                }
-
-                if (!scheduledTaskQueue.offer(this)) {
-                    logger.warning("Failed schedule task: " + this + " because there is no space in scheduledTaskQueue");
-                }
-            } else {
-                if (fut != null) {
-                    fut.complete(null);
-                }
-            }
-        }
-
-        @Override
-        public int compareTo(Eventloop.ScheduledTask that) {
-            if (that.deadlineNanos == this.deadlineNanos) {
-                return 0;
-            }
-
-            return this.deadlineNanos > that.deadlineNanos ? 1 : -1;
-        }
-
-        @Override
-        public String toString() {
-            return "ScheduledTask{"
-                    + "fut=" + fut
-                    + ", deadlineNanos=" + deadlineNanos
-                    + ", task=" + task
-                    + ", periodNanos=" + periodNanos
-                    + ", delayNanos=" + delayNanos
-                    + '}';
-        }
-    }
-
     /**
      * The {@link Runnable} containing the actual eventloop logic and is executed by by the eventloop {@link Thread}.
      */
@@ -526,145 +465,6 @@ public abstract class Eventloop implements Executor {
                     }
                 }
             }
-        }
-    }
-
-    /**
-     * Exposes methods that should only be called from within the {@link Eventloop}.
-     */
-    public abstract class Unsafe {
-
-        protected final NanoClock nanoClock;
-
-        protected Unsafe() {
-            this.nanoClock = clockRefreshInterval == 0
-                    ? new StandardNanoClock()
-                    : new CachedNanoClock(clockRefreshInterval);
-        }
-
-        public NanoClock nanoClock() {
-            return nanoClock;
-        }
-
-        /**
-         * Returns the {@link Eventloop} that belongs to this {@link Unsafe} instance.
-         *
-         * @return the Eventloop.
-         */
-        public Eventloop eventloop() {
-            return Eventloop.this;
-        }
-
-        public <E> Fut<E> newFut() {
-            return futAllocator.allocate();
-        }
-
-        /**
-         * Offers a task to be scheduled on the eventloop.
-         *
-         * @param task the task to schedule.
-         * @return true if the task was successfully offered, false otherwise.
-         */
-        public boolean offer(Runnable task) {
-            return localTaskQueue.offer(task);
-        }
-
-        /**
-         * Schedules a one shot action with the given delay.
-         *
-         * @param task  the task to execute.
-         * @param delay the delay
-         * @param unit  the unit of the delay
-         * @return true if the task was successfully scheduled.
-         * @throws NullPointerException     if task or unit is null
-         * @throws IllegalArgumentException when delay smaller than 0.
-         */
-        public boolean schedule(Runnable task, long delay, TimeUnit unit) {
-            checkNotNull(task);
-            checkNotNegative(delay, "delay");
-            checkNotNull(unit);
-
-            ScheduledTask scheduledTask = new ScheduledTask();
-            scheduledTask.task = task;
-            long deadlineNanos = nanoClock.nanoTime() + unit.toNanos(delay);
-            if (deadlineNanos < 0) {
-                // protection against overflow
-                deadlineNanos = Long.MAX_VALUE;
-            }
-            scheduledTask.deadlineNanos = deadlineNanos;
-            return scheduledTaskQueue.offer(scheduledTask);
-        }
-
-        /**
-         * Creates a periodically executing task with a fixed delay between the completion and start of
-         * the task.
-         *
-         * @param task         the task to periodically execute.
-         * @param initialDelay the initial delay
-         * @param delay        the delay between executions.
-         * @param unit         the unit of the initial delay and delay
-         * @return true if the task was successfully executed.
-         */
-        public boolean scheduleWithFixedDelay(Runnable task, long initialDelay, long delay, TimeUnit unit) {
-            checkNotNull(task);
-            checkNotNegative(initialDelay, "initialDelay");
-            checkNotNegative(delay, "delay");
-            checkNotNull(unit);
-
-            ScheduledTask scheduledTask = new ScheduledTask();
-            scheduledTask.task = task;
-            long deadlineNanos = nanoClock.nanoTime() + unit.toNanos(initialDelay);
-            if (deadlineNanos < 0) {
-                // protection against overflow
-                deadlineNanos = Long.MAX_VALUE;
-            }
-            scheduledTask.deadlineNanos = deadlineNanos;
-            scheduledTask.delayNanos = unit.toNanos(delay);
-            return scheduledTaskQueue.offer(scheduledTask);
-        }
-
-        /**
-         * Creates a periodically executing task with a fixed delay between the start of the task.
-         *
-         * @param task         the task to periodically execute.
-         * @param initialDelay the initial delay
-         * @param period       the period between executions.
-         * @param unit         the unit of the initial delay and delay
-         * @return true if the task was successfully executed.
-         */
-        public boolean scheduleAtFixedRate(Runnable task, long initialDelay, long period, TimeUnit unit) {
-            checkNotNull(task);
-            checkNotNegative(initialDelay, "initialDelay");
-            checkNotNegative(period, "period");
-            checkNotNull(unit);
-
-            ScheduledTask scheduledTask = new ScheduledTask();
-            scheduledTask.task = task;
-            long deadlineNanos = nanoClock.nanoTime() + unit.toNanos(initialDelay);
-            if (deadlineNanos < 0) {
-                // protection against overflow
-                deadlineNanos = Long.MAX_VALUE;
-            }
-            scheduledTask.deadlineNanos = deadlineNanos;
-            scheduledTask.periodNanos = unit.toNanos(period);
-            return scheduledTaskQueue.offer(scheduledTask);
-        }
-
-        public Fut sleep(long delay, TimeUnit unit) {
-            checkNotNegative(delay, "delay");
-            checkNotNull(unit, "unit");
-
-            Fut fut = newFut();
-            ScheduledTask scheduledTask = new ScheduledTask();
-            scheduledTask.fut = fut;
-            long deadlineNanos = nanoClock.nanoTime() + unit.toNanos(delay);
-            if (deadlineNanos < 0) {
-                // protection against overflow
-                deadlineNanos = Long.MAX_VALUE;
-            }
-            scheduledTask.deadlineNanos = deadlineNanos;
-            scheduledTaskQueue.add(scheduledTask);
-            return fut;
         }
     }
 

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/ScheduledTask.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/ScheduledTask.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc;
+
+final class ScheduledTask implements Runnable, Comparable<ScheduledTask> {
+
+    final Eventloop eventloop;
+    Fut fut;
+    long deadlineNanos;
+    Runnable task;
+    long periodNanos = -1;
+    long delayNanos = -1;
+
+    ScheduledTask(Eventloop eventloop) {
+        this.eventloop = eventloop;
+    }
+
+    @Override
+    public void run() {
+        if (task != null) {
+            task.run();
+        }
+
+        if (periodNanos != -1 || delayNanos != -1) {
+            if (periodNanos != -1) {
+                deadlineNanos += periodNanos;
+            } else {
+                deadlineNanos = eventloop.unsafe.nanoClock.nanoTime() + delayNanos;
+            }
+
+            if (deadlineNanos < 0) {
+                deadlineNanos = Long.MAX_VALUE;
+            }
+
+            if (!eventloop.scheduledTaskQueue.offer(this)) {
+                eventloop.logger.warning("Failed schedule task: " + this + " because there is no space in scheduledTaskQueue");
+            }
+        } else {
+            if (fut != null) {
+                fut.complete(null);
+            }
+        }
+    }
+
+    @Override
+    public int compareTo(ScheduledTask that) {
+        if (that.deadlineNanos == this.deadlineNanos) {
+            return 0;
+        }
+
+        return this.deadlineNanos > that.deadlineNanos ? 1 : -1;
+    }
+
+
+    @Override
+    public String toString() {
+        return "ScheduledTask{"
+                + "fut=" + fut
+                + ", deadlineNanos=" + deadlineNanos
+                + ", task=" + task
+                + ", periodNanos=" + periodNanos
+                + ", delayNanos=" + delayNanos
+                + '}';
+    }
+}

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Unsafe.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Unsafe.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc;
+
+import com.hazelcast.internal.tpc.util.CachedNanoClock;
+import com.hazelcast.internal.tpc.util.CircularQueue;
+import com.hazelcast.internal.tpc.util.NanoClock;
+import com.hazelcast.internal.tpc.util.StandardNanoClock;
+
+import java.util.PriorityQueue;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.internal.tpc.util.Preconditions.checkNotNegative;
+import static com.hazelcast.internal.tpc.util.Preconditions.checkNotNull;
+
+/**
+ * Exposes methods that should only be called from within the {@link Eventloop}.
+ */
+public abstract class Unsafe {
+
+    protected final NanoClock nanoClock;
+    private final Eventloop eventloop;
+    private final FutAllocator futAllocator;
+    private final CircularQueue<Runnable> localTaskQueue;
+    private final PriorityQueue<ScheduledTask> scheduledTaskQueue;
+
+    protected Unsafe(Eventloop eventloop) {
+        this.eventloop = checkNotNull(eventloop, "eventloop");
+        this.localTaskQueue = eventloop.localTaskQueue;
+        this.scheduledTaskQueue = eventloop.scheduledTaskQueue;
+        this.futAllocator = eventloop.futAllocator;
+        this.nanoClock = eventloop.clockRefreshInterval == 0
+                ? new StandardNanoClock()
+                : new CachedNanoClock(eventloop.clockRefreshInterval);
+    }
+
+    /**
+     * Returns the NanoClock.
+     *
+     * @return the NanoClock.
+     */
+    public final NanoClock nanoClock() {
+        return nanoClock;
+    }
+
+    /**
+     * Returns the {@link Eventloop} that belongs to this {@link Unsafe} instance.
+     *
+     * @return the Eventloop.
+     */
+    public final Eventloop eventloop() {
+        return eventloop;
+    }
+
+    /**
+     * Returns a new Fut.
+     *
+     * @return the future.
+     * @param <E> future.
+     */
+    public final <E> Fut<E> newFut() {
+        return futAllocator.allocate();
+    }
+
+    /**
+     * Offers a task to be scheduled on the eventloop.
+     *
+     * @param task the task to schedule.
+     * @return true if the task was successfully offered, false otherwise.
+     */
+    public final boolean offer(Runnable task) {
+        return localTaskQueue.offer(task);
+    }
+
+    /**
+     * Schedules a one shot action with the given delay.
+     *
+     * @param task  the task to execute.
+     * @param delay the delay
+     * @param unit  the unit of the delay
+     * @return true if the task was successfully scheduled.
+     * @throws NullPointerException     if task or unit is null
+     * @throws IllegalArgumentException when delay smaller than 0.
+     */
+    public final boolean schedule(Runnable task, long delay, TimeUnit unit) {
+        checkNotNull(task);
+        checkNotNegative(delay, "delay");
+        checkNotNull(unit);
+
+        ScheduledTask scheduledTask = new ScheduledTask(eventloop);
+        scheduledTask.task = task;
+        long deadlineNanos = nanoClock.nanoTime() + unit.toNanos(delay);
+        if (deadlineNanos < 0) {
+            // protection against overflow
+            deadlineNanos = Long.MAX_VALUE;
+        }
+        scheduledTask.deadlineNanos = deadlineNanos;
+        return scheduledTaskQueue.offer(scheduledTask);
+    }
+
+    /**
+     * Creates a periodically executing task with a fixed delay between the completion and start of
+     * the task.
+     *
+     * @param task         the task to periodically execute.
+     * @param initialDelay the initial delay
+     * @param delay        the delay between executions.
+     * @param unit         the unit of the initial delay and delay
+     * @return true if the task was successfully executed.
+     */
+    public final boolean scheduleWithFixedDelay(Runnable task, long initialDelay, long delay, TimeUnit unit) {
+        checkNotNull(task);
+        checkNotNegative(initialDelay, "initialDelay");
+        checkNotNegative(delay, "delay");
+        checkNotNull(unit);
+
+        ScheduledTask scheduledTask = new ScheduledTask(eventloop);
+        scheduledTask.task = task;
+        long deadlineNanos = nanoClock.nanoTime() + unit.toNanos(initialDelay);
+        if (deadlineNanos < 0) {
+            // protection against overflow
+            deadlineNanos = Long.MAX_VALUE;
+        }
+        scheduledTask.deadlineNanos = deadlineNanos;
+        scheduledTask.delayNanos = unit.toNanos(delay);
+        return scheduledTaskQueue.offer(scheduledTask);
+    }
+
+    /**
+     * Creates a periodically executing task with a fixed delay between the start of the task.
+     *
+     * @param task         the task to periodically execute.
+     * @param initialDelay the initial delay
+     * @param period       the period between executions.
+     * @param unit         the unit of the initial delay and delay
+     * @return true if the task was successfully executed.
+     */
+    public final boolean scheduleAtFixedRate(Runnable task, long initialDelay, long period, TimeUnit unit) {
+        checkNotNull(task);
+        checkNotNegative(initialDelay, "initialDelay");
+        checkNotNegative(period, "period");
+        checkNotNull(unit);
+
+        ScheduledTask scheduledTask = new ScheduledTask(eventloop);
+        scheduledTask.task = task;
+        long deadlineNanos = nanoClock.nanoTime() + unit.toNanos(initialDelay);
+        if (deadlineNanos < 0) {
+            // protection against overflow
+            deadlineNanos = Long.MAX_VALUE;
+        }
+        scheduledTask.deadlineNanos = deadlineNanos;
+        scheduledTask.periodNanos = unit.toNanos(period);
+        return scheduledTaskQueue.offer(scheduledTask);
+    }
+
+    public final Fut sleep(long delay, TimeUnit unit) {
+        checkNotNegative(delay, "delay");
+        checkNotNull(unit, "unit");
+
+        Fut fut = newFut();
+        ScheduledTask scheduledTask = new ScheduledTask(eventloop);
+        scheduledTask.fut = fut;
+        long deadlineNanos = nanoClock.nanoTime() + unit.toNanos(delay);
+        if (deadlineNanos < 0) {
+            // protection against overflow
+            deadlineNanos = Long.MAX_VALUE;
+        }
+        scheduledTask.deadlineNanos = deadlineNanos;
+        scheduledTaskQueue.add(scheduledTask);
+        return fut;
+    }
+}

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioEventloop.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioEventloop.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.tpc.nio;
 import com.hazelcast.internal.tpc.AsyncServerSocket;
 import com.hazelcast.internal.tpc.AsyncSocket;
 import com.hazelcast.internal.tpc.Eventloop;
+import com.hazelcast.internal.tpc.Unsafe;
 import com.hazelcast.internal.tpc.util.NanoClock;
 
 import java.io.IOException;
@@ -56,7 +57,7 @@ public final class NioEventloop extends Eventloop {
 
     @Override
     protected Unsafe createUnsafe() {
-        return new NioUnsafe();
+        return new NioUnsafe(this);
     }
 
     @Override
@@ -138,6 +139,4 @@ public final class NioEventloop extends Eventloop {
         closeQuietly(selector);
     }
 
-    private class NioUnsafe extends Unsafe {
-    }
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioUnsafe.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioUnsafe.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc.nio;
+
+import com.hazelcast.internal.tpc.Unsafe;
+
+class NioUnsafe extends Unsafe {
+
+    NioUnsafe(NioEventloop eventloop) {
+        super(eventloop);
+    }
+}


### PR DESCRIPTION
The primary reason is that there was significant performance overhead on accessing the localTaskQueue through the Unsafe because it wasn't a field on Unsafe, but on the enclosing class (the Eventloop). And I guess the JIT ran into problems because Eventloop itself is abstract.

So now it is clear; there is no more hidden field access to enclosing class.
