### PR TITLE
Upgrade surefire to 3.0.0-M8

### DIFF
--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/pom.xml
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/pom.xml
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>${maven.surefire.plugin.version}</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.hazelcast</groupId>

--- a/hazelcast-it/pom.xml
+++ b/hazelcast-it/pom.xml
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>${maven.surefire.plugin.version}</version>
                 <configuration>
                     <!-- Use TCP for IPC communication to avoid warnings: Corrupted STDOUT by directly writing... -->
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <maven.animal.sniffer.plugin.version>1.21</maven.animal.sniffer.plugin.version>
         <maven.git.commit.id.plugin.version>2.1.10</maven.git.commit.id.plugin.version>
 
-        <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.0.0-M8</maven.surefire.plugin.version>
         <maven.checkstyle.plugin.version>3.2.1</maven.checkstyle.plugin.version>
         <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
         <maven.failsafe.plugin.version>3.0.0-M8</maven.failsafe.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <maven.surefire.plugin.version>3.0.0-M8</maven.surefire.plugin.version>
         <maven.checkstyle.plugin.version>3.2.1</maven.checkstyle.plugin.version>
         <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
-        <maven.failsafe.plugin.version>3.0.0-M8</maven.failsafe.plugin.version>
+        <maven.failsafe.plugin.version>${maven.surefire.plugin.version}</maven.failsafe.plugin.version>
         <maven.cobertura.plugin.version>2.7</maven.cobertura.plugin.version>
         <maven.enforcer.plugin.version>3.1.0</maven.enforcer.plugin.version>
         <maven.os.plugin.version>1.7.1</maven.os.plugin.version>


### PR DESCRIPTION
In this release they resolved one of the performance issue (list is already filtered to M8 version):
https://issues.apache.org/jira/browse/SUREFIRE-2082?jql=project%20%3D%20SUREFIRE%20AND%20fixVersion%20%3D%203.0.0-M8%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC

Successful builds: 
https://jenkins.hazelcast.com/job/Hazelcast-master-OracleJDK8-memory-test/6/ (normal)
https://jenkins.hazelcast.com/job/Hazelcast-master-OpenJDK8-arm64/28/ (arm64 - with expected 5 test failures)

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible
- [X] Send backports/forwardports if fix needs to be applied to past/future releases
