### PR TITLE
Do not process JoinMessages from left members [HZ-1713] [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -704,9 +704,10 @@ public class ClusterJoinManager {
         // If I am the master, I will just suspect from the target. If it sends a new join request, it will be processed.
         // If I am not the current master, I can turn into the new master and start the claim process
         // after I suspect from the target.
-        if (clusterService.isMaster() || targetAddress.equals(clusterService.getMasterAddress())) {
+        if (!hasMemberLeft(joinMessage.getUuid())
+                && (clusterService.isMaster() || targetAddress.equals(clusterService.getMasterAddress()))) {
             String msg = format("New join request has been received from an existing endpoint %s."
-                    + " Removing old member and processing join request...", member);
+                    + " Removing old member and processing join request with UUID %s", member, joinMessage.getUuid());
             logger.warning(msg);
 
             clusterService.suspectMember(member, msg, false);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -355,6 +355,7 @@ public class MembershipManager {
         }
 
         for (MemberImpl member : removedMembers) {
+            clusterService.getClusterJoinManager().addLeftMember(member);
             closeConnections(member.getAddress(), "Member left event received from master");
             handleMemberRemove(memberMapRef.get(), member);
         }


### PR DESCRIPTION
In the case of temporary cluster splitting, just after discovery is finished, the `JoinMessage` from the split member can be stuck and reach other members when this member has changed their UUID. This leads to that old `JoinMessage` (with the outdated member UUID) considering as a new join request from the new member and splitting the cluster again.

Fixes https://github.com/hazelcast/hazelcast/issues/22713

(cherry picked from commit f7aa91b55615a63e3c3a929e96b79d705ea36570)

Backport of: https://github.com/hazelcast/hazelcast/pull/23281

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
