### PR TITLE
Disallow different types of generic records in GenericRecordBuilder.setGenericRecord API-1773

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
@@ -94,8 +94,8 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
     @Override
     public GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
         if (value != null && !(value instanceof CompactGenericRecord)) {
-            throw new HazelcastSerializationException("You can only use compact generic records in a compact"
-                    + " generic record builder");
+            throw new HazelcastSerializationException("You can only use Compact GenericRecords in a Compact"
+                    + " GenericRecordBuilder");
         }
         return write(fieldName, value, FieldKind.COMPACT);
     }
@@ -135,9 +135,9 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
     public GenericRecordBuilder setArrayOfGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord[] value) {
         if (value != null) {
             for (GenericRecord genericRecord : value) {
-                if (!(genericRecord instanceof CompactGenericRecord)) {
-                    throw new HazelcastSerializationException("You can only use compact generic records in a compact"
-                            + " generic record builder");
+                if (genericRecord != null && !(genericRecord instanceof CompactGenericRecord)) {
+                    throw new HazelcastSerializationException("You can only use Compact GenericRecords in a Compact"
+                            + " GenericRecordBuilder");
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
@@ -93,10 +93,7 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
     @Nonnull
     @Override
     public GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
-        if (value != null && !(value instanceof CompactGenericRecord)) {
-            throw new HazelcastSerializationException("You can only use Compact GenericRecords in a Compact"
-                    + " GenericRecordBuilder");
-        }
+        checkCompactGenericRecord(value);
         return write(fieldName, value, FieldKind.COMPACT);
     }
 
@@ -135,10 +132,7 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
     public GenericRecordBuilder setArrayOfGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord[] value) {
         if (value != null) {
             for (GenericRecord genericRecord : value) {
-                if (genericRecord != null && !(genericRecord instanceof CompactGenericRecord)) {
-                    throw new HazelcastSerializationException("You can only use Compact GenericRecords in a Compact"
-                            + " GenericRecordBuilder");
-                }
+                checkCompactGenericRecord(genericRecord);
             }
         }
         return write(fieldName, value, FieldKind.ARRAY_OF_COMPACT);
@@ -322,6 +316,13 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
         if (fd.getKind() != fieldKind) {
             throw new HazelcastSerializationException("Invalid field kind: '" + fieldName
                     + "' for " + schema + ", expected : " + fd.getKind() + ", given : " + fieldKind);
+        }
+    }
+
+    private static void checkCompactGenericRecord(GenericRecord value) {
+        if (value != null && !(value instanceof CompactGenericRecord)) {
+            throw new HazelcastSerializationException("You can only use Compact GenericRecords in a Compact"
+                    + " GenericRecordBuilder");
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
@@ -93,6 +93,10 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
     @Nonnull
     @Override
     public GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
+        if (value != null && !(value instanceof CompactGenericRecord)) {
+            throw new HazelcastSerializationException("You can only use compact generic records in a compact" +
+                    " generic record builder");
+        }
         return write(fieldName, value, FieldKind.COMPACT);
     }
 
@@ -129,6 +133,14 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
     @Nonnull
     @Override
     public GenericRecordBuilder setArrayOfGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord[] value) {
+        if (value != null) {
+            for (GenericRecord genericRecord : value) {
+                if (!(genericRecord instanceof CompactGenericRecord)) {
+                    throw new HazelcastSerializationException("You can only use compact generic records in a compact" +
+                            " generic record builder");
+                }
+            }
+        }
         return write(fieldName, value, FieldKind.ARRAY_OF_COMPACT);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/AbstractGenericRecordBuilder.java
@@ -94,8 +94,8 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
     @Override
     public GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
         if (value != null && !(value instanceof CompactGenericRecord)) {
-            throw new HazelcastSerializationException("You can only use compact generic records in a compact" +
-                    " generic record builder");
+            throw new HazelcastSerializationException("You can only use compact generic records in a compact"
+                    + " generic record builder");
         }
         return write(fieldName, value, FieldKind.COMPACT);
     }
@@ -136,8 +136,8 @@ abstract class AbstractGenericRecordBuilder implements GenericRecordBuilder {
         if (value != null) {
             for (GenericRecord genericRecord : value) {
                 if (!(genericRecord instanceof CompactGenericRecord)) {
-                    throw new HazelcastSerializationException("You can only use compact generic records in a compact" +
-                            " generic record builder");
+                    throw new HazelcastSerializationException("You can only use compact generic records in a compact"
+                            + " generic record builder");
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
@@ -171,10 +171,7 @@ public class PortableGenericRecordBuilder implements GenericRecordBuilder {
     @Nonnull
     @Override
     public GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
-        if (value != null && !(value instanceof PortableGenericRecord)) {
-            throw new HazelcastSerializationException("You can only use Portable GenericRecords in a Portable"
-                    + " GenericRecordBuilder");
-        }
+        checkPortableGenericRecord(value);
         return set(fieldName, value, FieldType.PORTABLE);
     }
 
@@ -213,13 +210,17 @@ public class PortableGenericRecordBuilder implements GenericRecordBuilder {
     public GenericRecordBuilder setArrayOfGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord[] value) {
         if (value != null) {
             for (GenericRecord genericRecord : value) {
-                if (!(genericRecord instanceof PortableGenericRecord)) {
-                    throw new HazelcastSerializationException("You can only use Portable GenericRecords in a Portable"
-                            + " GenericRecordBuilder");
-                }
+                checkPortableGenericRecord(genericRecord);
             }
         }
         return set(fieldName, value, FieldType.PORTABLE_ARRAY);
+    }
+
+    private static void checkPortableGenericRecord(GenericRecord genericRecord) {
+        if (genericRecord != null && !(genericRecord instanceof PortableGenericRecord)) {
+            throw new HazelcastSerializationException("You can only use Portable GenericRecords in a Portable"
+                    + " GenericRecordBuilder");
+        }
     }
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
@@ -172,8 +172,8 @@ public class PortableGenericRecordBuilder implements GenericRecordBuilder {
     @Override
     public GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
         if (value != null && !(value instanceof PortableGenericRecord)) {
-            throw new HazelcastSerializationException("You can only use portable generic records in a portable"
-                    + " generic record builder");
+            throw new HazelcastSerializationException("You can only use Portable GenericRecords in a Portable"
+                    + " GenericRecordBuilder");
         }
         return set(fieldName, value, FieldType.PORTABLE);
     }
@@ -214,8 +214,8 @@ public class PortableGenericRecordBuilder implements GenericRecordBuilder {
         if (value != null) {
             for (GenericRecord genericRecord : value) {
                 if (!(genericRecord instanceof PortableGenericRecord)) {
-                    throw new HazelcastSerializationException("You can only use portable generic records in a portable"
-                            + " generic record builder");
+                    throw new HazelcastSerializationException("You can only use Portable GenericRecords in a Portable"
+                            + " GenericRecordBuilder");
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.serialization.impl.portable;
 
-import com.hazelcast.internal.serialization.impl.compact.CompactGenericRecord;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
@@ -173,8 +172,8 @@ public class PortableGenericRecordBuilder implements GenericRecordBuilder {
     @Override
     public GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
         if (value != null && !(value instanceof PortableGenericRecord)) {
-            throw new HazelcastSerializationException("You can only use portable generic records in a portable" +
-                    " generic record builder");
+            throw new HazelcastSerializationException("You can only use portable generic records in a portable"
+                    + " generic record builder");
         }
         return set(fieldName, value, FieldType.PORTABLE);
     }
@@ -215,8 +214,8 @@ public class PortableGenericRecordBuilder implements GenericRecordBuilder {
         if (value != null) {
             for (GenericRecord genericRecord : value) {
                 if (!(genericRecord instanceof PortableGenericRecord)) {
-                    throw new HazelcastSerializationException("You can only use portable generic records in a portable" +
-                            " generic record builder");
+                    throw new HazelcastSerializationException("You can only use portable generic records in a portable"
+                            + " generic record builder");
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableGenericRecordBuilder.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization.impl.portable;
 
+import com.hazelcast.internal.serialization.impl.compact.CompactGenericRecord;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
@@ -171,6 +172,10 @@ public class PortableGenericRecordBuilder implements GenericRecordBuilder {
     @Nonnull
     @Override
     public GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value) {
+        if (value != null && !(value instanceof PortableGenericRecord)) {
+            throw new HazelcastSerializationException("You can only use portable generic records in a portable" +
+                    " generic record builder");
+        }
         return set(fieldName, value, FieldType.PORTABLE);
     }
 
@@ -207,6 +212,14 @@ public class PortableGenericRecordBuilder implements GenericRecordBuilder {
     @Nonnull
     @Override
     public GenericRecordBuilder setArrayOfGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord[] value) {
+        if (value != null) {
+            for (GenericRecord genericRecord : value) {
+                if (!(genericRecord instanceof PortableGenericRecord)) {
+                    throw new HazelcastSerializationException("You can only use portable generic records in a portable" +
+                            " generic record builder");
+                }
+            }
+        }
         return set(fieldName, value, FieldType.PORTABLE_ARRAY);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/genericrecord/GenericRecordBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/genericrecord/GenericRecordBuilder.java
@@ -461,14 +461,18 @@ public interface GenericRecordBuilder {
      *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist
-     *                                         in the schema/class definition or
-     *                                         the type of the field does not
+     * @throws HazelcastSerializationException 1. if the field name does not exist
+     *                                         in the schema/class definition.
+     *                                         2. The type of the field does not
      *                                         match the one in the schema/class
-     *                                         definition or the same field is
+     *                                         definition. 3. The same field is
      *                                         trying to be set without using
      *                                         {@link
      *                                         GenericRecord#newBuilderWithClone()}.
+     *                                         4. The type of the generic record is not
+     *                                         the same as the generic record that is
+     *                                         being built. e.g using portable generic
+     *                                         record in a compact generic record builder.
      */
     @Nonnull
     GenericRecordBuilder setGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord value);
@@ -1092,14 +1096,18 @@ public interface GenericRecordBuilder {
      *                  characters for {@link Portable} GenericRecords.
      * @param value     to set to GenericRecord
      * @return itself for chaining
-     * @throws HazelcastSerializationException if the field name does not exist
-     *                                         in the schema/class definition or
-     *                                         the type of the field does not
+     * @throws HazelcastSerializationException 1. if the field name does not exist
+     *                                         in the schema/class definition.
+     *                                         2. The type of the field does not
      *                                         match the one in the schema/class
-     *                                         definition or the same field is
+     *                                         definition. 3. The same field is
      *                                         trying to be set without using
      *                                         {@link
      *                                         GenericRecord#newBuilderWithClone()}.
+     *                                         4. The type of the generic record is not
+     *                                         the same as the generic record that is
+     *                                         being built. e.g using portable generic
+     *                                         record in a compact generic record builder.
      */
     @Nonnull
     GenericRecordBuilder setArrayOfGenericRecord(@Nonnull String fieldName, @Nullable GenericRecord[] value);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.internal.serialization.impl.InternalGenericRecord;
 import com.hazelcast.internal.util.FilteringClassLoader;
+import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
 import com.hazelcast.nio.serialization.FieldKind;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecord;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder;
@@ -33,8 +34,10 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import example.serialization.MainDTO;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -45,6 +48,7 @@ import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createMainDTO;
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createSerializationService;
 import static com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder.compact;
+import static com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder.portable;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -52,6 +56,9 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class GenericRecordTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testGenericRecordToStringValidJson() throws IOException {
@@ -258,5 +265,122 @@ public class GenericRecordTest {
         assertThatThrownBy(() -> {
             internalGenericRecord.getInt64("foo");
         }).isInstanceOf(HazelcastSerializationException.class).hasMessageContaining("Invalid field kind");
+    }
+
+    @Test
+    public void testSetGenericRecordDoesNotThrowWithSameTypeOfGenericRecord() {
+        GenericRecord fieldCompactRecord = compact("asd2").build();
+        // Regular builder
+        GenericRecordBuilder compactBuilder = compact("asd1");
+        compactBuilder.setGenericRecord("f", fieldCompactRecord);
+        GenericRecord record = compactBuilder.build();
+        // Cloner
+        GenericRecordBuilder cloner = record.newBuilderWithClone();
+        cloner.setGenericRecord("f", fieldCompactRecord).build();
+        // Schema bound builder
+        SchemaWriter schemaWriter = new SchemaWriter("asd1");
+        schemaWriter.addField(new FieldDescriptor("f", FieldKind.COMPACT));
+        Schema schema = schemaWriter.build();
+        GenericRecordBuilder builder = new DeserializedSchemaBoundGenericRecordBuilder(schema);
+        builder.setGenericRecord("f", fieldCompactRecord);
+        builder.build();
+    }
+
+    @Test
+    public void testSetGenericRecordThrowsWithDifferentTypeOfGenericRecord() {
+        thrown.expect(HazelcastSerializationException.class);
+        thrown.expectMessage("You can only use compact generic records in a compact");
+
+        GenericRecordBuilder compactBuilder = compact("asd1");
+        compactBuilder.setGenericRecord("f", portable(new ClassDefinitionBuilder(1, 1).build()).build());
+    }
+
+    @Test
+    public void testSetGenericRecordThrowsWithDifferentTypeOfGenericRecord_cloner() {
+        thrown.expect(HazelcastSerializationException.class);
+        thrown.expectMessage("You can only use compact generic records in a compact");
+
+        GenericRecordBuilder compactBuilder = compact("asd1");
+        compactBuilder.setGenericRecord("f", null);
+        GenericRecord record = compactBuilder.build();
+
+        GenericRecordBuilder cloner = record.newBuilderWithClone();
+        GenericRecord portableRecord = portable(new ClassDefinitionBuilder(1, 1).build()).build();
+        cloner.setGenericRecord("f", portableRecord);
+    }
+
+    @Test
+    public void testSetGenericRecordThrowsWithDifferentTypeOfGenericRecord_schemaBound() {
+        thrown.expect(HazelcastSerializationException.class);
+        thrown.expectMessage("You can only use compact generic records in a compact");
+
+        SchemaWriter schemaWriter = new SchemaWriter("asd1");
+        schemaWriter.addField(new FieldDescriptor("f", FieldKind.COMPACT));
+        Schema schema = schemaWriter.build();
+        GenericRecordBuilder builder = new DeserializedSchemaBoundGenericRecordBuilder(schema);
+        GenericRecord portableRecord = portable(new ClassDefinitionBuilder(1, 1).build()).build();
+        builder.setGenericRecord("f", portableRecord);
+    }
+
+    @Test
+    public void testSetArrayOfGenericRecordDoesNotThrowWithSameTypeOfGenericRecord() {
+        // Regular builder
+        GenericRecordBuilder compactBuilder = compact("asd1");
+        GenericRecord aCompact = compact("asd2").build();
+        GenericRecord aCompact2 = compact("asd3").build();
+        compactBuilder.setArrayOfGenericRecord("f", new GenericRecord[]{aCompact, aCompact2});
+        GenericRecord record = compactBuilder.build();
+        // Cloner
+        GenericRecordBuilder cloner = record.newBuilderWithClone();
+        cloner.setArrayOfGenericRecord("f", new GenericRecord[]{aCompact, aCompact2});
+        cloner.build();
+        // Schema bound builder
+        SchemaWriter schemaWriter = new SchemaWriter("asd1");
+        schemaWriter.addField(new FieldDescriptor("f", FieldKind.ARRAY_OF_COMPACT));
+        Schema schema = schemaWriter.build();
+        GenericRecordBuilder builder = new DeserializedSchemaBoundGenericRecordBuilder(schema);
+        builder.setArrayOfGenericRecord("f", new GenericRecord[]{aCompact, aCompact2});
+        builder.build();
+    }
+
+    @Test
+    public void testSetArrayOfGenericRecordThrowsWithDifferentTypeOfGenericRecord() {
+        thrown.expect(HazelcastSerializationException.class);
+        thrown.expectMessage("You can only use compact generic records in a compact");
+
+        GenericRecordBuilder compactBuilder = compact("asd1");
+        GenericRecord aPortable = portable(new ClassDefinitionBuilder(1, 1).build()).build();
+        GenericRecord aCompact = compact("asd2").build();
+        compactBuilder.setArrayOfGenericRecord("f", new GenericRecord[]{aPortable, aCompact});
+    }
+
+    @Test
+    public void testSetArrayOfGenericRecordThrowsWithDifferentTypeOfGenericRecord_cloner() {
+        thrown.expect(HazelcastSerializationException.class);
+        thrown.expectMessage("You can only use compact generic records in a compact");
+
+        GenericRecordBuilder compactBuilder = compact("asd1");
+        compactBuilder.setArrayOfGenericRecord("f", null);
+        GenericRecord record = compactBuilder.build();
+
+        GenericRecordBuilder cloner = record.newBuilderWithClone();
+        GenericRecord aPortable = portable(new ClassDefinitionBuilder(1, 1).build()).build();
+        GenericRecord aCompact = compact("asd2").build();
+        cloner.setArrayOfGenericRecord("f", new GenericRecord[]{aPortable, aCompact});
+    }
+
+    @Test
+    public void testSetArrayOfGenericRecordThrowsWithDifferentTypeOfGenericRecord_schemaBound() {
+        thrown.expect(HazelcastSerializationException.class);
+        thrown.expectMessage("You can only use compact generic records in a compact");
+
+        GenericRecord aPortable = portable(new ClassDefinitionBuilder(1, 1).build()).build();
+        GenericRecord aCompact = compact("asd2").build();
+
+        SchemaWriter schemaWriter = new SchemaWriter("asd1");
+        schemaWriter.addField(new FieldDescriptor("f", FieldKind.ARRAY_OF_COMPACT));
+        Schema schema = schemaWriter.build();
+        GenericRecordBuilder builder = new DeserializedSchemaBoundGenericRecordBuilder(schema);
+        builder.setArrayOfGenericRecord("f", new GenericRecord[]{aPortable, aCompact});
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
@@ -289,7 +289,7 @@ public class GenericRecordTest {
     @Test
     public void testSetGenericRecordThrowsWithDifferentTypeOfGenericRecord() {
         thrown.expect(HazelcastSerializationException.class);
-        thrown.expectMessage("You can only use compact generic records in a compact");
+        thrown.expectMessage("You can only use Compact GenericRecords in a Compact");
 
         GenericRecordBuilder compactBuilder = compact("asd1");
         compactBuilder.setGenericRecord("f", portable(new ClassDefinitionBuilder(1, 1).build()).build());
@@ -298,7 +298,7 @@ public class GenericRecordTest {
     @Test
     public void testSetGenericRecordThrowsWithDifferentTypeOfGenericRecord_cloner() {
         thrown.expect(HazelcastSerializationException.class);
-        thrown.expectMessage("You can only use compact generic records in a compact");
+        thrown.expectMessage("You can only use Compact GenericRecords in a Compact");
 
         GenericRecordBuilder compactBuilder = compact("asd1");
         compactBuilder.setGenericRecord("f", null);
@@ -312,7 +312,7 @@ public class GenericRecordTest {
     @Test
     public void testSetGenericRecordThrowsWithDifferentTypeOfGenericRecord_schemaBound() {
         thrown.expect(HazelcastSerializationException.class);
-        thrown.expectMessage("You can only use compact generic records in a compact");
+        thrown.expectMessage("You can only use Compact GenericRecords in a Compact");
 
         SchemaWriter schemaWriter = new SchemaWriter("asd1");
         schemaWriter.addField(new FieldDescriptor("f", FieldKind.COMPACT));
@@ -346,7 +346,7 @@ public class GenericRecordTest {
     @Test
     public void testSetArrayOfGenericRecordThrowsWithDifferentTypeOfGenericRecord() {
         thrown.expect(HazelcastSerializationException.class);
-        thrown.expectMessage("You can only use compact generic records in a compact");
+        thrown.expectMessage("You can only use Compact GenericRecords in a Compact");
 
         GenericRecordBuilder compactBuilder = compact("asd1");
         GenericRecord aPortable = portable(new ClassDefinitionBuilder(1, 1).build()).build();
@@ -357,7 +357,7 @@ public class GenericRecordTest {
     @Test
     public void testSetArrayOfGenericRecordThrowsWithDifferentTypeOfGenericRecord_cloner() {
         thrown.expect(HazelcastSerializationException.class);
-        thrown.expectMessage("You can only use compact generic records in a compact");
+        thrown.expectMessage("You can only use Compact GenericRecords in a Compact");
 
         GenericRecordBuilder compactBuilder = compact("asd1");
         compactBuilder.setArrayOfGenericRecord("f", null);
@@ -372,7 +372,7 @@ public class GenericRecordTest {
     @Test
     public void testSetArrayOfGenericRecordThrowsWithDifferentTypeOfGenericRecord_schemaBound() {
         thrown.expect(HazelcastSerializationException.class);
-        thrown.expectMessage("You can only use compact generic records in a compact");
+        thrown.expectMessage("You can only use Compact GenericRecords in a Compact");
 
         GenericRecord aPortable = portable(new ClassDefinitionBuilder(1, 1).build()).build();
         GenericRecord aCompact = compact("asd2").build();

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/GenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/GenericRecordTest.java
@@ -123,7 +123,7 @@ public class GenericRecordTest {
     @Test
     public void testSetGenericRecordThrowsWithDifferentTypeOfGenericRecord() {
         thrown.expect(HazelcastSerializationException.class);
-        thrown.expectMessage("You can only use portable generic records in a portable");
+        thrown.expectMessage("You can only use Portable GenericRecords in a Portable");
 
         GenericRecordBuilder portableBuilder = GenericRecordBuilder.portable(new ClassDefinitionBuilder(1, 1).build());
         portableBuilder.setGenericRecord("f", GenericRecordBuilder.compact("asd1").build());
@@ -144,7 +144,7 @@ public class GenericRecordTest {
     @Test
     public void testSetArrayOfGenericRecordThrowsWithDifferentTypeOfGenericRecord() {
         thrown.expect(HazelcastSerializationException.class);
-        thrown.expectMessage("You can only use portable generic records in a portable");
+        thrown.expectMessage("You can only use Portable GenericRecords in a Portable");
 
         ClassDefinitionBuilder classDefinitionBuilder = new ClassDefinitionBuilder(1, 1);
         ClassDefinition fieldClassDefinition = new ClassDefinitionBuilder(1, 2).build();

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/GenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/portable/GenericRecordTest.java
@@ -23,13 +23,16 @@ import com.hazelcast.internal.serialization.impl.TestSerializationConstants;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
 import com.hazelcast.nio.serialization.FieldKind;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecord;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -40,6 +43,9 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class GenericRecordTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testUnsupportedMethods() {
@@ -102,5 +108,50 @@ public class GenericRecordTest {
 
         assertEquals(FieldKind.STRING, internalGenericRecord.getFieldKind("s"));
         assertEquals(FieldKind.NOT_AVAILABLE, internalGenericRecord.getFieldKind("ss"));
+    }
+
+    @Test
+    public void testSetGenericRecordDoesNotThrowWithSameTypeOfGenericRecord() {
+        ClassDefinitionBuilder classDefinitionBuilder = new ClassDefinitionBuilder(1, 1);
+        ClassDefinition fieldClassDefinition = new ClassDefinitionBuilder(1, 2).build();
+        ClassDefinition classDefinition = classDefinitionBuilder.addPortableField("f", fieldClassDefinition).build();
+        GenericRecordBuilder portableBuilder = GenericRecordBuilder.portable(classDefinition);
+        portableBuilder.setGenericRecord("f", GenericRecordBuilder.portable(fieldClassDefinition).build());
+        portableBuilder.build();
+    }
+
+    @Test
+    public void testSetGenericRecordThrowsWithDifferentTypeOfGenericRecord() {
+        thrown.expect(HazelcastSerializationException.class);
+        thrown.expectMessage("You can only use portable generic records in a portable");
+
+        GenericRecordBuilder portableBuilder = GenericRecordBuilder.portable(new ClassDefinitionBuilder(1, 1).build());
+        portableBuilder.setGenericRecord("f", GenericRecordBuilder.compact("asd1").build());
+    }
+
+    @Test
+    public void testSetArrayOfGenericRecordDoesNotThrowWithSameTypeOfGenericRecord() {
+        ClassDefinitionBuilder classDefinitionBuilder = new ClassDefinitionBuilder(1, 1);
+        ClassDefinition fieldClassDefinition = new ClassDefinitionBuilder(1, 2).build();
+        ClassDefinition classDefinition = classDefinitionBuilder.addPortableArrayField("f", fieldClassDefinition).build();
+        GenericRecordBuilder portableBuilder = GenericRecordBuilder.portable(classDefinition);
+        GenericRecord aPortable = GenericRecordBuilder.portable(new ClassDefinitionBuilder(1, 2).build()).build();
+        GenericRecord aPortable2 = GenericRecordBuilder.portable(new ClassDefinitionBuilder(1, 2).build()).build();
+        portableBuilder.setArrayOfGenericRecord("f", new GenericRecord[]{aPortable, aPortable2});
+        portableBuilder.build();
+    }
+
+    @Test
+    public void testSetArrayOfGenericRecordThrowsWithDifferentTypeOfGenericRecord() {
+        thrown.expect(HazelcastSerializationException.class);
+        thrown.expectMessage("You can only use portable generic records in a portable");
+
+        ClassDefinitionBuilder classDefinitionBuilder = new ClassDefinitionBuilder(1, 1);
+        ClassDefinition fieldClassDefinition = new ClassDefinitionBuilder(1, 2).build();
+        ClassDefinition classDefinition = classDefinitionBuilder.addPortableArrayField("f", fieldClassDefinition).build();
+        GenericRecordBuilder portableBuilder = GenericRecordBuilder.portable(classDefinition);
+        GenericRecord aPortable = GenericRecordBuilder.portable(new ClassDefinitionBuilder(1, 2).build()).build();
+        GenericRecord aCompact = GenericRecordBuilder.compact("asd1").build();
+        portableBuilder.setArrayOfGenericRecord("f", new GenericRecord[]{aPortable, aCompact});
     }
 }


### PR DESCRIPTION
Right now, GenericRecordBuilder.setGenericRecord does not throw if the value is not of the same type of generic record. (compact for compact, portable for portable) 

We instead throw a cast exception while trying to do toData.  We should do it during the setter.

Breaking changes (list specific methods/types/messages):
* If some users were misusing the API, they may be affected

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc


I don't think we need backports for this change.