### PR TITLE
Explicitly specify executor for CF calls in the 'cp' package [HZ-2005]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/TransferLeadershipOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/TransferLeadershipOp.java
@@ -35,6 +35,8 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import java.io.IOException;
 import java.util.function.BiConsumer;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
+
 /**
  * Triggers the local CP member to transfer Raft group leadership to given CP
  * member for the given CP group
@@ -57,7 +59,7 @@ public class TransferLeadershipOp extends Operation implements RaftSystemOperati
     public CallStatus call() throws Exception {
         RaftService service = getService();
         InternalCompletableFuture future = service.transferLeadership(groupId, (CPMemberInfo) destination);
-        future.whenCompleteAsync(this);
+        future.whenCompleteAsync(this, CALLER_RUNS);
         return CallStatus.VOID;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/LeadershipTransferState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/LeadershipTransferState.java
@@ -19,6 +19,7 @@ package com.hazelcast.cp.internal.raft.impl.state;
 import com.hazelcast.cp.internal.raft.impl.RaftEndpoint;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.spi.impl.InternalCompletableFuture.completingCallback;
 
 /**
@@ -55,7 +56,7 @@ public class LeadershipTransferState {
 
     public void notify(RaftEndpoint targetEndpoint, final InternalCompletableFuture otherFuture) {
         if (this.endpoint.equals(targetEndpoint)) {
-            resultFuture.whenCompleteAsync(completingCallback(otherFuture));
+            resultFuture.whenCompleteAsync(completingCallback(otherFuture), CALLER_RUNS);
         } else {
             otherFuture.completeExceptionally(
                     new IllegalStateException("There is an ongoing leadership transfer process to " + endpoint));


### PR DESCRIPTION
Moving away from using the `ForkJoinPool#commonPool` for the `cp` package. 

Related to https://github.com/hazelcast/hazelcast/issues/18190

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
