### PR TITLE
Ensure that global logger is configured when using HazelcastParametrizedRunner

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParametrizedRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParametrizedRunner.java
@@ -27,6 +27,22 @@ import org.junit.runners.model.Statement;
  */
 public class HazelcastParametrizedRunner extends Parameterized {
 
+    static {
+        // Ensure that AbstractHazelcastClassRunner static initialization is run,
+        // to configure global logger.
+        //
+        // If a test class inherits HazelcastTestSupport (as most do),
+        // HazelcastParametrizedRunner causes the test class to be initialized in its constructor.
+        // However, at the time when HazelcastParametrizedRunner is created,
+        // AbstractHazelcastClassRunner may not have been initialized yet.
+        // Due to that TestLoggerFactory configured by AbstractHazelcastClassRunner is ignored
+        // because HazelcastTestSupport.LOGGER obtains logger earlier and creates NoLogFactory.
+        //
+        // This does not affect users of LoggingService, because it creates a new LoggerFactory when needed.
+        // This affects cases when com.hazelcast.logging.Logger.getLogger() method is used directly.
+        AbstractHazelcastClassRunner.getTestMethodName();
+    }
+
     public HazelcastParametrizedRunner(Class<?> klass) throws Throwable {
         super(klass);
     }


### PR DESCRIPTION
When first test executed in given JVM used `HazelcastParametrizedRunner`,
global logger (`com.hazelcast.logging.Logger.getLogger()`) was not configured using `TestLoggingUtils.initializeLogging()` which meant that some logs were missing.
This did not affect `LoggingService`.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
