### PR TITLE
[ALTO] Added reactor name for debugging

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Reactor.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Reactor.java
@@ -68,6 +68,7 @@ public abstract class Reactor implements Executor {
     public final CircularQueue<Runnable> localTaskQueue;
     protected final boolean spin;
     protected final Thread eventloopThread;
+    protected final String name;
     protected volatile State state = NEW;
 
     TpcEngine engine;
@@ -93,6 +94,16 @@ public abstract class Reactor implements Executor {
         if (builder.threadNameSupplier != null) {
             eventloopThread.setName(builder.threadNameSupplier.get());
         }
+        this.name = builder.reactorNameSupplier.get();
+    }
+
+    /**
+     * Gets the name of this reactor. Useful for debugging purposes.
+     *
+     * @return the name.
+     */
+    public final String name() {
+        return name;
     }
 
     /**
@@ -285,6 +296,11 @@ public abstract class Reactor implements Executor {
         } else {
             return false;
         }
+    }
+
+    @Override
+    public String toString() {
+        return name;
     }
 
     /**

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/ReactorBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/ReactorBuilder.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.tpc;
 import com.hazelcast.internal.util.ThreadAffinity;
 
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static com.hazelcast.internal.tpc.util.Preconditions.checkNotNegative;
@@ -48,6 +49,15 @@ public abstract class ReactorBuilder {
     protected final ReactorType type;
     Supplier<Scheduler> schedulerSupplier = NopScheduler::new;
     Supplier<String> threadNameSupplier;
+    Supplier<String> reactorNameSupplier = new Supplier<String>() {
+        private final AtomicInteger idGenerator = new AtomicInteger();
+
+        @Override
+        public String get() {
+            return "Reactor-" + idGenerator.incrementAndGet();
+        }
+    };
+
     ThreadAffinity threadAffinity = ThreadAffinity.newSystemThreadAffinity(NAME_REACTOR_AFFINITY);
 
     ThreadFactory threadFactory = Thread::new;
@@ -77,6 +87,16 @@ public abstract class ReactorBuilder {
      * @return the created Reactor.
      */
     public abstract Reactor build();
+
+    /**
+     * Sets the reactor name supplier.
+     *
+     * @param reactorNameSupplier the reactor name supplier.
+     * @throws NullPointerException if reactorNameSupplier is null.
+     */
+    public void setReactorNameSupplier(Supplier<String> reactorNameSupplier) {
+        this.reactorNameSupplier = checkNotNull(reactorNameSupplier, "reactorNameSupplier");
+    }
 
     /**
      * Sets the clock refresh period.

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/ReactorBuilderTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/ReactorBuilderTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.util.ThreadAffinity;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -30,6 +31,28 @@ import static org.junit.Assert.assertTrue;
 public abstract class ReactorBuilderTest {
 
     public abstract ReactorBuilder newBuilder();
+
+    @Test
+    public void test_setReactorNameSupplier_whenNull() {
+        ReactorBuilder builder = newBuilder();
+        assertThrows(NullPointerException.class, () -> builder.setReactorNameSupplier(null));
+    }
+
+    @Test
+    public void test_setReactorNameSupplier() {
+        ReactorBuilder builder = newBuilder();
+        builder.setReactorNameSupplier(new Supplier<String>() {
+            private AtomicInteger idGenerator = new AtomicInteger();
+
+            @Override
+            public String get() {
+                return "banana-" + idGenerator.incrementAndGet();
+            }
+        });
+        Reactor reactor1 = builder.build();
+        assertEquals("banana-1", reactor1.name());
+        assertEquals("banana-1", reactor1.toString());
+    }
 
     @Test
     public void test_setThreadFactory_whenNull() {


### PR DESCRIPTION
Sometimes it is useful to use the toString of the reactor for debugging purposes.