### PR TITLE
Explicitly specify executor for CF calls in general classes [HZ-2006]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -29,6 +29,7 @@ import com.hazelcast.executor.impl.operations.MemberCallableTaskOperation;
 import com.hazelcast.executor.impl.operations.ShutdownOperation;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.FutureUtil.ExceptionHandler;
 import com.hazelcast.internal.util.Timer;
 import com.hazelcast.logging.ILogger;
@@ -36,7 +37,6 @@ import com.hazelcast.partition.PartitionAware;
 import com.hazelcast.spi.impl.AbstractDistributedObject;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.impl.operationservice.impl.InvocationFuture;
@@ -55,7 +55,6 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -94,14 +93,12 @@ public class ExecutorServiceProxy
     private final Random random = new Random(-System.currentTimeMillis());
     private final int partitionCount;
     private final ILogger logger;
-    private final Executor internalAsyncExecutor;
 
     public ExecutorServiceProxy(String name, NodeEngine nodeEngine, DistributedExecutorService service) {
         super(nodeEngine, service);
         this.name = name;
         this.partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         this.logger = nodeEngine.getLogger(ExecutorServiceProxy.class);
-        this.internalAsyncExecutor = nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR);
         getLocalExecutorStats();
     }
 
@@ -376,12 +373,12 @@ public class ExecutorServiceProxy
                 .createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, partitionId)
                 .invoke();
         if (callback != null) {
-            future.whenCompleteAsync(new ExecutionCallbackAdapter<>(callback), internalAsyncExecutor)
+            future.whenCompleteAsync(new ExecutionCallbackAdapter<>(callback), ConcurrencyUtil.getDefaultAsyncExecutor())
                     .whenCompleteAsync((v, t) -> {
                         if (t instanceof RejectedExecutionException) {
                             callback.onFailure(t);
                         }
-                    }, internalAsyncExecutor);
+                    }, ConcurrencyUtil.getDefaultAsyncExecutor());
         }
     }
 
@@ -418,12 +415,12 @@ public class ExecutorServiceProxy
                 .createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, address)
                 .invoke();
         if (callback != null) {
-            future.whenCompleteAsync(new ExecutionCallbackAdapter<>(callback), internalAsyncExecutor)
+            future.whenCompleteAsync(new ExecutionCallbackAdapter<>(callback), ConcurrencyUtil.getDefaultAsyncExecutor())
                     .whenCompleteAsync((v, t) -> {
                         if (t instanceof RejectedExecutionException) {
                             callback.onFailure(t);
                         }
-                    }, internalAsyncExecutor);
+                    }, ConcurrencyUtil.getDefaultAsyncExecutor());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyUtil.java
@@ -47,7 +47,7 @@ public final class ConcurrencyUtil {
 
     // Default executor for async callbacks: ForkJoinPool.commonPool() or a thread-per-task executor when
     // the common pool does not support parallelism
-    private static volatile Executor defaultAsyncExecutor;
+    private static Executor defaultAsyncExecutor;
 
     static {
         Executor asyncExecutor;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyUtil.java
@@ -47,7 +47,7 @@ public final class ConcurrencyUtil {
 
     // Default executor for async callbacks: ForkJoinPool.commonPool() or a thread-per-task executor when
     // the common pool does not support parallelism
-    private static Executor defaultAsyncExecutor;
+    private static volatile Executor defaultAsyncExecutor;
 
     static {
         Executor asyncExecutor;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -27,6 +27,7 @@ import com.hazelcast.internal.util.iterator.RestartingMemberIterator;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationResponseHandler;
 import com.hazelcast.spi.properties.ClusterProperty;
@@ -242,7 +243,7 @@ public final class InvocationUtil {
                     } else {
                         future.completeExceptionally(t);
                     }
-                });
+                }, nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
@@ -17,11 +17,10 @@
 
 package com.hazelcast.internal.util.futures;
 
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.util.Iterator;
-
-import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 
 /**
  * Iterates over supplied {@link InternalCompletableFuture} serially.
@@ -59,7 +58,7 @@ public class ChainingFuture<T> extends InternalCompletableFuture<T> {
                     completeExceptionally(t);
                 }
             }
-        }, CALLER_RUNS);
+        }, ConcurrencyUtil.getDefaultAsyncExecutor());
     }
 
     private void advanceOrComplete(T response, Iterator<InternalCompletableFuture<T>> invocationIterator) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
@@ -21,6 +21,8 @@ import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.util.Iterator;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
+
 /**
  * Iterates over supplied {@link InternalCompletableFuture} serially.
  * It advances to the next future only when the previous future is completed.
@@ -57,7 +59,7 @@ public class ChainingFuture<T> extends InternalCompletableFuture<T> {
                     completeExceptionally(t);
                 }
             }
-        });
+        }, CALLER_RUNS);
     }
 
     private void advanceOrComplete(T response, Iterator<InternalCompletableFuture<T>> invocationIterator) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
@@ -17,7 +17,6 @@
 
 package com.hazelcast.internal.util.futures;
 
-import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 
 import java.util.Iterator;
@@ -58,7 +57,7 @@ public class ChainingFuture<T> extends InternalCompletableFuture<T> {
                     completeExceptionally(t);
                 }
             }
-        }, ConcurrencyUtil.getDefaultAsyncExecutor());
+        }, defaultExecutor());
     }
 
     private void advanceOrComplete(T response, Iterator<InternalCompletableFuture<T>> invocationIterator) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -47,6 +47,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.internal.util.ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static java.util.Objects.requireNonNull;
@@ -1003,9 +1004,9 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
         // both futures are done
         if (otherFuture.isCompletedExceptionally()) {
-            otherFuture.whenComplete((v, t) -> {
+            otherFuture.whenCompleteAsync((v, t) -> {
                 future.completeExceptionally(t);
-            });
+            }, CALLER_RUNS);
             return;
         }
         U otherValue = otherFuture.join();
@@ -1051,9 +1052,9 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
         // both futures are done
         if (otherFuture.isCompletedExceptionally()) {
-            otherFuture.whenComplete((v, t) -> {
+            otherFuture.whenCompleteAsync((v, t) -> {
                 future.completeExceptionally(t);
-            });
+            }, CALLER_RUNS);
             return;
         }
         U otherValue = otherFuture.join();
@@ -1098,9 +1099,9 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         }
         // both futures are done
         if (otherFuture.isCompletedExceptionally()) {
-            otherFuture.whenComplete((v, t) -> {
+            otherFuture.whenCompleteAsync((v, t) -> {
                 future.completeExceptionally(t);
-            });
+            }, CALLER_RUNS);
             return;
         }
         runAfter0(future, action, executor);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingCompletableFuture.java
@@ -36,6 +36,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static java.util.Objects.requireNonNull;
 
@@ -99,7 +100,7 @@ public class DelegatingCompletableFuture<V> extends InternalCompletableFuture<V>
         this.serializationService = (InternalSerializationService) serializationService;
         this.result = result;
         if (listenFutureCompletion) {
-            this.future.whenComplete((v, t) -> completeSuper(v, (Throwable) t));
+            this.future.whenCompleteAsync((v, t) -> completeSuper(v, (Throwable) t), CALLER_RUNS);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractContainerMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractContainerMerger.java
@@ -19,12 +19,14 @@ package com.hazelcast.spi.impl.merge;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.merge.MergingValue;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -53,6 +55,7 @@ public abstract class AbstractContainerMerger<C, V, T extends MergingValue<V>> i
     private final SplitBrainMergePolicyProvider splitBrainMergePolicyProvider;
 
     private int operationCount;
+    private final Executor internalAsyncExecutor;
 
     protected AbstractContainerMerger(AbstractContainerCollector<C> collector, NodeEngine nodeEngine) {
         this.collector = collector;
@@ -67,6 +70,7 @@ public abstract class AbstractContainerMerger<C, V, T extends MergingValue<V>> i
         };
         this.operationService = nodeEngine.getOperationService();
         this.splitBrainMergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
+        this.internalAsyncExecutor = nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR);
     }
 
     @Override
@@ -126,7 +130,7 @@ public abstract class AbstractContainerMerger<C, V, T extends MergingValue<V>> i
             operationCount++;
             operationService
                     .invokeOnPartition(serviceName, operation, partitionId)
-                    .whenCompleteAsync(mergeCallback);
+                    .whenCompleteAsync(mergeCallback, internalAsyncExecutor);
         } catch (Throwable t) {
             throw rethrow(t);
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.BiConsumer;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareFactoryAccessor.extractPartitionAware;
 import static com.hazelcast.internal.util.CollectionUtil.toIntArray;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
@@ -118,7 +119,7 @@ final class InvokeOnPartitions {
                     .setTryCount(TRY_COUNT)
                     .setTryPauseMillis(TRY_PAUSE_MILLIS)
                     .invoke()
-                    .whenCompleteAsync(new FirstAttemptExecutionCallback(partitions));
+                    .whenCompleteAsync(new FirstAttemptExecutionCallback(partitions), CALLER_RUNS);
         }
     }
 
@@ -141,7 +142,7 @@ final class InvokeOnPartitions {
                                 setPartitionResult(partitionId, throwable);
                                 decrementLatchAndHandle(1);
                             }
-                        });
+                        }, CALLER_RUNS);
     }
 
     private void decrementLatchAndHandle(int count) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/tenantcontrol/impl/TenantControlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/tenantcontrol/impl/TenantControlServiceImpl.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterSerial;
 import static com.hazelcast.spi.tenantcontrol.TenantControlFactory.NOOP_TENANT_CONTROL_FACTORY;
 
@@ -155,7 +156,7 @@ public class TenantControlServiceImpl
                 if (t != null) {
                     logger.warning("Failed to propagate tenant control", t);
                 }
-            });
+            }, CALLER_RUNS);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
@@ -18,6 +18,7 @@ package com.hazelcast.transaction.impl;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
@@ -155,7 +156,7 @@ public class TransactionLog {
             operationService.invokeOnTarget(op.getServiceName(), op, target);
         } else {
             operationService.invokeOnPartitionAsync(op.getServiceName(), op, op.getPartitionId())
-                    .whenCompleteAsync(callback);
+                    .whenCompleteAsync(callback, nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
@@ -17,8 +17,8 @@
 package com.hazelcast.transaction.impl;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.spi.impl.NodeEngine;
-import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
@@ -156,7 +156,7 @@ public class TransactionLog {
             operationService.invokeOnTarget(op.getServiceName(), op, target);
         } else {
             operationService.invokeOnPartitionAsync(op.getServiceName(), op, op.getPartitionId())
-                    .whenCompleteAsync(callback, nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR));
+                    .whenCompleteAsync(callback, ConcurrencyUtil.getDefaultAsyncExecutor());
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/futures/ChainingFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/futures/ChainingFutureTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.iterator.RestartingMemberIterator;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
@@ -58,6 +59,7 @@ public class ChainingFutureTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
+        ConcurrencyUtil.setDefaultAsyncExecutor(CALLER_RUNS);
         Set<Member> members = new HashSet<>();
         members.add(mock(Member.class));
         when(clusterService.getMembers()).thenReturn(members);

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/futures/ChainingFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/futures/ChainingFutureTest.java
@@ -28,12 +28,12 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nonnull;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -189,7 +189,7 @@ public class ChainingFutureTest extends HazelcastTestSupport {
         return InternalCompletableFuture.withExecutor(executor);
     }
 
-    @NotNull
+    @Nonnull
     private <T> ChainingFuture newChainingFuture(CountingIterator<InternalCompletableFuture<T>> iterator, ChainingFuture.ExceptionHandler handler) {
         return new ChainingFuture(iterator, handler) {
             @Override


### PR DESCRIPTION
Moving away from using the `ForkJoinPool#commonPool`. 
Related to https://github.com/hazelcast/hazelcast/issues/18190

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
