### PR TITLE
Explicitly specify executor for CF calls in the 'map' package [HZ-2007]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
@@ -281,7 +281,7 @@ abstract class CacheProxySupport<K, V>
                 if (t != null) {
                     logger.warning("Problem in loadAll task", t);
                 }
-            });
+            }, internalAsyncExecutor);
         } catch (Exception e) {
             if (completionListener != null) {
                 completionListener.onException(e);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
@@ -281,7 +281,7 @@ abstract class CacheProxySupport<K, V>
                 if (t != null) {
                     logger.warning("Problem in loadAll task", t);
                 }
-            }, internalAsyncExecutor);
+            }, future.defaultExecutor());
         } catch (Exception e) {
             if (completionListener != null) {
                 completionListener.onException(e);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
@@ -29,6 +29,7 @@ import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.FutureUtil;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
@@ -281,7 +282,7 @@ abstract class CacheProxySupport<K, V>
                 if (t != null) {
                     logger.warning("Problem in loadAll task", t);
                 }
-            }, future.defaultExecutor());
+            }, ConcurrencyUtil.getDefaultAsyncExecutor());
         } catch (Exception e) {
             if (completionListener != null) {
                 completionListener.onException(e);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxySupport.java
@@ -29,7 +29,6 @@ import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.FutureUtil;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
@@ -70,6 +69,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
 import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLETION;
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrowAllowedTypeFirst;
 import static com.hazelcast.internal.util.SetUtil.createHashSet;
@@ -282,7 +282,7 @@ abstract class CacheProxySupport<K, V>
                 if (t != null) {
                     logger.warning("Problem in loadAll task", t);
                 }
-            }, ConcurrencyUtil.getDefaultAsyncExecutor());
+            }, CALLER_RUNS);
         } catch (Exception e) {
             if (completionListener != null) {
                 completionListener.onException(e);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
@@ -30,6 +30,8 @@ import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
 
 import java.io.IOException;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
+
 /**
  * Gets a cache configuration or creates one, if a matching cache config is found in this member's config.
  *
@@ -75,7 +77,7 @@ public class CacheGetConfigOperation extends AbstractNamedOperation implements I
                 } else {
                     CacheGetConfigOperation.this.sendResponse(t);
                 }
-            });
+            }, CALLER_RUNS);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -181,6 +182,7 @@ public class MapKeyLoader {
      */
     private final Semaphore nodeWideLoadedKeyLimiter;
     private final ClusterService clusterService;
+    private final Executor internalAsyncExecutor;
 
     public MapKeyLoader(String mapName, OperationService opService, IPartitionService ps,
                         ClusterService clusterService, ExecutionService execService,
@@ -193,6 +195,7 @@ public class MapKeyLoader {
         this.execService = execService;
         this.logger = getLogger(MapKeyLoader.class);
         this.nodeWideLoadedKeyLimiter = nodeWideLoadedKeyLimiter;
+        this.internalAsyncExecutor = execService.getExecutor(ExecutionService.ASYNC_EXECUTOR);
     }
 
     /**
@@ -265,7 +268,7 @@ public class MapKeyLoader {
                 return false;
             });
 
-            execService.asCompletableFuture(sent).whenCompleteAsync(keyLoadFinished);
+            execService.asCompletableFuture(sent).whenCompleteAsync(keyLoadFinished, internalAsyncExecutor);
         }
 
         return keyLoadFinished;
@@ -289,7 +292,7 @@ public class MapKeyLoader {
                 opService.<Boolean>invokeOnPartition(SERVICE_NAME, op, mapNamePartition)
                         // required since loading may be triggered after migration
                         // and in this case the callback is the only way to get to know if the key load finished or not.
-                        .whenCompleteAsync(loadingFinishedCallback());
+                        .whenCompleteAsync(loadingFinishedCallback(), internalAsyncExecutor);
             });
         }
         return keyLoadFinished;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.FutureUtil;
 import com.hazelcast.internal.util.StateMachine;
 import com.hazelcast.internal.util.concurrent.BackoffIdleStrategy;
@@ -268,7 +269,8 @@ public class MapKeyLoader {
                 return false;
             });
 
-            execService.asCompletableFuture(sent).whenCompleteAsync(keyLoadFinished, internalAsyncExecutor);
+            execService.asCompletableFuture(sent).whenCompleteAsync(keyLoadFinished,
+                    ConcurrencyUtil.getDefaultAsyncExecutor());
         }
 
         return keyLoadFinished;
@@ -292,7 +294,7 @@ public class MapKeyLoader {
                 opService.<Boolean>invokeOnPartition(SERVICE_NAME, op, mapNamePartition)
                         // required since loading may be triggered after migration
                         // and in this case the callback is the only way to get to know if the key load finished or not.
-                        .whenCompleteAsync(loadingFinishedCallback(), internalAsyncExecutor);
+                        .whenCompleteAsync(loadingFinishedCallback(), ConcurrencyUtil.getDefaultAsyncExecutor());
             });
         }
         return keyLoadFinished;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -38,6 +38,7 @@ import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.IterableUtil;
 import com.hazelcast.internal.util.IterationType;
@@ -1052,7 +1053,7 @@ abstract class MapProxySupport<K, V>
             };
             for (Entry<Address, List<Integer>> entry : memberPartitionsMap.entrySet()) {
                 invokePutAllOperation(entry.getKey(), entry.getValue(), entriesPerPartition, triggerMapLoader)
-                        .whenCompleteAsync(callback, internalAsyncExecutor);
+                        .whenCompleteAsync(callback, ConcurrencyUtil.getDefaultAsyncExecutor());
             }
             // if executing in sync mode, block for the responses
             if (future == null) {
@@ -1289,7 +1290,7 @@ abstract class MapProxySupport<K, V>
                     } else {
                         resultFuture.completeExceptionally(throwable);
                     }
-                }, internalAsyncExecutor);
+                }, ConcurrencyUtil.getDefaultAsyncExecutor());
         return resultFuture;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -1052,7 +1052,7 @@ abstract class MapProxySupport<K, V>
             };
             for (Entry<Address, List<Integer>> entry : memberPartitionsMap.entrySet()) {
                 invokePutAllOperation(entry.getKey(), entry.getValue(), entriesPerPartition, triggerMapLoader)
-                        .whenCompleteAsync(callback);
+                        .whenCompleteAsync(callback, internalAsyncExecutor);
             }
             // if executing in sync mode, block for the responses
             if (future == null) {
@@ -1289,7 +1289,7 @@ abstract class MapProxySupport<K, V>
                     } else {
                         resultFuture.completeExceptionally(throwable);
                     }
-                });
+                }, internalAsyncExecutor);
         return resultFuture;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -148,7 +148,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
                 } else {
                     invalidateNearCache(ncKey);
                 }
-            });
+            }, internalAsyncExecutor);
         }
         return future;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.nearcache.impl.invalidation.BatchNearCacheInvalida
 import com.hazelcast.internal.nearcache.impl.invalidation.Invalidation;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.InterceptorRegistry;
 import com.hazelcast.map.impl.MapEntries;
@@ -148,7 +149,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
                 } else {
                     invalidateNearCache(ncKey);
                 }
-            }, internalAsyncExecutor);
+            }, ConcurrencyUtil.getDefaultAsyncExecutor());
         }
         return future;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.query;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.partition.IPartition;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
@@ -27,7 +28,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
-import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.AbstractNamedOperation;
 import com.hazelcast.spi.impl.operationservice.CallStatus;
 import com.hazelcast.spi.impl.operationservice.ExceptionAction;
@@ -201,7 +201,7 @@ public class QueryOperation extends AbstractNamedOperation implements ReadonlyOp
             getOperationService().executeOnPartitions(
                     new QueryTaskFactory(query, queryRunner, future), localPartitions);
             future.whenCompleteAsync(new ExecutionCallbackImpl(queryRunner, query),
-                    nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR));
+                    ConcurrencyUtil.getDefaultAsyncExecutor());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -27,6 +27,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.AbstractNamedOperation;
 import com.hazelcast.spi.impl.operationservice.CallStatus;
 import com.hazelcast.spi.impl.operationservice.ExceptionAction;
@@ -199,7 +200,8 @@ public class QueryOperation extends AbstractNamedOperation implements ReadonlyOp
             QueryFuture future = new QueryFuture(localPartitions.cardinality());
             getOperationService().executeOnPartitions(
                     new QueryTaskFactory(query, queryRunner, future), localPartitions);
-            future.whenCompleteAsync(new ExecutionCallbackImpl(queryRunner, query));
+            future.whenCompleteAsync(new ExecutionCallbackImpl(queryRunner, query),
+                    nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.monitor.impl.LocalMultiMapStatsImpl;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.services.DistributedObjectNamespace;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.ThreadUtil;
 import com.hazelcast.internal.util.Timer;
@@ -155,7 +156,7 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
             };
             for (Map.Entry<Address, List<Integer>> entry : memberPartitionsMap.entrySet()) {
                 invokePutAllOperation(entry.getKey(), entry.getValue(), entriesPerPartition)
-                        .whenCompleteAsync(callback, internalAsyncExecutor);
+                        .whenCompleteAsync(callback, ConcurrencyUtil.getDefaultAsyncExecutor());
             }
             // if executing in sync mode, block for the responses
             if (future == null) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -154,7 +154,8 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
                 }
             };
             for (Map.Entry<Address, List<Integer>> entry : memberPartitionsMap.entrySet()) {
-                invokePutAllOperation(entry.getKey(), entry.getValue(), entriesPerPartition).whenCompleteAsync(callback);
+                invokePutAllOperation(entry.getKey(), entry.getValue(), entriesPerPartition)
+                        .whenCompleteAsync(callback, internalAsyncExecutor);
             }
             // if executing in sync mode, block for the responses
             if (future == null) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractDistributedObject.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.services.RemoteService;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.impl.operationservice.impl.InvocationFuture;
@@ -29,6 +30,7 @@ import com.hazelcast.spi.impl.proxyservice.ProxyService;
 import com.hazelcast.version.Version;
 
 import java.util.UUID;
+import java.util.concurrent.Executor;
 
 /**
  * Abstract DistributedObject implementation. Useful to provide basic functionality.
@@ -38,6 +40,7 @@ import java.util.UUID;
 public abstract class AbstractDistributedObject<S extends RemoteService> implements DistributedObject {
 
     protected static final PartitioningStrategy PARTITIONING_STRATEGY = StringPartitioningStrategy.INSTANCE;
+    protected final Executor internalAsyncExecutor;
 
     private volatile NodeEngine nodeEngine;
     private volatile S service;
@@ -45,6 +48,7 @@ public abstract class AbstractDistributedObject<S extends RemoteService> impleme
     protected AbstractDistributedObject(NodeEngine nodeEngine, S service) {
         this.nodeEngine = nodeEngine;
         this.service = service;
+        this.internalAsyncExecutor = nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR);
     }
 
     protected String getDistributedObjectName() {

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxyTest.java
@@ -23,9 +23,11 @@ import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorProxy.IdBatchAndWaitTime;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.util.executor.ManagedExecutorService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -84,11 +86,17 @@ public class FlakeIdGeneratorProxyTest {
         clusterService = mock(ClusterService.class);
         NodeEngine nodeEngine = mock(NodeEngine.class);
         FlakeIdGeneratorService service = mock(FlakeIdGeneratorService.class);
+        ExecutionService mockExecutionService = mock(ExecutionService.class);
+        ManagedExecutorService mockManagedExecutorService = mock(ManagedExecutorService.class);
+
         when(nodeEngine.getLogger(FlakeIdGeneratorProxy.class)).thenReturn(logger);
         when(nodeEngine.isRunning()).thenReturn(true);
         config.setName("foo");
         when(nodeEngine.getConfig()).thenReturn(new Config().addFlakeIdGeneratorConfig(config));
         when(nodeEngine.getClusterService()).thenReturn(clusterService);
+        when(nodeEngine.getExecutionService()).thenReturn(mockExecutionService);
+        when(mockExecutionService.getExecutor(ExecutionService.ASYNC_EXECUTOR)).thenReturn(mockManagedExecutorService);
+
         Address address = null;
         try {
             address = new Address("127.0.0.1", 5701);


### PR DESCRIPTION
Moving away from using the `ForkJoinPool#commonPool` for the `map` package. 
Related to https://github.com/hazelcast/hazelcast/issues/18190

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
