### PR TITLE
Add some tests for compact serialization coverage API-1790

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/ArrayOfFixedSizeFieldsDTOSerializerReadingNullable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/ArrayOfFixedSizeFieldsDTOSerializerReadingNullable.java
@@ -32,33 +32,68 @@ public class ArrayOfFixedSizeFieldsDTOSerializerReadingNullable implements Compa
         Long[] l = reader.readArrayOfNullableInt64("l");
         Float[] f = reader.readArrayOfNullableFloat32("f");
         Double[] d = reader.readArrayOfNullableFloat64("d");
-        byte[] pBytes = new byte[b.length];
-        for (int k = 0; k < b.length; k++) {
-            pBytes[k] = b[k];
+        byte[] pBytes;
+        if (b == null) {
+            pBytes = null;
+        } else {
+            pBytes = new byte[b.length];
+            for (int k = 0; k < b.length; k++) {
+                pBytes[k] = b[k];
+            }
         }
-        boolean[] pBools = new boolean[bool.length];
-        for (int k = 0; k < bool.length; k++) {
-            pBools[k] = bool[k];
+        boolean[] pBools;
+        if (bool == null) {
+            pBools = null;
+        } else {
+            pBools = new boolean[bool.length];
+            for (int k = 0; k < bool.length; k++) {
+                pBools[k] = bool[k];
+            }
         }
-        short[] pShorts = new short[s.length];
-        for (int k = 0; k < s.length; k++) {
-            pShorts[k] = s[k];
+        short[] pShorts;
+        if (s == null) {
+            pShorts = null;
+        } else {
+            pShorts = new short[s.length];
+            for (int k = 0; k < s.length; k++) {
+                pShorts[k] = s[k];
+            }
         }
-        int[] pInts = new int[i.length];
-        for (int k = 0; k < i.length; k++) {
-            pInts[k] = i[k];
+        int[] pInts;
+        if (i == null) {
+            pInts = null;
+        } else {
+            pInts = new int[i.length];
+            for (int k = 0; k < i.length; k++) {
+                pInts[k] = i[k];
+            }
         }
-        long[] pLongs = new long[l.length];
-        for (int k = 0; k < l.length; k++) {
-            pLongs[k] = l[k];
+        long[] pLongs;
+        if (l == null) {
+            pLongs = null;
+        } else {
+            pLongs = new long[l.length];
+            for (int k = 0; k < l.length; k++) {
+                pLongs[k] = l[k];
+            }
         }
-        float[] pFloats = new float[f.length];
-        for (int k = 0; k < f.length; k++) {
-            pFloats[k] = f[k];
+        float[] pFloats;
+        if (f == null) {
+            pFloats = null;
+        } else {
+            pFloats = new float[f.length];
+            for (int k = 0; k < f.length; k++) {
+                pFloats[k] = f[k];
+            }
         }
-        double[] pDoubles = new double[d.length];
-        for (int k = 0; k < d.length; k++) {
-            pDoubles[k] = d[k];
+        double[] pDoubles;
+        if (d == null) {
+            pDoubles = null;
+        } else {
+            pDoubles = new double[d.length];
+            for (int k = 0; k < d.length; k++) {
+                pDoubles[k] = d[k];
+            }
         }
         return new ArrayOfFixedSizeFieldsDTO(pBytes, pBools, pShorts, pInts, pLongs, pFloats, pDoubles);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/ArrayOfFixedSizeFieldsDTOSerializerWritingNullable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/ArrayOfFixedSizeFieldsDTOSerializerWritingNullable.java
@@ -37,41 +37,69 @@ public class ArrayOfFixedSizeFieldsDTOSerializerWritingNullable implements Compa
 
     @Override
     public void write(@Nonnull CompactWriter out, @Nonnull ArrayOfFixedSizeFieldsDTO object) {
-        Byte[] bb = new Byte[object.b.length];
-        for (int k = 0; k < object.b.length; k++) {
-            bb[k] = object.b[k];
+        if (object.b == null) {
+            out.writeArrayOfNullableInt8("b", null);
+        } else {
+            Byte[] bb = new Byte[object.b.length];
+            for (int k = 0; k < object.b.length; k++) {
+                bb[k] = object.b[k];
+            }
+            out.writeArrayOfNullableInt8("b", bb);
         }
-        Boolean[] bools = new Boolean[object.bool.length];
-        for (int k = 0; k < object.bool.length; k++) {
-            bools[k] = object.bool[k];
+        if (object.bool == null) {
+            out.writeArrayOfNullableBoolean("bool", null);
+        } else {
+            Boolean[] bools = new Boolean[object.bool.length];
+            for (int k = 0; k < object.bool.length; k++) {
+                bools[k] = object.bool[k];
+            }
+            out.writeArrayOfNullableBoolean("bool", bools);
         }
-        Short[] ss = new Short[object.s.length];
-        for (int k = 0; k < object.s.length; k++) {
-            ss[k] = object.s[k];
+        if (object.s == null) {
+            out.writeArrayOfNullableInt16("s", null);
+        } else {
+            Short[] ss = new Short[object.s.length];
+            for (int k = 0; k < object.s.length; k++) {
+                ss[k] = object.s[k];
+            }
+            out.writeArrayOfNullableInt16("s", ss);
         }
-        Integer[] ii = new Integer[object.i.length];
-        for (int k = 0; k < object.i.length; k++) {
-            ii[k] = object.i[k];
+        if (object.i == null) {
+            out.writeArrayOfNullableInt32("i", null);
+        } else {
+            Integer[] ii = new Integer[object.i.length];
+            for (int k = 0; k < object.i.length; k++) {
+                ii[k] = object.i[k];
+            }
+            out.writeArrayOfNullableInt32("i", ii);
         }
-        Long[] ll = new Long[object.l.length];
-        for (int k = 0; k < object.l.length; k++) {
-            ll[k] = object.l[k];
+        if (object.l == null) {
+            out.writeArrayOfNullableInt64("l", null);
+        } else {
+            Long[] ll = new Long[object.l.length];
+            for (int k = 0; k < object.l.length; k++) {
+                ll[k] = object.l[k];
+            }
+            out.writeArrayOfNullableInt64("l", ll);
         }
-        Float[] ff = new Float[object.f.length];
-        for (int k = 0; k < object.f.length; k++) {
-            ff[k] = object.f[k];
+        if (object.f == null) {
+            out.writeArrayOfNullableFloat32("f", null);
+        } else {
+            Float[] ff = new Float[object.f.length];
+            for (int k = 0; k < object.f.length; k++) {
+                ff[k] = object.f[k];
+            }
+            out.writeArrayOfNullableFloat32("f", ff);
         }
-        Double[] dd = new Double[object.d.length];
-        for (int k = 0; k < object.d.length; k++) {
-            dd[k] = object.d[k];
+        if (object.d == null) {
+            out.writeArrayOfNullableFloat64("d", null);
+        } else {
+            Double[] dd = new Double[object.d.length];
+            for (int k = 0; k < object.d.length; k++) {
+                dd[k] = object.d[k];
+            }
+            out.writeArrayOfNullableFloat64("d", dd);
         }
-        out.writeArrayOfNullableInt8("b", bb);
-        out.writeArrayOfNullableBoolean("bool", bools);
-        out.writeArrayOfNullableInt16("s", ss);
-        out.writeArrayOfNullableInt32("i", ii);
-        out.writeArrayOfNullableInt64("l", ll);
-        out.writeArrayOfNullableFloat32("f", ff);
-        out.writeArrayOfNullableFloat64("d", dd);
     }
 
     @Nonnull

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactNullablePrimitiveInteroperabilityTest.java
@@ -32,6 +32,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createArrayOfFixedSizeFieldsDTO;
+import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createArrayOfFixedSizeFieldsDTOAsNullValues;
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createFixedSizeFieldsDTO;
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createSerializationService;
 import static com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder.compact;
@@ -131,6 +132,17 @@ public class CompactNullablePrimitiveInteroperabilityTest {
     @Test
     public void testWriteArraysOfPrimitiveReadNullableCustomSerializer() {
         ArrayOfFixedSizeFieldsDTO arrayOfFixedSizeFieldsDTO = createArrayOfFixedSizeFieldsDTO();
+        SerializationService serializationService = createSerializationService(ArrayOfFixedSizeFieldsDTOSerializerReadingNullable::new);
+
+        Data data = serializationService.toData(arrayOfFixedSizeFieldsDTO);
+        ArrayOfFixedSizeFieldsDTO obj = serializationService.toObject(data);
+
+        assertEquals(obj, arrayOfFixedSizeFieldsDTO);
+    }
+
+    @Test
+    public void testWriteArraysOfPrimitiveAsNullReadNullableCustomSerializer() {
+        ArrayOfFixedSizeFieldsDTO arrayOfFixedSizeFieldsDTO = createArrayOfFixedSizeFieldsDTOAsNullValues();
         SerializationService serializationService = createSerializationService(ArrayOfFixedSizeFieldsDTOSerializerReadingNullable::new);
 
         Data data = serializationService.toData(arrayOfFixedSizeFieldsDTO);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -516,7 +516,7 @@ public class CompactSerializationTest {
         private final String foo;
         private final long bar;
 
-        public FooBar(String foo, long bar) {
+        FooBar(String foo, long bar) {
             this.foo = foo;
             this.bar = bar;
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -41,7 +41,6 @@ import example.serialization.MainDTOSerializer;
 import example.serialization.SameClassEmployeeDTOSerializer;
 import example.serialization.SameTypeNameEmployeeDTOSerializer;
 import example.serialization.SerializableEmployeeDTO;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -532,27 +531,27 @@ public class CompactSerializationTest {
     }
 
     private static class FooBarSerializer implements CompactSerializer<FooBar> {
-        @NotNull
+        @Nonnull
         @Override
-        public FooBar read(@NotNull CompactReader reader) {
+        public FooBar read(@Nonnull CompactReader reader) {
             String foo = reader.readString("foo");
             long bar = reader.readInt64("bar");
             return new FooBar(foo, bar);
         }
 
         @Override
-        public void write(@NotNull CompactWriter writer, @NotNull FooBar object) {
+        public void write(@Nonnull CompactWriter writer, @Nonnull FooBar object) {
             writer.writeString("foo", object.foo);
             writer.writeInt64("bar", object.bar);
         }
 
-        @NotNull
+        @Nonnull
         @Override
         public String getTypeName() {
             return "foobar";
         }
 
-        @NotNull
+        @Nonnull
         @Override
         public Class getCompactClass() {
             return FooBar.class;

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -16,12 +16,10 @@
 
 package com.hazelcast.internal.serialization.impl.compact;
 
-import com.hazelcast.config.CompactSerializationConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.compact.CompactReader;
 import com.hazelcast.nio.serialization.compact.CompactSerializer;

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -438,14 +438,7 @@ public class CompactSerializationTest {
         FooBarSerializer serializer = spy(new FooBarSerializer());
         FooBar fooBar = new FooBar("foo", 42L);
 
-        SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
-        CompactSerializationConfig compactSerializationConfig = new CompactSerializationConfig();
-        compactSerializationConfig.addSerializer(serializer);
-        SerializationService serializationService = new DefaultSerializationServiceBuilder()
-                .setSchemaService(schemaService)
-                .setConfig(new SerializationConfig().setCompactSerializationConfig(compactSerializationConfig))
-                .build();
-
+        SerializationService serializationService = createSerializationService(() -> serializer);
         // Add correct schema to classToSchemaMap
         serializationService.toData(fooBar);
         // Change serializer's write method
@@ -470,19 +463,7 @@ public class CompactSerializationTest {
         FooBar fooBar = new FooBar("foo", 42L);
         FooBarSerializer serializer = spy(new FooBarSerializer());
 
-        SchemaWriter schemaWriter = new SchemaWriter(serializer.getTypeName());
-        serializer.write(schemaWriter, fooBar);
-        Schema schema = schemaWriter.build();
-
-        SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
-        schemaService.put(schema);
-        CompactSerializationConfig compactSerializationConfig = new CompactSerializationConfig();
-        compactSerializationConfig.addSerializer(serializer);
-        SerializationService serializationService = new DefaultSerializationServiceBuilder()
-                .setSchemaService(schemaService)
-                .setConfig(new SerializationConfig().setCompactSerializationConfig(compactSerializationConfig))
-                .build();
-
+        SerializationService serializationService = createSerializationService(() -> serializer);
         // Add correct schema to classToSchemaMap
         serializationService.toData(fooBar);
         // Change serializer's write method

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
@@ -216,6 +216,11 @@ public final class CompactTestUtil {
                 new float[]{12312.123f, 12312.123f}, new double[]{1111.1111111123123, 1111.1111111123123});
     }
 
+    @Nonnull
+    static ArrayOfFixedSizeFieldsDTO createArrayOfFixedSizeFieldsDTOAsNullValues() {
+        return new ArrayOfFixedSizeFieldsDTO(null, null, null, null, null, null, null);
+    }
+
     public static SerializationService createSerializationService() {
         SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
         return new DefaultSerializationServiceBuilder()


### PR DESCRIPTION
Add tests for schema different than CompactWriter, field does not exist or different type. See https://hazelcast.atlassian.net/browse/API-1790 for more.

There are three points in the jira issue: 

1. I added test for this one.
2. I added test for this one.
3. It was already covered. 

Breaking changes (list specific methods/types/messages):
- none

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
