### PR TITLE
[CN-714] Add support of IMDSv2 for AWS Discovery plugin

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
@@ -130,6 +130,10 @@ public final class RestClient {
         return callWithRetries("POST");
     }
 
+    public Response put() {
+        return callWithRetries("PUT");
+    }
+
     private Response callWithRetries(String method) {
         return RetryUtils.retry(() -> call(method), retries);
     }


### PR DESCRIPTION
Before making requests to metadata service we now try to get token using `/latest/api/token` endpoint.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
