### PR TITLE
[ALTO] Async socket OP_WRITE first

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocket.java
@@ -501,12 +501,12 @@ public final class NioAsyncSocket extends AsyncSocket {
 
             int readyOps = key.readyOps();
 
-            if ((readyOps & OP_READ) != 0) {
-                handleReadReady();
-            }
-
             if ((readyOps & OP_WRITE) != 0) {
                 handleWriteReady();
+            }
+
+            if ((readyOps & OP_READ) != 0) {
+                handleReadReady();
             }
 
             if ((readyOps & OP_CONNECT) != 0) {


### PR DESCRIPTION
When OP_READ is called, typically it leads to an increase in memory usage because all kinds of data are loaded from socket buffers into memory.

Calling OP_WRITE first typically leads to a reduction in because we move things from in memory into the socket buffer.

So when you do OP_READ first, you first increase and then reduce. But when doing OP_WRITE first, you first reduce and then increase. So you reduce the size of the resource bubble.
