### PR TITLE
Simplified multitenancy checking for Payara.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -152,6 +152,7 @@ public class NodeEngineImpl implements NodeEngine {
             this.proxyService = new ProxyServiceImpl(this);
             this.serviceManager = new ServiceManagerImpl(this);
             this.executionService = new ExecutionServiceImpl(this);
+            this.tenantControlService = new TenantControlServiceImpl(this);
             this.tpcServerBootstrap = new TpcServerBootstrap(this);
             this.operationService = new OperationServiceImpl(this);
             this.eventService = new EventServiceImpl(this);
@@ -180,7 +181,6 @@ public class NodeEngineImpl implements NodeEngine {
 
             checkMapMergePolicies(node);
 
-            this.tenantControlService = new TenantControlServiceImpl(this);
 
             serviceManager.registerService(OperationServiceImpl.SERVICE_NAME, operationService);
             serviceManager.registerService(OperationParker.SERVICE_NAME, operationParker);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
@@ -65,7 +65,7 @@ public abstract class OperationRunner {
      * timed out or has run successfully
      * @throws Exception if there was an exception raised while processing the packet
      */
-    public abstract boolean run(Packet packet) throws Exception;
+    public abstract void run(Packet packet) throws Exception;
 
     public abstract void run(Runnable task);
 
@@ -73,11 +73,8 @@ public abstract class OperationRunner {
      * Runs the provided operation.
      *
      * @param task the operation to execute
-     * @return {@code true} if this operation was not executed and should be retried at a later time,
-     * {@code false} if the operation should not be retried, either because it
-     * timed out or has run successfully
      */
-    public abstract boolean run(Operation task);
+    public abstract void run(Operation task);
 
     /**
      * Returns the current task that is executing. This value could be null

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -137,11 +137,10 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
 
     void process(Object task) {
         try {
-            boolean putBackInQueue = false;
             if (task.getClass() == Packet.class) {
-                putBackInQueue = process((Packet) task);
+                process((Packet) task);
             } else if (task instanceof Operation) {
-                putBackInQueue = process((Operation) task);
+                process((Operation) task);
             } else if (task instanceof PartitionSpecificRunnable) {
                 process((PartitionSpecificRunnable) task);
             } else if (task instanceof Runnable) {
@@ -151,12 +150,8 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
             } else {
                 throw new IllegalStateException("Unhandled task:" + task);
             }
-            if (putBackInQueue) {
-                // retry later if not ready
-                queue.add(task, priority);
-            } else {
-                completedTotalCount.inc();
-            }
+
+            completedTotalCount.inc();
         } catch (Throwable t) {
             errorCount.inc();
             inspectOutOfMemoryError(t);
@@ -174,37 +169,21 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
      * {@code false} if the operation should not be retried, either because it
      * timed out or has run successfully
      */
-    private boolean process(Operation operation) {
+    private void process(Operation operation) {
         currentRunner = operationRunner(operation.getPartitionId());
-        try {
-            if (currentRunner.run(operation)) {
-                return true;
-            } else {
-                completedOperationCount.inc();
-                return false;
-            }
-        } finally {
-            operation.clearThreadContext();
-        }
+        currentRunner.run(operation);
     }
 
     /**
      * Processes/executes the provided packet.
      *
      * @param packet the packet to execute
-     * @return {@code true} if this packet was not executed and should be retried at a later time,
-     * {@code false} if the packet should not be retried, either because it
-     * timed out or has run successfully
      * @throws Exception if there was an exception raised while processing the packet
      */
-    private boolean process(Packet packet) throws Exception {
+    private void process(Packet packet) throws Exception {
         currentRunner = operationRunner(packet.getPartitionId());
-        if (currentRunner.run(packet)) {
-            return true;
-        } else {
-            completedPacketCount.inc();
-            return false;
-        }
+        currentRunner.run(packet);
+        completedPacketCount.inc();
     }
 
     private void process(PartitionSpecificRunnable runnable) {
@@ -227,9 +206,7 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
 
         try {
             if (task instanceof Operation) {
-                if (process((Operation) task)) {
-                    queue.add(task, false);
-                }
+                process((Operation) task);
             } else if (task instanceof Runnable) {
                 process((Runnable) task);
             } else {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -107,13 +107,13 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
     static final int AD_HOC_PARTITION_ID = -2;
 
     final OperationServiceImpl operationService;
+    @Probe(name = OPERATION_METRIC_OPERATION_RUNNER_EXECUTED_OPERATIONS_COUNT, level = DEBUG)
     final Counter executedOperationsCounter;
 
     private final ILogger logger;
     private final Node node;
     private final NodeEngineImpl nodeEngine;
 
-    @Probe(name = OPERATION_METRIC_OPERATION_RUNNER_EXECUTED_OPERATIONS_COUNT, level = DEBUG)
     private final Address thisAddress;
     private final boolean staleReadOnMigrationEnabled;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -266,7 +266,8 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
         } catch (Throwable e) {
             handleOperationError(op, e);
         } finally {
-             if (publishCurrentTask) {
+            op.afterRunFinal();
+            if (publishCurrentTask) {
                 currentTask = null;
             }
             record(op, startNanos);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -280,7 +280,12 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
             if (op instanceof PartitionIteratingOperation) {
                 c = ((PartitionIteratingOperation) op).getOperationFactory().getClass();
             }
-            LatencyDistribution distribution = opLatencyDistributions.computeIfAbsent(c, k -> new LatencyDistribution());
+
+            LatencyDistribution distribution = opLatencyDistributions.get(c);
+            // Note: we want to prevent lock here, if collision happened.
+            if (distribution == null) {
+                distribution = opLatencyDistributions.computeIfAbsent(c, k -> new LatencyDistribution());
+            }
             distribution.recordNanos(System.nanoTime() - startNanos);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -106,13 +106,14 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
 
     static final int AD_HOC_PARTITION_ID = -2;
 
+    final OperationServiceImpl operationService;
+    final Counter executedOperationsCounter;
+
     private final ILogger logger;
-    private final OperationServiceImpl operationService;
     private final Node node;
     private final NodeEngineImpl nodeEngine;
 
     @Probe(name = OPERATION_METRIC_OPERATION_RUNNER_EXECUTED_OPERATIONS_COUNT, level = DEBUG)
-    private final Counter executedOperationsCounter;
     private final Address thisAddress;
     private final boolean staleReadOnMigrationEnabled;
 
@@ -201,22 +202,18 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
                 currentTask = null;
             }
 
-            if (opLatencyDistributions != null) {
-                Class c = task.getClass();
-                LatencyDistribution distribution = opLatencyDistributions.computeIfAbsent(c, k -> new LatencyDistribution());
-                distribution.done(startNanos);
-            }
+            record(task, startNanos);
         }
     }
 
-    private boolean publishCurrentTask() {
+    boolean publishCurrentTask() {
         boolean isClientRunnable = currentTask instanceof MessageTask;
         return getPartitionId() != AD_HOC_PARTITION_ID && (currentTask == null || isClientRunnable);
     }
 
     @Override
-    public boolean run(Operation op) {
-        return run(op, System.nanoTime());
+    public void run(Operation op) {
+         run(op, System.nanoTime());
     }
 
     public boolean metWithPreconditions(Operation op) {
@@ -251,7 +248,7 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
      * {@code false} if the operation should not be retried, either because it
      * timed out or has run successfully
      */
-    private boolean run(Operation op, long startNanos) {
+    protected void run(Operation op, long startNanos) {
         executedOperationsCounter.inc();
 
         boolean publishCurrentTask = publishCurrentTask();
@@ -261,41 +258,33 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
 
         try {
             if (!metWithPreconditions(op)) {
-                return false;
+                return;
             }
 
-            if (op.isTenantAvailable()) {
-                op.pushThreadContext();
-                op.beforeRun();
-                call(op);
-            } else {
-                return true;
-            }
+            op.beforeRun();
+            call(op);
         } catch (Throwable e) {
             handleOperationError(op, e);
         } finally {
-            op.afterRunFinal();
-            if (publishCurrentTask) {
+             if (publishCurrentTask) {
                 currentTask = null;
             }
-            op.popThreadContext();
-            if (opLatencyDistributions != null) {
-                Class c = op.getClass();
-                if (op instanceof PartitionIteratingOperation) {
-                    c = ((PartitionIteratingOperation) op).getOperationFactory().getClass();
-                }
-                LatencyDistribution distribution = opLatencyDistributions.get(c);
-                // Note: we want to prevent lock here, if collision happened.
-                if (distribution == null) {
-                    distribution = opLatencyDistributions.computeIfAbsent(c, k -> new LatencyDistribution());
-                }
-                distribution.recordNanos(System.nanoTime() - startNanos);
-            }
+            record(op, startNanos);
         }
-        return false;
     }
 
-    private void call(Operation op) throws Exception {
+    protected void record(Object op, long startNanos) {
+        if (opLatencyDistributions != null) {
+            Class c = op.getClass();
+            if (op instanceof PartitionIteratingOperation) {
+                c = ((PartitionIteratingOperation) op).getOperationFactory().getClass();
+            }
+            LatencyDistribution distribution = opLatencyDistributions.computeIfAbsent(c, k -> new LatencyDistribution());
+            distribution.recordNanos(System.nanoTime() - startNanos);
+        }
+    }
+
+    void call(Operation op) throws Exception {
         CallStatus callStatus = op.call();
 
         switch (callStatus.ordinal()) {
@@ -471,7 +460,7 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
     }
 
     @Override
-    public boolean run(Packet packet) throws Exception {
+    public void run(Packet packet) throws Exception {
         long startNanos = System.nanoTime();
         boolean publishCurrentTask = publishCurrentTask();
 
@@ -493,13 +482,13 @@ public class OperationRunnerImpl extends OperationRunner implements StaticMetric
             setOperationResponseHandler(op);
 
             if (!ensureValidMember(op)) {
-                return false;
+                return;
             }
 
             if (publishCurrentTask) {
                 currentTask = null;
             }
-            return run(op, startNanos);
+            run(op, startNanos);
         } catch (Throwable throwable) {
             // If exception happens we need to extract the callId from the bytes directly!
             long callId = extractOperationCallId(packet);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TenantAwareOperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TenantAwareOperationRunnerImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.internal.util.LatencyDistribution;
+import com.hazelcast.internal.util.counters.Counter;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.util.concurrent.ConcurrentMap;
+
+public class TenantAwareOperationRunnerImpl extends OperationRunnerImpl {
+
+    TenantAwareOperationRunnerImpl(OperationServiceImpl operationService,
+                                   int partitionId,
+                                   int genericId,
+                                   Counter failedBackupsCounter,
+                                   ConcurrentMap<Class, LatencyDistribution> opLatencyDistributions) {
+        super(operationService, partitionId, genericId, failedBackupsCounter, opLatencyDistributions);
+    }
+
+    @Override
+    protected void run(Operation op, long startNanos) {
+        try {
+            executedOperationsCounter.inc();
+
+            boolean publishCurrentTask = publishCurrentTask();
+            if (publishCurrentTask) {
+                currentTask = op;
+            }
+
+            try {
+                if (!metWithPreconditions(op)) {
+                    return;
+                }
+
+                if (op.isTenantAvailable()) {
+                    op.pushThreadContext();
+                    op.beforeRun();
+                    call(op);
+                } else {
+                    operationService.operationExecutor.execute(op);
+                }
+            } catch (Throwable e) {
+                handleOperationError(op, e);
+            } finally {
+                op.afterRunFinal();
+                if (publishCurrentTask) {
+                    currentTask = null;
+                }
+                op.popThreadContext();
+                record(op, startNanos);
+            }
+        } finally {
+            op.clearThreadContext();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/tenantcontrol/impl/TenantControlServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/tenantcontrol/impl/TenantControlServiceImpl.java
@@ -203,7 +203,7 @@ public class TenantControlServiceImpl
     /**
      * Returns {@code true} if tenant control is enabled.
      */
-    private boolean isTenantControlEnabled() {
+    public boolean isTenantControlEnabled() {
         return tenantControlFactory != NOOP_TENANT_CONTROL_FACTORY;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -235,15 +235,14 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
         }
 
         @Override
-        public boolean run(Packet packet) throws Exception {
+        public void run(Packet packet) throws Exception {
             packets.add(packet);
             Operation op = serializationService.toObject(packet);
             run(op);
-            return false;
         }
 
         @Override
-        public boolean run(Operation task) {
+        public void run(Operation task) {
             operations.add(task);
 
             currentTask = task;
@@ -254,7 +253,6 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
             } finally {
                 currentTask = null;
             }
-            return false;
         }
     }
 


### PR DESCRIPTION
Instead of pushing the complexity into the OperationRunner and OperationThread, it is now moved to the TenantAwareOperationRunner.

Check the following issue for more details:

https://github.com/hazelcast/hazelcast/issues/23559