### PR TITLE
[5.2.z] Allow serializing an unsupported type with reflective serializer if there's an explicit serializer for it API-1829 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -195,7 +195,8 @@ public final class CompactUtil {
                 + "cannot be serialized with zero configuration Compact "
                 + "serialization because this type is not supported yet. If you "
                 + "want to serialize '" + clazz + "' which uses this class in "
-                + "its fields, consider writing a CompactSerializer for it.");
+                + "its fields, consider writing a CompactSerializer for either the '"
+                + clazz + "' or the '" + fieldClass + "'.");
     }
 
     public static void verifyFieldClassShouldBeSerializedAsCompact(CompactStreamSerializer compactStreamSerializer,
@@ -208,8 +209,10 @@ public final class CompactUtil {
                 + "cannot be serialized with zero configuration Compact "
                 + "serialization because this type can be serialized with another "
                 + "serialization mechanism. If you want to serialize "
-                + "'" + clazz + "' which uses this class in its fields, consider"
-                + "overriding that serialization mechanism.");
+                + "'" + clazz + "' which uses this class in its fields, consider "
+                + "overriding that serialization mechanism. You can do that by "
+                + "adding '" + fieldClass + "' to CompactSerializationConfig, or "
+                + "writing and registering an explicit CompactSerializer for it.");
     }
 
     private static boolean canBeSerializedAsCompact(Class<?> clazz) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
@@ -210,9 +210,13 @@ public final class ValueReaderWriters {
             return constructor.apply(fieldName);
         }
 
-        // The nested field might not be Compact serializable
-        verifyFieldClassIsCompactSerializable(type, clazz);
-        verifyFieldClassShouldBeSerializedAsCompact(compactStreamSerializer, type, clazz);
+        boolean isRegisteredAsCompact = compactStreamSerializer.isRegisteredAsCompact(type);
+        // We allow serializing classes regardless of the following checks if there is an explicit serializer for them.
+        if (!isRegisteredAsCompact) {
+            // The nested field might not be Compact serializable
+            verifyFieldClassIsCompactSerializable(type, clazz);
+            verifyFieldClassShouldBeSerializedAsCompact(compactStreamSerializer, type, clazz);
+        }
         return new CompactReaderWriter(fieldName);
     }
 
@@ -228,9 +232,13 @@ public final class ValueReaderWriters {
             return constructor.apply(fieldName);
         }
 
-        // Elements of the array might not be Compact serializable
-        verifyFieldClassIsCompactSerializable(componentType, clazz);
-        verifyFieldClassShouldBeSerializedAsCompact(compactStreamSerializer, componentType, clazz);
+        boolean isRegisteredAsCompact = compactStreamSerializer.isRegisteredAsCompact(componentType);
+        // We allow serializing classes regardless of the following checks if there is an explicit serializer for them.
+        if (!isRegisteredAsCompact) {
+            // Elements of the array might not be Compact serializable
+            verifyFieldClassIsCompactSerializable(componentType, clazz);
+            verifyFieldClassShouldBeSerializedAsCompact(compactStreamSerializer, componentType, clazz);
+        }
         return new CompactArrayReaderWriter(fieldName, componentType);
     }
 


### PR DESCRIPTION
Backport of: #23449. There were two simple conflicts one of it in one of the errors we throw in CompactUtil([here](https://github.com/hazelcast/hazelcast/pull/23569/files#diff-32af5e9a5a67fca71ae2a8fccb68339a093782cf5a9ecd9ddf7cf87a7de453ebR214)), the other in the copyright year. I merged them. 


This is requested from a customer through
salesforce https://hazelcast.lightning.force.com/lightning/r/Case/5006e00001rNjuwAAC/view

There is a PR opened https://github.com/hazelcast/hazelcast/pull/23372 specifically for `java.time.Instant`. We decided to solve this generally, so in this commit, I allowed serializing unsupported types via zero config serializer if there's a explicit serializer for the unsupported type.

Breaking changes (list specific methods/types/messages):
* None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
