### PR TITLE
[ALTO] Reactor accepts any object.

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/NopScheduler.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/NopScheduler.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.internal.tpc;
 
-import com.hazelcast.internal.tpc.iobuffer.IOBuffer;
-
 /**
  * A scheduler that doesn't do anything.
  */
@@ -32,6 +30,6 @@ public class NopScheduler implements Scheduler {
     }
 
     @Override
-    public void schedule(IOBuffer task) {
+    public void schedule(Object task) {
     }
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Scheduler.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Scheduler.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.internal.tpc;
 
-import com.hazelcast.internal.tpc.iobuffer.IOBuffer;
-
 /**
  * Every Reactor has a scheduler. So incoming work (IOBuffers) can be scheduled
  * and it is up to the Scheduler to process these tasks. The Scheduler gets a frequent
@@ -51,7 +49,7 @@ public interface Scheduler {
     /**
      * Schedules a task to be processed by this Scheduler.
      *
-     * @param task the IOBuffer containing the task to schedule.
+     * @param task the task.
      */
-    void schedule(IOBuffer task);
+    void schedule(Object task);
 }


### PR DESCRIPTION
Before this change, the reactor would only accept IOBuffers and Runnables. Now it will accept anything. Runnables will be processed by the Reactor. Anything else will be offered to the scheduler.