### PR TITLE
Enhance error handling in KubernetesClient [5.2.z]

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -765,5 +765,11 @@
             <artifactId>HikariCP</artifactId>
             <version>${hikari.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.kubernetes;
 
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.instance.impl.ClusterTopologyIntentTracker;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonArray;
@@ -23,6 +24,7 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.util.HostnameUtil;
 import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.internal.util.concurrent.BackoffIdleStrategy;
 import com.hazelcast.kubernetes.KubernetesConfig.ExposeExternallyMode;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -30,8 +32,12 @@ import com.hazelcast.spi.exception.RestClientException;
 import com.hazelcast.spi.utils.RestClient;
 import com.hazelcast.spi.utils.RetryUtils;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,6 +49,8 @@ import java.util.Objects;
 import static com.hazelcast.instance.impl.ClusterTopologyIntentTracker.UNKNOWN;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Responsible for connecting to the Kubernetes API.
@@ -52,6 +60,9 @@ import static java.util.Collections.emptyList;
 @SuppressWarnings("checkstyle:methodcount")
 class KubernetesClient {
     private static final ILogger LOGGER = Logger.getLogger(KubernetesClient.class);
+    private static final int HTTP_GONE = 410;
+    private static final int HTTP_UNAUTHORIZED = 401;
+    private static final int HTTP_FORBIDDEN = 403;
 
     private static final List<String> NON_RETRYABLE_KEYWORDS = asList(
             "\"reason\":\"Forbidden\"",
@@ -98,6 +109,32 @@ class KubernetesClient {
         }
         this.apiProvider =  buildKubernetesApiUrlProvider();
         this.stsName = extractStsName();
+        this.stsMonitorThread = (clusterTopologyIntentTracker != null && clusterTopologyIntentTracker.isEnabled())
+                ? new Thread(new StsMonitor(), "hz-k8s-sts-monitor") : null;
+    }
+
+    // constructor that allows overriding detected statefulset name for usage in tests
+    @SuppressWarnings("checkstyle:parameternumber")
+    KubernetesClient(String namespace, String kubernetesMaster, KubernetesTokenProvider tokenProvider,
+                     String caCertificate, int retries, ExposeExternallyMode exposeExternallyMode,
+                     boolean useNodeNameAsExternalAddress, String servicePerPodLabelName,
+                     String servicePerPodLabelValue, @Nullable ClusterTopologyIntentTracker clusterTopologyIntentTracker,
+                     String stsName) {
+        this.namespace = namespace;
+        this.kubernetesMaster = kubernetesMaster;
+        this.tokenProvider = tokenProvider;
+        this.caCertificate = caCertificate;
+        this.retries = retries;
+        this.exposeExternallyMode = exposeExternallyMode;
+        this.useNodeNameAsExternalAddress = useNodeNameAsExternalAddress;
+        this.servicePerPodLabelName = servicePerPodLabelName;
+        this.servicePerPodLabelValue = servicePerPodLabelValue;
+        this.clusterTopologyIntentTracker = clusterTopologyIntentTracker;
+        if (clusterTopologyIntentTracker != null) {
+            clusterTopologyIntentTracker.initialize();
+        }
+        this.apiProvider =  buildKubernetesApiUrlProvider();
+        this.stsName = stsName;
         this.stsMonitorThread = (clusterTopologyIntentTracker != null && clusterTopologyIntentTracker.isEnabled())
                 ? new Thread(new StsMonitor(), "hz-k8s-sts-monitor") : null;
     }
@@ -271,24 +308,6 @@ class KubernetesClient {
             stsName = stsName.substring(0, dashIndex);
         }
         return stsName;
-    }
-
-    @Nullable
-    private RuntimeContext extractStsList(JsonObject jsonObject) {
-        String resourceVersion = jsonObject.get("metadata").asObject().getString("resourceVersion",
-                null);
-        // identify stateful set this pod belongs to
-        for (JsonValue item : toJsonArray(jsonObject.get("items"))) {
-            String itemName = item.asObject().get("metadata").asObject().getString("name", null);
-            if (stsName.equals(itemName)) {
-                // identified the stateful set
-                int specReplicas = item.asObject().get("spec").asObject().getInt("replicas", UNKNOWN);
-                int readyReplicas = item.asObject().get("status").asObject().getInt("readyReplicas", UNKNOWN);
-                int replicas = item.asObject().get("status").asObject().getInt("currentReplicas", UNKNOWN);
-                return new RuntimeContext(specReplicas, readyReplicas, replicas, resourceVersion);
-            }
-        }
-        return null;
     }
 
     private RuntimeContext extractSts(JsonObject jsonObject) {
@@ -547,15 +566,14 @@ class KubernetesClient {
                 .asObject(), retries, NON_RETRYABLE_KEYWORDS);
     }
 
-    @SuppressWarnings("checkstyle:magicnumber")
     private List<Endpoint> handleKnownException(RestClientException e) {
-        if (e.getHttpErrorCode() == 401) {
+        if (e.getHttpErrorCode() == HTTP_UNAUTHORIZED) {
             if (!isKnownExceptionAlreadyLogged) {
                 LOGGER.warning("Kubernetes API authorization failure! To use Hazelcast Kubernetes discovery, "
                         + "please check your 'api-token' property. Starting standalone.");
                 isKnownExceptionAlreadyLogged = true;
             }
-        } else if (e.getHttpErrorCode() == 403) {
+        } else if (e.getHttpErrorCode() == HTTP_FORBIDDEN) {
             if (!isKnownExceptionAlreadyLogged) {
                 LOGGER.warning("Kubernetes API access is forbidden! Starting standalone. To use Hazelcast Kubernetes discovery,"
                         + " configure the required RBAC. For 'default' service account in 'default' namespace execute: "
@@ -693,8 +711,28 @@ class KubernetesClient {
     }
 
     final class StsMonitor implements Runnable {
-        private String latestResourceVersion;
-        private RuntimeContext latestRuntimeContext;
+
+        // backoff properties when retrying
+        private static final int MAX_SPINS = 3;
+        private static final int MAX_YIELDS = 10;
+        private static final int MIN_PARK_PERIOD_MILLIS = 1;
+        private static final int MAX_PARK_PERIOD_SECONDS = 10;
+
+        // used only for tests
+        volatile boolean running = true;
+
+        String latestResourceVersion;
+        RuntimeContext latestRuntimeContext;
+        int idleCount;
+
+        private final String stsUrlString;
+        private final BackoffIdleStrategy backoffIdleStrategy;
+
+        StsMonitor() {
+            stsUrlString = formatStsListUrl();
+            backoffIdleStrategy = new BackoffIdleStrategy(MAX_SPINS, MAX_YIELDS,
+                    MILLISECONDS.toNanos(MIN_PARK_PERIOD_MILLIS), SECONDS.toNanos(MAX_PARK_PERIOD_SECONDS));
+        }
 
         /**
          * Initializes and watches information about the StatefulSet in which Hazelcast is being executed.
@@ -706,27 +744,27 @@ class KubernetesClient {
          */
         @Override
         public void run() {
-            String stsUrlString = String.format("%s/apis/apps/v1/namespaces/%s/statefulsets", kubernetesMaster,
-                    namespace);
-            JsonObject jsonObject = callGet(stsUrlString);
-            latestResourceVersion = jsonObject.get("metadata").asObject().getString("resourceVersion",
-                    null);
-            latestRuntimeContext = extractStsList(jsonObject);
-            LOGGER.info("Initializing cluster topology tracker with initial context: "
-                    + latestRuntimeContext);
-            clusterTopologyIntentTracker.update(UNKNOWN,
-                    latestRuntimeContext.getSpecifiedReplicaCount(),
-                    UNKNOWN, latestRuntimeContext.getReadyReplicas(),
-                    UNKNOWN, latestRuntimeContext.getCurrentReplicas());
-            while (true) {
+            RestClient.WatchResponse watchResponse;
+            String message;
+
+            while (running) {
                 if (Thread.interrupted()) {
                     break;
                 }
-                RestClient restClient = RestClient.create(stsUrlString)
-                        .withHeader("Authorization", String.format("Bearer %s", tokenProvider.getToken()))
-                        .withCaCertificates(caCertificate);
-                RestClient.WatchResponse watchResponse = restClient.watch(latestResourceVersion);
-                String message;
+                try {
+                    // read initial statefulset list
+                    RuntimeContext previous = latestRuntimeContext;
+                    readInitialStsList();
+                    // update tracker
+                    updateTracker(previous, latestRuntimeContext);
+                    watchResponse = sendWatchRequest();
+                } catch (RestClientException e) {
+                    handleFailure(e);
+                    // always retry after a RestClientException
+                    continue;
+                }
+                // reset backoff-idle count
+                idleCount = 0;
                 try {
                     while ((message = watchResponse.nextLine()) != null) {
                         onMessage(message);
@@ -735,15 +773,81 @@ class KubernetesClient {
                     LOGGER.info("Exception while watching for StatefulSet changes", e);
                     try {
                         watchResponse.disconnect();
-                    } catch (Throwable t) {
+                    } catch (Exception t) {
                         LOGGER.fine("Exception while closing connection after an IOException", t);
                     }
                 }
             }
         }
 
+        private void handleFailure(RestClientException e) {
+            if (e.getHttpErrorCode() == HTTP_GONE) {
+                // occurs when the resource version we are watching for is stale
+                LOGGER.info("StatefulSet watcher has fallen behind, re-reading sts list and resuming watch: "
+                        + e.getMessage());
+            } else {
+                // watch failed with another HTTP error code, let's log at WARNING level,
+                // backoff and try to resume again
+                LOGGER.warning("Error while attempting to watch kubernetes API for StatefulSets: "
+                        + e.getHttpErrorCode() + " " + e.getMessage() + ". Backing off (n: " + idleCount
+                        + " ) before retrying.");
+                backoffIdleStrategy.idle(idleCount);
+                idleCount++;
+            }
+        }
+
+        String formatStsListUrl() {
+            String fieldSelectorValue = String.format("metadata.name=%s", stsName);
+            try {
+                fieldSelectorValue = URLEncoder.encode(fieldSelectorValue, StandardCharsets.UTF_8.name());
+            } catch (UnsupportedEncodingException e) {
+                throw new HazelcastException(e);
+            }
+            return String.format("%s/apis/apps/v1/namespaces/%s/statefulsets?fieldSelector=%s", kubernetesMaster,
+                    namespace, fieldSelectorValue);
+        }
+
+        // GET statefulsets list and update the latest runtime context
+        void readInitialStsList() {
+            JsonObject jsonObject = callGet(stsUrlString);
+            latestResourceVersion = jsonObject.get("metadata").asObject().getString("resourceVersion",
+                    null);
+            latestRuntimeContext = parseStsList(jsonObject);
+        }
+
+        /**
+         * Send a watch request
+         * @return a {@link com.hazelcast.spi.utils.RestClient.WatchResponse} that can be used to poll for watch events
+         *          from Kubernetes API server.
+         */
+        @Nonnull
+        RestClient.WatchResponse sendWatchRequest() {
+            RestClient restClient = RestClient.create(stsUrlString)
+                    .withHeader("Authorization", String.format("Bearer %s", tokenProvider.getToken()))
+                    .withCaCertificates(caCertificate);
+            return restClient.watch(latestResourceVersion);
+        }
+
+        @Nullable
+        RuntimeContext parseStsList(JsonObject jsonObject) {
+            String resourceVersion = jsonObject.get("metadata").asObject().getString("resourceVersion",
+                    null);
+            // identify stateful set this pod belongs to
+            for (JsonValue item : toJsonArray(jsonObject.get("items"))) {
+                String itemName = item.asObject().get("metadata").asObject().getString("name", null);
+                if (stsName.equals(itemName)) {
+                    // identified the stateful set
+                    int specReplicas = item.asObject().get("spec").asObject().getInt("replicas", UNKNOWN);
+                    int readyReplicas = item.asObject().get("status").asObject().getInt("readyReplicas", UNKNOWN);
+                    int replicas = item.asObject().get("status").asObject().getInt("currentReplicas", UNKNOWN);
+                    return new RuntimeContext(specReplicas, readyReplicas, replicas, resourceVersion);
+                }
+            }
+            return null;
+        }
+
         @SuppressWarnings("checkstyle:cyclomaticcomplexity")
-        private void onMessage(String message) {
+        void onMessage(String message) {
             if (LOGGER.isFinestEnabled()) {
                 LOGGER.finest("Complete message from kubernetes API: " + message);
             }
@@ -772,14 +876,26 @@ class KubernetesClient {
                     LOGGER.info("Unknown watch type " + watchType + ", complete message:\n" + message);
             }
             if (latestRuntimeContext != null && ctx != null) {
-                LOGGER.info("Updating cluster topology tracker with previous: "
-                    + latestRuntimeContext + ", updated: " + ctx);
-                clusterTopologyIntentTracker.update(latestRuntimeContext.getSpecifiedReplicaCount(),
-                        ctx.getSpecifiedReplicaCount(),
-                        latestRuntimeContext.getReadyReplicas(), ctx.getReadyReplicas(),
-                        latestRuntimeContext.getCurrentReplicas(), ctx.getCurrentReplicas());
+                updateTracker(latestRuntimeContext, ctx);
             }
             latestRuntimeContext = ctx;
+        }
+
+        void updateTracker(RuntimeContext previous, RuntimeContext updated) {
+            if (previous != null) {
+                LOGGER.info("Updating cluster topology tracker with previous: "
+                        + previous + ", updated: " + updated);
+                clusterTopologyIntentTracker.update(previous.getSpecifiedReplicaCount(),
+                        updated.getSpecifiedReplicaCount(),
+                        previous.getReadyReplicas(), updated.getReadyReplicas(),
+                        previous.getCurrentReplicas(), updated.getCurrentReplicas());
+            } else {
+                LOGGER.info("Initializing cluster topology tracker with initial context: "
+                        + latestRuntimeContext);
+                clusterTopologyIntentTracker.update(UNKNOWN, updated.getSpecifiedReplicaCount(),
+                        UNKNOWN, updated.getReadyReplicas(),
+                        UNKNOWN, updated.getCurrentReplicas());
+            }
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
@@ -58,7 +58,7 @@ public final class RestClient {
      */
     public static final int HTTP_NOT_FOUND = 404;
 
-    private static final String WATCH_FORMAT = "?watch=1&resourceVersion=%s";
+    private static final String WATCH_FORMAT = "watch=1&resourceVersion=%s";
 
     private final String url;
     private final List<Parameter> headers = new ArrayList<>();
@@ -181,7 +181,9 @@ public final class RestClient {
     public WatchResponse watch(String resourceVersion) {
         HttpURLConnection connection = null;
         try {
-            String completeUrl = url + String.format(WATCH_FORMAT, resourceVersion);
+            String appendWatchParameter = (url.contains("?") ? "&" : "?")
+                    + String.format(WATCH_FORMAT, resourceVersion);
+            String completeUrl = url + appendWatchParameter;
             URL urlToConnect = new URL(completeUrl);
             connection = (HttpURLConnection) urlToConnect.openConnection();
             if (connection instanceof HttpsURLConnection && caCertificate != null) {

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/StsMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/StsMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/StsMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/StsMonitorTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.kubernetes;
+
+import com.hazelcast.instance.impl.ClusterTopologyIntentTracker;
+import com.hazelcast.instance.impl.NoOpClusterTopologyIntentTracker;
+import com.hazelcast.internal.util.FutureUtil;
+import com.hazelcast.spi.utils.RestClient;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import io.fabric8.kubernetes.api.model.ListMetaBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetListBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetSpecBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetStatusBuilder;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.fabric8.mockwebserver.dsl.ReturnOrWebsocketable;
+import io.fabric8.mockwebserver.dsl.TimesOnceableOrHttpHeaderable;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.quality.Strictness;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
+import static com.hazelcast.test.HazelcastTestSupport.spawn;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+// test interaction of KubernetesClient with Kubernetes mock API server
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class StsMonitorTest {
+
+    private static final String DEFAULT_STS_NAME = "hz-hazelcast";
+
+    @Rule
+    public KubernetesServer kubernetesServer = new KubernetesServer(false);
+
+    String apiServerBaseUrl;
+    String namespace;
+    NamespacedKubernetesClient mockServerClient;
+    String token;
+
+    @Before
+    public void setup() {
+        mockServerClient = kubernetesServer.getClient();
+        namespace = mockServerClient.getNamespace();
+        token = mockServerClient.getConfiguration().getOauthToken();
+        apiServerBaseUrl = mockServerClient.getMasterUrl().toString();
+        if (apiServerBaseUrl.endsWith("/")) {
+            // our KubernetesClient expects a base url without trailing /
+            apiServerBaseUrl = apiServerBaseUrl.substring(0, apiServerBaseUrl.length() - 1);
+        }
+    }
+
+    @Test
+    public void testInitialStsList() {
+        expectAndReturnStsList("1", "2").always();
+
+        KubernetesClient.StsMonitor stsMonitor = buildStsMonitor(namespace, apiServerBaseUrl, token);
+
+        stsMonitor.readInitialStsList();
+        RuntimeContext runtimeContext = stsMonitor.latestRuntimeContext;
+        assertEquals("1", runtimeContext.getResourceVersion());
+        assertEquals(3, runtimeContext.getCurrentReplicas());
+        assertEquals(3, runtimeContext.getReadyReplicas());
+        assertEquals(3, runtimeContext.getSpecifiedReplicaCount());
+    }
+
+    @Test
+    public void testWatchSts() throws IOException {
+        expectAndReturnStsList("1", "2").once();
+        kubernetesServer.expect().get()
+                .withPath("/apis/apps/v1/namespaces/" + namespace
+                        + "/statefulsets?fieldSelector=metadata.name%3D" + DEFAULT_STS_NAME
+                        + "&watch=1&resourceVersion=1")
+                .andReturn(200, new WatchEvent(buildDefaultSts("4"), "MODIFIED"))
+                .always();
+
+        KubernetesClient.StsMonitor stsMonitor = buildStsMonitor(namespace, apiServerBaseUrl, token);
+        stsMonitor.readInitialStsList();
+        RestClient.WatchResponse watchResponse = stsMonitor.sendWatchRequest();
+        String nextLine = watchResponse.nextLine();
+        stsMonitor.onMessage(nextLine);
+        assertEquals("4", stsMonitor.latestResourceVersion);
+        RuntimeContext runtimeContext = stsMonitor.latestRuntimeContext;
+        assertEquals("4", runtimeContext.getResourceVersion());
+        assertEquals(3, runtimeContext.getCurrentReplicas());
+        assertEquals(3, runtimeContext.getReadyReplicas());
+        assertEquals(3, runtimeContext.getSpecifiedReplicaCount());
+    }
+
+    @Test
+    public void testWatchResumesAfter410Gone() {
+        ClusterTopologyIntentTracker tracker = Mockito.mock(ClusterTopologyIntentTracker.class, Mockito.withSettings().strictness(Strictness.LENIENT));
+        KubernetesClient.StsMonitor stsMonitor = buildStsMonitor(namespace, apiServerBaseUrl, token, tracker);
+
+        // initial STS list
+        expectAndReturnStsList("1", "2").once();
+        // first watch request fails with 410 GONE
+        expectWatch("1").andReturn(410, null).once();
+        // second STS list (as StsMonitor re-initializes)
+        expectAndReturnStsList("3", "4").once();
+        // second watch request accepted and sends an event
+        expectWatch("3")
+                .andReturn(200, new WatchEvent(buildDefaultSts("5"), "MODIFIED"))
+                .once();
+        // next event replies with HTTP code 500
+        expectWatch("5").andReturn(500, null).once();
+        // attempts to initialize sts list again
+        expectStsList().andReply(200, request -> {
+                    // after failure with HTTP code 500, stsMonitor retries reading the sts list
+                    // let's stop the stsMonitor run loop here
+                    stsMonitor.running = false;
+                    return buildDefaultStsList("1", "2");
+                }).once();
+
+        // stsMonitor.run():
+        // - gets initial list of statefulsets
+        // - issues watch request
+        // - if response is 410 GONE, lists STS's again and resumes watch
+        stsMonitor.run();
+
+        // verify
+        // 1st time initialization: StsMonitor reads initial statefulset list and provides update
+        Mockito.verify(tracker, Mockito.times(1)).update(-1, 3, -1, 3, -1, 3);
+        // during resume, tracker is updated
+        Mockito.verify(tracker, Mockito.times(3)).update(3, 3, 3, 3, 3, 3);
+    }
+
+    @Test
+    public void testStsMonitor_whenKubernetesApiWatchFailure() {
+        // sts list succeeds, but watch always fails
+        expectAndReturnStsList("1", "2").always();
+        expectWatch("1").andReturn(500, null).always();
+
+        KubernetesClient.StsMonitor stsMonitor = buildStsMonitor(namespace, apiServerBaseUrl, token);
+        Future<Void> runFuture = spawn(stsMonitor::run);
+        sleepSeconds(10);
+        stsMonitor.running = false;
+        FutureUtil.waitWithDeadline(Collections.singleton(runFuture), 5, TimeUnit.SECONDS);
+        assertTrue("Backoff should be triggered due to API faults and idleCount should be > 0",
+                stsMonitor.idleCount > 0);
+    }
+
+    @Test
+    public void testStsMonitor_whenKubernetesApiListFailure() {
+        // sts list fails
+        expectStsList().andReturn(500, null).always();
+
+        KubernetesClient.StsMonitor stsMonitor = buildStsMonitor(namespace, apiServerBaseUrl, token);
+        Future<Void> runFuture = spawn(stsMonitor::run);
+        sleepSeconds(10);
+        stsMonitor.running = false;
+        FutureUtil.waitWithDeadline(Collections.singleton(runFuture), 5, TimeUnit.SECONDS);
+        assertTrue("Backoff should be triggered due to API faults and idleCount should be > 0",
+                stsMonitor.idleCount > 0);
+    }
+
+    // respond with 200 OK and statefulset list
+    private TimesOnceableOrHttpHeaderable expectAndReturnStsList(String listResourceVersion, String stsResourceVersion) {
+        return expectStsList().andReturn(200, buildDefaultStsList(listResourceVersion, stsResourceVersion));
+    }
+
+    private ReturnOrWebsocketable<TimesOnceableOrHttpHeaderable<Void>> expectWatch(String resourceVersion) {
+        return expectPath(watchUrl(resourceVersion));
+    }
+
+    private ReturnOrWebsocketable<TimesOnceableOrHttpHeaderable<Void>> expectStsList() {
+        return expectPath(stsListUrl());
+    }
+
+    private ReturnOrWebsocketable<TimesOnceableOrHttpHeaderable<Void>> expectPath(String path) {
+        return kubernetesServer.expect().get().withPath(path);
+    }
+
+    private String watchUrl(String resourceVersion) {
+        return "/apis/apps/v1/namespaces/" + namespace
+                + "/statefulsets?fieldSelector=metadata.name%3D" + DEFAULT_STS_NAME
+                + "&watch=1&resourceVersion=" + resourceVersion;
+    }
+
+    private String stsListUrl() {
+        return "/apis/apps/v1/namespaces/" + namespace
+                + "/statefulsets?fieldSelector=metadata.name%3D" + DEFAULT_STS_NAME;
+    }
+
+    StatefulSetList buildDefaultStsList(String resourceVersion, String stsResourceVersion) {
+        return new StatefulSetListBuilder().withItems(buildDefaultSts(stsResourceVersion))
+                .withMetadata(new ListMetaBuilder().withResourceVersion(resourceVersion).build())
+                .build();
+    }
+
+    StatefulSet buildDefaultSts(String resourceVersion) {
+        return buildSts("default", DEFAULT_STS_NAME, 3, 3, 3, 3, resourceVersion);
+    }
+
+    StatefulSet buildSts(String namespace,
+                         String name,
+                         int specReplicas,
+                         int replicas,
+                         int currentReplicas,
+                         int readyReplicas,
+                         String resourceVersion) {
+        StatefulSetSpecBuilder stsSpecBuilder = new StatefulSetSpecBuilder().withReplicas(specReplicas);
+        StatefulSetStatusBuilder stsStatusBuilder = new StatefulSetStatusBuilder().withReplicas(replicas)
+                .withCurrentReplicas(currentReplicas)
+                .withReadyReplicas(readyReplicas);
+        StatefulSetBuilder builder = new StatefulSetBuilder().withSpec(stsSpecBuilder.build())
+                .withStatus(stsStatusBuilder.build())
+                .withMetadata(
+                        new ObjectMetaBuilder().withName(name).withNamespace(namespace)
+                                                .withResourceVersion(resourceVersion).build());
+        return builder.build();
+    }
+
+    KubernetesClient.StsMonitor buildStsMonitor(String namespace, String masterUrl,
+                                                String oauthToken) {
+        return buildStsMonitor(namespace, masterUrl, oauthToken, new NoOpClusterTopologyIntentTracker());
+    }
+
+    KubernetesClient.StsMonitor buildStsMonitor(String namespace, String masterUrl,
+                                                      String oauthToken, ClusterTopologyIntentTracker tracker) {
+        StaticTokenProvider tokenProvider = new StaticTokenProvider(oauthToken);
+        return new KubernetesClient(namespace, masterUrl,
+                tokenProvider, null, 3,
+                KubernetesConfig.ExposeExternallyMode.DISABLED, false,
+                null, null, tracker, DEFAULT_STS_NAME).new StsMonitor();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/StsMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/StsMonitorTest.java
@@ -41,7 +41,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.quality.Strictness;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -119,7 +118,7 @@ public class StsMonitorTest {
 
     @Test
     public void testWatchResumesAfter410Gone() {
-        ClusterTopologyIntentTracker tracker = Mockito.mock(ClusterTopologyIntentTracker.class, Mockito.withSettings().strictness(Strictness.LENIENT));
+        ClusterTopologyIntentTracker tracker = Mockito.mock(ClusterTopologyIntentTracker.class, Mockito.withSettings().lenient());
         KubernetesClient.StsMonitor stsMonitor = buildStsMonitor(namespace, apiServerBaseUrl, token, tracker);
 
         // initial STS list

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
         <archunit.version>0.22.0</archunit.version>
         <errorprone.version>2.15.0</errorprone.version>
         <awaitility.version>4.1.1</awaitility.version>
+        <kubernetes-server-mock.version>6.4.0</kubernetes-server-mock.version>
         <hikari.version>4.0.3</hikari.version>
 
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
@@ -1923,6 +1924,11 @@
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-server-mock</artifactId>
+                <version>${kubernetes-server-mock.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Handle errors from kubernetes API:
- when watch receives 410 GONE reply, list statefulsets and resume watching from updated resource version. Fixes [HZ-1979].
- on other Kubernetes API failures, backoff and retry with appropriate logging instead of exiting the statefulset monitor loop. Fixes [HZ-1922]

Backport of #23538 to 5.2.z

[HZ-1979]: https://hazelcast.atlassian.net/browse/HZ-1979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HZ-1922]: https://hazelcast.atlassian.net/browse/HZ-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ