### PR TITLE
[ALTO] Redesign of AsyncSocket.activate

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AcceptRequest.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AcceptRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc;
+
+import java.util.function.Consumer;
+
+/**
+ * Contains an accept request when a socket connects to the {@link AsyncServerSocket}.
+ * For more information see {@link AsyncServerSocket#accept(Consumer)}.
+ * <p/>
+ * Currently it is just a dumb placeholder so that we can pass the appropriate resource
+ * (e.g. the accepted SocketChannel) to the constructor of the AsyncSocket.
+ */
+public interface AcceptRequest {
+}

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncServerSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncServerSocket.java
@@ -184,11 +184,10 @@ public abstract class AsyncServerSocket extends Socket {
      * @param consumer a function that is called when a socket has connected.
      * @throws NullPointerException if consumer is null.
      */
-    public abstract void accept(Consumer<AsyncSocket> consumer);
+    public abstract void accept(Consumer<AcceptRequest> consumer);
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + "[" + getLocalAddress() + "]";
     }
-
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncSocket.java
@@ -31,7 +31,7 @@ import static com.hazelcast.internal.tpc.util.Preconditions.checkNotNull;
  * A 'client' Socket that is asynchronous. So reads and writes do not block,
  * but are executed on an {@link Reactor}.
  * <p/>
- * The socket should be configured and then activated before it is shared
+ * The socket should be configured and then started before it is shared
  * with other threads.
  */
 @SuppressWarnings({"checkstyle:MethodCount", "checkstyle:VisibilityModifier"})
@@ -107,8 +107,7 @@ public abstract class AsyncSocket extends Socket {
     /**
      * Gets the {@link Reactor} this {@link AsyncSocket} belongs to.
      *
-     * @return the {@link Reactor} this AsyncSocket belongs to or null if
-     * the AsyncSocket has not been activated yet.
+     * @return the {@link Reactor} this AsyncSocket belongs.
      */
     public abstract Reactor reactor();
 
@@ -277,7 +276,7 @@ public abstract class AsyncSocket extends Socket {
     public abstract int getSendBufferSize();
 
     /**
-     * Sets the read handler. Should be called before this AsyncSocket is activated.
+     * Sets the read handler. Should be called before this AsyncSocket is started.
      *
      * @param readHandler the ReadHandler
      * @throws NullPointerException if readHandler is null.
@@ -303,8 +302,6 @@ public abstract class AsyncSocket extends Socket {
      * This call can safely be made from any thread, but typically you want to call it from the
      * eventloop-thread. This call is blocking; this isn't an issue for the eventloop thread
      * because it is an instantaneous call. For any other thread this call is not cheap.
-     * <p/>
-     * This call should only be made after the socket is activated.
      *
      * @param readable the new readable status.
      * @throws RuntimeException if the readable status could not be set.
@@ -324,20 +321,14 @@ public abstract class AsyncSocket extends Socket {
     public abstract boolean isReadable();
 
     /**
-     * Activates an AsyncSocket by hooking it up to a Reactor.
-     * <p>
-     * This method should only be called once.
-     * <p>
-     * This method is not thread-safe.
-     * <p>
+     * Start the AsyncSocket. The Socket should be started only once.
+     * <p/>
      * Typically you do not want to share this AsyncSocket with other threads till this
      * method is called.
      *
-     * @param reactor the Reactor this AsyncSocket belongs to.
-     * @throws NullPointerException  if reactor is null.
-     * @throws IllegalStateException if this AsyncSocket is already activated.
+     * @throws RuntimeException if the Socket could not be started.
      */
-    public abstract void activate(Reactor reactor);
+    public abstract void start();
 
     /**
      * Ensures that any scheduled IOBuffers are flushed to the socket.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Reactor.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Reactor.java
@@ -163,21 +163,25 @@ public abstract class Reactor implements Executor {
     public abstract AsyncServerSocket openTcpAsyncServerSocket();
 
     /**
-     * Opens TCP/IP (stream) based async socket. The returned socket assumes IPv4. When support for
-     * IPv6 is added, a boolean 'ipv4' flag needs to be added.
-     * <p/>
-     * The opened AsyncSocket isn't tied to this Reactor. After it is opened, it needs to be assigned
-     * to a particular reactor by calling {@link AsyncSocket#activate(Reactor)}. The reason why
-     * this isn't done in 1 go, is that it could be that when the AsyncServerSocket accepts an
-     * AsyncSocket, we want to assign that AsyncSocket to a different Reactor. Otherwise if there
-     * would be 1 AsyncServerSocket, connected AsyncSockets can only run on top of the reactor of
-     * the AsyncServerSocket instead of being distributed over multiple reactors.
+     * Opens client-side TCP/IP (stream) based async socket. The returned socket assumes IPv4.
+     * When support for IPv6 is added, a boolean 'ipv4' flag needs to be added.
      * <p>
      * This method is thread-safe.
      *
      * @return the opened AsyncSocket.
      */
     public abstract AsyncSocket openTcpAsyncSocket();
+
+    /**
+     * Opens a server-side async socket. The AcceptRequest contains all the information to
+     * determine the type of socket.
+     * <p>
+     * This method is thread-safe.
+     *
+     * @return the opened AsyncSocket.
+     */
+
+    public abstract AsyncSocket openAsyncSocket(AcceptRequest request);
 
     /**
      * Creates the Eventloop run by this Reactor.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAcceptRequest.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAcceptRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc.nio;
+
+import com.hazelcast.internal.tpc.AcceptRequest;
+
+import java.nio.channels.SocketChannel;
+
+public class NioAcceptRequest implements AcceptRequest {
+
+    private final SocketChannel socketChannel;
+
+    public NioAcceptRequest(SocketChannel socketChannel) {
+        this.socketChannel = socketChannel;
+    }
+
+    public SocketChannel getSocketChannel() {
+        return socketChannel;
+    }
+}

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioReactor.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioReactor.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.tpc.nio;
 
 import com.hazelcast.internal.tpc.AsyncServerSocket;
 import com.hazelcast.internal.tpc.AsyncSocket;
+import com.hazelcast.internal.tpc.AcceptRequest;
 import com.hazelcast.internal.tpc.Eventloop;
 import com.hazelcast.internal.tpc.Reactor;
 import com.hazelcast.internal.tpc.ReactorBuilder;
@@ -41,12 +42,17 @@ public final class NioReactor extends Reactor {
 
     @Override
     public AsyncServerSocket openTcpAsyncServerSocket() {
-        return NioAsyncServerSocket.openTcpServerSocket(this);
+        return new NioAsyncServerSocket(this);
     }
 
     @Override
     public AsyncSocket openTcpAsyncSocket() {
-        return NioAsyncSocket.openTcpSocket();
+        return new NioAsyncSocket(this);
+    }
+
+    @Override
+    public AsyncSocket openAsyncSocket(AcceptRequest request) {
+        return new NioAsyncSocket(this, (NioAcceptRequest) request);
     }
 
     @Override

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocketTest.java
@@ -54,7 +54,7 @@ public abstract class AsyncSocketTest {
         Reactor reactor = newReactor();
         AsyncSocket socket = reactor.openTcpAsyncSocket();
         socket.setReadHandler(mock(ReadHandler.class));
-        socket.activate(reactor);
+        socket.start();
 
         SocketAddress remoteAddress = socket.getRemoteAddress();
         assertNull(remoteAddress);
@@ -65,7 +65,7 @@ public abstract class AsyncSocketTest {
         Reactor reactor = newReactor();
         AsyncSocket socket = reactor.openTcpAsyncSocket();
         socket.setReadHandler(mock(ReadHandler.class));
-        socket.activate(reactor);
+        socket.start();
 
         SocketAddress localAddress = socket.getLocalAddress();
         System.out.println(localAddress);
@@ -151,12 +151,12 @@ public abstract class AsyncSocketTest {
 
         SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
         serverSocket.bind(serverAddress);
-        serverSocket.accept(asyncSocket -> {
+        serverSocket.accept(acceptRequest -> {
         });
 
         AsyncSocket clientSocket = reactor.openTcpAsyncSocket();
         clientSocket.setReadHandler(mock(ReadHandler.class));
-        clientSocket.activate(reactor);
+        clientSocket.start();
 
         CompletableFuture<Void> connect = clientSocket.connect(serverAddress);
 
@@ -181,7 +181,7 @@ public abstract class AsyncSocketTest {
         Reactor reactor = newReactor();
         AsyncSocket socket = reactor.openTcpAsyncSocket();
         socket.setReadHandler(mock(ReadHandler.class));
-        socket.activate(reactor);
+        socket.start();
 
         CompletableFuture<Void> future = socket.connect(new InetSocketAddress(50000));
 
@@ -209,25 +209,16 @@ public abstract class AsyncSocketTest {
         assertTrue(socket.isClosed());
     }
 
+
     @Test
-    public void test_activate_whenNull() {
+    public void test_start_whenAlreadyStarted() {
         Reactor reactor = newReactor();
+
         AsyncSocket socket = reactor.openTcpAsyncSocket();
         socket.setReadHandler(mock(ReadHandler.class));
 
-        assertThrows(NullPointerException.class, () -> socket.activate(null));
-    }
-
-    @Test
-    public void test_activate_whenAlreadyActivated() {
-        Reactor reactor1 = newReactor();
-        Reactor reactor2 = newReactor();
-
-        AsyncSocket socket = reactor1.openTcpAsyncSocket();
-        socket.setReadHandler(mock(ReadHandler.class));
-
-        socket.activate(reactor1);
-        assertThrows(CompletionException.class, () -> socket.activate(reactor2));
+        socket.start();
+        assertThrows(CompletionException.class, () -> socket.start());
     }
 
     @Test
@@ -235,7 +226,7 @@ public abstract class AsyncSocketTest {
         Reactor reactor = newReactor();
 
         AsyncSocket socket = reactor.openTcpAsyncSocket();
-        assertThrows(CompletionException.class, () -> socket.activate(reactor));
+        assertThrows(CompletionException.class, () -> socket.start());
     }
 
     @Test
@@ -247,7 +238,7 @@ public abstract class AsyncSocketTest {
 
         AsyncSocket socket = reactor.openTcpAsyncSocket();
         socket.setReadHandler(mock(ReadHandler.class));
-        socket.activate(reactor);
+        socket.start();
         socket.connect(serverAddress).join();
 
         assertTrue(socket.isReadable());

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_LargePayloadTest.java
@@ -268,7 +268,7 @@ public abstract class AsyncSocket_LargePayloadTest {
                 }
             }
         });
-        clientSocket.activate(clientReactor);
+        clientSocket.start();
         clientSocket.connect(serverAddress).join();
 
         return clientSocket;
@@ -279,7 +279,8 @@ public abstract class AsyncSocket_LargePayloadTest {
         serverSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
         serverSocket.bind(serverAddress);
 
-        serverSocket.accept(socket -> {
+        serverSocket.accept(acceptRequest -> {
+            AsyncSocket socket = serverReactor.openAsyncSocket(acceptRequest);
             socket.setTcpNoDelay(true);
             socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
             socket.setReceiveBufferSize(serverSocket.getReceiveBufferSize());
@@ -328,7 +329,7 @@ public abstract class AsyncSocket_LargePayloadTest {
                     }
                 }
             });
-            socket.activate(serverReactor);
+            socket.start();
         });
 
         return serverSocket;

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_ReadableTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_ReadableTest.java
@@ -62,15 +62,16 @@ public abstract class AsyncSocket_ReadableTest {
         AsyncServerSocket serverSocket = serverReactor.openTcpAsyncServerSocket();
         CompletableFuture<AsyncSocket> remoteSocketFuture = new CompletableFuture<>();
         serverSocket.bind(serverAddress);
-        serverSocket.accept(asyncSocket -> {
+        serverSocket.accept(acceptRequest -> {
+            AsyncSocket asyncSocket = serverReactor.openAsyncSocket(acceptRequest);
             asyncSocket.setReadHandler(new NullReadHandler());
-            asyncSocket.activate(serverReactor);
+            asyncSocket.start();
             remoteSocketFuture.complete(asyncSocket);
         });
 
         AsyncSocket localSocket = clientReactor.openTcpAsyncSocket();
         localSocket.setReadHandler(new NullReadHandler());
-        localSocket.activate(clientReactor);
+        localSocket.start();
         localSocket.connect(serverAddress).join();
 
         AsyncSocket remoteSocket = remoteSocketFuture.join();

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_RpcTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_RpcTest.java
@@ -318,7 +318,7 @@ public abstract class AsyncSocket_RpcTest {
                 }
             }
         });
-        clientSocket.activate(clientReactor);
+        clientSocket.start();
         clientSocket.connect(serverAddress).join();
         return clientSocket;
     }
@@ -328,7 +328,8 @@ public abstract class AsyncSocket_RpcTest {
         serverSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
         serverSocket.bind(serverAddress);
 
-        serverSocket.accept(socket -> {
+        serverSocket.accept(acceptRequest -> {
+            AsyncSocket socket = serverReactor.openAsyncSocket(acceptRequest);
             socket.setTcpNoDelay(true);
             socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
             socket.setReceiveBufferSize(serverSocket.getReceiveBufferSize());
@@ -370,7 +371,7 @@ public abstract class AsyncSocket_RpcTest {
                     }
                 }
             });
-            socket.activate(serverReactor);
+            socket.start();
         });
 
         return serverSocket;

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/ReactorTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/ReactorTest.java
@@ -188,15 +188,15 @@ public abstract class ReactorTest {
         serverSocket.accept(socket -> {
         });
 
-        AsyncSocket clientSocket = serverReactor.openTcpAsyncSocket();
+        Reactor clientReactor = newReactor();
+        AsyncSocket clientSocket = clientReactor.openTcpAsyncSocket();
         clientSocket.setReadHandler(new ReadHandler() {
             @Override
             public void onRead(ByteBuffer receiveBuffer) {
             }
         });
-        Reactor clientReactor = newReactor();
         clientReactor.start();
-        clientSocket.activate(clientReactor);
+        clientSocket.start();
         clientSocket.connect(serverAddress);
 
         clientReactor.shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/internal/bootstrap/TpcServerBootstrap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/bootstrap/TpcServerBootstrap.java
@@ -27,6 +27,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.tpc.AsyncServerSocket;
+import com.hazelcast.internal.tpc.AsyncSocket;
 import com.hazelcast.internal.tpc.Configuration;
 import com.hazelcast.internal.tpc.Reactor;
 import com.hazelcast.internal.tpc.ReadHandler;
@@ -169,13 +170,14 @@ public class TpcServerBootstrap {
             serverSocket.setReceiveBufferSize(receiveBufferSize);
             serverSocket.setReuseAddress(true);
             port = bind(serverSocket, port, limit);
-            serverSocket.accept(socket -> {
+            serverSocket.accept(acceptRequest -> {
+                AsyncSocket socket = reactor.openAsyncSocket(acceptRequest);
                 socket.setReadHandler(readHandlerSuppliers.get(reactor).get());
                 socket.setSendBufferSize(sendBufferSize);
                 socket.setReceiveBufferSize(receiveBufferSize);
                 socket.setTcpNoDelay(tcpNoDelay);
                 socket.setKeepAlive(true);
-                socket.activate(reactor);
+                socket.start();
             });
         }
     }


### PR DESCRIPTION
The idea behind AsyncSocket.activate was that you could create an AsyncSocket on one reactor and then activate it on another. This is useful on the serverside so you can run the accepted socket on a different reactor than the reactor of the AsyncServerSocket that accepted the socket.

This led to a bit of a weird design because you need to active with a reactor you want to attach to and made it impossible to set fields of the AsyncSocket on creation because you don't know the reactor at construction time.

This PR solves that by always making the AsyncSocket on the appropriate Reactor. And instead of listening to created AsyncSocket on the AsyncServerSocket, you listen to AcceptRequest and then you create the Socket on the appropriate reactor.

So we keep the flexibility and most fields of the AsyncSocket can now be final.