### PR TITLE
NioHandler cleanup

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocket.java
@@ -224,7 +224,7 @@ public final class NioAsyncServerSocket extends AsyncServerSocket {
         }
 
         @Override
-        public void handle(SelectionKey key) throws IOException {
+        public void handle() throws IOException {
             if (!key.isValid()) {
                 throw new CancelledKeyException();
             }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocket.java
@@ -574,7 +574,7 @@ public final class NioAsyncSocket extends AsyncSocket {
         }
 
         @Override
-        public void handle(SelectionKey key) throws IOException {
+        public void handle() throws IOException {
             if (!key.isValid()) {
                 throw new CancelledKeyException();
             }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioEventloop.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioEventloop.java
@@ -82,7 +82,7 @@ class NioEventloop extends Eventloop {
 
                     NioHandler handler = (NioHandler) key.attachment();
                     try {
-                        handler.handle(key);
+                        handler.handle();
                     } catch (IOException e) {
                         handler.close(null, e);
                     }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioHandler.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioHandler.java
@@ -36,8 +36,7 @@ public interface NioHandler {
     /**
      * Signals that something interesting happened on a SelectionKey.
      *
-     * @param key the SelectionKey
      * @throws IOException if handling lead to problems.
      */
-    void handle(SelectionKey key) throws IOException;
+    void handle() throws IOException;
 }


### PR DESCRIPTION
[ALTO] The key doesn't need to be passed since each handler always knows its key.
