### PR TITLE
Add tests to verify JDBC schema support [HZ-1973]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DeleteJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DeleteJdbcSqlConnectorTest.java
@@ -19,7 +19,10 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
+
+import java.sql.SQLException;
 
 import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_REF;
 
@@ -186,6 +189,22 @@ public class DeleteJdbcSqlConnectorTest extends JdbcSqlTestSupport {
 
         execute("DELETE FROM " + tableName + " WHERE \"person-id\" = 0");
         assertJdbcRowsAnyOrder(tableName);
+    }
+
+    @Test
+    @Ignore("https://github.com/hazelcast/hazelcast/issues/23476")
+    public void deleteFromTableNonDefaultSchema() throws SQLException {
+        String schemaName = randomName();
+        executeJdbc("CREATE SCHEMA " + schemaName);
+        String fullyQualifiedTable = schemaName + "." + tableName;
+
+        createTable(fullyQualifiedTable);
+        insertItems(fullyQualifiedTable, 2);
+        createMapping(fullyQualifiedTable);
+
+        execute("DELETE FROM \"" + fullyQualifiedTable + "\"");
+
+        assertJdbcRowsAnyOrder(fullyQualifiedTable);
     }
 
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/InsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/InsertJdbcSqlConnectorTest.java
@@ -174,7 +174,6 @@ public class InsertJdbcSqlConnectorTest extends JdbcSqlTestSupport {
 
     @Test
     public void insertIntoTableNonDefaultSchema() throws SQLException {
-
         createTable(alternativeSchemaTable);
         createMapping(alternativeSchemaTable);
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/InsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/InsertJdbcSqlConnectorTest.java
@@ -173,6 +173,7 @@ public class InsertJdbcSqlConnectorTest extends JdbcSqlTestSupport {
     }
 
     @Test
+    @Ignore("Requires https://github.com/hazelcast/hazelcast/pull/23634")
     public void insertIntoTableNonDefaultSchema() throws SQLException {
         createTable(alternativeSchemaTable);
         createMapping(alternativeSchemaTable);
@@ -183,6 +184,7 @@ public class InsertJdbcSqlConnectorTest extends JdbcSqlTestSupport {
 
 
     @Test
+    @Ignore("Requires https://github.com/hazelcast/hazelcast/pull/23634")
     public void insertIntoTableWithExternalNameNonDefaultSchema() throws Exception {
         createTable(alternativeSchemaTable);
         String mappingName = "mapping_" + randomName();

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
@@ -218,7 +218,6 @@ public class JdbcJoinTest extends JdbcSqlTestSupport {
 
     @Test
     public void joinWithOtherJdbcNonDefaultSchema() throws SQLException {
-
         String schemaName = randomTableName();
         executeJdbc("CREATE SCHEMA " + schemaName);
         String fullyQualifiedTable = schemaName + "." + tableName;

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
@@ -215,4 +215,29 @@ public class JdbcJoinTest extends JdbcSqlTestSupport {
                 )
         );
     }
+
+    @Test
+    public void joinWithOtherJdbcNonDefaultSchema() throws SQLException {
+
+        String schemaName = randomTableName();
+        executeJdbc("CREATE SCHEMA " + schemaName);
+        String fullyQualifiedTable = schemaName + "." + tableName;
+        createTable(fullyQualifiedTable);
+        insertItems(fullyQualifiedTable, ITEM_COUNT);
+        createMapping(fullyQualifiedTable);
+
+        assertRowsAnyOrder(
+                "SELECT t1.id, t2.name " +
+                        "FROM " + tableName + " t1 " +
+                        "JOIN \"" + fullyQualifiedTable + "\" t2 " +
+                        "   ON t1.id = t2.id",
+                newArrayList(
+                        new Row(0, "name-0"),
+                        new Row(1, "name-1"),
+                        new Row(2, "name-2"),
+                        new Row(3, "name-3"),
+                        new Row(4, "name-4")
+                )
+        );
+    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -217,6 +218,7 @@ public class JdbcJoinTest extends JdbcSqlTestSupport {
     }
 
     @Test
+    @Ignore("Requires https://github.com/hazelcast/hazelcast/pull/23634")
     public void joinWithOtherJdbcNonDefaultSchema() throws SQLException {
         String schemaName = randomTableName();
         executeJdbc("CREATE SCHEMA " + schemaName);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectJdbcSqlConnectorTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -219,6 +220,7 @@ public class SelectJdbcSqlConnectorTest extends JdbcSqlTestSupport {
     }
 
     @Test
+    @Ignore("Requires https://github.com/hazelcast/hazelcast/pull/23634")
     public void selectAllFromTableNonDefaultSchema() throws SQLException {
         String schemaName = randomName();
         executeJdbc("CREATE SCHEMA " + schemaName);
@@ -241,6 +243,7 @@ public class SelectJdbcSqlConnectorTest extends JdbcSqlTestSupport {
     }
 
     @Test
+    @Ignore("Requires https://github.com/hazelcast/hazelcast/pull/23634")
     public void selectAllFromTableSpaceInSchema() throws SQLException {
         String schemaName = "\"prefix " + randomName() + "\"";
         executeJdbc("CREATE SCHEMA " + schemaName);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/UpdateJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/UpdateJdbcSqlConnectorTest.java
@@ -19,7 +19,10 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
+
+import java.sql.SQLException;
 
 import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_REF;
 
@@ -439,6 +442,25 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         execute("UPDATE " + tableName + " SET \"full-name\" = 'updated' WHERE id = 0");
         assertJdbcRowsAnyOrder(tableName,
                 new Row(0, "updated")
+        );
+    }
+
+    @Test
+    @Ignore("https://github.com/hazelcast/hazelcast/issues/23476")
+    public void updateTableNonDefaultSchema() throws SQLException {
+        String schemaName = randomName();
+        executeJdbc("CREATE SCHEMA " + schemaName);
+        String fullyQualifiedTable = schemaName + "." + tableName;
+
+        createTable(fullyQualifiedTable);
+        insertItems(fullyQualifiedTable, 2);
+        createMapping(fullyQualifiedTable);
+
+        execute("UPDATE \"" + fullyQualifiedTable + "\" SET name = 'updated'");
+
+        assertJdbcRowsAnyOrder(fullyQualifiedTable,
+                new Row(0, "updated"),
+                new Row(1, "updated")
         );
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
@@ -26,7 +26,7 @@ public class MySQLDatabaseProvider implements TestDatabaseProvider {
 
     @Override
     public String createDatabase(String dbName) {
-        jdbcUrl = "jdbc:tc:mysql:8.0.29:///" + dbName + "?TC_DAEMON=true&sessionVariables=sql_mode=ANSI";
+        jdbcUrl = "jdbc:tc:mysql:8.0.29:///" + dbName + "?TC_DAEMON=true&sessionVariables=sql_mode=ANSI&user=root&password=";
         waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
     }


### PR DESCRIPTION
This includes tests to verify the standard CRUD operations when the target table is defined under a non-default schema. Tests for UPDATE/DELETE are ignored currently
(see https://github.com/hazelcast/hazelcast/issues/23476).

