### PR TITLE
ArchUnit rules for CompletableFuture methods usage [HZ-2003]

### DIFF
--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
@@ -16,25 +16,15 @@
 
 package com.hazelcast.test.archunit;
 
-import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaModifier;
-import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
-import com.tngtech.archunit.lang.ConditionEvents;
-import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 import java.io.Serializable;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static com.hazelcast.test.archunit.ArchUnitRules.SerialVersionUidFieldCondition.haveValidSerialVersionUid;
+import static com.hazelcast.test.archunit.SerialVersionUidFieldCondition.haveValidSerialVersionUid;
 import static com.hazelcast.test.archunit.CompletableFutureUsageCondition.useExplicitExecutorServiceInCFAsyncMethods;
-import static com.tngtech.archunit.lang.conditions.ArchConditions.beFinal;
-import static com.tngtech.archunit.lang.conditions.ArchConditions.beStatic;
-import static com.tngtech.archunit.lang.conditions.ArchConditions.haveRawType;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-
 
 public final class ArchUnitRules {
     /**
@@ -60,25 +50,4 @@ public final class ArchUnitRules {
     private ArchUnitRules() {
     }
 
-    static class SerialVersionUidFieldCondition extends ArchCondition<JavaClass> {
-        private static final String FIELD_NAME = "serialVersionUID";
-
-        SerialVersionUidFieldCondition() {
-            super("have a valid " + FIELD_NAME);
-        }
-
-        @Override
-        public void check(JavaClass clazz, ConditionEvents events) {
-            Optional<JavaField> field = clazz.tryGetField(FIELD_NAME);
-            if (field.isPresent()) {
-                haveRawType("long").and(beFinal()).and(beStatic()).check(field.get(), events);
-            } else {
-                events.add(SimpleConditionEvent.violated(clazz, FIELD_NAME + " field is missing in class " + clazz.getName()));
-            }
-        }
-
-        static SerialVersionUidFieldCondition haveValidSerialVersionUid() {
-            return new SerialVersionUidFieldCondition();
-        }
-    }
 }

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
@@ -26,8 +26,10 @@ import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 import java.io.Serializable;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.test.archunit.ArchUnitRules.SerialVersionUidFieldCondition.haveValidSerialVersionUid;
+import static com.hazelcast.test.archunit.CompletableFutureUsageCondition.useExplicitExecutorServiceInCFAsyncMethods;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.beFinal;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.beStatic;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.haveRawType;
@@ -47,6 +49,13 @@ public final class ArchUnitRules {
             .and().areNotAnonymousClasses()
             .should(haveValidSerialVersionUid())
             .allowEmptyShould(true);
+
+    /**
+     * ArchUnit rule checking that only {@link CompletableFuture} {@code async} methods version with explicitly
+     * defined executor service is used.
+     */
+    public static final ArchRule COMPLETABLE_FUTURE_USED_ONLY_WITH_EXPLICIT_EXECUTOR = classes()
+            .should(useExplicitExecutorServiceInCFAsyncMethods());
 
     private ArchUnitRules() {
     }

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/CompletableFutureUsageCondition.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/CompletableFutureUsageCondition.java
@@ -79,7 +79,7 @@ public class CompletableFutureUsageCondition extends ArchCondition<JavaClass> {
     public void check(JavaClass item, ConditionEvents events) {
         for (JavaMethodCall methodCalled : item.getMethodCallsFromSelf()) {
             String calledMethodName = methodCalled.getTarget().getName();
-            if (isFromCompletableFuture(methodCalled)
+            if (isFromCompletionStage(methodCalled)
                     && isAsyncMethod(calledMethodName)
                     && isNotOverrideCompletableFutureMethod(methodCalled, item)) {
                 List<JavaType> parameterTypes = methodCalled.getTarget().getParameterTypes();
@@ -92,9 +92,9 @@ public class CompletableFutureUsageCondition extends ArchCondition<JavaClass> {
         }
     }
 
-    private boolean isFromCompletableFuture(JavaMethodCall methodCalled) {
+    private boolean isFromCompletionStage(JavaMethodCall methodCalled) {
         JavaClass calledClass = methodCalled.getTarget().getOwner();
-        return calledClass.isAssignableTo(CompletableFuture.class);
+        return calledClass.isAssignableTo(CompletionStage.class);
     }
 
     private boolean isNotOverrideCompletableFutureMethod(JavaMethodCall methodCalled, JavaClass item) {

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/CompletableFutureUsageCondition.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/CompletableFutureUsageCondition.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+
+/**
+ * <ul>
+ * <li> from {@link CompletionStage} create a list of methods that have an {@code Async} counterpart
+ * <li> based on this list, filtering all their calls on the {@link CompletableFuture} {@code instanceof} objects
+ * <li> checking that no non-Async methods versions are used
+ * <li> checking that for Async methods the {@link Executor} service is specified
+ * <li> skipping methods that override {@link CompletableFuture} base class methods
+ * </ul>
+ */
+public class CompletableFutureUsageCondition extends ArchCondition<JavaClass> {
+
+    private static final Set<String> COMPLETION_STAGE_METHODS = new ClassFileImporter().importClass(CompletionStage.class)
+            .getMethods().stream()
+            .map(JavaMember::getName)
+            .collect(Collectors.toSet());
+
+    private static final Set<String> SYNC_AND_ASYNC_METHODS = collectSyncAndAsyncCounterpartMethods();
+
+    CompletableFutureUsageCondition() {
+        super("use only CompletableFuture async methods with explicit executor service");
+    }
+
+    private static Set<String> collectSyncAndAsyncCounterpartMethods() {
+        return COMPLETION_STAGE_METHODS.stream()
+                .flatMap(method -> {
+                    if (method.endsWith("Async")) {
+                        String syncMethod = method.substring(0, method.lastIndexOf(("Async")));
+                        return COMPLETION_STAGE_METHODS.contains(syncMethod) ? Stream.of(syncMethod, method) : Stream.of(method);
+                    } else {
+                        return Stream.empty();
+                    }
+                })
+                .collect(Collectors.toSet());
+    }
+
+    static ArchCondition<? super JavaClass> useExplicitExecutorServiceInCFAsyncMethods() {
+        return new CompletableFutureUsageCondition();
+    }
+
+    public void check(JavaClass item, ConditionEvents events) {
+        for (JavaMethodCall methodCalled : item.getMethodCallsFromSelf()) {
+            String calledMethodName = methodCalled.getTarget().getName();
+            if (isFromCompletableFuture(methodCalled)
+                    && isAsyncMethod(calledMethodName)
+                    && isNotOverrideCompletableFutureMethod(methodCalled, item)) {
+                List<JavaType> parameterTypes = methodCalled.getTarget().getParameterTypes();
+                if (withoutExecutorArgument(parameterTypes)) {
+                    String violatingMethodName = methodCalled.getOwner().getFullName();
+                    events.add(violated(item, violatingMethodName + ":" + methodCalled.getLineNumber()
+                            + " calls CompletableFuture." + calledMethodName));
+                }
+            }
+        }
+    }
+
+    private boolean isFromCompletableFuture(JavaMethodCall methodCalled) {
+        JavaClass calledClass = methodCalled.getTarget().getOwner();
+        return calledClass.isAssignableTo(CompletableFuture.class);
+    }
+
+    private boolean isNotOverrideCompletableFutureMethod(JavaMethodCall methodCalled, JavaClass item) {
+        return !item.isAssignableTo(CompletableFuture.class)
+                || !COMPLETION_STAGE_METHODS.contains(methodCalled.getOwner().getName());
+    }
+
+    private boolean isAsyncMethod(String methodName) {
+        return SYNC_AND_ASYNC_METHODS.contains(methodName);
+    }
+
+    private boolean withoutExecutorArgument(List<JavaType> parameterTypes) {
+        return parameterTypes.isEmpty()
+                || !parameterTypes.get(parameterTypes.size() - 1).toErasure().isEquivalentTo(Executor.class);
+    }
+}

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/SerialVersionUidFieldCondition.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/SerialVersionUidFieldCondition.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+
+import java.util.Optional;
+
+import static com.tngtech.archunit.lang.conditions.ArchConditions.beFinal;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.beStatic;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.haveRawType;
+
+public class SerialVersionUidFieldCondition extends ArchCondition<JavaClass> {
+    private static final String FIELD_NAME = "serialVersionUID";
+
+    SerialVersionUidFieldCondition() {
+        super("have a valid " + FIELD_NAME);
+    }
+
+    @Override
+    public void check(JavaClass clazz, ConditionEvents events) {
+        Optional<JavaField> field = clazz.tryGetField(FIELD_NAME);
+        if (field.isPresent()) {
+            haveRawType("long").and(beFinal()).and(beStatic()).check(field.get(), events);
+        } else {
+            events.add(SimpleConditionEvent.violated(clazz, FIELD_NAME + " field is missing in class " + clazz.getName()));
+        }
+    }
+
+    static SerialVersionUidFieldCondition haveValidSerialVersionUid() {
+        return new SerialVersionUidFieldCondition();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/HazelcastCompletableFutureAsyncUsageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/HazelcastCompletableFutureAsyncUsageTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast;
+
+import com.hazelcast.jet.impl.util.NonCompletableFuture;
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
+import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
+import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
+
+public class HazelcastCompletableFutureAsyncUsageTest {
+
+    @Test
+    public void noClassUsesCompletableFuture() {
+        String basePackage = "com.hazelcast";
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(onlyCurrentModule())
+                .importPackages(basePackage);
+
+        JavaClasses javaClassesFiltered = classes
+                .that(are(not(equivalentTo(NonCompletableFuture.class))))
+                .that(are(not(resideInAPackage("com.hazelcast.jet.."))));
+        ArchUnitRules.COMPLETABLE_FUTURE_USED_ONLY_WITH_EXPLICIT_EXECUTOR.check(javaClassesFiltered);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/HazelcastCompletableFutureAsyncUsageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/HazelcastCompletableFutureAsyncUsageTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast;
 
-import com.hazelcast.jet.impl.util.NonCompletableFuture;
 import com.hazelcast.test.archunit.ArchUnitRules;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
@@ -24,7 +23,6 @@ import org.junit.Test;
 
 import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
-import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 
@@ -38,7 +36,6 @@ public class HazelcastCompletableFutureAsyncUsageTest {
                 .importPackages(basePackage);
 
         JavaClasses javaClassesFiltered = classes
-                .that(are(not(equivalentTo(NonCompletableFuture.class))))
                 .that(are(not(resideInAPackage("com.hazelcast.jet.."))));
         ArchUnitRules.COMPLETABLE_FUTURE_USED_ONLY_WITH_EXPLICIT_EXECUTOR.check(javaClassesFiltered);
     }


### PR DESCRIPTION
Define ArchUnit rules checking that only the `CompletableFuture` async methods version with explicitly specified Executor service is used.

Fixes https://github.com/hazelcast/hazelcast/issues/18190

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
