### PR TITLE
[CN-714] Add support of IMDSv2 for AWS Discovery plugin (#23545)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsMetadataApi.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsMetadataApi.java
@@ -23,6 +23,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.utils.RestClient;
 
 import java.util.Optional;
+import java.time.Instant;
 
 import static com.hazelcast.aws.AwsRequestUtils.createRestClient;
 import static com.hazelcast.spi.utils.RestClient.HTTP_NOT_FOUND;
@@ -40,17 +41,24 @@ class AwsMetadataApi {
     private static final String EC2_METADATA_ENDPOINT = "http://169.254.169.254/latest/meta-data";
     private static final String ECS_IAM_ROLE_METADATA_ENDPOINT = "http://169.254.170.2" + System.getenv(
         "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI");
+    private static final String EC2_METADATA_TOKEN_ENDPOINT = "http://169.254.169.254/latest/api/token";
     private static final String ECS_TASK_METADATA_ENDPOINT = System.getenv("ECS_CONTAINER_METADATA_URI");
 
     private static final String SECURITY_CREDENTIALS_URI = "/iam/security-credentials/";
+    private static final long METADATA_TOKEN_TTL_SECONDS = 21600;
 
     private final String ec2MetadataEndpoint;
+    private final String ec2MetadataTokenEndpoint;
     private final String ecsIamRoleEndpoint;
     private final String ecsTaskMetadataEndpoint;
     private final AwsConfig awsConfig;
 
+    private String metadataToken;
+    private Instant metadataExpiry;
+
     AwsMetadataApi(AwsConfig awsConfig) {
         this.ec2MetadataEndpoint = EC2_METADATA_ENDPOINT;
+        this.ec2MetadataTokenEndpoint = EC2_METADATA_TOKEN_ENDPOINT;
         this.ecsIamRoleEndpoint = ECS_IAM_ROLE_METADATA_ENDPOINT;
         this.ecsTaskMetadataEndpoint = ECS_TASK_METADATA_ENDPOINT;
         this.awsConfig = awsConfig;
@@ -60,8 +68,9 @@ class AwsMetadataApi {
      * For test purposes only.
      */
     AwsMetadataApi(String ec2MetadataEndpoint, String ecsIamRoleEndpoint, String ecsTaskMetadataEndpoint,
-                   AwsConfig awsConfig) {
+                   String ec2MetadataTokenEndpoint, AwsConfig awsConfig) {
         this.ec2MetadataEndpoint = ec2MetadataEndpoint;
+        this.ec2MetadataTokenEndpoint = ec2MetadataTokenEndpoint;
         this.ecsIamRoleEndpoint = ecsIamRoleEndpoint;
         this.ecsTaskMetadataEndpoint = ecsTaskMetadataEndpoint;
         this.awsConfig = awsConfig;
@@ -69,7 +78,7 @@ class AwsMetadataApi {
 
     String availabilityZoneEc2() {
         String uri = ec2MetadataEndpoint.concat("/placement/availability-zone/");
-        return createRestClient(uri, awsConfig).get().getBody();
+        return metadataClient(uri, awsConfig).get().getBody();
     }
 
     Optional<String> placementGroupEc2() {
@@ -93,7 +102,7 @@ class AwsMetadataApi {
     private Optional<String> getOptionalMetadata(String uri, String loggedName) {
         RestClient.Response response;
         try {
-            response = createRestClient(uri, awsConfig)
+            response = metadataClient(uri, awsConfig)
                     .expectResponseCodes(HTTP_OK, HTTP_NOT_FOUND)
                     .get();
         } catch (Exception e) {
@@ -114,17 +123,17 @@ class AwsMetadataApi {
 
     String defaultIamRoleEc2() {
         String uri = ec2MetadataEndpoint.concat(SECURITY_CREDENTIALS_URI);
-        return createRestClient(uri, awsConfig).get().getBody();
+        return metadataClient(uri, awsConfig).get().getBody();
     }
 
     AwsCredentials credentialsEc2(String iamRole) {
         String uri = ec2MetadataEndpoint.concat(SECURITY_CREDENTIALS_URI).concat(iamRole);
-        String response = createRestClient(uri, awsConfig).get().getBody();
+        String response = metadataClient(uri, awsConfig).get().getBody();
         return parseCredentials(response);
     }
 
     AwsCredentials credentialsEcs() {
-        String response = createRestClient(ecsIamRoleEndpoint, awsConfig).get().getBody();
+        String response = metadataClient(ecsIamRoleEndpoint, awsConfig).get().getBody();
         return parseCredentials(response);
     }
 
@@ -166,5 +175,31 @@ class AwsMetadataApi {
         String getClusterArn() {
             return clusterArn;
         }
+    }
+
+    RestClient metadataClient(String url, AwsConfig awsConfig) {
+        return createRestClient(url, awsConfig)
+            .withHeader("X-aws-ec2-metadata-token", metadataToken());
+    }
+
+    String metadataToken() {
+        if (!tokenValid()) {
+            metadataToken = retrieveToken();
+        }
+        return metadataToken;
+    }
+
+    String retrieveToken() {
+        String response = createRestClient(ec2MetadataTokenEndpoint, awsConfig)
+            .withHeader("X-aws-ec2-metadata-token-ttl-seconds", Long.toString(METADATA_TOKEN_TTL_SECONDS))
+            .put()
+            .getBody();
+        // we want to refresh token before it expires
+        metadataExpiry = Instant.now().plusSeconds(METADATA_TOKEN_TTL_SECONDS / 2);
+        return response;
+    }
+
+    boolean tokenValid() {
+        return metadataExpiry != null && metadataExpiry.isAfter(Instant.now());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
@@ -126,6 +126,10 @@ public final class RestClient {
         return callWithRetries("POST");
     }
 
+    public Response put() {
+        return callWithRetries("PUT");
+    }
+
     private Response callWithRetries(String method) {
         return RetryUtils.retry(() -> call(method), retries);
     }

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsMetadataApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsMetadataApiTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.moreThan;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -42,6 +43,7 @@ public class AwsMetadataApiTest {
 
     private final String GROUP_NAME_URL = "/placement/group-name/";
     private final String PARTITION_NO_URL = "/placement/partition-number/";
+    private final String METADATA_TOKEN_URL = "/latest/api/token";
     private final int RETRY_COUNT = 3;
 
     private AwsMetadataApi awsMetadataApi;
@@ -53,7 +55,10 @@ public class AwsMetadataApiTest {
     public void setUp() {
         AwsConfig awsConfig = AwsConfig.builder().setConnectionRetries(RETRY_COUNT).build();
         String endpoint = String.format("http://localhost:%s", wireMockRule.port());
-        awsMetadataApi = new AwsMetadataApi(endpoint, endpoint, endpoint, awsConfig);
+        stubFor(put(urlEqualTo(METADATA_TOKEN_URL))
+            .willReturn(aResponse().withStatus(200).withBody("defaulttoken")));
+        String tokenEndpoint = endpoint.concat(METADATA_TOKEN_URL);
+        awsMetadataApi = new AwsMetadataApi(endpoint, endpoint, endpoint, tokenEndpoint, awsConfig);
     }
 
     @Test
@@ -239,5 +244,19 @@ public class AwsMetadataApiTest {
         assertTrue(exception.getMessage().contains(Integer.toString(errorCode)));
         assertTrue(exception.getMessage().contains(errorMessage));
         verify(moreThan(RETRY_COUNT), getRequestedFor(urlMatching("/.*")));
+    }
+
+    @Test
+    public void retrieveToken() {
+        // given
+        String token = "retrievetoken";
+        stubFor(put(urlEqualTo(METADATA_TOKEN_URL))
+            .willReturn(aResponse().withStatus(200).withBody(token)));
+
+        // when
+        String result = awsMetadataApi.retrieveToken();
+
+        // then
+        assertEquals(token, result);
     }
 }


### PR DESCRIPTION
Before making requests to metadata service we now try to get token using `/latest/api/token` endpoint.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

Backport: https://github.com/hazelcast/hazelcast/pull/23545

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases