### PR TITLE
Add test for GenericMapStore during shutdown [HZ-1823]

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStore.java
@@ -297,7 +297,9 @@ public class GenericMapStore<K> implements MapStore<K, GenericRecord>, MapLoader
 
         asyncExecutor.submit(() -> {
             awaitInitFinished();
-            dropMapping(mapping);
+            if (instance.node.isRunning()) {
+                dropMapping(mapping);
+            }
         });
     }
 


### PR DESCRIPTION
MapStore#destroy is called in 2 cases:
- During Map#destroy - which should destroy the MapStore as well so it doesn't leak resources. In this case, the mapping should be removed.

- During member shutdown - in this case, the mapping should not be removed because it might be just one member shutting down, not the whole cluster.

Note that the test passes without the new check in the destroy method. It is because when the node is shutting down the SQL query to remove the mapping can't be executed, so it's not removed. However, it prevents
`HazelcastInstance is not active!` exception.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
