### PR TITLE
Provide metrics from the compactor to the metrics subsystem [HZ-1761]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -620,16 +620,26 @@ public final class MetricDescriptorConstants {
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_MAX = "tstore.hlog.paging.frequency.max";
 
     public static final String TSTORE_HLOG_COMPACTION_PREFIX = "tstore.hlog.compaction.";
-    public static final String TSTORE_HLOG_COMPACTION_DUMMY_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "dummyRecords.count";
-    public static final String TSTORE_HLOG_COMPACTION_DUMMY_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX + "dummyRecords.size";
-    public static final String TSTORE_HLOG_COMPACTION_NON_DUMMY_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "nonDummyRecords.count";
-    public static final String TSTORE_HLOG_COMPACTION_NON_DUMMY_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX + "nonDummyRecords.size";
-    public static final String TSTORE_HLOG_COMPACTION_ALIVE_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "aliveRecords.count";
-    public static final String TSTORE_HLOG_COMPACTION_ALIVE_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX + "aliveRecords.size";
-    public static final String TSTORE_HLOG_COMPACTION_DEAD_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "deadRecords.count";
-    public static final String TSTORE_HLOG_COMPACTION_DEAD_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX + "deadRecords.size";
-    public static final String TSTORE_HLOG_COMPACTION_VISITED_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "visitedRecords.count";
-    public static final String TSTORE_HLOG_COMPACTION_VISITED_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX + "visitedRecords.size";
+    public static final String TSTORE_HLOG_COMPACTION_DUMMY_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX
+            + "dummyRecords.count";
+    public static final String TSTORE_HLOG_COMPACTION_DUMMY_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX
+            + "dummyRecords.size";
+    public static final String TSTORE_HLOG_COMPACTION_NON_DUMMY_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX
+            + "nonDummyRecords.count";
+    public static final String TSTORE_HLOG_COMPACTION_NON_DUMMY_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX
+            + "nonDummyRecords.size";
+    public static final String TSTORE_HLOG_COMPACTION_ALIVE_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX
+            + "aliveRecords.count";
+    public static final String TSTORE_HLOG_COMPACTION_ALIVE_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX
+            + "aliveRecords.size";
+    public static final String TSTORE_HLOG_COMPACTION_DEAD_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX
+            + "deadRecords.count";
+    public static final String TSTORE_HLOG_COMPACTION_DEAD_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX
+            + "deadRecords.size";
+    public static final String TSTORE_HLOG_COMPACTION_VISITED_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX
+            + "visitedRecords.count";
+    public static final String TSTORE_HLOG_COMPACTION_VISITED_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX
+            + "visitedRecords.size";
     public static final String TSTORE_HLOG_COMPACTION_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "count";
     public static final String TSTORE_HLOG_COMPACTION_QUEUE_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "queue.count";
     public static final String TSTORE_HLOG_COMPACTION_FAILED_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "failed.count";

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -620,11 +620,16 @@ public final class MetricDescriptorConstants {
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_MAX = "tstore.hlog.paging.frequency.max";
 
     public static final String TSTORE_HLOG_COMPACTION_PREFIX = "tstore.hlog.compaction.";
-    public static final String TSTORE_HLOG_COMPACTION_DUMMY_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "dummyRecords";
-    public static final String TSTORE_HLOG_COMPACTION_NON_DUMMY_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "nonDummyRecords";
-    public static final String TSTORE_HLOG_COMPACTION_ALIVE_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "aliveRecords";
-    public static final String TSTORE_HLOG_COMPACTION_DEAD_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "deadRecords";
-    public static final String TSTORE_HLOG_COMPACTION_VISITED_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "visitedRecords";
+    public static final String TSTORE_HLOG_COMPACTION_DUMMY_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "dummyRecords.count";
+    public static final String TSTORE_HLOG_COMPACTION_DUMMY_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX + "dummyRecords.size";
+    public static final String TSTORE_HLOG_COMPACTION_NON_DUMMY_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "nonDummyRecords.count";
+    public static final String TSTORE_HLOG_COMPACTION_NON_DUMMY_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX + "nonDummyRecords.size";
+    public static final String TSTORE_HLOG_COMPACTION_ALIVE_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "aliveRecords.count";
+    public static final String TSTORE_HLOG_COMPACTION_ALIVE_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX + "aliveRecords.size";
+    public static final String TSTORE_HLOG_COMPACTION_DEAD_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "deadRecords.count";
+    public static final String TSTORE_HLOG_COMPACTION_DEAD_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX + "deadRecords.size";
+    public static final String TSTORE_HLOG_COMPACTION_VISITED_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "visitedRecords.count";
+    public static final String TSTORE_HLOG_COMPACTION_VISITED_RECORDS_SIZE = TSTORE_HLOG_COMPACTION_PREFIX + "visitedRecords.size";
     public static final String TSTORE_HLOG_COMPACTION_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "count";
     public static final String TSTORE_HLOG_COMPACTION_QUEUE_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "queue.count";
     public static final String TSTORE_HLOG_COMPACTION_FAILED_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "failed.count";

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -618,6 +618,23 @@ public final class MetricDescriptorConstants {
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_AVG = "tstore.hlog.paging.frequency.avg";
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_MIN = "tstore.hlog.paging.frequency.min";
     public static final String TSTORE_HLOG_PAGING_FREQUENCY_MAX = "tstore.hlog.paging.frequency.max";
+
+    public static final String TSTORE_HLOG_COMPACTION_PREFIX = "tstore.hlog.compaction.";
+    public static final String TSTORE_HLOG_COMPACTION_DUMMY_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "dummyRecords";
+    public static final String TSTORE_HLOG_COMPACTION_NON_DUMMY_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "nonDummyRecords";
+    public static final String TSTORE_HLOG_COMPACTION_ALIVE_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "aliveRecords";
+    public static final String TSTORE_HLOG_COMPACTION_DEAD_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "deadRecords";
+    public static final String TSTORE_HLOG_COMPACTION_VISITED_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "visitedRecords";
+    public static final String TSTORE_HLOG_COMPACTION_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "count";
+    public static final String TSTORE_HLOG_COMPACTION_FAILED_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "failed.count";
+    public static final String TSTORE_HLOG_COMPACTION_IN_PROGRESS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "inProgress.count";
+
+    public static final String TSTORE_HLOG_COMPACTION_TIME_TOTAL = TSTORE_HLOG_COMPACTION_PREFIX + "time.total";
+    public static final String TSTORE_HLOG_COMPACTION_TIME_MIN = TSTORE_HLOG_COMPACTION_PREFIX + "time.min";
+    public static final String TSTORE_HLOG_COMPACTION_TIME_MAX = TSTORE_HLOG_COMPACTION_PREFIX + "time.max";
+    public static final String TSTORE_HLOG_COMPACTION_TIME_AVG = TSTORE_HLOG_COMPACTION_PREFIX + "time.avg";
+    public static final String TSTORE_HLOG_COMPACTION_IO_TIME_TOTAL = TSTORE_HLOG_COMPACTION_PREFIX + "ioTime.total";
+
     // ===[/TSTORE]=====================================================
 
     // ===[WAN]=========================================================

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -626,8 +626,14 @@ public final class MetricDescriptorConstants {
     public static final String TSTORE_HLOG_COMPACTION_DEAD_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "deadRecords";
     public static final String TSTORE_HLOG_COMPACTION_VISITED_RECORDS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "visitedRecords";
     public static final String TSTORE_HLOG_COMPACTION_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "count";
+    public static final String TSTORE_HLOG_COMPACTION_QUEUE_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "queue.count";
     public static final String TSTORE_HLOG_COMPACTION_FAILED_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "failed.count";
     public static final String TSTORE_HLOG_COMPACTION_IN_PROGRESS_COUNT = TSTORE_HLOG_COMPACTION_PREFIX + "inProgress.count";
+
+    public static final String TSTORE_HLOG_COMPACTION_QUEUE_TIME_TOTAL = TSTORE_HLOG_COMPACTION_PREFIX + "queueTime.total";
+    public static final String TSTORE_HLOG_COMPACTION_QUEUE_TIME_MIN = TSTORE_HLOG_COMPACTION_PREFIX + "queueTime.min";
+    public static final String TSTORE_HLOG_COMPACTION_QUEUE_TIME_MAX = TSTORE_HLOG_COMPACTION_PREFIX + "queueTime.max";
+    public static final String TSTORE_HLOG_COMPACTION_QUEUE_TIME_AVG = TSTORE_HLOG_COMPACTION_PREFIX + "queueTime.avg";
 
     public static final String TSTORE_HLOG_COMPACTION_TIME_TOTAL = TSTORE_HLOG_COMPACTION_PREFIX + "time.total";
     public static final String TSTORE_HLOG_COMPACTION_TIME_MIN = TSTORE_HLOG_COMPACTION_PREFIX + "time.min";


### PR DESCRIPTION
Additional metrics definitions for TStore compactors.

Fixes HZ-1761
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/5719

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
