### PR TITLE
Update condition for running clear expired task [5.0.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
@@ -107,11 +107,13 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable {
 
     @Override
     public void run() {
+        if (!nodeEngine.isStartCompleted()) {
+            return;
+        }
+        if (!singleRunPermit.compareAndSet(false, true)) {
+            return;
+        }
         try {
-            if (!singleRunPermit.compareAndSet(false, true)) {
-                return;
-            }
-
             runInternal();
 
         } finally {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngine.java
@@ -225,6 +225,12 @@ public interface NodeEngine {
     boolean isRunning();
 
     /**
+     * @return      {@code true} if this {@code Node} has completed startup, {@code false} otherwise.
+     * @see         com.hazelcast.instance.impl.NodeExtension#isStartCompleted()
+     */
+    boolean isStartCompleted();
+
+    /**
      * Returns the HazelcastInstance that this {@link NodeEngine} belongs to.
      *
      * @return the HazelcastInstance

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -397,6 +397,11 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     @Override
+    public boolean isStartCompleted() {
+        return node.getNodeExtension().isStartCompleted();
+    }
+
+    @Override
     public HazelcastInstance getHazelcastInstance() {
         return node.hazelcastInstance;
     }


### PR DESCRIPTION
- only reset singleRunPermit to false if previous CAS succeeded in setting it to true. Otherwise, the finally block resets it to false
 while another run is in progress.
- do not start clear expired records task unless node is started. Currently not checking
if node is started may result in a lot of unnecessary logging about operation failing due to failing checkNodeState checks in OperationRunnerImpl (in particular when recovering from persistence).

(cherry picked from commit 2d1a336fdefe3dd2cc33e8cbfd7ced24640ceec3)
Backport of #23110 to 5.0.z