### PR TITLE
[ALTO] Register server socket channel in eventloop

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocket.java
@@ -59,27 +59,9 @@ public final class NioAsyncServerSocket extends AsyncServerSocket {
             this.options = builder.options;
             this.eventloopThread = reactor.eventloopThread();
             this.serverSocketChannel = builder.serverSocketChannel;
-            this.key = register();
+            this.key = serverSocketChannel.register(reactor.selector, 0, new Handler());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
-        }
-    }
-
-    private SelectionKey register() throws IOException {
-        if (Thread.currentThread() == eventloopThread) {
-            return serverSocketChannel.register(reactor.selector, 0, new Handler());
-        } else {
-            CompletableFuture<SelectionKey> future = new CompletableFuture<>();
-            reactor.execute(() -> {
-                try {
-                    future.complete(serverSocketChannel.register(reactor.selector, 0, new Handler()));
-                } catch (Throwable t) {
-                    future.completeExceptionally(t);
-                    throw sneakyThrow(t);
-                }
-            });
-
-            return future.join();
         }
     }
 


### PR DESCRIPTION
After https://github.com/hazelcast/hazelcast/issues/23534, server socket
channels are no longer registered in reactor threads. This causes
deadlock. You can observe this deadlock by simply running `ClientMain`.
This PR solves that by building server socket in the eventloop.

~In the future maybe we could have an API which returns future in Reactor.~