### PR TITLE
Remove excessive logging for not supported DB [HZ-1546]

### DIFF
--- a/extensions/mapstore/src/test/resources/container-license-acceptance.txt
+++ b/extensions/mapstore/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,0 @@
-mcr.microsoft.com/mssql/server:latest

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -747,12 +747,14 @@
             <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
@@ -765,6 +767,7 @@
             <version>${postgresql.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
@@ -777,6 +780,20 @@
             <version>${mysql.connector.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mssqlserver</artifactId>
+            <version>1.17.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>11.2.2.jre8</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -65,8 +65,6 @@ public class JdbcSqlConnector implements SqlConnector {
 
     public static final String JDBC_BATCH_LIMIT_DEFAULT_VALUE = "100";
 
-    private final SupportedDatabases supportedDatabases = new SupportedDatabases();
-
     @Override
     public String typeName() {
         return TYPE_NAME;
@@ -256,7 +254,7 @@ public class JdbcSqlConnector implements SqlConnector {
         try (Connection connection = dataSource.getConnection()) {
             DatabaseMetaData databaseMetaData = connection.getMetaData();
             SqlDialect dialect = SqlDialectFactoryImpl.INSTANCE.create(databaseMetaData);
-            supportedDatabases.logOnceIfDatabaseNotSupported(databaseMetaData);
+            SupportedDatabases.logOnceIfDatabaseNotSupported(databaseMetaData);
             return dialect;
         } catch (Exception e) {
             throw new HazelcastException("Could not determine dialect for dataLinkRef: "
@@ -368,7 +366,7 @@ public class JdbcSqlConnector implements SqlConnector {
         JdbcTable jdbcTable = (JdbcTable) context.getTable();
 
         // If dialect is supported
-        if (supportedDatabases.isDialectSupported(jdbcTable)) {
+        if (SupportedDatabases.isDialectSupported(jdbcTable)) {
             // Get the upsert statement
             String upsertStatement = UpsertBuilder.getUpsertStatement(jdbcTable);
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -24,8 +24,6 @@ import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
@@ -67,7 +65,7 @@ public class JdbcSqlConnector implements SqlConnector {
 
     public static final String JDBC_BATCH_LIMIT_DEFAULT_VALUE = "100";
 
-    private static final ILogger LOG = Logger.getLogger(JdbcSqlConnector.class);
+    private final SupportedDatabases supportedDatabases = new SupportedDatabases();
 
     @Override
     public String typeName() {
@@ -256,19 +254,10 @@ public class JdbcSqlConnector implements SqlConnector {
         DataSource dataSource = createDataLink(nodeEngine, dataLinkRef);
 
         try (Connection connection = dataSource.getConnection()) {
-            SqlDialect dialect = SqlDialectFactoryImpl.INSTANCE.create(connection.getMetaData());
-            String databaseProductName = connection.getMetaData().getDatabaseProductName();
-            switch (databaseProductName) {
-                case "MySQL":
-                case "PostgreSQL":
-                case "H2":
-                    return dialect;
-
-                default:
-                    LOG.warning("Database " + databaseProductName + " is not officially supported");
-                    return dialect;
-            }
-
+            DatabaseMetaData databaseMetaData = connection.getMetaData();
+            SqlDialect dialect = SqlDialectFactoryImpl.INSTANCE.create(databaseMetaData);
+            supportedDatabases.logOnceIfDatabaseNotSupported(databaseMetaData);
+            return dialect;
         } catch (Exception e) {
             throw new HazelcastException("Could not determine dialect for dataLinkRef: "
                                          + dataLinkRef, e);
@@ -379,7 +368,7 @@ public class JdbcSqlConnector implements SqlConnector {
         JdbcTable jdbcTable = (JdbcTable) context.getTable();
 
         // If dialect is supported
-        if (UpsertBuilder.isUpsertDialectSupported(jdbcTable)) {
+        if (supportedDatabases.isDialectSupported(jdbcTable)) {
             // Get the upsert statement
             String upsertStatement = UpsertBuilder.getUpsertStatement(jdbcTable);
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
@@ -42,7 +42,7 @@ final class SupportedDatabases {
         SUPPORTED_DATABASE_NAMES.add("POSTGRESQL");
         SUPPORTED_DATABASE_NAMES.add("H2");
         // Uncomment when officially supported
-        // DATABASE_NAMES.add("MICROSOFT SQL SERVER");
+        // SUPPORTED_DATABASE_NAMES.add("MICROSOFT SQL SERVER");
     }
 
     private SupportedDatabases() {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
@@ -29,30 +29,33 @@ import java.sql.SQLException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-class SupportedDatabases {
+final class SupportedDatabases {
 
     private static final ILogger LOGGER = Logger.getLogger(SupportedDatabases.class);
 
-    private final Set<String> databaseNames = ConcurrentHashMap.newKeySet();
+    private static final Set<String> DATABASE_NAMES = ConcurrentHashMap.newKeySet();
 
-    SupportedDatabases() {
+    static {
         // Add supported database names in upper case
-        databaseNames.add("MYSQL");
-        databaseNames.add("POSTGRESQL");
-        databaseNames.add("H2");
+        DATABASE_NAMES.add("MYSQL");
+        DATABASE_NAMES.add("POSTGRESQL");
+        DATABASE_NAMES.add("H2");
     }
 
-    void logOnceIfDatabaseNotSupported(DatabaseMetaData databaseMetaData) throws SQLException {
+    private SupportedDatabases() {
+    }
+
+    static void logOnceIfDatabaseNotSupported(DatabaseMetaData databaseMetaData) throws SQLException {
         // Get product name from the JDBC driver
         String databaseProductName = databaseMetaData.getDatabaseProductName();
         logOnceByProductName(databaseProductName);
     }
 
-    boolean logOnceByProductName(String databaseProductName) {
+    static boolean logOnceByProductName(String databaseProductName) {
         // Make the DB name upper case
         String uppercaseProductName = StringUtil.upperCaseInternal(databaseProductName);
 
-        boolean newDatabaseName = databaseNames.add(uppercaseProductName);
+        boolean newDatabaseName = DATABASE_NAMES.add(uppercaseProductName);
         if (newDatabaseName) {
             // If this Database name is new, log a message
             LOGGER.warning("Database " + uppercaseProductName + " is not officially supported");
@@ -60,7 +63,7 @@ class SupportedDatabases {
         return newDatabaseName;
     }
 
-    boolean isDialectSupported(JdbcTable jdbcTable) {
+    static boolean isDialectSupported(JdbcTable jdbcTable) {
         SqlDialect dialect = jdbcTable.sqlDialect();
         return dialect instanceof MysqlSqlDialect ||
                dialect instanceof PostgresqlSqlDialect ||

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
@@ -40,6 +40,7 @@ final class SupportedDatabases {
         DATABASE_NAMES.add("MYSQL");
         DATABASE_NAMES.add("POSTGRESQL");
         DATABASE_NAMES.add("H2");
+        //DATABASE_NAMES.add("MICROSOFT SQL SERVER");
     }
 
     private SupportedDatabases() {
@@ -68,5 +69,6 @@ final class SupportedDatabases {
         return dialect instanceof MysqlSqlDialect ||
                dialect instanceof PostgresqlSqlDialect ||
                dialect instanceof H2SqlDialect;
+               //dialect instanceof MssqlSqlDialect
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
@@ -26,6 +26,7 @@ import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -33,7 +34,7 @@ final class SupportedDatabases {
 
     private static final ILogger LOGGER = Logger.getLogger(SupportedDatabases.class);
 
-    private static final Set<String> SUPPORTED_DATABASE_NAMES = ConcurrentHashMap.newKeySet();
+    private static final Set<String> SUPPORTED_DATABASE_NAMES = new HashSet<>();
     private static final Set<String> DETECTED_DATABASE_NAMES = ConcurrentHashMap.newKeySet();
 
     static {
@@ -53,15 +54,12 @@ final class SupportedDatabases {
 
         boolean newDatabaseName = isNewDatabase(uppercaseProductName);
         if (newDatabaseName) {
-            // If this Database name is new, log a message
             LOGGER.warning("Database " + uppercaseProductName + " is not officially supported");
         }
     }
 
     private static String getProductName(DatabaseMetaData databaseMetaData) throws SQLException {
-        // Get product name from the JDBC driver
         String productName = databaseMetaData.getDatabaseProductName();
-        // Make the name upper case
         return StringUtil.upperCaseInternal(productName);
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
@@ -77,6 +77,7 @@ final class SupportedDatabases {
         return dialect instanceof MysqlSqlDialect ||
                dialect instanceof PostgresqlSqlDialect ||
                dialect instanceof H2SqlDialect;
-        //dialect instanceof MssqlSqlDialect
+        // Uncomment when officially supported
+        // dialect instanceof MssqlSqlDialect
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.jdbc;
+
+import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.H2SqlDialect;
+import org.apache.calcite.sql.dialect.MysqlSqlDialect;
+import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
+
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+class SupportedDatabases {
+
+    private static final ILogger LOGGER = Logger.getLogger(SupportedDatabases.class);
+
+    private final Set<String> databaseNames = ConcurrentHashMap.newKeySet();
+
+    SupportedDatabases() {
+        // Add supported database names in upper case
+        databaseNames.add("MYSQL");
+        databaseNames.add("POSTGRESQL");
+        databaseNames.add("H2");
+    }
+
+    void logOnceIfDatabaseNotSupported(DatabaseMetaData databaseMetaData) throws SQLException {
+        // Get product name from the JDBC driver
+        String databaseProductName = databaseMetaData.getDatabaseProductName();
+        logOnceByProductName(databaseProductName);
+    }
+
+    boolean logOnceByProductName(String databaseProductName) {
+        // Make the DB name upper case
+        String uppercaseProductName = StringUtil.upperCaseInternal(databaseProductName);
+
+        boolean newDatabaseName = databaseNames.add(uppercaseProductName);
+        if (newDatabaseName) {
+            // If this Database name is new, log a message
+            LOGGER.warning("Database " + uppercaseProductName + " is not officially supported");
+        }
+        return newDatabaseName;
+    }
+
+    boolean isDialectSupported(JdbcTable jdbcTable) {
+        SqlDialect dialect = jdbcTable.sqlDialect();
+        return dialect instanceof MysqlSqlDialect ||
+               dialect instanceof PostgresqlSqlDialect ||
+               dialect instanceof H2SqlDialect;
+    }
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/UpsertBuilder.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/UpsertBuilder.java
@@ -29,14 +29,6 @@ final class UpsertBuilder {
     private UpsertBuilder() {
     }
 
-    // Returns if upsert is supported for the given dialect
-    static boolean isUpsertDialectSupported(JdbcTable jdbcTable) {
-        SqlDialect dialect = jdbcTable.sqlDialect();
-        return dialect instanceof MysqlSqlDialect ||
-               dialect instanceof PostgresqlSqlDialect ||
-               dialect instanceof H2SqlDialect;
-    }
-
     static String getUpsertStatement(JdbcTable jdbcTable) {
         SqlDialect sqlDialect = jdbcTable.sqlDialect();
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabasesTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabasesTest.java
@@ -23,15 +23,17 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-public class UpsertBuilderTest {
+public class SupportedDatabasesTest {
 
     @Mock
     JdbcTable jdbcTable;
 
+    // Create mock dialects for JdbcTable
     @Mock
     SybaseSqlDialect sybaseSqlDialect;
 
@@ -48,7 +50,8 @@ public class UpsertBuilderTest {
 
         when(jdbcTable.sqlDialect()).thenReturn(sybaseSqlDialect);
 
-        boolean result = UpsertBuilder.isUpsertDialectSupported(jdbcTable);
+        SupportedDatabases supportedDatabases = new SupportedDatabases();
+        boolean result = supportedDatabases.isDialectSupported(jdbcTable);
         assertFalse(result);
     }
 
@@ -57,8 +60,22 @@ public class UpsertBuilderTest {
 
         when(jdbcTable.sqlDialect()).thenReturn(mysqlSqlDialect);
 
-        boolean result = UpsertBuilder.isUpsertDialectSupported(jdbcTable);
+        SupportedDatabases supportedDatabases = new SupportedDatabases();
+        boolean result = supportedDatabases.isDialectSupported(jdbcTable);
         assertTrue(result);
     }
 
+    @Test
+    public void logByProductName_supportedDB() {
+        SupportedDatabases supportedDatabases = new SupportedDatabases();
+        boolean newDB = supportedDatabases.logOnceByProductName("mysql");
+        assertThat(newDB).isFalse();
+    }
+
+    @Test
+    public void logByProductName_notSupportedDB() {
+        SupportedDatabases supportedDatabases = new SupportedDatabases();
+        boolean newDB = supportedDatabases.logOnceByProductName("cassandra");
+        assertThat(newDB).isTrue();
+    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabasesTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabasesTest.java
@@ -50,8 +50,7 @@ public class SupportedDatabasesTest {
 
         when(jdbcTable.sqlDialect()).thenReturn(sybaseSqlDialect);
 
-        SupportedDatabases supportedDatabases = new SupportedDatabases();
-        boolean result = supportedDatabases.isDialectSupported(jdbcTable);
+        boolean result = SupportedDatabases.isDialectSupported(jdbcTable);
         assertFalse(result);
     }
 
@@ -60,22 +59,19 @@ public class SupportedDatabasesTest {
 
         when(jdbcTable.sqlDialect()).thenReturn(mysqlSqlDialect);
 
-        SupportedDatabases supportedDatabases = new SupportedDatabases();
-        boolean result = supportedDatabases.isDialectSupported(jdbcTable);
+        boolean result = SupportedDatabases.isDialectSupported(jdbcTable);
         assertTrue(result);
     }
 
     @Test
     public void logByProductName_supportedDB() {
-        SupportedDatabases supportedDatabases = new SupportedDatabases();
-        boolean newDB = supportedDatabases.logOnceByProductName("mysql");
+        boolean newDB = SupportedDatabases.logOnceByProductName("mysql");
         assertThat(newDB).isFalse();
     }
 
     @Test
     public void logByProductName_notSupportedDB() {
-        SupportedDatabases supportedDatabases = new SupportedDatabases();
-        boolean newDB = supportedDatabases.logOnceByProductName("cassandra");
+        boolean newDB = SupportedDatabases.logOnceByProductName("cassandra");
         assertThat(newDB).isTrue();
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabasesTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabasesTest.java
@@ -65,8 +65,12 @@ public class SupportedDatabasesTest {
 
     @Test
     public void logByProductName_supportedDB() {
-        boolean newDB = SupportedDatabases.logOnceByProductName("mysql");
-        assertThat(newDB).isFalse();
+        String dbName = "mysql";
+        boolean newDB1 = SupportedDatabases.logOnceByProductName(dbName);
+        assertThat(newDB1).isFalse();
+
+        boolean newDB2 = SupportedDatabases.logOnceByProductName(dbName);
+        assertThat(newDB2).isFalse();
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabasesTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabasesTest.java
@@ -64,18 +64,30 @@ public class SupportedDatabasesTest {
     }
 
     @Test
-    public void logByProductName_supportedDB() {
-        String dbName = "mysql";
-        boolean newDB1 = SupportedDatabases.logOnceByProductName(dbName);
+    public void testMySQL() {
+        String dbName = "MYSQL";
+        boolean newDB1 = SupportedDatabases.isNewDatabase(dbName);
         assertThat(newDB1).isFalse();
-
-        boolean newDB2 = SupportedDatabases.logOnceByProductName(dbName);
-        assertThat(newDB2).isFalse();
     }
 
     @Test
-    public void logByProductName_notSupportedDB() {
-        boolean newDB = SupportedDatabases.logOnceByProductName("cassandra");
+    public void testPostgreSQL() {
+        String dbName = "POSTGRESQL";
+        boolean newDB = SupportedDatabases.isNewDatabase(dbName);
+        assertThat(newDB).isFalse();
+    }
+
+    @Test
+    public void testH2() {
+        String dbName = "H2";
+        boolean newDB = SupportedDatabases.isNewDatabase(dbName);
+        assertThat(newDB).isFalse();
+    }
+
+    @Test
+    public void test_notSupportedDB() {
+        String dbName = "cassandra";
+        boolean newDB = SupportedDatabases.isNewDatabase(dbName);
         assertThat(newDB).isTrue();
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabasesTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabasesTest.java
@@ -47,7 +47,6 @@ public class SupportedDatabasesTest {
 
     @Test
     public void testUpsertDialectNotSupported() {
-
         when(jdbcTable.sqlDialect()).thenReturn(sybaseSqlDialect);
 
         boolean result = SupportedDatabases.isDialectSupported(jdbcTable);
@@ -56,7 +55,6 @@ public class SupportedDatabasesTest {
 
     @Test
     public void testUpsertDialectSupported() {
-
         when(jdbcTable.sqlDialect()).thenReturn(mysqlSqlDialect);
 
         boolean result = SupportedDatabases.isDialectSupported(jdbcTable);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSinkIntoJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSinkIntoJdbcSqlConnectorTest.java
@@ -29,7 +29,7 @@ public class MSSQLSinkIntoJdbcSqlConnectorTest extends SinkJdbcSqlConnectorTest 
     public static void beforeClass() {
         initialize(new MSSQLDatabaseProvider());
     }
-    //Disable this test by overriding it until official MSSQL supported
+    //Disable this test by overriding it until official MSSQL support
     @Override
     public void updateTableWithColumns() {
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSinkIntoJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSinkIntoJdbcSqlConnectorTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.jdbc.mssql;
+
+import com.hazelcast.jet.sql.impl.connector.jdbc.SinkJdbcSqlConnectorTest;
+import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.jdbc.MSSQLDatabaseProvider;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+
+@Category(NightlyTest.class)
+public class MSSQLSinkIntoJdbcSqlConnectorTest extends SinkJdbcSqlConnectorTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(new MSSQLDatabaseProvider());
+    }
+
+    @Override
+    public void updateTableWithColumns() {
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSinkIntoJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSinkIntoJdbcSqlConnectorTest.java
@@ -29,7 +29,7 @@ public class MSSQLSinkIntoJdbcSqlConnectorTest extends SinkJdbcSqlConnectorTest 
     public static void beforeClass() {
         initialize(new MSSQLDatabaseProvider());
     }
-
+    //Disable this test by overriding it until official MSSQL supported
     @Override
     public void updateTableWithColumns() {
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/MSSQLDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/MSSQLDatabaseProvider.java
@@ -26,7 +26,7 @@ public class MSSQLDatabaseProvider implements TestDatabaseProvider {
 
     @Override
     public String createDatabase(String dbName) {
-        jdbcUrl = "jdbc:tc:sqlserver:latest:///" + dbName;
+        jdbcUrl = "jdbc:tc:sqlserver:2017-CU12:///" + dbName;
         waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
     }

--- a/hazelcast/src/test/resources/container-license-acceptance.txt
+++ b/hazelcast/src/test/resources/container-license-acceptance.txt
@@ -1,0 +1,1 @@
+mcr.microsoft.com/mssql/server:2017-CU12


### PR DESCRIPTION
When a SQL statement is executed, if an officially supported DB is **not used**, then the member is printing a log sentence
Make the member print this log only once.

Fixes : https://github.com/hazelcast/hazelcast/issues/22395
Jira : https://hazelcast.atlassian.net/browse/HZ-1546

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
