### PR TITLE
Implement dynamic task reconfiguration of Kafka Source Connectors [HZ-1972]

### DIFF
--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/KafkaConnectSource.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/KafkaConnectSource.java
@@ -61,7 +61,7 @@ public class KafkaConnectSource {
     private Map<Map<String, ?>, Map<String, ?>> partitionsToOffset = new ConcurrentHashMap<>();
     private final AtomicBoolean taskRunning = new AtomicBoolean();
 
-    private volatile boolean taskReconfigurationRequested = false;
+    private volatile boolean taskReconfigurationRequested;
 
 
     public KafkaConnectSource(Properties properties) {
@@ -209,7 +209,7 @@ public class KafkaConnectSource {
         }
     }
 
-    private class JetSourceTaskContext implements SourceTaskContext {
+    private final class JetSourceTaskContext implements SourceTaskContext {
         private final Map<String, String> taskConfig;
 
         private JetSourceTaskContext(Map<String, String> taskConfig) {

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/KafkaConnectSource.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/KafkaConnectSource.java
@@ -48,7 +48,7 @@ public class KafkaConnectSource {
      * stored as map.
      * See {@link SourceRecord} for more information regarding the format.
      */
-    private Map<Map<String, ?>, Map<String, ?>> partitionsToOffset = new ConcurrentHashMap<>();
+    private final Map<Map<String, ?>, Map<String, ?>> partitionsToOffset = new ConcurrentHashMap<>();
 
     public KafkaConnectSource(Properties properties) {
         String connectorClazz = checkRequiredProperty(properties, "connector.class");

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/KafkaConnectSource.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/KafkaConnectSource.java
@@ -83,7 +83,7 @@ public class KafkaConnectSource {
             return;
         }
         if (LOGGER.isFineEnabled()) {
-            LOGGER.fine("Get " + records.size() + " records from task poll");
+            LOGGER.fine("Got " + records.size() + " records from task poll");
         }
         for (SourceRecord record : records) {
             addToBuffer(record, buf);

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/TaskRunner.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/TaskRunner.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.connect.impl;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTask;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
+
+class TaskRunner {
+    private static final ILogger LOGGER = Logger.getLogger(TaskRunner.class);
+    private static final int AWAIT_STOP_TIMEOUT = 1_000;
+    private final SourceConnector connector;
+    private final AtomicBoolean running = new AtomicBoolean();
+    private CountDownLatch taskStoppedLatch = new CountDownLatch(1);
+    private SourceTask task;
+    private volatile boolean reconfigurationRequested;
+    private final Map<Map<String, ?>, Map<String, ?>> partitionsToOffset;
+
+    TaskRunner(SourceConnector connector, Map<Map<String, ?>, Map<String, ?>> partitionsToOffset) {
+        this.connector = connector;
+        this.partitionsToOffset = partitionsToOffset;
+    }
+
+    List<SourceRecord> poll() {
+        restartTaskIfNeeded();
+        return doPoll();
+    }
+
+    void stop() {
+        LOGGER.info("Stopping task if running");
+        if (running.compareAndSet(true, false)) {
+            try {
+                if (task != null) {
+                    LOGGER.fine("Stopping task");
+                    task.stop();
+                    LOGGER.fine("Task stopped");
+                }
+            } finally {
+                taskStoppedLatch.countDown();
+                taskStoppedLatch = new CountDownLatch(1);
+                task = null;
+            }
+        }
+    }
+
+    void requestReconfiguration() {
+        LOGGER.info("Task reconfiguration requested");
+        reconfigurationRequested = true;
+    }
+
+    private List<SourceRecord> doPoll() {
+        try {
+            return task.poll();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw rethrow(e);
+        }
+    }
+
+    private void restartTaskIfNeeded() {
+        if (reconfigurationRequested) {
+            reconfigurationRequested = false;
+            stopTaskAndAwait();
+        }
+        if (running.get()) {
+            LOGGER.info("Not starting task, already running");
+            return;
+        }
+        startTaskIfNotRunning();
+    }
+
+    private void startTaskIfNotRunning() {
+        LOGGER.info("Starting tasks if the previous not running");
+        if (running.compareAndSet(false, true)) {
+            LOGGER.info("Starting tasks");
+
+            List<Map<String, String>> taskConfigs = connector.taskConfigs(1);
+            if (!taskConfigs.isEmpty()) {
+                Map<String, String> taskConfig = taskConfigs.get(0);
+                this.task = newInstance(connector.taskClass().asSubclass(SourceTask.class));
+                LOGGER.info("Initializing task: " + task);
+                task.initialize(new JetSourceTaskContext(taskConfig));
+                LOGGER.info("Starting task: " + task + " with task config: " + taskConfig);
+                task.start(taskConfig);
+            } else {
+                LOGGER.info("No task configs!");
+            }
+        }
+    }
+
+    @Nonnull
+    private static <T> T newInstance(Class<? extends T> clazz) {
+        try {
+            return clazz.getConstructor().newInstance();
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    private void stopTaskAndAwait() {
+        stop();
+        if (!awaitStop()) {
+            LOGGER.info("Waiting for stopping task timed-out");
+        }
+    }
+
+    private boolean awaitStop() {
+        try {
+            LOGGER.info("Waiting for stopping the previous task");
+            return taskStoppedLatch.await(AWAIT_STOP_TIMEOUT, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            return false;
+        }
+    }
+
+    private final class JetSourceTaskContext implements SourceTaskContext {
+        private final Map<String, String> taskConfig;
+
+        private JetSourceTaskContext(Map<String, String> taskConfig) {
+            this.taskConfig = taskConfig;
+        }
+
+        @Override
+        public Map<String, String> configs() {
+            return taskConfig;
+        }
+
+        @Override
+        public OffsetStorageReader offsetStorageReader() {
+            return new SourceOffsetStorageReader(partitionsToOffset);
+        }
+    }
+}

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/TaskRunner.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/TaskRunner.java
@@ -83,7 +83,11 @@ class TaskRunner {
     private void restartTaskIfNeeded() {
         if (reconfigurationRequested) {
             reconfigurationRequested = false;
-            stop();
+            try {
+                stop();
+            } catch (Exception ex) {
+                LOGGER.warning("Stopping task failed but proceeding with re-start", ex);
+            }
         }
         start();
     }

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/DummySourceConnector.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/DummySourceConnector.java
@@ -93,6 +93,10 @@ public final class DummySourceConnector extends SourceConnector {
         return initialized;
     }
 
+    public void setProperty(String key, String value) {
+        properties.put(key, value);
+    }
+
     public static final class DummyTask extends SourceTask {
         static DummyTask INSTANCE;
 
@@ -172,6 +176,10 @@ public final class DummySourceConnector extends SourceConnector {
 
         public boolean isStarted() {
             return started;
+        }
+
+        public boolean isStopped() {
+            return !started;
         }
 
         public boolean isInitialized() {

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/TaskRunnerTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/TaskRunnerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.connect.impl;
+
+import com.hazelcast.jet.kafka.connect.impl.DummySourceConnector.DummyTask;
+import com.hazelcast.test.OverridePropertyRule;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.hazelcast.jet.kafka.connect.impl.DummySourceConnector.ITEMS_SIZE;
+import static com.hazelcast.test.OverridePropertyRule.set;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TaskRunnerTest {
+
+    @ClassRule
+    public static final OverridePropertyRule enableLogging = set("hazelcast.logging.type", "log4j2");
+    private final DummySourceConnector connector = new DummySourceConnector();
+    private final HashMap<Map<String, ?>, Map<String, ?>> partitionsToOffset = new HashMap<>();
+    private final TaskRunner taskRunner = new TaskRunner(connector, partitionsToOffset);
+
+    @Test
+    public void should_poll_data() {
+        connector.start(minimalProperties());
+
+        assertPolledRecordsSize(3);
+        assertThat(DummyTask.INSTANCE.isStarted()).isTrue();
+        assertThat(DummyTask.INSTANCE.isInitialized()).isTrue();
+    }
+
+    @Test
+    public void should_stop_and_recreate_task() {
+        connector.start(minimalProperties());
+
+        taskRunner.poll();
+        DummyTask taskInstance_1 = DummyTask.INSTANCE;
+        assertThat(taskInstance_1.isStarted()).isTrue();
+
+        taskRunner.stop();
+        assertThat(taskInstance_1.isStopped()).isTrue();
+        connector.setProperty(ITEMS_SIZE, String.valueOf(5));
+
+        assertPolledRecordsSize(5);
+
+        DummyTask taskInstance_2 = DummyTask.INSTANCE;
+        assertThat(taskInstance_2.isStarted()).isTrue();
+        assertThat(taskInstance_1).isNotSameAs(taskInstance_2);
+    }
+
+    @Test
+    public void should_reconfigure_task() {
+        connector.start(minimalProperties());
+        assertPolledRecordsSize(3);
+        connector.setProperty(ITEMS_SIZE, String.valueOf(5));
+        assertPolledRecordsSize(3);
+
+        taskRunner.requestReconfiguration();
+
+        assertPolledRecordsSize(5);
+    }
+
+    private void assertPolledRecordsSize(int expected) {
+        List<SourceRecord> secondSourceRecords = taskRunner.poll();
+        assertThat(secondSourceRecords).hasSize(expected);
+    }
+
+    @Nonnull
+    private static Map<String, String> minimalProperties() {
+        Map<String, String> taskProperties = new HashMap<>();
+        taskProperties.put(ITEMS_SIZE, String.valueOf(3));
+        return taskProperties;
+    }
+
+}


### PR DESCRIPTION
Adds support for dynamic reconfiguration of the Kafka Connect Source Connectors. It's required for connectors that react to the changes from external systems (e.g. adding or removing data tables in DB source). Also, it's required for connectors that perform asynchronous initialisation. 

Fixes https://hazelcast.atlassian.net/browse/HZ-1972

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
