### PR TITLE
Revert "Bump maven-shade-plugin from 3.2.4 to 3.4.1 (#22634)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <maven.assembly.plugin.version>3.4.2</maven.assembly.plugin.version>
         <maven.rar.plugin.version>2.2</maven.rar.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
-        <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
+        <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
         <maven.dependency.plugin.version>3.5.0</maven.dependency.plugin.version>
         <maven.animal.sniffer.plugin.version>1.22</maven.animal.sniffer.plugin.version>
         <maven.git.commit.id.plugin.version>2.1.10</maven.git.commit.id.plugin.version>


### PR DESCRIPTION
This reverts commit 864e3c8f8bcbee61e5e1b3d4fc95c9273545af95.

It breaks integration tests:
```
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.5.1:testCompile (default-testCompile) on project jet-cdc-it-runner: Compilation failure
12:58:26 /home/ec2-user/workspace/Hazelcast-EE-pr-builder-with-arm64/hazelcast-enterprise-it/enterprise-tests-using-docker/jet-cdc-it/runner/src/test/java/com/hazelcast/jet/cdc/it/mysql/AbstractCdcMysqlBaseTest.java:[10,34] error: package io.debezium.connector.mysql does not exist
```

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
