### PR TITLE
Code against the ClientConnection interface in client related services

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlClientExecuteCloseRaceTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlClientExecuteCloseRaceTest.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.jet.sql;
 
+import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SqlCloseCodec;
 import com.hazelcast.client.impl.protocol.codec.SqlExecuteCodec;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.sql.SqlExpectedResultType;
 import com.hazelcast.sql.impl.QueryId;
 import com.hazelcast.sql.impl.SqlErrorCode;
@@ -83,7 +83,7 @@ public class SqlClientExecuteCloseRaceTest extends SqlTestSupport {
         QueryId queryId = QueryId.create(UUID.randomUUID());
 
         // Send "execute"
-        Connection connection = clientService.getQueryConnection();
+        ClientConnection connection = clientService.getQueryConnection();
 
         ClientMessage executeResponse = sendExecuteRequest(connection, queryId);
 
@@ -104,7 +104,7 @@ public class SqlClientExecuteCloseRaceTest extends SqlTestSupport {
         QueryId queryId = QueryId.create(UUID.randomUUID());
 
         // Send "close"
-        Connection connection = clientService.getQueryConnection();
+        ClientConnection connection = clientService.getQueryConnection();
 
         ClientMessage closeRequest = SqlCloseCodec.encodeRequest(queryId);
 
@@ -125,7 +125,7 @@ public class SqlClientExecuteCloseRaceTest extends SqlTestSupport {
         QueryId queryId = QueryId.create(UUID.randomUUID());
 
         // Send "close"
-        Connection connection = clientService.getQueryConnection();
+        ClientConnection connection = clientService.getQueryConnection();
 
         ClientMessage closeRequest = SqlCloseCodec.encodeRequest(queryId);
 
@@ -152,7 +152,7 @@ public class SqlClientExecuteCloseRaceTest extends SqlTestSupport {
         }
     }
 
-    private ClientMessage sendExecuteRequest(Connection connection, QueryId queryId) {
+    private ClientMessage sendExecuteRequest(ClientConnection connection, QueryId queryId) {
         ClientMessage executeRequest = SqlExecuteCodec.encodeRequest(
                 SQL,
                 Collections.emptyList(),

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorClientTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlErrorClientTest.java
@@ -17,9 +17,9 @@
 package com.hazelcast.jet.sql;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SqlExecute_reservedCodec;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.map.IMap;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -287,7 +287,7 @@ public class SqlErrorClientTest extends SqlErrorAbstractTest {
 
             SqlClientService clientService = ((SqlClientService) client.getSql());
 
-            Connection connection = clientService.getQueryConnection();
+            ClientConnection connection = clientService.getQueryConnection();
             clientService.invokeOnConnection(connection, message);
 
             fail("Must fail");

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/ClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/ClientConnectionManager.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.impl.connection;
 
 import com.hazelcast.client.HazelcastClientOfflineException;
 import com.hazelcast.client.impl.management.ClientConnectionProcessListener;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionListenable;
 
 import javax.annotation.Nonnull;
@@ -62,7 +61,7 @@ public interface ClientConnectionManager extends ConnectionListenable<ClientConn
      */
     boolean clientInitializedOnCluster();
 
-    Collection<Connection> getActiveConnections();
+    Collection<ClientConnection> getActiveConnections();
 
     UUID getClientUuid();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/ClientICMPManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/ClientICMPManager.java
@@ -17,9 +17,9 @@
 package com.hazelcast.client.impl.connection.tcp;
 
 import com.hazelcast.client.config.ClientIcmpPingConfig;
+import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.cluster.fd.PingFailureDetector;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.util.ICMPHelper;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
@@ -49,7 +49,7 @@ public final class ClientICMPManager {
     public static void start(ClientIcmpPingConfig clientIcmpPingConfig,
                              TaskScheduler taskScheduler,
                              ILogger logger,
-                             Collection<Connection> unmodifiableActiveConnections) {
+                             Collection<ClientConnection> unmodifiableActiveConnections) {
         if (!clientIcmpPingConfig.isEnabled()) {
             return;
         }
@@ -73,10 +73,10 @@ public final class ClientICMPManager {
                     + MIN_ICMP_INTERVAL_MILLIS + "ms");
         }
 
-        PingFailureDetector<Connection> failureDetector = new PingFailureDetector<>(icmpMaxAttempts);
+        PingFailureDetector<ClientConnection> failureDetector = new PingFailureDetector<>(icmpMaxAttempts);
         taskScheduler.scheduleWithRepetition(() -> {
             failureDetector.retainAttemptsForAliveEndpoints(unmodifiableActiveConnections);
-            for (Connection connection : unmodifiableActiveConnections) {
+            for (ClientConnection connection : unmodifiableActiveConnections) {
                 // we don't want an isReachable call to an address stopping us to check other addresses.
                 // so we run each check in its own thread
                 taskScheduler.execute(() -> ping(logger, failureDetector, connection, icmpTtl, icmpTimeoutMillis));
@@ -108,7 +108,7 @@ public final class ClientICMPManager {
         return false;
     }
 
-    private static void ping(ILogger logger, PingFailureDetector<Connection> failureDetector, Connection connection,
+    private static void ping(ILogger logger, PingFailureDetector<ClientConnection> failureDetector, ClientConnection connection,
                              int icmpTtl, int icmpTimeoutMillis) {
         Address address = connection.getRemoteAddress();
         logger.fine(format("will ping %s", address));

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/HeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/HeartbeatManager.java
@@ -17,10 +17,10 @@
 package com.hazelcast.client.impl.connection.tcp;
 
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientPingCodec;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
@@ -46,10 +46,10 @@ public final class HeartbeatManager {
                              ILogger logger,
                              long heartbeatIntervalMillis,
                              long heartbeatTimeoutMillis,
-                             Collection<Connection> unmodifiableActiveConnections) {
+                             Collection<ClientConnection> unmodifiableActiveConnections) {
         taskScheduler.scheduleWithRepetition(() -> {
             long now = Clock.currentTimeMillis();
-            for (Connection connection : unmodifiableActiveConnections) {
+            for (ClientConnection connection : unmodifiableActiveConnections) {
                 if (!connection.isAlive()) {
                     return;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTransactionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/ClientTransactionUtil.java
@@ -17,9 +17,9 @@
 package com.hazelcast.client.impl.proxy.txn;
 
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.transaction.TransactionException;
 
 import java.util.concurrent.Future;
@@ -45,7 +45,7 @@ public final class ClientTransactionUtil {
      * sends IOException to user. This wraps that exception into a TransactionException.
      */
     public static ClientMessage invoke(ClientMessage request, Object objectName, HazelcastClientInstanceImpl client,
-                                       Connection connection) {
+                                       ClientConnection connection) {
         try {
             final ClientInvocation clientInvocation = new ClientInvocation(client, request, objectName, connection);
             final Future<ClientMessage> future = clientInvocation.invoke();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientInvocation.java
@@ -24,7 +24,6 @@ import com.hazelcast.client.impl.spi.EventHandler;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.core.OperationTimeoutException;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
@@ -64,7 +63,7 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
     private final CallIdSequence callIdSequence;
     private final UUID uuid;
     private final int partitionId;
-    private final Connection connection;
+    private final ClientConnection connection;
     private final long startTimeMillis;
     private final long retryPauseMillis;
     private final Object objectName;
@@ -93,7 +92,7 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
                                Object objectName,
                                int partitionId,
                                UUID uuid,
-                               Connection connection) {
+                               ClientConnection connection) {
         super(((ClientInvocationServiceImpl) client.getInvocationService()).invocationLogger);
         this.lifecycleService = client.getLifecycleService();
         this.invocationService = (ClientInvocationServiceImpl) client.getInvocationService();
@@ -139,7 +138,7 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
      * Create an invocation that will be executed on given {@code connection}.
      */
     public ClientInvocation(HazelcastClientInstanceImpl client, ClientMessage clientMessage, Object objectName,
-                            Connection connection) {
+                            ClientConnection connection) {
         this(client, clientMessage, objectName, UNASSIGNED_PARTITION, null, connection);
     }
 
@@ -181,7 +180,7 @@ public class ClientInvocation extends BaseInvocation implements Runnable {
             }
 
             if (isBindToSingleConnection()) {
-                boolean invoked = invocationService.invokeOnConnection(this, (ClientConnection) connection);
+                boolean invoked = invocationService.invokeOnConnection(this, connection);
                 if (!invoked) {
                     notifyExceptionWithOwnedPermission(new IOException("Could not invoke on connection " + connection));
                 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerRegistration.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerRegistration.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.client.impl.spi.impl.listener;
 
+import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.spi.EventHandler;
 import com.hazelcast.client.impl.spi.impl.ListenerMessageCodec;
-import com.hazelcast.internal.nio.Connection;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,7 +27,7 @@ public class ClientListenerRegistration {
 
     private final ListenerMessageCodec codec;
     private final EventHandler handler;
-    private final Map<Connection, ClientConnectionRegistration> registrations = new ConcurrentHashMap<>();
+    private final Map<ClientConnection, ClientConnectionRegistration> registrations = new ConcurrentHashMap<>();
 
     ClientListenerRegistration(EventHandler handler, ListenerMessageCodec codec) {
         this.handler = handler;
@@ -42,7 +42,7 @@ public class ClientListenerRegistration {
         return handler;
     }
 
-    Map<Connection, ClientConnectionRegistration> getConnectionRegistrations() {
+    Map<ClientConnection, ClientConnectionRegistration> getConnectionRegistrations() {
         return registrations;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/listener/ClientListenerServiceImpl.java
@@ -32,7 +32,6 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.StaticMetricsProvider;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.nio.ConnectionListener;
 import com.hazelcast.internal.util.EmptyStatement;
 import com.hazelcast.internal.util.ExceptionUtil;
@@ -65,7 +64,8 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CLIENT_PR
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
-public class ClientListenerServiceImpl implements ClientListenerService, StaticMetricsProvider, ConnectionListener {
+public class ClientListenerServiceImpl
+        implements ClientListenerService, StaticMetricsProvider, ConnectionListener<ClientConnection> {
 
     private final HazelcastClientInstanceImpl client;
     private final Map<UUID, ClientListenerRegistration> registrations = new ConcurrentHashMap<>();
@@ -102,8 +102,8 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
 
             ClientListenerRegistration registration = new ClientListenerRegistration(handler, codec);
             registrations.put(userRegistrationId, registration);
-            Collection<Connection> connections = clientConnectionManager.getActiveConnections();
-            for (Connection connection : connections) {
+            Collection<ClientConnection> connections = clientConnectionManager.getActiveConnections();
+            for (ClientConnection connection : connections) {
                 try {
                     invoke(registration, connection);
                 } catch (Exception e) {
@@ -190,7 +190,7 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
         eventHandler.handle(clientMessage);
     }
 
-    protected void invoke(ClientListenerRegistration listenerRegistration, Connection connection) throws Exception {
+    protected void invoke(ClientListenerRegistration listenerRegistration, ClientConnection connection) throws Exception {
         //This method should only be called from registrationExecutor
         assert (Thread.currentThread().getName().contains("eventRegistration"));
 
@@ -230,7 +230,7 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
     }
 
     @Override
-    public void connectionAdded(final Connection connection) {
+    public void connectionAdded(final ClientConnection connection) {
         //This method should not be called from registrationExecutor
         assert (!Thread.currentThread().getName().contains("eventRegistration"));
 
@@ -252,7 +252,7 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
     }
 
     @Override
-    public void connectionRemoved(final Connection connection) {
+    public void connectionRemoved(final ClientConnection connection) {
         //This method should not be called from registrationExecutor
         assert (!Thread.currentThread().getName().contains("eventRegistration"));
 
@@ -269,11 +269,11 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
     }
 
     //For Testing
-    public Map<Connection, ClientConnectionRegistration> getActiveRegistrations(final UUID uuid) {
+    public Map<ClientConnection, ClientConnectionRegistration> getActiveRegistrations(final UUID uuid) {
         //This method should not be called from registrationExecutor
         assert (!Thread.currentThread().getName().contains("eventRegistration"));
 
-        Future<Map<Connection, ClientConnectionRegistration>> future = registrationExecutor.submit(() -> {
+        Future<Map<ClientConnection, ClientConnectionRegistration>> future = registrationExecutor.submit(() -> {
             ClientListenerRegistration listenerRegistration = registrations.get(uuid);
             if (listenerRegistration == null) {
                 return Collections.emptyMap();
@@ -292,7 +292,7 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
         return Collections.unmodifiableMap(registrations);
     }
 
-    private void invokeFromInternalThread(ClientListenerRegistration registrationKey, Connection connection) {
+    private void invokeFromInternalThread(ClientListenerRegistration registrationKey, ClientConnection connection) {
         //This method should only be called from registrationExecutor
         assert (Thread.currentThread().getName().contains("eventRegistration"));
 
@@ -317,12 +317,12 @@ public class ClientListenerServiceImpl implements ClientListenerService, StaticM
             return false;
         }
 
-        Map<Connection, ClientConnectionRegistration> registrations = listenerRegistration.getConnectionRegistrations();
+        Map<ClientConnection, ClientConnectionRegistration> registrations = listenerRegistration.getConnectionRegistrations();
         CompletableFuture[] futures = new CompletableFuture[registrations.size()];
         int i = 0;
-        for (Map.Entry<Connection, ClientConnectionRegistration> entry : registrations.entrySet()) {
+        for (Map.Entry<ClientConnection, ClientConnectionRegistration> entry : registrations.entrySet()) {
             ClientConnectionRegistration registration = entry.getValue();
-            ClientConnection subscriber = (ClientConnection) entry.getKey();
+            ClientConnection subscriber = entry.getKey();
             //remove local handler
             subscriber.removeEventHandler(registration.getCallId());
             //the rest is for deleting remote registration

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlClientResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlClientResult.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.sql.impl.client;
 
+import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlRow;
@@ -48,7 +48,7 @@ public class SqlClientResult implements SqlResult {
     private final Function<QueryId, ClientMessage> sqlExecuteMessageSupplier;
     private final boolean selectQuery;
     private volatile QueryId queryId;
-    private Connection connection;
+    private ClientConnection connection;
     private int resubmissionCount;
 
     /** Mutex to synchronize access between operations. */
@@ -77,7 +77,7 @@ public class SqlClientResult implements SqlResult {
 
     public SqlClientResult(
             SqlClientService service,
-            Connection connection,
+            ClientConnection connection,
             QueryId queryId,
             int cursorBufferSize,
             Function<QueryId, ClientMessage> sqlExecuteMessageSupplier,

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlResubmissionResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlResubmissionResult.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.sql.impl.client;
 
-import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.sql.SqlRowMetadata;
 
 class SqlResubmissionResult {
-    private final Connection connection;
+    private final ClientConnection connection;
     private final SqlError sqlError;
     private final SqlRowMetadata rowMetadata;
     private final SqlPage rowPage;
@@ -34,7 +34,7 @@ class SqlResubmissionResult {
         this.updateCount = 0;
     }
 
-    SqlResubmissionResult(Connection connection, SqlRowMetadata rowMetadata, SqlPage rowPage, long updateCount) {
+    SqlResubmissionResult(ClientConnection connection, SqlRowMetadata rowMetadata, SqlPage rowPage, long updateCount) {
         this.connection = connection;
         this.rowMetadata = rowMetadata;
         this.rowPage = rowPage;
@@ -42,7 +42,7 @@ class SqlResubmissionResult {
         this.sqlError = null;
     }
 
-    Connection getConnection() {
+    ClientConnection getConnection() {
         return connection;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.listeners;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.clientside.ClientTestUtil;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.spi.impl.listener.ClientConnectionRegistration;
 import com.hazelcast.client.impl.spi.impl.listener.ClientListenerServiceImpl;
 import com.hazelcast.client.test.ClientTestSupport;
@@ -31,7 +32,6 @@ import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
@@ -358,12 +358,12 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
         assertTrueEventually(() -> {
             int size = smartRouting ? clusterSize : 1;
-            Map<Connection, ClientConnectionRegistration> registrations = getClientEventRegistrations(client,
+            Map<ClientConnection, ClientConnectionRegistration> registrations = getClientEventRegistrations(client,
                     registrationId);
             assertEquals(size, registrations.size());
             if (smartRouting) {
                 Collection<Member> members = clientInstanceImpl.getClientClusterService().getMemberList();
-                for (Connection registeredSubscriber : registrations.keySet()) {
+                for (ClientConnection registeredSubscriber : registrations.keySet()) {
                     boolean contains = false;
                     for (Member member : members) {
                         contains |= registeredSubscriber.getRemoteAddress().equals(member.getAddress());
@@ -372,9 +372,9 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
                             contains);
                 }
             } else {
-                Iterator<Connection> expectedIterator = registrations.keySet().iterator();
+                Iterator<ClientConnection> expectedIterator = registrations.keySet().iterator();
                 assertTrue(expectedIterator.hasNext());
-                Iterator<Connection> iterator = clientInstanceImpl.getConnectionManager().getActiveConnections().iterator();
+                Iterator<ClientConnection> iterator = clientInstanceImpl.getConnectionManager().getActiveConnections().iterator();
                 assertTrue(iterator.hasNext());
                 assertEquals(iterator.next(), expectedIterator.next());
             }
@@ -409,7 +409,7 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
         instances[randNode].getLifecycleService().terminate();
     }
 
-    private Map<Connection, ClientConnectionRegistration> getClientEventRegistrations(HazelcastInstance client, UUID id) {
+    private Map<ClientConnection, ClientConnectionRegistration> getClientEventRegistrations(HazelcastInstance client, UUID id) {
         HazelcastClientInstanceImpl clientImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);
         ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) clientImpl.getListenerService();
         return listenerService.getActiveRegistrations(id);

--- a/hazelcast/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
@@ -25,7 +25,6 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.test.HazelcastTestSupport;
 
 import java.util.Collection;
@@ -104,10 +103,10 @@ public class ClientTestSupport extends HazelcastTestSupport {
 
     protected Map<Long, EventHandler> getAllEventHandlers(HazelcastInstance client) {
         ClientConnectionManager connectionManager = getHazelcastClientInstanceImpl(client).getConnectionManager();
-        Collection<Connection> activeConnections = connectionManager.getActiveConnections();
+        Collection<ClientConnection> activeConnections = connectionManager.getActiveConnections();
         HashMap<Long, EventHandler> map = new HashMap<>();
-        for (Connection activeConnection : activeConnections) {
-            map.putAll(((ClientConnection) activeConnection).getEventHandlers());
+        for (ClientConnection activeConnection : activeConnections) {
+            map.putAll(activeConnection.getEventHandlers());
         }
         return map;
     }


### PR DESCRIPTION
We have various client-related services where we code against the Connection interface, and perform a cast to ClientConnection when it is necessary.

I believe, those casts are ugly, and we are better off coding against the ClientConnection interface directly so that we won't need any such casts.

This PR updates various services and tests accordingly.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/5742