### PR TITLE
Support for non-ObjectId _id fields

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
@@ -246,7 +246,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
         private final FunctionEx<Document, I> mapItemFn;
         private final List<Bson> aggregates;
         private Traverser<Document> delegate;
-        private ObjectId lastKey;
+        private Object lastKey;
 
         private BatchMongoReader(
                 String databaseName,
@@ -303,7 +303,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
         public Traverser<I> nextChunkTraverser() {
             return delegate
                     .map(item -> {
-                        lastKey = item.getObjectId("_id");
+                        lastKey = item.get("_id");
                         return mapItemFn.apply(item);
                     });
         }
@@ -321,7 +321,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
 
         @Override
         public void restore(Object value) {
-            lastKey = (ObjectId) value;
+            lastKey = value;
         }
     }
 

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoDBSourceVariousIdTypesTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoDBSourceVariousIdTypesTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.mongodb;
+
+import com.hazelcast.collection.IList;
+import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
+import static com.hazelcast.jet.mongodb.MongoDBSources.batch;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParametrizedRunner.class)
+@Category({QuickTest.class})
+public class MongoDBSourceVariousIdTypesTest extends AbstractMongoDBTest {
+
+    @Parameter(0)
+    public Object id1;
+    @Parameter(1)
+    public Object id2;
+    @Parameter(2)
+    public String idType;
+
+    @Parameters(name = "IdType:{2}")
+    public static Object[] filterProjectionSortMatrix() {
+        return new Object[] {
+                new Object[] { new ObjectId(), new ObjectId(), "ObjectId" },
+                new Object[] { "a", "abc", "string" },
+                new Object[] { 1, 2, "integer" },
+                new Object[] { "a", 2, "string-integer" }
+        };
+    }
+
+    @Test
+    public void testIdType() {
+        IList<Object> list = instance().getList(testName.getMethodName());
+        final String connectionString = mongoContainer.getConnectionString();
+
+        MongoDatabase database = mongo.getDatabase(defaultDatabase());
+        MongoCollection<Document> collection = database.getCollection(testName.getMethodName());
+
+        collection.insertOne(new Document("_id", id1));
+        collection.insertOne(new Document("_id", id2));
+
+        Pipeline pipeline = Pipeline.create();
+        pipeline.readFrom(batch(SOURCE_NAME, connectionString, defaultDatabase(), testName.getMethodName(), null, null))
+                .setLocalParallelism(3)
+                .writeTo(Sinks.list(list));
+
+        instance().getJet().newJob(pipeline, new JobConfig().setProcessingGuarantee(EXACTLY_ONCE)).join();
+
+        List<Object> local = new ArrayList<>(list);
+        assertEquals(2, local.size());
+    }
+
+}


### PR DESCRIPTION
While `_id` field is now mandatory and `ObjectId` by default, we have no guarantee it's `ObjectId`. Adjusted code to take this into consideration.


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
