### PR TITLE
Fix SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.testTryAcquire_shouldReleaseSessionsOnRuntimeError [HZ-1829]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -76,7 +76,7 @@ public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends H
         assertEquals(5, getSessionAcquireCount());
         Future future = spawn(() -> {
             Thread.currentThread().interrupt();
-            //Make the semaphore block, so that Thread.interrupt() can be detected
+            // Make the semaphore block, so that Thread.interrupt() can be detected
             semaphore.acquire(6);
         });
 
@@ -96,7 +96,7 @@ public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends H
         assertEquals(1, getSessionAcquireCount());
         Future future = spawn(() -> {
             Thread.currentThread().interrupt();
-            //Make the semaphore block, so that Thread.interrupt() can be detected
+            // Make the semaphore block, so that Thread.interrupt() can be detected
             semaphore.tryAcquire(2, 10, TimeUnit.MINUTES);
         });
 

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -96,7 +96,8 @@ public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends H
         assertEquals(1, getSessionAcquireCount());
         Future future = spawn(() -> {
             Thread.currentThread().interrupt();
-            semaphore.tryAcquire(10, TimeUnit.MINUTES);
+            //Make the semaphore block, so that Thread.interrupt() can be detected
+            semaphore.tryAcquire(2, 10, TimeUnit.MINUTES);
         });
 
         try {


### PR DESCRIPTION
The test is failing because AbstractInvocationFuture, which is a custom implementation of CompletableFuture needs to spin over a loop to detect if thread is interrupted. However, if semaphore.tryAcquire() response is received before the loop, the test fails.
Therefore, we need to make sure that semaphore does not respond. I have changed the semaphore tryAcquire permit from 1 to 2 to make the semaphore not respond and allow the AbstractInvocationFuture to spin the loop to do thread.interrupt check

Jira : https://hazelcast.atlassian.net/browse/HZ-1829
Fixes : https://github.com/hazelcast/hazelcast/issues/20038

There was a similar fix for another test. See 
https://github.com/hazelcast/hazelcast/pull/22995

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

