### PR TITLE
Created tests for serial operation invoker [HZ-2075]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -63,9 +63,14 @@ public final class InvocationUtil {
      * implies the operation should be idempotent.
      *
      * <p>
-     * If there is an exception - other than {@link com.hazelcast.core.MemberLeftException} or
-     * {@link com.hazelcast.spi.exception.TargetNotMemberException} while invoking then the iteration
+     * If there is an exception - other than {@link MemberLeftException},
+     * {@link TargetNotMemberException} or
+     * {@link HazelcastInstanceNotActiveException} while invoking then the iteration
      * is interrupted and the exception is propagated to the caller.
+     * <p>
+     * When invocations fail with <b>only</b> {@link ClusterTopologyChangedException}, the invocations are retried.
+     * When invocations fail {@link MemberLeftException}, {@link TargetNotMemberException} or
+     * {@link HazelcastInstanceNotActiveException} the exceptions are ignored.
      */
     public static <V> InternalCompletableFuture<V> invokeOnStableClusterSerial(
             NodeEngine nodeEngine,

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/SerialOperationInvokerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/SerialOperationInvokerTest.java
@@ -1,0 +1,449 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.instance.SimpleMemberImpl;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.cluster.impl.ClusterTopologyChangedException;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.exception.TargetNotMemberException;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.operationservice.ExceptionAction;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.MemberVersion;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static com.hazelcast.instance.impl.TestUtil.getNode;
+import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterSerial;
+import static com.hazelcast.spi.properties.ClusterProperty.INVOCATION_RETRY_PAUSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SerialOperationInvokerTest extends HazelcastTestSupport {
+    @Rule
+    public TestName testNameRule = new TestName();
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    private Config config;
+    private HazelcastInstance instance1;
+    private HazelcastInstance instance2;
+    private HazelcastInstance instance3;
+
+    @Before
+    public void setup() {
+        config = smallInstanceConfig();
+        config.getJetConfig().setEnabled(false);
+        config.setProperty(INVOCATION_RETRY_PAUSE.getName(), "10");
+        instance1 = factory.newHazelcastInstance(config);
+        instance2 = factory.newHazelcastInstance(config);
+        instance3 = factory.newHazelcastInstance(config);
+    }
+
+    @After
+    public void teardown() {
+        factory.terminateAll();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        InvokedMemberRecordingOperation.TEST_NAME_TO_INVOKED_MEMBER_UUIDS.clear();
+    }
+
+    @Test
+    public void testInvoke() {
+        String testName = testNameRule.getMethodName();
+
+        Node node = getNode(instance1);
+        InternalCompletableFuture<Object> clusterSerial = invokeOnStableClusterSerial(
+                node.getNodeEngine(),
+                () -> new InvokedMemberRecordingOperation(testName),
+                0
+        );
+
+        clusterSerial.join();
+
+        Collection<UUID> expectedUuids = getMembersUuids(node);
+        assertExpectedUuids(testName, expectedUuids);
+    }
+
+    @Test
+    public void testInvoke_withSingleMember() {
+        String testName = testNameRule.getMethodName();
+
+        instance2.shutdown();
+        instance3.shutdown();
+
+        assertClusterSizeEventually(1, instance1);
+
+        Node node = getNode(instance1);
+        InternalCompletableFuture<Object> clusterSerial = invokeOnStableClusterSerial(
+                node.getNodeEngine(),
+                () -> new InvokedMemberRecordingOperation(testName),
+                0
+        );
+
+        clusterSerial.join();
+
+        Collection<UUID> expectedUuids = getMembersUuids(node);
+        assertExpectedUuids(testName, expectedUuids);
+    }
+
+    @Test
+    public void testInvoke_withDelayedOperations() {
+        String testName = testNameRule.getMethodName();
+
+        Node node = getNode(instance1);
+        InternalCompletableFuture<Object> clusterSerial = invokeOnStableClusterSerial(
+                node.getNodeEngine(),
+                () -> new InvokedMemberRecordingDelayedOperation(testName),
+                0
+        );
+
+        clusterSerial.join();
+
+        Collection<UUID> expectedUuids = getMembersUuids(node);
+        assertExpectedUuids(testName, expectedUuids);
+    }
+
+    @Test
+    public void testInvoke_IsRestarted_whenAddedMember() {
+        String testName = testNameRule.getMethodName();
+
+        Node node = getNode(instance1);
+        InternalCompletableFuture<Object> clusterSerial = invokeOnStableClusterSerial(
+                node.getNodeEngine(),
+                () -> new AwaitingAddMemberOperation(testName, 3, 4),
+                2
+        );
+
+        Collection<UUID> expectedUuids = new ArrayList<>(getMembersUuids(node));
+        HazelcastInstance instance4 = factory.newHazelcastInstance(config);
+        assertClusterSizeEventually(4, instance1, instance2, instance3, instance4);
+
+        clusterSerial.join();
+
+        expectedUuids.addAll(getMembersUuids(node));
+        assertExpectedUuids(testName, expectedUuids);
+    }
+
+    @Test
+    public void testInvoke_IsRestarted_whenRemovedMember() {
+        String testName = testNameRule.getMethodName();
+
+        Node node = getNode(instance1);
+        InternalCompletableFuture<Object> clusterSerial = invokeOnStableClusterSerial(
+                node.getNodeEngine(),
+                () -> new AwaitingRemoveMemberOperation(testName, 3, 2),
+                2
+        );
+
+        instance3.shutdown();
+        assertClusterSizeEventually(2, instance1, instance2);
+        Collection<UUID> expectedUuids = new ArrayList<>(getMembersUuids(node));
+
+        clusterSerial.join();
+
+        expectedUuids.addAll(getMembersUuids(node));
+        assertExpectedUuids(testName, expectedUuids);
+    }
+
+    @Test
+    public void testInvoke_withThrowingTerminalException() {
+        String testName = testNameRule.getMethodName();
+
+        Node node = getNode(instance2);
+        assertThatThrownBy(() -> invokeOnStableClusterSerial(
+                node.getNodeEngine(),
+                () -> new ExceptionThrowingOperation(testName, new RuntimeException("expected")),
+                0
+        ).join()).isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(RuntimeException.class)
+                .hasStackTraceContaining("expected");
+    }
+
+    @Test
+    public void testInvoke_withThrowingCompletionExceptionWithNullCause() {
+        String testName = testNameRule.getMethodName();
+
+        Node node = getNode(instance2);
+        assertThatThrownBy(() -> invokeOnStableClusterSerial(
+                node.getNodeEngine(),
+                () -> new ExceptionThrowingOperation(testName, new CompletionException(null)),
+                0
+        ).join()).isInstanceOf(CompletionException.class)
+                .hasCause(null);
+    }
+
+    @Test
+    public void testInvoke_withThrowingIgnorableTargetNotMemberException() {
+        assertExceptionIgnored(new TargetNotMemberException("expected"));
+    }
+
+    @Test
+    public void testInvoke_withThrowingIgnorableMemberLeftException() {
+        SimpleMemberImpl member = new SimpleMemberImpl(
+                MemberVersion.UNKNOWN,
+                UUID.randomUUID(),
+                new InetSocketAddress("127.0.0.1", 55555)
+        );
+        assertExceptionIgnored(new MemberLeftException(member));
+    }
+
+    @Test
+    public void testInvoke_withThrowingIgnorableHazelcastInstanceNotActiveException() {
+        assertExceptionIgnored(new HazelcastInstanceNotActiveException("expected"));
+    }
+
+    private void assertExceptionIgnored(Exception exception) {
+        String testName = testNameRule.getMethodName();
+
+        Node node = getNode(instance3);
+        InternalCompletableFuture<Object> clusterSerial = invokeOnStableClusterSerial(
+                node.getNodeEngine(),
+                () -> new ExceptionThrowingOperation(testName, exception),
+                2
+        );
+
+        clusterSerial.join();
+
+        Collection<UUID> expectedUuids = getMembersUuids(node);
+        assertExpectedUuids(testName, expectedUuids);
+    }
+
+    @Test
+    public void testInvoke_withThrowingTopologyChangeException() {
+        String testName = testNameRule.getMethodName();
+
+        Node node = getNode(instance3);
+        assertThatThrownBy(() -> invokeOnStableClusterSerial(
+                node.getNodeEngine(),
+                () -> new ExceptionThrowingOperation(testName, new ClusterTopologyChangedException("expected")),
+                20
+        ).join()).isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(HazelcastException.class)
+                .hasStackTraceContaining("Cluster topology was not stable for 20 retries");
+    }
+
+    private List<UUID> getMembersUuids(Node node) {
+        return node.getNodeEngine().getClusterService().getMembers().stream()
+                .map(Member::getUuid)
+                .collect(Collectors.toList());
+    }
+
+    private void assertExpectedUuids(String testName, Collection<UUID> expectedUuids) {
+        assertThat(InvokedMemberRecordingOperation.TEST_NAME_TO_INVOKED_MEMBER_UUIDS.get(testName))
+                .containsExactlyElementsOf(expectedUuids);
+    }
+
+    private static class ExceptionThrowingOperation extends InvokedMemberRecordingOperation {
+        private Exception exception;
+
+        ExceptionThrowingOperation() {
+        }
+
+        ExceptionThrowingOperation(String testName, Exception exception) {
+            super(testName);
+            this.exception = exception;
+        }
+
+        @Override
+        public void run() throws Exception {
+            super.run();
+            throw exception;
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            super.writeInternal(out);
+            out.writeObject(exception);
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            super.readInternal(in);
+            exception = in.readObject();
+        }
+
+        @Override
+        public ExceptionAction onInvocationException(Throwable throwable) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+    }
+
+    private static class InvokedMemberRecordingOperation extends Operation {
+        protected static final Map<String, Collection<UUID>> TEST_NAME_TO_INVOKED_MEMBER_UUIDS = new ConcurrentHashMap<>();
+        protected String testName;
+
+        InvokedMemberRecordingOperation() {
+        }
+
+        InvokedMemberRecordingOperation(String testName) {
+            this.testName = testName;
+        }
+
+        @Override
+        public void run() throws Exception {
+            TEST_NAME_TO_INVOKED_MEMBER_UUIDS
+                    .computeIfAbsent(testName, k -> new CopyOnWriteArrayList<>())
+                    .add(getNodeEngine().getLocalMember().getUuid());
+            super.run();
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            super.writeInternal(out);
+            out.writeString(testName);
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            super.readInternal(in);
+            testName = in.readString();
+        }
+    }
+
+    private static class AwaitingAddMemberOperation extends InvokedMemberRecordingOperation {
+
+        private static final AtomicInteger COUNT = new AtomicInteger(0);
+        private int membersCount;
+        private int expectedMemberCount;
+
+        AwaitingAddMemberOperation() {
+        }
+
+        AwaitingAddMemberOperation(String testName, int membersCount, int expectedMemberCount) {
+            super(testName);
+            this.membersCount = membersCount;
+            this.expectedMemberCount = expectedMemberCount;
+        }
+
+        @Override
+        public void run() throws Exception {
+            if (COUNT.getAndIncrement() == (membersCount - 1)) {
+                while (getNodeEngine().getClusterService().getMembers().size() != expectedMemberCount) {
+                    Thread.sleep(100);
+                }
+            }
+            super.run();
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            super.writeInternal(out);
+            out.writeInt(membersCount);
+            out.writeInt(expectedMemberCount);
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            super.readInternal(in);
+            membersCount = in.readInt();
+            expectedMemberCount = in.readInt();
+        }
+    }
+
+    private static class AwaitingRemoveMemberOperation extends InvokedMemberRecordingOperation {
+
+        private static final AtomicInteger COUNT = new AtomicInteger(0);
+        private int membersCount;
+        private int expectedMemberCount;
+
+        AwaitingRemoveMemberOperation() {
+        }
+
+        AwaitingRemoveMemberOperation(String testName, int membersCount, int expectedMemberCount) {
+            super(testName);
+            this.membersCount = membersCount;
+            this.expectedMemberCount = expectedMemberCount;
+        }
+
+        @Override
+        public void run() throws Exception {
+            if (COUNT.getAndIncrement() == (membersCount - 1)) {
+                while (getNodeEngine().getClusterService().getMembers().size() != expectedMemberCount) {
+                    Thread.sleep(100);
+                }
+            }
+            super.run();
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            super.writeInternal(out);
+            out.writeInt(membersCount);
+            out.writeInt(expectedMemberCount);
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            super.readInternal(in);
+            membersCount = in.readInt();
+            expectedMemberCount = in.readInt();
+        }
+    }
+
+    private static class InvokedMemberRecordingDelayedOperation extends InvokedMemberRecordingOperation {
+        private static final AtomicInteger delaySec = new AtomicInteger(3);
+
+        InvokedMemberRecordingDelayedOperation() {
+        }
+
+        InvokedMemberRecordingDelayedOperation(String testName) {
+            super(testName);
+        }
+
+        @Override
+        public void run() throws Exception {
+            sleepSeconds(delaySec.getAndDecrement());
+            super.run();
+        }
+    }
+}


### PR DESCRIPTION
Updated the `InvocationUtil#invokeOnStableClusterSerial` method's JavaDoc according to its behaviour and created tests for this method.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
