### PR TITLE
Do not cache outputstream [HZ-2085]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSerDeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSerDeHelper.java
@@ -77,7 +77,7 @@ public final class ChunkSerDeHelper {
 
     public void writeChunkedOperations(ObjectDataOutput out) throws IOException {
         assert out instanceof BufferObjectDataOutput;
-        
+
         BufferObjectDataOutput bufferedOut = (BufferObjectDataOutput) out;
         IsEndOfChunk isEndOfChunk = new IsEndOfChunk(maxTotalChunkedDataInBytes);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSerDeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSerDeHelper.java
@@ -106,10 +106,15 @@ public final class ChunkSerDeHelper {
                 break;
             }
         }
+
         // indicates end of chunked state
         out.writeObject(null);
 
         logEndOfAllChunks(isEndOfChunk);
+
+        for (ChunkSupplier chunkSupplier : chunkSuppliers) {
+            chunkSupplier.signalEndOfChunkWith(null);
+        }
     }
 
     private void logCurrentChunk(ChunkSupplier chunkSupplier) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSupplier.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.partition;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.Iterator;
-import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 
 /**
  * An iterator over collection of {@link Operation} which has
@@ -34,7 +34,7 @@ public interface ChunkSupplier extends Iterator<Operation> {
     /**
      * @param isEndOfChunk boolean supplier to signal end of chunk.
      */
-    default void signalEndOfChunkWith(BooleanSupplier isEndOfChunk) {
+    default void signalEndOfChunkWith(Predicate isEndOfChunk) {
 
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSupplier.java
@@ -33,7 +33,7 @@ import java.util.function.Predicate;
 public interface ChunkSupplier extends Iterator<Operation> {
 
     /**
-     * @param isEndOfChunk boolean supplier to signal end of chunk.
+     * @param isEndOfChunk {@link Predicate} to test end of chunk.
      */
     default void signalEndOfChunkWith(Predicate<BufferObjectDataOutput> isEndOfChunk) {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSupplier.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.partition;
 
+import com.hazelcast.internal.nio.BufferObjectDataOutput;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.Iterator;
@@ -34,7 +35,7 @@ public interface ChunkSupplier extends Iterator<Operation> {
     /**
      * @param isEndOfChunk boolean supplier to signal end of chunk.
      */
-    default void signalEndOfChunkWith(Predicate isEndOfChunk) {
+    default void signalEndOfChunkWith(Predicate<BufferObjectDataOutput> isEndOfChunk) {
 
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSuppliers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSuppliers.java
@@ -22,7 +22,7 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static com.hazelcast.internal.util.Preconditions.checkNoNullInside;
@@ -111,7 +111,7 @@ public final class ChunkSuppliers {
         }
 
         @Override
-        public void signalEndOfChunkWith(BooleanSupplier isEndOfChunk) {
+        public void signalEndOfChunkWith(Predicate isEndOfChunk) {
             for (int i = 0; i < chain.size(); i++) {
                 chain.get(i).signalEndOfChunkWith(isEndOfChunk);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSuppliers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ChunkSuppliers.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.partition;
 
+import com.hazelcast.internal.nio.BufferObjectDataOutput;
 import com.hazelcast.internal.util.CollectionUtil;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
@@ -111,7 +112,7 @@ public final class ChunkSuppliers {
         }
 
         @Override
-        public void signalEndOfChunkWith(Predicate isEndOfChunk) {
+        public void signalEndOfChunkWith(Predicate<BufferObjectDataOutput> isEndOfChunk) {
             for (int i = 0; i < chain.size(); i++) {
                 chain.get(i).signalEndOfChunkWith(isEndOfChunk);
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapChunkSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapChunkSupplier.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.internal.nio.BufferObjectDataOutput;
 import com.hazelcast.internal.partition.ChunkSupplier;
 import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.map.impl.operation.MapChunk;
@@ -31,7 +32,7 @@ class MapChunkSupplier implements ChunkSupplier {
 
     protected final MapChunkContext context;
 
-    protected Predicate isEndOfChunk;
+    protected Predicate<BufferObjectDataOutput> isEndOfChunk;
 
     private final int partitionId;
     private final int replicaIndex;
@@ -60,7 +61,7 @@ class MapChunkSupplier implements ChunkSupplier {
     }
 
     @Override
-    public final void signalEndOfChunkWith(Predicate isEndOfChunk) {
+    public final void signalEndOfChunkWith(Predicate<BufferObjectDataOutput> isEndOfChunk) {
         this.isEndOfChunk = isEndOfChunk;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapChunkSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapChunkSupplier.java
@@ -22,7 +22,7 @@ import com.hazelcast.map.impl.operation.MapChunk;
 import com.hazelcast.map.impl.operation.MapChunkContext;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
-import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 
 /**
  * Once instance created per record-store during migration.
@@ -31,7 +31,7 @@ class MapChunkSupplier implements ChunkSupplier {
 
     protected final MapChunkContext context;
 
-    protected BooleanSupplier isEndOfChunk;
+    protected Predicate isEndOfChunk;
 
     private final int partitionId;
     private final int replicaIndex;
@@ -60,7 +60,7 @@ class MapChunkSupplier implements ChunkSupplier {
     }
 
     @Override
-    public final void signalEndOfChunkWith(BooleanSupplier isEndOfChunk) {
+    public final void signalEndOfChunkWith(Predicate isEndOfChunk) {
         this.isEndOfChunk = isEndOfChunk;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapChunk.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapChunk.java
@@ -62,7 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
-import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 
 import static com.hazelcast.config.MaxSizePolicy.PER_NODE;
 import static com.hazelcast.internal.util.CollectionUtil.isNotEmpty;
@@ -85,7 +85,7 @@ public class MapChunk extends Operation
 
     protected transient ILogger logger;
     protected transient MapChunkContext context;
-    protected transient BooleanSupplier isEndOfChunk;
+    protected transient Predicate isEndOfChunk;
     protected transient String mapName;
 
     private transient boolean loaded;
@@ -106,7 +106,7 @@ public class MapChunk extends Operation
     }
 
     public MapChunk(MapChunkContext context, int chunkNumber,
-                    BooleanSupplier isEndOfChunk) {
+                    Predicate isEndOfChunk) {
         this.context = context;
         this.isEndOfChunk = isEndOfChunk;
         this.firstChunk = (chunkNumber == 1);
@@ -521,7 +521,7 @@ public class MapChunk extends Operation
             Records.writeExpiry(out, context.getExpiryMetadata(dataKey));
             recordCount++;
 
-            if (isEndOfChunk.getAsBoolean()) {
+            if (isEndOfChunk.test(out)) {
                 break;
             }
         }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/23750

ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/5757

**Issue:**
`BufferObjectDataOutput` is being cached inside `IsEndOfChunk` instance then this `IsEndOfChunk` instance is set to chunk-supplier object, chunk-supplier object is kept in-memory till migration for a namespace is finished. This is creating unnecessary occupation of heap till the migration for a namespace is finished and it can cause OOME.

**Fix:**
Now `IsEndOfChunk` is not doing any caching of `BufferObjectDataOutput`.

**Verification:**
Danny test is passing now, before it was failing.

- [ ] Do backports
