### PR TITLE
Enhance sync consumer logic [HZ-2011] (#23580) [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/services/WanSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/services/WanSupportingService.java
@@ -17,8 +17,9 @@
 package com.hazelcast.internal.services;
 
 import com.hazelcast.config.WanAcknowledgeType;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.wan.impl.InternalWanEvent;
+
+import java.util.Collection;
 
 /**
  * An interface that can be implemented by internal services to give them the
@@ -37,12 +38,12 @@ public interface WanSupportingService {
     void onReplicationEvent(InternalWanEvent event, WanAcknowledgeType acknowledgeType);
 
     /**
-     * Processes a WAN sync event.
+     * Processes a WAN sync batch.
      *
-     * @param event the event
-     * @param futures the array to save invocations
-     * @param offset place in the array where new invocation should be saved
-     * @return
+     * @param batch           collection of events, which represents a batch
+     * @param acknowledgeType determines should this method wait for the event to be processed fully
+     *                        or should it return after the event has been dispatched to the
+     *                        appropriate member
      */
-    int onSyncEvent(InternalWanEvent event, InternalCompletableFuture<Boolean>[] futures, int offset);
+    void onSyncBatch(Collection<InternalWanEvent> batch, WanAcknowledgeType acknowledgeType);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -53,7 +53,6 @@ import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nearcache.NearCacheStats;
 import com.hazelcast.query.LocalIndexStats;
 import com.hazelcast.spi.impl.CountingMigrationAwareService;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.EventFilter;
@@ -211,8 +210,8 @@ public class MapService implements ManagedService, ChunkedMigrationAwareService,
     }
 
     @Override
-    public int onSyncEvent(InternalWanEvent event, InternalCompletableFuture<Boolean>[] futures, int offset) {
-        return wanSupportingService.onSyncEvent(event, futures, offset);
+    public void onSyncBatch(Collection<InternalWanEvent> batch, WanAcknowledgeType acknowledgeType) {
+        wanSupportingService.onSyncBatch(batch, acknowledgeType);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/WanMapSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/WanMapSupportingService.java
@@ -23,13 +23,13 @@ import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.map.impl.wan.WanMapAddOrUpdateEvent;
 import com.hazelcast.map.impl.wan.WanMapRemoveEvent;
-import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.wan.WanEventCounters;
 import com.hazelcast.wan.impl.InternalWanEvent;
 
+import java.util.Collection;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
@@ -58,7 +58,7 @@ class WanMapSupportingService implements WanSupportingService {
     }
 
     @Override
-    public int onSyncEvent(InternalWanEvent event, InternalCompletableFuture<Boolean>[] futures, int offset) {
+    public void onSyncBatch(Collection<InternalWanEvent> batch, WanAcknowledgeType acknowledgeType) {
         // code should never reach here
         throw new UnsupportedOperationException("WAN Synchronization requires Hazelcast Enterprise Edition");
     }


### PR DESCRIPTION
A recently reported issue showed that wan replication was swallowing  exceptions in the target side. This was caused by the usage of `CompletableFuture.allOf()` because `InternalCompletableFuture` can  complete normally even if an exception occurred. We would handle this  scenario during join(). This would mean that `CompletableFuture.allOf()` may not see an exception even though some futures would throw if join()  were to be called. This PR fixes that by using a joining for loop.

Additionally, while investigating this, I realized that sync batches are more prone to timeouts now, because we execute them concurrently. I  added a one time serial retry logic for timed out sync events. This code path  isn't expected to be taken under normal scenarios, and if taken it can act as a backpressure mechanism for the target cluster.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/5688

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/5756

Backport of: https://github.com/hazelcast/hazelcast/pull/23580
