### PR TITLE
Use older JDK8-compatible Neo4j kafka connector in integration tests

### DIFF
--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectNeo4jIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectNeo4jIntegrationTest.java
@@ -60,6 +60,8 @@ public class KafkaConnectNeo4jIntegrationTest extends JetTestSupport {
             .withoutAuthentication();
     private static final ILogger LOGGER = Logger.getLogger(KafkaConnectNeo4jIntegrationTest.class);
     private static final int ITEM_COUNT = 1_000;
+
+    //This is the last JDK8-compatible version of the Neo4j connector
     private static final String CONNECTOR_URL = "https://repository.hazelcast.com/download"
             + "/tests/neo4j-kafka-connect-neo4j-2.0.1.zip";
 

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectNeo4jIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectNeo4jIntegrationTest.java
@@ -61,7 +61,7 @@ public class KafkaConnectNeo4jIntegrationTest extends JetTestSupport {
     private static final ILogger LOGGER = Logger.getLogger(KafkaConnectNeo4jIntegrationTest.class);
     private static final int ITEM_COUNT = 1_000;
     private static final String CONNECTOR_URL = "https://repository.hazelcast.com/download"
-            + "/tests/neo4j-kafka-connect-neo4j-5.0.2.zip";
+            + "/tests/neo4j-kafka-connect-neo4j-2.0.1.zip";
 
     @Test
     public void testReadFromNeo4jConnector() throws Exception {


### PR DESCRIPTION
Use in tests an older Kafka Connector for Neo4j that works with JDK8

Related to https://github.com/hazelcast/hazelcast/pull/23739

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
