### PR TITLE
No error on null key [HZ-2086]

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/ChangeRecord.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/ChangeRecord.java
@@ -128,7 +128,7 @@ public interface ChangeRecord {
     /**
      * Returns the key part of the CDC event. It identifies the affected record.
      */
-    @Nonnull
+    @Nullable
     RecordPart key();
 
     /**

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
@@ -47,7 +47,7 @@ public class ChangeRecordImpl implements ChangeRecord {
             long sequenceSource,
             long sequenceValue,
             Operation operation,
-            @Nonnull String keyJson,
+            @Nullable String keyJson,
             Supplier<String> oldValueJsonSupplier,
             Supplier<String> newValueJsonSupplier,
             String table,
@@ -58,7 +58,7 @@ public class ChangeRecordImpl implements ChangeRecord {
         this.sequenceSource = sequenceSource;
         this.sequenceValue = sequenceValue;
         this.operation = operation;
-        this.keyJson = requireNonNull(keyJson, "keyJson");
+        this.keyJson = keyJson;
         this.oldValue = oldValueJsonSupplier == null ? null : new RecordPartImpl(oldValueJsonSupplier);
         this.newValue = newValueJsonSupplier == null ? null : new RecordPartImpl(newValueJsonSupplier);
         this.table = table;
@@ -71,7 +71,7 @@ public class ChangeRecordImpl implements ChangeRecord {
             long sequenceSource,
             long sequenceValue,
             Operation operation,
-            @Nonnull String keyJson,
+            String keyJson,
             String oldValueJson,
             String newValueJson,
             String table,
@@ -82,7 +82,7 @@ public class ChangeRecordImpl implements ChangeRecord {
         this.sequenceSource = sequenceSource;
         this.sequenceValue = sequenceValue;
         this.operation = operation;
-        this.keyJson = requireNonNull(keyJson, "keyJson");
+        this.keyJson = keyJson;
         this.oldValue = oldValueJson == null ? null : new RecordPartImpl(oldValueJson);
         this.newValue = newValueJson == null ? null : new RecordPartImpl(newValueJson);
         this.table = table;
@@ -120,9 +120,12 @@ public class ChangeRecordImpl implements ChangeRecord {
     }
 
     @Override
-    @Nonnull
+    @Nullable
     public RecordPart key() {
         if (key == null) {
+            if (keyJson == null) {
+                return null;
+            }
             key = new RecordPartImpl(() -> keyJson);
         }
         return key;

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -113,8 +113,9 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
             //when
             try (Connection connection = getMySqlConnection(container.withDatabaseName("inventory").getJdbcUrl(),
-                    container.getUsername(), container.getPassword())) {
-                Statement statement = connection.createStatement();
+                    container.getUsername(), container.getPassword());
+                 Statement statement = connection.createStatement()
+            ) {
                 statement.addBatch("UPDATE customers SET first_name='Anne Marie' WHERE id=1004");
                 statement.addBatch("INSERT INTO customers VALUES (1005, 'Jason', 'Bourne', 'jason@bourne.org')");
                 statement.addBatch("DELETE FROM customers WHERE id=1005");
@@ -291,11 +292,12 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
             try (Connection connection = getPostgreSqlConnection(container.getJdbcUrl(), container.getUsername(),
                     container.getPassword())) {
                 connection.setSchema("inventory");
-                Statement statement = connection.createStatement();
-                statement.addBatch("UPDATE customers SET first_name='Anne Marie' WHERE id=1004");
-                statement.addBatch("INSERT INTO customers VALUES (1005, 'Jason', 'Bourne', 'jason@bourne.org')");
-                statement.addBatch("DELETE FROM customers WHERE id=1005");
-                statement.executeBatch();
+                try (Statement statement = connection.createStatement()) {
+                    statement.addBatch("UPDATE customers SET first_name='Anne Marie' WHERE id=1004");
+                    statement.addBatch("INSERT INTO customers VALUES (1005, 'Jason', 'Bourne', 'jason@bourne.org')");
+                    statement.addBatch("DELETE FROM customers WHERE id=1005");
+                    statement.executeBatch();
+                }
             }
 
             //then


### PR DESCRIPTION
Debezium relaxed the requirement for keys - it can be null now. In such cases, do not throw an exception.

Fixes #23655

Breaking changes (list specific methods/types/messages):
* `ChangeRecord#key()` is now `@Nullable`, was `@Nonnull`

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
