### PR TITLE
[ALTO] Send heartbeats to Alto channels [ALTO-46]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -442,14 +442,13 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         long heartbeatInterval = properties.getPositiveMillisOrDefault(HEARTBEAT_INTERVAL);
         ILogger logger = loggingService.getLogger(HeartbeatManager.class);
         HeartbeatManager.start(this, executionService, logger,
-                heartbeatInterval, heartbeatTimeout,
-                Collections.unmodifiableCollection(connectionManager.getActiveConnections()));
+                heartbeatInterval, heartbeatTimeout, connectionManager.getActiveConnections());
     }
 
     private void startIcmpPing() {
         ILogger logger = loggingService.getLogger(HeartbeatManager.class);
         ClientICMPManager.start(config.getNetworkConfig().getClientIcmpPingConfig(), executionService, logger,
-                Collections.unmodifiableCollection(connectionManager.getActiveConnections()));
+                connectionManager.getActiveConnections());
     }
 
     public void disposeOnClusterChange(Disposable disposable) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/ClientConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/ClientConnection.java
@@ -18,8 +18,10 @@ package com.hazelcast.client.impl.connection;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.spi.EventHandler;
+import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.nio.Connection;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.UUID;
 
@@ -52,4 +54,11 @@ public interface ClientConnection extends Connection {
     // used in tests
     Map<Long, EventHandler> getEventHandlers();
 
+    /**
+     * Returns the Alto channels associated with this connection,
+     * or {@code null}, if the client is not Alto-aware or the
+     * Alto is disabled on the server-side.
+     */
+    @Nullable
+    Channel[] getAltoChannels();
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/AltoChannelClientConnectionAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/AltoChannelClientConnectionAdapter.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.connection.tcp;
+
+import com.hazelcast.client.impl.connection.ClientConnection;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.spi.EventHandler;
+import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.networking.Channel;
+import com.hazelcast.internal.networking.OutboundFrame;
+
+import javax.annotation.Nullable;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+
+public class AltoChannelClientConnectionAdapter implements ClientConnection {
+
+    private final Channel channel;
+
+    public AltoChannelClientConnectionAdapter(Channel channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public boolean write(OutboundFrame frame) {
+        return channel.write(frame);
+    }
+
+    @Override
+    public Address getRemoteAddress() {
+        return (Address) channel.attributeMap().get(Address.class);
+    }
+
+    @Override
+    public String getCloseReason() {
+        return "The Alto channel " + channel + " is closed";
+    }
+
+    @Override
+    public Throwable getCloseCause() {
+        return null;
+    }
+
+    @Override
+    public void handleClientMessage(ClientMessage message) {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public EventHandler getEventHandler(long correlationId) {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public void removeEventHandler(long correlationId) {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public void addEventHandler(long correlationId, EventHandler handler) {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public void setClusterUuid(UUID uuid) {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public UUID getClusterUuid() {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public Map<Long, EventHandler> getEventHandlers() {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Nullable
+    @Override
+    public Channel[] getAltoChannels() {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public ConcurrentMap attributeMap() {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public boolean isAlive() {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public long lastReadTimeMillis() {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public long lastWriteTimeMillis() {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Nullable
+    @Override
+    public InetSocketAddress getRemoteSocketAddress() {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public void setRemoteAddress(Address remoteAddress) {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Nullable
+    @Override
+    public UUID getRemoteUuid() {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public void setRemoteUuid(UUID remoteUuid) {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Nullable
+    @Override
+    public InetAddress getInetAddress() {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+
+    @Override
+    public void close(String reason, Throwable cause) {
+        throw new UnsupportedOperationException("Not supported for Alto channels");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/AltoChannelCloseListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/AltoChannelCloseListener.java
@@ -31,7 +31,9 @@ import com.hazelcast.internal.networking.ChannelCloseListener;
  * of the Alto channel, such as heartbeats.
  */
 public class AltoChannelCloseListener implements ChannelCloseListener {
+
     private final HazelcastClientInstanceImpl client;
+
     public AltoChannelCloseListener(HazelcastClientInstanceImpl client) {
         this.client = client;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/AltoChannelCloseListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/AltoChannelCloseListener.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.connection.tcp;
+
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.connection.ClientConnection;
+import com.hazelcast.internal.networking.Channel;
+import com.hazelcast.internal.networking.ChannelCloseListener;
+
+/**
+ * A listener to notify pending invocations that are sent
+ * over the Alto channels with exception, in case the Alto
+ * channel is closed.
+ * <p>
+ * The invocations that will be notified with this listener
+ * are the ones that are sent with the ClientConnection adapter
+ * of the Alto channel, such as heartbeats.
+ */
+public class AltoChannelCloseListener implements ChannelCloseListener {
+    private final HazelcastClientInstanceImpl client;
+    public AltoChannelCloseListener(HazelcastClientInstanceImpl client) {
+        this.client = client;
+    }
+
+    @Override
+    public void onClose(Channel channel) {
+        ClientConnection adapter = (ClientConnection) channel.attributeMap().get(AltoChannelClientConnectionAdapter.class);
+        assert adapter != null;
+
+        client.getInvocationService().onConnectionClose(adapter);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/ClientICMPManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/ClientICMPManager.java
@@ -49,7 +49,7 @@ public final class ClientICMPManager {
     public static void start(ClientIcmpPingConfig clientIcmpPingConfig,
                              TaskScheduler taskScheduler,
                              ILogger logger,
-                             Collection<ClientConnection> unmodifiableActiveConnections) {
+                             Collection<ClientConnection> connectionsView) {
         if (!clientIcmpPingConfig.isEnabled()) {
             return;
         }
@@ -75,8 +75,8 @@ public final class ClientICMPManager {
 
         PingFailureDetector<ClientConnection> failureDetector = new PingFailureDetector<>(icmpMaxAttempts);
         taskScheduler.scheduleWithRepetition(() -> {
-            failureDetector.retainAttemptsForAliveEndpoints(unmodifiableActiveConnections);
-            for (ClientConnection connection : unmodifiableActiveConnections) {
+            failureDetector.retainAttemptsForAliveEndpoints(connectionsView);
+            for (ClientConnection connection : connectionsView) {
                 // we don't want an isReachable call to an address stopping us to check other addresses.
                 // so we run each check in its own thread
                 taskScheduler.execute(() -> ping(logger, failureDetector, connection, icmpTtl, icmpTimeoutMillis));

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/HeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/HeartbeatManager.java
@@ -21,19 +21,21 @@ import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientPingCodec;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
+import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.impl.executionservice.TaskScheduler;
 
 import java.util.Collection;
+import java.util.concurrent.ConcurrentMap;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Periodically on each `heartbeatInterval` pings active connections.
  * Connections not receiving any packages for `heartbeatTimeout` duration
- * is closed with  {@link TargetDisconnectedException}.
+ * is closed with {@link TargetDisconnectedException}.
  */
 public final class HeartbeatManager {
 
@@ -44,30 +46,101 @@ public final class HeartbeatManager {
     public static void start(HazelcastClientInstanceImpl client,
                              TaskScheduler taskScheduler,
                              ILogger logger,
-                             long heartbeatIntervalMillis,
-                             long heartbeatTimeoutMillis,
-                             Collection<ClientConnection> unmodifiableActiveConnections) {
-        taskScheduler.scheduleWithRepetition(() -> {
-            long now = Clock.currentTimeMillis();
-            for (ClientConnection connection : unmodifiableActiveConnections) {
-                if (!connection.isAlive()) {
-                    return;
-                }
+                             long heartbeatInterval,
+                             long heartbeatTimeout,
+                             Collection<ClientConnection> connectionsView) {
 
-                if (now - connection.lastReadTimeMillis() > heartbeatTimeoutMillis) {
-                    logger.warning("Heartbeat failed over the connection: " + connection);
-                    connection.close("Heartbeat timed out",
-                            new TargetDisconnectedException("Heartbeat timed out to connection " + connection));
-                    return;
-                }
+        HeartbeatChecker heartbeatChecker = new HeartbeatChecker(client,
+                logger,
+                heartbeatInterval,
+                heartbeatTimeout,
+                connectionsView);
 
-                if (now - connection.lastWriteTimeMillis() > heartbeatIntervalMillis) {
-                    ClientMessage request = ClientPingCodec.encodeRequest();
-                    ClientInvocation invocation = new ClientInvocation(client, request, null, connection);
-                    invocation.invokeUrgent();
-                }
-            }
-        }, heartbeatIntervalMillis, heartbeatIntervalMillis, MILLISECONDS);
+        taskScheduler.scheduleWithRepetition(heartbeatChecker, heartbeatInterval, heartbeatInterval, MILLISECONDS);
     }
 
+    private static final class HeartbeatChecker implements Runnable {
+
+        private final HazelcastClientInstanceImpl client;
+        private final ILogger logger;
+        private final long heartbeatInterval;
+        private final long heartbeatTimeout;
+        private final Collection<ClientConnection> connectionsView;
+
+        private HeartbeatChecker(HazelcastClientInstanceImpl client,
+                                 ILogger logger,
+                                 long heartbeatInterval,
+                                 long heartbeatTimeout,
+                                 Collection<ClientConnection> connectionsView) {
+            this.client = client;
+            this.heartbeatTimeout = heartbeatTimeout;
+            this.heartbeatInterval = heartbeatInterval;
+            this.connectionsView = connectionsView;
+            this.logger = logger;
+        }
+
+        @Override
+        public void run() {
+            long now = Clock.currentTimeMillis();
+            for (ClientConnection connection : connectionsView) {
+                check(connection, now);
+
+                // Check Alto channels as well, if they exist
+                Channel[] altoChannels = connection.getAltoChannels();
+                if (altoChannels != null) {
+                    for (Channel altoChannel : altoChannels) {
+                        check(altoChannel, connection, now);
+                    }
+                }
+            }
+        }
+
+        private void check(ClientConnection connection, long now) {
+            if (!connection.isAlive()) {
+                return;
+            }
+
+            if (now - connection.lastReadTimeMillis() > heartbeatTimeout) {
+                logger.warning("Heartbeat failed over the connection: " + connection);
+                connection.close("Heartbeat timed out",
+                        new TargetDisconnectedException("Heartbeat timed out to connection " + connection));
+                return;
+            }
+
+            if (now - connection.lastWriteTimeMillis() > heartbeatInterval) {
+                sendPing(connection);
+            }
+        }
+
+        private void check(Channel altoChannel, ClientConnection connection, long now) {
+            if (altoChannel.isClosed()) {
+                return;
+            }
+
+            long lastReadTime = altoChannel.lastReadTimeMillis();
+            // TODO: remove the lastReadTime > 0 check while doing the
+            //  auth changes. Right now, it is needed because we are
+            //  not reading anything during the initial connection, hence
+            //  it is returning -1, which fails the check immediately
+            if (lastReadTime > 0 && now - lastReadTime > heartbeatTimeout) {
+                logger.warning("Heartbeat failed over the Alto channel " + altoChannel + " for connection: " + connection);
+                connection.close("Heartbeat timed out",
+                        new TargetDisconnectedException("Heartbeat timed out to the Alto channel "
+                                + altoChannel + " for connection: " + connection));
+                return;
+            }
+
+            if (now - altoChannel.lastWriteTimeMillis() > heartbeatInterval) {
+                ConcurrentMap attributeMap = altoChannel.attributeMap();
+                ClientConnection adapter = (ClientConnection) attributeMap.get(AltoChannelClientConnectionAdapter.class);
+                sendPing(adapter);
+            }
+        }
+
+        private void sendPing(ClientConnection connection) {
+            ClientMessage request = ClientPingCodec.encodeRequest();
+            ClientInvocation invocation = new ClientInvocation(client, request, null, connection);
+            invocation.invokeUrgent();
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/HeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/HeartbeatManager.java
@@ -40,7 +40,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public final class HeartbeatManager {
 
     private HeartbeatManager() {
-
     }
 
     public static void start(HazelcastClientInstanceImpl client,
@@ -113,7 +112,7 @@ public final class HeartbeatManager {
         }
 
         private void check(Channel altoChannel, ClientConnection connection, long now) {
-            if (altoChannel.isClosed()) {
+            if (altoChannel.isClosed() || !connection.isAlive()) {
                 return;
             }
 
@@ -123,10 +122,9 @@ public final class HeartbeatManager {
             //  not reading anything during the initial connection, hence
             //  it is returning -1, which fails the check immediately
             if (lastReadTime > 0 && now - lastReadTime > heartbeatTimeoutMillis) {
-                logger.warning("Heartbeat failed over the Alto channel " + altoChannel + " for connection: " + connection);
-                connection.close("Heartbeat timed out",
-                        new TargetDisconnectedException("Heartbeat timed out to the Alto channel "
-                                + altoChannel + " for connection: " + connection));
+                String message = "Heartbeat failed over the Alto channel: " + altoChannel + " for connection: " + connection;
+                logger.warning(message);
+                connection.close("Heartbeat timed out", new TargetDisconnectedException(message));
                 return;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnection.java
@@ -346,7 +346,6 @@ public class TcpClientConnection implements ClientConnection {
         this.altoChannels = altoChannels;
     }
 
-    // Used in tests
     public Channel[] getAltoChannels() {
         return altoChannels;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -788,9 +788,12 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             bindSocketToPort(socket);
             Channel channel = networking.register(channelInitializer, socketChannel, true);
 
+            channel.addCloseListener(new AltoChannelCloseListener(client));
+
             ConcurrentMap attributeMap = channel.attributeMap();
             attributeMap.put(Address.class, address);
             attributeMap.put(TcpClientConnection.class, connection);
+            attributeMap.put(AltoChannelClientConnectionAdapter.class, new AltoChannelClientConnectionAdapter(channel));
 
             InetSocketAddress socketAddress = new InetSocketAddress(address.getHost(), address.getPort());
             channel.connect(socketAddress, connectionTimeoutMillis);

--- a/hazelcast/src/test/java/com/hazelcast/client/alto/ClientAltoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/alto/ClientAltoTest.java
@@ -398,6 +398,8 @@ public class ClientAltoTest extends ClientTestSupport {
         assertClientConnectsAllAltoPortsEventually(connections, config.getAltoConfig().getEventloopCount());
 
         ClientConnection connection = connectionManager.getRandomConnection();
+        assertTrue(connection.isAlive());
+
         Channel[] altoChannels = connection.getAltoChannels();
         assertNotNull(altoChannels);
 

--- a/hazelcast/src/test/java/com/hazelcast/client/alto/ClientAltoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/alto/ClientAltoTest.java
@@ -18,9 +18,15 @@ package com.hazelcast.client.alto;
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.connection.ClientConnection;
 import com.hazelcast.client.impl.connection.ClientConnectionManager;
+import com.hazelcast.client.impl.connection.tcp.AltoChannelClientConnectionAdapter;
 import com.hazelcast.client.impl.connection.tcp.TcpClientConnection;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapPutCodec;
+import com.hazelcast.client.impl.spi.impl.ClientInvocation;
+import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
@@ -30,6 +36,9 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.OutboundFrame;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.util.ThreadUtil;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapStoreAdapter;
 import com.hazelcast.partition.PartitionService;
@@ -46,7 +55,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.client.properties.ClientProperty.HEARTBEAT_INTERVAL;
+import static com.hazelcast.client.properties.ClientProperty.HEARTBEAT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -271,19 +283,8 @@ public class ClientAltoTest extends ClientTestSupport {
 
     @Test
     public void testPartitionBoundPendingInvocations_whenConnectionCloses() {
-        Config config = getMemberConfig();
-        MapStoreConfig mapStoreConfig = new MapStoreConfig();
-        mapStoreConfig.setEnabled(true).setImplementation(new MapStoreAdapter<Integer, Integer>() {
-            @Override
-            public Integer load(Integer key) {
-                // Simulate a long-running operation
-                sleepSeconds(1000);
-                return super.load(key);
-            }
-        });
         String mapName = randomMapName();
-        config.addMapConfig(new MapConfig(mapName).setMapStoreConfig(mapStoreConfig));
-
+        Config config = getMemberWithMapStoreConfig(mapName);
         Hazelcast.newHazelcastInstance(config);
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient(getClientConfig());
@@ -295,6 +296,50 @@ public class ClientAltoTest extends ClientTestSupport {
         IMap<Integer, Integer> map = client.getMap(mapName);
         CompletableFuture<Integer> future = map.putAsync(1, 1).toCompletableFuture();
         connections.iterator().next().close("Expected", null);
+
+        // Should get TargetDisconnectedException and retried based on our rules,
+        // which bubbles the exception to the user for non-retryable messages
+        assertThatThrownBy(future::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(TargetDisconnectedException.class);
+    }
+
+    @Test
+    public void testAltoChannelTargetedPendingInvocations_whenConnectionCloses() {
+        // We don't send invocations to Alto channels this way, but this is just
+        // to make sure that invocation directly to the Alto channels work, and
+        // closing the connection (hence the channel) cleanups the pending invocations
+        String mapName = randomMapName();
+        Config config = getMemberWithMapStoreConfig(mapName);
+        Hazelcast.newHazelcastInstance(config);
+
+        HazelcastClientInstanceImpl client
+                = getHazelcastClientInstanceImpl(HazelcastClient.newHazelcastClient(getClientConfig()));
+        ClientConnectionManager connectionManager = client.getConnectionManager();
+        Collection<ClientConnection> connections = connectionManager.getActiveConnections();
+
+        assertClientConnectsAllAltoPortsEventually(connections, config.getAltoConfig().getEventloopCount());
+
+        ClientConnection connection = connections.iterator().next();
+        Channel[] altoChannels = connection.getAltoChannels();
+
+        int key = 1;
+        int value = 1;
+
+        int partitionId = client.getPartitionService().getPartition(key).getPartitionId();
+        Channel targetChannel = altoChannels[partitionId % altoChannels.length];
+        ClientConnection adapter
+                = (ClientConnection) targetChannel.attributeMap().get(AltoChannelClientConnectionAdapter.class);
+
+        InternalSerializationService serializationService = client.getSerializationService();
+
+        Data keyData = serializationService.toData(key);
+        Data valueData = serializationService.toData(value);
+
+        ClientMessage request = MapPutCodec.encodeRequest(mapName, keyData, valueData, ThreadUtil.getThreadId(), -1);
+        ClientInvocationFuture future = new ClientInvocation(client, request, mapName, adapter).invoke();
+
+        connection.close("Expected", null);
 
         // Should get TargetDisconnectedException and retried based on our rules,
         // which bubbles the exception to the user for non-retryable messages
@@ -336,6 +381,69 @@ public class ClientAltoTest extends ClientTestSupport {
 
         map.put("42", "42");
         assertEquals("42", map.get("42"));
+    }
+
+    @Test
+    public void testAltoClient_heartbeatsToIdleAltoChannels() {
+        Config config = getMemberConfig();
+        Hazelcast.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = getClientConfig();
+        clientConfig.setProperty(HEARTBEAT_INTERVAL.getName(), "1000");
+
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        ClientConnectionManager connectionManager = getConnectionManager(client);
+        Collection<ClientConnection> connections = connectionManager.getActiveConnections();
+        assertClientConnectsAllAltoPortsEventually(connections, config.getAltoConfig().getEventloopCount());
+
+        ClientConnection connection = connectionManager.getRandomConnection();
+        Channel[] altoChannels = connection.getAltoChannels();
+        assertNotNull(altoChannels);
+
+        long now = System.currentTimeMillis();
+        assertTrueEventually(() -> {
+            for (Channel channel : altoChannels) {
+                assertTrue(channel.lastWriteTimeMillis() > now);
+            }
+        });
+    }
+
+    @Test
+    public void testAltoClient_heartbeatsToNotRespondingAltoChannelsTimeouts() {
+        Config config = getMemberConfig();
+        Hazelcast.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = getClientConfig();
+        clientConfig.setProperty(HEARTBEAT_INTERVAL.getName(), "1000");
+        clientConfig.setProperty(HEARTBEAT_TIMEOUT.getName(), "3000");
+
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        ClientConnectionManager connectionManager = getConnectionManager(client);
+        Collection<ClientConnection> connections = connectionManager.getActiveConnections();
+
+        assertClientConnectsAllAltoPortsEventually(connections, config.getAltoConfig().getEventloopCount());
+
+        ClientConnection connection = connections.iterator().next();
+        assertTrue(connection.isAlive());
+
+        // This is a long-running task that will block the Alto thread, and it
+        // should not be able to respond to ping requests
+        spawn(() -> {
+            String mapName = randomMapName();
+            IMap<Integer, Integer> map = client.getMap(mapName);
+            map.put(1, 1);
+            map.executeOnKey(1, entry -> {
+                try {
+                    Thread.sleep(TimeUnit.SECONDS.toMillis(1_000));
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                return null;
+            });
+        });
+
+        assertTrueEventually(() -> assertFalse(connection.isAlive()));
     }
 
     private void assertNoConnectionToAltoPortsAllTheTime(Collection<ClientConnection> connections) {
@@ -384,6 +492,21 @@ public class ClientAltoTest extends ClientTestSupport {
         config.getAltoConfig()
                 .setEnabled(true)
                 .setEventloopCount(loopCount);
+        return config;
+    }
+
+    private Config getMemberWithMapStoreConfig(String mapName) {
+        Config config = getMemberConfig();
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setEnabled(true).setImplementation(new MapStoreAdapter<Integer, Integer>() {
+            @Override
+            public Integer load(Integer key) {
+                // Simulate a long-running operation
+                sleepSeconds(1000);
+                return super.load(key);
+            }
+        });
+        config.addMapConfig(new MapConfig(mapName).setMapStoreConfig(mapStoreConfig));
         return config;
     }
 }


### PR DESCRIPTION
This PR introduces an adapter for client connection for Alto channels
to be able to send invocations to Alto channels directly.

Also, it refactors the heartbeat manager so that the Alto channels
are pinged as well, in case of idle channel connections.

Should be merged after #23302 and #23712