### PR TITLE
Custom traverser instead of reading in chunks

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/CursorTraverser.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/CursorTraverser.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.jet.mongodb.impl;
+
+import com.hazelcast.jet.Traverser;
+import com.mongodb.client.MongoCursor;
+
+/**
+ * A traverser that will emit {@link MongoCursor#tryNext()} value
+ * or {@link EmptyItem#INSTANCE} in case of first null encountered.
+ */
+public class CursorTraverser implements Traverser<Object> {
+    private final MongoCursor<?> cursor;
+    private volatile boolean ended;
+
+    public CursorTraverser(MongoCursor<?> cursor) {
+        this.cursor = cursor;
+        this.ended = false;
+    }
+
+    @Override
+    public Object next() {
+        Object next = cursor.tryNext();
+        if (next == null) {
+            boolean alreadyEmittedLast = ended;
+            ended = true;
+            return alreadyEmittedLast ? null : EmptyItem.INSTANCE;
+        }
+        return next;
+    }
+
+    enum EmptyItem {
+        INSTANCE
+    }
+}

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.jet.mongodb.impl;
 
-import com.mongodb.client.MongoCursor;
 import com.mongodb.client.model.Field;
 import com.mongodb.client.model.Filters;
 import org.bson.BsonArray;

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
@@ -87,26 +87,4 @@ final class MongoUtilities {
         return aggregateList;
     }
 
-    /**
-     * Reads data from the cursor up to {@code maxSize} elements or until
-     * first null from {@link MongoCursor#tryNext()}
-     */
-    static <T> List<T> readChunk(MongoCursor<T> cursor, int maxSize) {
-        List<T> chunk = new ArrayList<>(maxSize);
-        int count = 0;
-        boolean eagerEnd = false;
-        while (count < maxSize && !eagerEnd) {
-            // note: do not use `hasNext` and `next` - those methods blocks for new elements
-            // and we don't want to block
-            T doc = cursor.tryNext();
-            if (doc != null) {
-                chunk.add(doc);
-                count++;
-            } else {
-                eagerEnd = true;
-            }
-        }
-        return chunk;
-    }
-
 }


### PR DESCRIPTION
To make Frantisek happy :)

Also watermark checks were removed - in case of a crash new instances will be spawned, so no need to compare values.

Note: I was thinking about returning some wrapper from the cursor that would guide if we want to flatMapIdle or map item, but it will create a lot of object unnecessarily. This way we have only 1 singleton-marker object

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible