### PR TITLE
Fix tests with multiple HZ instances and the same TStore base directory

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -53,7 +53,6 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
     private static final ILogger SUPPORT_LOGGER = Logger.getLogger(SimpleTestInClusterSupport.class);
 
     private static TestHazelcastFactory factory;
-    private static Config config;
     private static HazelcastInstance[] instances;
     private static HazelcastInstance client;
 
@@ -66,7 +65,6 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
         if (config == null) {
             config = smallInstanceConfig();
         }
-        SimpleTestInClusterSupport.config = config;
         // create members
         for (int i = 0; i < memberCount; i++) {
             instances[i] = factory.newHazelcastInstance(config);
@@ -160,15 +158,6 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
     @Nonnull
     protected static TestHazelcastFactory factory() {
         return factory;
-    }
-
-    /**
-     * Returns the config used to create member instances (even if null was
-     * passed).
-     */
-    @Nonnull
-    protected static Config jetConfig() {
-        return config;
     }
 
     /**


### PR DESCRIPTION
INSERT_PR_DESCRIPTION_HERE

Fixes HZ-2095

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
