### PR TITLE
[CN-751] Add null checks for fields in AddCacheConfigMessageTask [5.0.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import java.util.ArrayList;
 import java.util.List;
 
+@SuppressWarnings("checkstyle:npathcomplexity")
 public class AddCacheConfigMessageTask
         extends AbstractAddConfigMessageTask<DynamicConfigAddCacheConfigCodec.RequestParameters> {
 
@@ -58,7 +59,9 @@ public class AddCacheConfigMessageTask
         config.setCacheWriter(parameters.cacheWriter);
         config.setCacheWriterFactory(parameters.cacheWriterFactory);
         config.setDisablePerEntryInvalidationEvents(parameters.disablePerEntryInvalidationEvents);
-        config.setEvictionConfig(parameters.evictionConfig.asEvictionConfg(serializationService));
+        if (parameters.evictionConfig != null) {
+            config.setEvictionConfig(parameters.evictionConfig.asEvictionConfg(serializationService));
+        }
         if (parameters.expiryPolicyFactoryClassName != null) {
             config.setExpiryPolicyFactory(parameters.expiryPolicyFactoryClassName);
         } else if (parameters.timedExpiryPolicyFactoryConfig != null) {
@@ -66,12 +69,18 @@ public class AddCacheConfigMessageTask
                     new ExpiryPolicyFactoryConfig(parameters.timedExpiryPolicyFactoryConfig);
             config.setExpiryPolicyFactoryConfig(expiryPolicyFactoryConfig);
         }
-        config.setEventJournalConfig(parameters.eventJournalConfig);
-        config.setHotRestartConfig(parameters.hotRestartConfig);
+        if (parameters.eventJournalConfig != null) {
+            config.setEventJournalConfig(parameters.eventJournalConfig);
+        }
+        if (parameters.hotRestartConfig != null) {
+            config.setHotRestartConfig(parameters.hotRestartConfig);
+        }
         config.setInMemoryFormat(InMemoryFormat.valueOf(parameters.inMemoryFormat));
         config.setKeyType(parameters.keyType);
         config.setManagementEnabled(parameters.managementEnabled);
-        config.setMergePolicyConfig(mergePolicyConfig(parameters.mergePolicy, parameters.mergeBatchSize));
+        if (parameters.mergePolicy != null) {
+            config.setMergePolicyConfig(mergePolicyConfig(parameters.mergePolicy, parameters.mergeBatchSize));
+        }
         config.setName(parameters.name);
         if (parameters.partitionLostListenerConfigs != null && !parameters.partitionLostListenerConfigs.isEmpty()) {
             List<CachePartitionLostListenerConfig> listenerConfigs = (List<CachePartitionLostListenerConfig>)
@@ -86,7 +95,7 @@ public class AddCacheConfigMessageTask
         config.setValueType(parameters.valueType);
         config.setWanReplicationRef(parameters.wanReplicationRef);
         config.setWriteThrough(parameters.writeThrough);
-        if (parameters.isMerkleTreeConfigExists) {
+        if (parameters.isMerkleTreeConfigExists && parameters.merkleTreeConfig != null) {
             config.setMerkleTreeConfig(parameters.merkleTreeConfig);
         }
         return config;

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTaskTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.dynamicconfig;
+
+import com.hazelcast.client.impl.ClientEndpoint;
+import com.hazelcast.client.impl.ClientEndpointManager;
+import com.hazelcast.client.impl.ClientEngine;
+import com.hazelcast.client.impl.protocol.ClientExceptionFactory;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddCacheConfigCodec;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.instance.impl.NodeExtension;
+import com.hazelcast.internal.dynamicconfig.ClusterWideConfigurationService;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
+import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.internal.nio.ConnectionType;
+import com.hazelcast.internal.server.ServerConnection;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.cluster.Address.createUnresolvedAddress;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class AddCacheConfigMessageTaskTest {
+    private Node mockNode;
+    private Connection mockConnection;
+
+    @Before
+    public void setup() {
+        // setup mocks
+        mockNode = mock(Node.class);
+        mockConnection = mock(ServerConnection.class);
+        ClientEngine mockClientEngine = mock(ClientEngine.class);
+        ClientEndpointManager mockClientEndpointManager = mock(ClientEndpointManager.class);
+        ClientEndpoint mockClientEndpoint = mock(ClientEndpoint.class);
+        NodeEngineImpl mockNodeEngineImpl = mock(NodeEngineImpl.class);
+        NodeExtension mockNodeExtension = mock(NodeExtension.class);
+        ClusterWideConfigurationService mockConfigurationService = mock(ClusterWideConfigurationService.class);
+        InternalCompletableFuture<Object> mockFuture = mock(InternalCompletableFuture.class);
+
+        when(mockNode.getClientEngine()).thenReturn(mockClientEngine);
+        when(mockNode.getConfig()).thenReturn(new Config());
+        when(mockNode.getLogger(any(Class.class))).thenReturn(Logger.getLogger(AddMapConfigMessageTaskTest.class));
+        when(mockNode.getNodeExtension()).thenReturn(mockNodeExtension);
+        when(mockNode.getNodeEngine()).thenReturn(mockNodeEngineImpl);
+
+        when(mockClientEngine.getEndpointManager()).thenReturn(mockClientEndpointManager);
+        when(mockClientEngine.getExceptionFactory()).thenReturn(new ClientExceptionFactory(false,
+                new Config().getClassLoader()));
+
+        when(mockClientEndpoint.getClientType()).thenReturn(ConnectionType.JAVA_CLIENT);
+        when(mockClientEndpoint.isAuthenticated()).thenReturn(true);
+        when(mockClientEndpointManager.getEndpoint(mockConnection)).thenReturn(mockClientEndpoint);
+
+        when(mockNodeEngineImpl.getConfig()).thenReturn(new DynamicConfigurationAwareConfig(
+                new Config(),
+                new HazelcastProperties(new Config()))
+        );
+        when(mockNodeEngineImpl.getService(ClusterWideConfigurationService.SERVICE_NAME)).thenReturn(mockConfigurationService);
+
+        when(mockConfigurationService.broadcastConfigAsync(any(IdentifiedDataSerializable.class)))
+                .thenReturn(mockFuture);
+        when(mockNodeExtension.isStartCompleted()).thenReturn(true);
+        when(mockConnection.getRemoteAddress()).thenReturn(createUnresolvedAddress("127.0.0.1", 5701));
+    }
+
+    @Test
+    public void doNotThrowException_whenNullValuesProvidedForNullableFields() throws Exception {
+        CacheConfig<Object, Object> cacheConfig = new CacheConfig<>("my-cache");
+        ClientMessage addMapConfigClientMessage = DynamicConfigAddCacheConfigCodec.encodeRequest(
+                cacheConfig.getName(),
+                null,
+                null,
+                cacheConfig.isStatisticsEnabled(),
+                cacheConfig.isManagementEnabled(),
+                cacheConfig.isReadThrough(),
+                cacheConfig.isWriteThrough(),
+                null,
+                null,
+                null,
+                null,
+                cacheConfig.getBackupCount(),
+                cacheConfig.getAsyncBackupCount(),
+                cacheConfig.getInMemoryFormat().name(),
+                null,
+                null,
+                0,
+                cacheConfig.isDisablePerEntryInvalidationEvents(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+        AddCacheConfigMessageTask addCacheConfigMessageTask = new AddCacheConfigMessageTask(addMapConfigClientMessage, mockNode, mockConnection);
+        addCacheConfigMessageTask.run();
+        CacheConfig transmittedCacheConfig = new CacheConfig((CacheSimpleConfig) addCacheConfigMessageTask.getConfig());
+        assertEquals(cacheConfig, transmittedCacheConfig);
+    }
+}


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

This PR adds null checks for fields that are incorrectly marked as nullable.

Backport of: #21664, only fixes for null checks are taken from the PR

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible