### PR TITLE
Fix BsonTimestamp creation

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoDBSourceBuilder.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoDBSourceBuilder.java
@@ -355,7 +355,7 @@ public final class MongoDBSourceBuilder {
          * @return this builder
          */
         @Nonnull @Override
-        public Stream<T> database(@Nullable String database) {
+        public Stream<T> database(@Nonnull String database) {
             params.setDatabaseName(database);
             return this;
         }
@@ -377,7 +377,7 @@ public final class MongoDBSourceBuilder {
          * @return this builder
          */
         @Nonnull @Override
-        public Stream<Document> collection(@Nullable String collectionName) {
+        public Stream<Document> collection(@Nonnull String collectionName) {
             return collection(collectionName, Document.class);
         }
 
@@ -409,7 +409,7 @@ public final class MongoDBSourceBuilder {
         @Nonnull
         @SuppressWarnings("unchecked")
         @Override
-        public <T_NEW> Stream<T_NEW> collection(@Nullable String collectionName, @Nonnull Class<T_NEW> mongoType) {
+        public <T_NEW> Stream<T_NEW> collection(@Nonnull String collectionName, @Nonnull Class<T_NEW> mongoType) {
             Stream<T_NEW> newThis = (Stream<T_NEW>) this;
             newThis.params.setCollectionName(collectionName);
             newThis.params.setMapStreamFn(streamToClass(mongoType));
@@ -441,7 +441,7 @@ public final class MongoDBSourceBuilder {
          */
         @Nonnull
         public Stream<T> startAtOperationTime(@Nonnull BsonTimestamp startAtOperationTime) {
-            this.params.setStartAtTimestamp(startAtOperationTime.getValue());
+            this.params.setStartAtTimestamp(startAtOperationTime);
             return this;
         }
 

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoDBSources.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoDBSources.java
@@ -32,6 +32,8 @@ import org.bson.conversions.Bson;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 /**
  * Contains factory methods for MongoDB sources.
  * <p>
@@ -224,7 +226,7 @@ public final class MongoDBSources {
         if (filter != null) {
             builder.filter(filter);
         }
-        builder.startAtOperationTime(new BsonTimestamp(System.currentTimeMillis()));
+        builder.startAtOperationTime(new BsonTimestamp((int) MILLISECONDS.toSeconds(System.currentTimeMillis()), 0));
         return builder.build();
     }
 }

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
@@ -372,7 +372,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
 
     private final class StreamMongoReader extends MongoChunkedReader {
         private final FunctionEx<ChangeStreamDocument<Document>, I> mapFn;
-        private final Long startTimestamp;
+        private final BsonTimestamp startTimestamp;
         private final List<Bson> aggregates;
         private final EventTimeMapper<I> eventTimeMapper;
         private MongoCursor<ChangeStreamDocument<Document>> cursor;
@@ -382,7 +382,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
                 String databaseName,
                 String collectionName,
                 FunctionEx<ChangeStreamDocument<Document>, I> mapFn,
-                Long startTimestamp,
+                BsonTimestamp startTimestamp,
                 List<Bson> aggregates,
                 EventTimeMapper<I> eventTimeMapper
         ) {
@@ -411,7 +411,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
             if (resumeToken != null) {
                 changeStream.resumeAfter(resumeToken);
             } else if (startTimestamp != null) {
-                changeStream.startAtOperationTime(new BsonTimestamp(startTimestamp));
+                changeStream.startAtOperationTime(startTimestamp);
             }
             cursor = changeStream.batchSize(BATCH_SIZE).fullDocument(UPDATE_LOOKUP).iterator();
         }

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoParams.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoParams.java
@@ -20,6 +20,7 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
@@ -39,7 +40,7 @@ public class ReadMongoParams<I> implements Serializable {
     String collectionName;
     FunctionEx<Document, I> mapItemFn;
 
-    Long startAtTimestamp;
+    BsonTimestamp startAtTimestamp;
     EventTimePolicy<? super I> eventTimePolicy;
     FunctionEx<ChangeStreamDocument<Document>, I> mapStreamFn;
 
@@ -102,11 +103,11 @@ public class ReadMongoParams<I> implements Serializable {
         return this;
     }
 
-    public Long getStartAtTimestamp() {
+    public BsonTimestamp getStartAtTimestamp() {
         return startAtTimestamp;
     }
 
-    public ReadMongoParams<I> setStartAtTimestamp(Long startAtTimestamp) {
+    public ReadMongoParams<I> setStartAtTimestamp(BsonTimestamp startAtTimestamp) {
         this.startAtTimestamp = startAtTimestamp;
         return this;
     }


### PR DESCRIPTION
Because BsonTimestamp is not  like Timestamp and it's value isn't just normal Unix epoch timestamp.

Nullability change is "by the way" - it makes no sense if user uses e.g. `collection` function and provides null.
  
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations

