### PR TITLE
Explicitly specify executor for CF calls in general classes [HZ-2006]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientReliableTopicProxy.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static com.hazelcast.internal.util.Preconditions.checkNoNullInside;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -292,7 +293,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
             } else {
                 returnFuture.complete(null);
             }
-        });
+        }, CALLER_RUNS);
     }
 
     private void addAsyncOrFail(@Nonnull Collection<? extends E> payload, InternalCompletableFuture<Void> returnFuture,
@@ -306,7 +307,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
             } else {
                 returnFuture.complete(null);
             }
-        });
+        }, CALLER_RUNS);
     }
 
     private InternalCompletableFuture<Void> addAsync(List<ReliableTopicMessage> messages, OverflowPolicy overflowPolicy) {
@@ -317,7 +318,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
             } else {
                 returnFuture.complete(null);
             }
-        });
+        }, CALLER_RUNS);
         return returnFuture;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -27,6 +27,7 @@ import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.security.UsernamePasswordCredentials;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -35,6 +36,7 @@ import javax.security.auth.login.LoginException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URLDecoder;
+import java.util.concurrent.Executor;
 
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_BINARY;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_JSON;
@@ -112,11 +114,13 @@ public abstract class HttpCommandProcessor<T extends HttpCommand> extends Abstra
 
     protected final ILogger logger;
     protected final RestCallCollector restCallCollector;
+    protected final Executor internalAsyncExecutor;
 
     protected HttpCommandProcessor(TextCommandService textCommandService, ILogger logger) {
         super(textCommandService);
         this.logger = logger;
         this.restCallCollector = textCommandService.getRestCallCollector();
+        internalAsyncExecutor = getNode().getNodeEngine().getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -216,7 +216,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
                 command.send500();
                 textCommandService.sendResponse(command);
             }
-        });
+        }, internalAsyncExecutor);
     }
 
     private void handleGetCPSessions(final HttpGetCommand command) {
@@ -243,7 +243,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
 
                         textCommandService.sendResponse(command);
                     }
-                });
+                }, internalAsyncExecutor);
     }
 
     private void handleGetCPGroupByName(final HttpGetCommand command) {
@@ -273,7 +273,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
                 command.send500();
                 textCommandService.sendResponse(command);
             }
-        });
+        }, internalAsyncExecutor);
     }
 
     private void handleGetCPMembers(final HttpGetCommand command) {
@@ -290,7 +290,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
                 command.send500();
                 textCommandService.sendResponse(command);
             }
-        });
+        }, internalAsyncExecutor);
     }
 
     private void handleGetLocalCPMember(final HttpGetCommand command) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -486,7 +486,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                         command.send500();
                         textCommandService.sendResponse(command);
                     }
-                });
+                }, internalAsyncExecutor);
     }
 
     private void handleRemoveCPMember(final HttpPostCommand command) {
@@ -509,7 +509,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
 
                         textCommandService.sendResponse(command);
                     }
-                });
+                }, internalAsyncExecutor);
     }
 
     private void handleCPGroup(HttpPostCommand command) throws UnsupportedEncodingException {
@@ -551,7 +551,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                         command.send500();
                         textCommandService.sendResponse(command);
                     }
-                });
+                }, internalAsyncExecutor);
     }
 
     private void handleForceDestroyCPGroup(final HttpPostCommand command) {
@@ -579,7 +579,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                         }
                         textCommandService.sendResponse(command);
                     }
-                });
+                }, internalAsyncExecutor);
     }
 
     private void handleResetCPSubsystem(final HttpPostCommand command) throws UnsupportedEncodingException {
@@ -596,7 +596,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                         command.send500();
                         textCommandService.sendResponse(command);
                     }
-                });
+                }, internalAsyncExecutor);
     }
 
     private CPSubsystemManagementService getCpSubsystemManagementService() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -107,6 +107,7 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MIGRATION
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_PREFIX;
 import static com.hazelcast.internal.metrics.ProbeUnit.BOOLEAN;
 import static com.hazelcast.internal.partition.IPartitionService.SERVICE_NAME;
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.memory.MemoryUnit.MEGABYTES;
 import static com.hazelcast.spi.impl.executionservice.ExecutionService.ASYNC_EXECUTOR;
 import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_CHUNKED_MAX_MIGRATING_DATA_IN_MB;
@@ -1164,11 +1165,11 @@ public class MigrationManager {
 
                 try {
                     CompletionStage<Boolean> f = new AsyncMigrationTask(migration).run();
-                    f.thenRun(() -> {
+                    f.thenRunAsync(() -> {
                         logger.fine("AsyncMigrationTask completed: " + migration);
                         boolean offered = completed.offer(migration);
                         assert offered : "Failed to offer completed migration: " + migration;
-                    });
+                    }, CALLER_RUNS);
                 } catch (Throwable e) {
                     logger.warning("AsyncMigrationTask failed: " + migration, e);
                     boolean offered = completed.offer(migration);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -952,13 +952,13 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
             executor.execute(() -> {
                 try {
                     CompletionStage<U> r = function.apply(res);
-                    r.whenComplete((v, t) -> {
+                    r.whenCompleteAsync((v, t) -> {
                         if (t == null) {
                             future.complete(v);
                         } else {
                             future.completeExceptionally(t);
                         }
-                    });
+                    }, CALLER_RUNS);
                 } catch (Throwable t) {
                     future.completeExceptionally(t);
                 }
@@ -1664,13 +1664,13 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
                 executor.execute(() -> {
                     try {
                         CompletionStage<U> r = function.apply((T) resolved);
-                        r.whenComplete((v, t) -> {
+                        r.whenCompleteAsync((v, t) -> {
                             if (t == null) {
                                 future.complete(v);
                             } else {
                                 future.completeExceptionally(t);
                             }
-                        });
+                        }, CALLER_RUNS);
                     } catch (Throwable t) {
                         future.completeExceptionally(t);
                     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
+import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static com.hazelcast.internal.util.Preconditions.checkNoNullInside;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -349,7 +350,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
             } else {
                 returnFuture.complete(null);
             }
-        });
+        }, CALLER_RUNS);
     }
 
     private InternalCompletableFuture<Void> addAsync(List<ReliableTopicMessage> messages, OverflowPolicy overflowPolicy) {
@@ -360,7 +361,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
             } else {
                 returnFuture.complete(null);
             }
-        });
+        }, CALLER_RUNS);
         return returnFuture;
     }
 
@@ -378,6 +379,6 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
             } else {
                 returnFuture.complete(null);
             }
-        });
+        }, CALLER_RUNS);
     }
 }


### PR DESCRIPTION
Moving away from using the ForkJoinPool#commonPool.

Related to https://github.com/hazelcast/hazelcast/issues/18190

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
