### PR TITLE
[ALTO] Fixed problem with eventloop and clock update.

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Eventloop.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/Eventloop.java
@@ -114,6 +114,7 @@ public abstract class Eventloop {
                 return false;
             }
 
+            // the task first needs to be removed from the task queue.
             scheduledTaskQueue0.poll();
             earliestDeadlineNanos = -1;
             try {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioEventloop.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioEventloop.java
@@ -67,13 +67,13 @@ class NioEventloop extends Eventloop {
                                 ? selector0.selectNow()
                                 : selector0.select(timeoutMillis);
                     }
+                    // we need to update the clock because we could have been blocked for quite
+                    // some time and clock could be very much out of sync.
+                    nanoClock0.update();
                 } else {
                     keyCount = selector0.selectNow();
                 }
                 wakeupNeeded0.set(false);
-                // we need to update the clock because we could have been blocked for quite
-                // some time and clock could be very much out of sync.
-                nanoClock0.update();
             }
 
             if (keyCount > 0) {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioEventloop.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioEventloop.java
@@ -71,6 +71,9 @@ class NioEventloop extends Eventloop {
                     keyCount = selector0.selectNow();
                 }
                 wakeupNeeded0.set(false);
+                // we need to update the clock because we could have been blocked for quite
+                // some time and clock could be very much out of sync.
+                nanoClock0.update();
             }
 
             if (keyCount > 0) {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/CachedNanoClock.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/CachedNanoClock.java
@@ -43,6 +43,12 @@ public class CachedNanoClock implements NanoClock {
     }
 
     @Override
+    public void update() {
+        value = System.nanoTime() - START_TIME;
+        iteration = 0;
+    }
+
+    @Override
     public long nanoTime() {
         if (iteration == refreshPeriod) {
             value = System.nanoTime() - START_TIME;

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/NanoClock.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/NanoClock.java
@@ -37,4 +37,11 @@ public interface NanoClock {
      * @return the time in nanoseconds.
      */
     long nanoTime();
+
+    /**
+     * Forces the nanoclock to update the time. The time can be cached. This
+     * method should be made after some blocking is done on e.g. a Selector so
+     * that the clock remains reasonably up to date.
+     */
+    void update();
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/StandardNanoClock.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/util/StandardNanoClock.java
@@ -29,4 +29,8 @@ public class StandardNanoClock implements NanoClock {
     public long nanoTime() {
         return System.nanoTime() - START_TIME;
     }
+
+    @Override
+    public void update() {
+    }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/EventloopTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/EventloopTest.java
@@ -38,8 +38,7 @@ public abstract class EventloopTest {
     @Before
     public void before() {
         ReactorBuilder reactorBuilder = newReactorBuilder();
-        reactor = reactorBuilder.build();
-        reactor.start();
+        reactor = reactorBuilder.build().start();
     }
 
     @After
@@ -48,7 +47,7 @@ public abstract class EventloopTest {
     }
 
     @Test
-    public void test() {
+    public void test_schedule() {
         Task task = new Task();
 
         reactor.offer(() -> reactor.eventloop.schedule(task, 1, SECONDS));
@@ -56,7 +55,7 @@ public abstract class EventloopTest {
         assertTrueEventually(() -> assertEquals(1, task.count.get()));
     }
 
-    private final class Task implements Runnable {
+    private static final class Task implements Runnable {
         private final AtomicLong count = new AtomicLong();
 
         @Override

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioEventloopTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioEventloopTest.java
@@ -17,12 +17,12 @@
 package com.hazelcast.internal.tpc.nio;
 
 import com.hazelcast.internal.tpc.EventloopTest;
-import com.hazelcast.internal.tpc.Reactor;
+import com.hazelcast.internal.tpc.ReactorBuilder;
 
 public class NioEventloopTest extends EventloopTest {
 
     @Override
-    public Reactor newReactor() {
-        return new NioReactor();
+    public ReactorBuilder newReactorBuilder() {
+        return new NioReactorBuilder();
     }
 }


### PR DESCRIPTION
The Eventloop should force updating the cached clock after it does a blocking call to Selector.select because it could have been blocked for a long time.
