### PR TITLE
Update hazelcast-coverage-report modules

### DIFF
--- a/hazelcast-coverage-report/pom.xml
+++ b/hazelcast-coverage-report/pom.xml
@@ -81,6 +81,12 @@
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-tpc-engine</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-archunit-rules</artifactId>
             <version>${project.version}</version>
             <type>pom</type>


### PR DESCRIPTION
Update the list of modules in hazelcast-coverage-report dependencies

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible
