### PR TITLE
Renaming: MongoDB prefix to Mongo

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSinkBuilder.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSinkBuilder.java
@@ -46,7 +46,7 @@ import static com.mongodb.WriteConcern.MAJORITY;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
- * See {@link MongoDBSinks#builder}
+ * See {@link MongoSinks#builder}
  *
  * @since 5.3
  *
@@ -54,7 +54,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
  */
 @Beta
 @SuppressWarnings("UnusedReturnValue")
-public final class MongoDBSinkBuilder<T> {
+public final class MongoSinkBuilder<T> {
 
     @SuppressWarnings("checkstyle:MagicNumber")
     private static final TransactionOptions DEFAULT_TRANSACTION_OPTION = TransactionOptions
@@ -77,9 +77,9 @@ public final class MongoDBSinkBuilder<T> {
     private int preferredLocalParallelism = 2;
 
     /**
-     * See {@link MongoDBSinks#builder}
+     * See {@link MongoSinks#builder}
      */
-    MongoDBSinkBuilder(
+    MongoSinkBuilder(
             @Nonnull String name,
             @Nonnull Class<T> documentClass,
             @Nonnull SupplierEx<MongoClient> clientSupplier
@@ -104,7 +104,7 @@ public final class MongoDBSinkBuilder<T> {
      * @param selectCollectionNameFn selects collection name for each item individually
      */
     @Nonnull
-    public MongoDBSinkBuilder<T> into(
+    public MongoSinkBuilder<T> into(
             @Nonnull FunctionEx<T, String> selectDatabaseNameFn,
             @Nonnull FunctionEx<T, String> selectCollectionNameFn
     ) {
@@ -118,7 +118,7 @@ public final class MongoDBSinkBuilder<T> {
      * @param collectionName collection name to which objects will be inserted/updated.
      */
     @Nonnull
-    public MongoDBSinkBuilder<T> into(@Nonnull String databaseName, @Nonnull String collectionName) {
+    public MongoSinkBuilder<T> into(@Nonnull String databaseName, @Nonnull String collectionName) {
         params.setDatabaseName(databaseName);
         params.setCollectionName(collectionName);
         return this;
@@ -128,7 +128,7 @@ public final class MongoDBSinkBuilder<T> {
      * See {@link SinkBuilder#preferredLocalParallelism(int)}.
      */
     @Nonnull
-    public MongoDBSinkBuilder<T> preferredLocalParallelism(int preferredLocalParallelism) {
+    public MongoSinkBuilder<T> preferredLocalParallelism(int preferredLocalParallelism) {
         this.preferredLocalParallelism = Vertex.checkLocalParallelism(preferredLocalParallelism);
         return this;
     }
@@ -138,7 +138,7 @@ public final class MongoDBSinkBuilder<T> {
      * By default {@linkplain ReplaceOptions#upsert(boolean) upsert} is only enabled.
      */
     @Nonnull
-    public MongoDBSinkBuilder<T> withCustomReplaceOptions(@Nonnull ConsumerEx<ReplaceOptions> adjustConsumer) {
+    public MongoSinkBuilder<T> withCustomReplaceOptions(@Nonnull ConsumerEx<ReplaceOptions> adjustConsumer) {
         params.setReplaceOptionAdjuster(checkNonNullAndSerializable(adjustConsumer, "adjustConsumer"));
         return this;
     }
@@ -149,7 +149,7 @@ public final class MongoDBSinkBuilder<T> {
      * @param documentIdentityFn function that extracts ID from given item; will be compared against {@code fieldName}
      */
     @Nonnull
-    public MongoDBSinkBuilder<T> identifyDocumentBy(
+    public MongoSinkBuilder<T> identifyDocumentBy(
             @Nonnull String fieldName,
             @Nonnull FunctionEx<T, Object> documentIdentityFn) {
         checkNotNull(fieldName, "fieldName cannot be null");
@@ -170,7 +170,7 @@ public final class MongoDBSinkBuilder<T> {
      * Default value is {@linkplain #DEFAULT_COMMIT_RETRY_STRATEGY}.
      */
     @Nonnull
-    public MongoDBSinkBuilder<T> commitRetryStrategy(@Nonnull RetryStrategy commitRetryStrategy) {
+    public MongoSinkBuilder<T> commitRetryStrategy(@Nonnull RetryStrategy commitRetryStrategy) {
         params.setCommitRetryStrategy(commitRetryStrategy);
         return this;
     }
@@ -185,7 +185,7 @@ public final class MongoDBSinkBuilder<T> {
      * Default value is {@linkplain #DEFAULT_TRANSACTION_OPTION}.
      */
     @Nonnull
-    public MongoDBSinkBuilder<T> transactionOptions(@Nonnull SupplierEx<TransactionOptions> transactionOptionsSup) {
+    public MongoSinkBuilder<T> transactionOptions(@Nonnull SupplierEx<TransactionOptions> transactionOptionsSup) {
         params.setTransactionOptions(transactionOptionsSup);
         return this;
     }

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSinks.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSinks.java
@@ -32,9 +32,9 @@ import javax.annotation.Nonnull;
  * @since 5.3
  */
 @Beta
-public final class MongoDBSinks {
+public final class MongoSinks {
 
-    private MongoDBSinks() {
+    private MongoSinks() {
     }
 
     /**
@@ -74,12 +74,12 @@ public final class MongoDBSinks {
      * @param <T>                type of the items the sink accepts
      */
     @Beta
-    public static <T> MongoDBSinkBuilder<T> builder(
+    public static <T> MongoSinkBuilder<T> builder(
             @Nonnull String name,
             @Nonnull Class<T> itemClass,
             @Nonnull SupplierEx<MongoClient> clientSupplier
     ) {
-        return new MongoDBSinkBuilder<>(name, itemClass, clientSupplier);
+        return new MongoSinkBuilder<>(name, itemClass, clientSupplier);
     }
 
 
@@ -115,7 +115,7 @@ public final class MongoDBSinks {
             @Nonnull String database,
             @Nonnull String collection
     ) {
-        return MongoDBSinks
+        return MongoSinks
                 .builder(name, Document.class, () -> MongoClients.create(connectionString))
                 .into(database, collection)
                 .identifyDocumentBy("_id", doc -> doc.get("_id"))

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSourceBuilder.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSourceBuilder.java
@@ -53,9 +53,9 @@ import static com.hazelcast.jet.mongodb.impl.Mappers.toClass;
  *
  */
 @Beta
-public final class MongoDBSourceBuilder {
+public final class MongoSourceBuilder {
 
-    private MongoDBSourceBuilder() {
+    private MongoSourceBuilder() {
     }
 
     /**
@@ -73,7 +73,7 @@ public final class MongoDBSourceBuilder {
      * @param clientSupplier a function that creates MongoDB client
      */
     @Nonnull
-    public static MongoDBSourceBuilder.Batch<Document> batch(
+    public static MongoSourceBuilder.Batch<Document> batch(
             @Nonnull String name,
             @Nonnull SupplierEx<? extends MongoClient> clientSupplier
     ) {
@@ -93,7 +93,7 @@ public final class MongoDBSourceBuilder {
      * @param clientSupplier a function that creates MongoDB client
      */
     @Nonnull
-    public static MongoDBSourceBuilder.Stream<Document> stream(
+    public static MongoSourceBuilder.Stream<Document> stream(
             @Nonnull String name,
             @Nonnull SupplierEx<? extends MongoClient> clientSupplier
     ) {

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSources.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSources.java
@@ -17,8 +17,8 @@
 package com.hazelcast.jet.mongodb;
 
 import com.hazelcast.function.SupplierEx;
-import com.hazelcast.jet.mongodb.MongoDBSourceBuilder.Batch;
-import com.hazelcast.jet.mongodb.MongoDBSourceBuilder.Stream;
+import com.hazelcast.jet.mongodb.MongoSourceBuilder.Batch;
+import com.hazelcast.jet.mongodb.MongoSourceBuilder.Stream;
 import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.spi.annotation.Beta;
@@ -37,17 +37,17 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 /**
  * Contains factory methods for MongoDB sources.
  * <p>
- * See {@link MongoDBSourceBuilder} for creating custom MongoDB sources.
+ * See {@link MongoSourceBuilder} for creating custom MongoDB sources.
  *
  * @since 5.3
  */
-public final class MongoDBSources {
+public final class MongoSources {
 
-    private MongoDBSources() {
+    private MongoSources() {
     }
 
     /**
-     * Creates as builder for new batch mongo source. Equivalent to calling {@link MongoDBSourceBuilder#batch}.
+     * Creates as builder for new batch mongo source. Equivalent to calling {@link MongoSourceBuilder#batch}.
      * <p>
      * Example usage:
      * <pre>{@code
@@ -68,17 +68,17 @@ public final class MongoDBSources {
      */
     @Beta
     @Nonnull
-    public static MongoDBSourceBuilder.Batch<Document> batch(
+    public static MongoSourceBuilder.Batch<Document> batch(
             @Nonnull String name,
             @Nonnull SupplierEx<? extends MongoClient> clientSupplier) {
-        return MongoDBSourceBuilder.batch(name, clientSupplier);
+        return MongoSourceBuilder.batch(name, clientSupplier);
     }
 
     /**
      * Returns a MongoDB batch source which queries the collection using given
      * {@code filter} and applies the given {@code projection} on the documents.
      * <p>
-     * See {@link MongoDBSourceBuilder} for creating custom MongoDB sources.
+     * See {@link MongoSourceBuilder} for creating custom MongoDB sources.
      * <p>
      * Here's an example which queries documents in a collection having the
      * field {@code age} with a value greater than {@code 10} and applies a
@@ -119,7 +119,7 @@ public final class MongoDBSources {
             @Nullable Bson filter,
             @Nullable Bson projection
     ) {
-        Batch<Document> builder = MongoDBSourceBuilder
+        Batch<Document> builder = MongoSourceBuilder
                 .batch(name, () -> MongoClients.create(connectionString))
                 .database(database)
                 .collection(collection);
@@ -133,7 +133,7 @@ public final class MongoDBSources {
     }
 
     /**
-     * Creates as builder for new stream mongo source. Equivalent to calling {@link MongoDBSourceBuilder#stream}.
+     * Creates as builder for new stream mongo source. Equivalent to calling {@link MongoSourceBuilder#stream}.
      *
      * Example usage:
      * <pre>{@code
@@ -155,10 +155,10 @@ public final class MongoDBSources {
      */
     @Beta
     @Nonnull
-    public static MongoDBSourceBuilder.Stream<Document> stream(
+    public static MongoSourceBuilder.Stream<Document> stream(
             @Nonnull String name,
             @Nonnull SupplierEx<? extends MongoClient> clientSupplier) {
-        return MongoDBSourceBuilder.stream(name, clientSupplier);
+        return MongoSourceBuilder.stream(name, clientSupplier);
     }
 
     /**
@@ -172,7 +172,7 @@ public final class MongoDBSources {
      * encryption-at-rest feature. You cannot watch on system collections and
      * collections in admin, local and config databases.
      * <p>
-     * See {@link MongoDBSourceBuilder} for creating custom MongoDB sources.
+     * See {@link MongoSourceBuilder} for creating custom MongoDB sources.
      * <p>
      * Here's an example which streams inserts on a collection having the
      * field {@code age} with a value greater than {@code 10} and applies a
@@ -215,7 +215,7 @@ public final class MongoDBSources {
             @Nullable Document filter,
             @Nullable Document projection
     ) {
-        Stream<Document> builder = MongoDBSourceBuilder
+        Stream<Document> builder = MongoSourceBuilder
                 .stream(name, () -> MongoClients.create(connectionString))
                 .database(database)
                 .collection(collection)

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoConnection.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoConnection.java
@@ -31,7 +31,7 @@ import static com.hazelcast.jet.retry.IntervalFunction.exponentialBackoffWithCap
 /***
  * Manages connection to MongoDB, reconnects if necessary.
  */
-class MongoDbConnection {
+class MongoConnection {
     @SuppressWarnings("checkstyle:MagicNumber")
     private static final RetryStrategy RETRY_STRATEGY =
             RetryStrategies.custom()
@@ -42,11 +42,11 @@ class MongoDbConnection {
     private final SupplierEx<? extends MongoClient> clientSupplier;
     private final ConsumerEx<MongoClient> afterConnection;
     private final RetryTracker connectionRetryTracker;
-    private final ILogger logger = Logger.getLogger(MongoDbConnection.class);
+    private final ILogger logger = Logger.getLogger(MongoConnection.class);
 
     private MongoClient mongoClient;
 
-    MongoDbConnection(SupplierEx<? extends MongoClient> clientSupplier, ConsumerEx<MongoClient> afterConnection) {
+    MongoConnection(SupplierEx<? extends MongoClient> clientSupplier, ConsumerEx<MongoClient> afterConnection) {
         this.clientSupplier = clientSupplier;
         this.afterConnection = afterConnection;
         this.connectionRetryTracker = new RetryTracker(RETRY_STRATEGY);

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
@@ -86,7 +86,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
 
     private boolean snapshotInProgress;
     private final MongoChunkedReader reader;
-    private final MongoDbConnection connection;
+    private final MongoConnection connection;
 
     private Traverser<?> traverser;
     private Traverser<Entry<BroadcastKey<Integer>, Object>> snapshotTraverser;
@@ -101,7 +101,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
             this.reader = new BatchMongoReader(params.databaseName, params.collectionName, params.mapItemFn,
                     params.aggregates);
         }
-        this.connection = new MongoDbConnection(params.clientSupplier, client -> reader.connect(client,
+        this.connection = new MongoConnection(params.clientSupplier, client -> reader.connect(client,
                 snapshotsEnabled));
     }
 

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/WriteMongoP.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/WriteMongoP.java
@@ -84,7 +84,7 @@ public class WriteMongoP<I> extends AbstractProcessor {
      */
     private static final int MAX_BATCH_SIZE = 2_000;
 
-    private final MongoDbConnection connection;
+    private final MongoConnection connection;
     private final Class<I> documentType;
     private ILogger logger;
 
@@ -105,7 +105,7 @@ public class WriteMongoP<I> extends AbstractProcessor {
      * Creates a new processor that will always insert to the same database and collection.
      */
     public WriteMongoP(WriteMongoParams<I> params) {
-        this.connection = new MongoDbConnection(params.clientSupplier, client -> {
+        this.connection = new MongoConnection(params.clientSupplier, client -> {
         });
         this.documentIdentityFn = params.documentIdentityFn;
         this.documentIdentityFieldName = params.documentIdentityFieldName;

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/AbstractMongoTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/AbstractMongoTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertEquals;
 
 import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 
-public abstract class AbstractMongoDBTest extends SimpleTestInClusterSupport {
+public abstract class AbstractMongoTest extends SimpleTestInClusterSupport {
     static final String TEST_MONGO_VERSION = System.getProperty("test.mongo.version", "6.0.3");
 
     static final String SOURCE_NAME = "source";

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSinkResilienceTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSinkResilienceTest.java
@@ -57,7 +57,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
-import static com.hazelcast.jet.mongodb.AbstractMongoDBTest.TEST_MONGO_VERSION;
+import static com.hazelcast.jet.mongodb.AbstractMongoTest.TEST_MONGO_VERSION;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
 import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static eu.rekawek.toxiproxy.model.ToxicDirection.DOWNSTREAM;
@@ -67,8 +67,8 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({NightlyTest.class})
-public class MongoDBSinkResilienceTest extends SimpleTestInClusterSupport {
-    private static final ILogger logger = Logger.getLogger(MongoDBSinkResilienceTest.class);
+public class MongoSinkResilienceTest extends SimpleTestInClusterSupport {
+    private static final ILogger logger = Logger.getLogger(MongoSinkResilienceTest.class);
 
     @Rule
     public Network network = Network.newNetwork();
@@ -127,10 +127,10 @@ public class MongoDBSinkResilienceTest extends SimpleTestInClusterSupport {
                         .append("key", doc.getKey())
                         .append("other", "" + doc.getValue())
                 ).setLocalParallelism(2)
-                .writeTo(MongoDBSinks.builder("mongoSink", Document.class, () -> mongoClient(connectionString))
-                                     .into(databaseName, collectionName)
-                                     .preferredLocalParallelism(2)
-                                     .build());
+                .writeTo(MongoSinks.builder("mongoSink", Document.class, () -> mongoClient(connectionString))
+                                   .into(databaseName, collectionName)
+                                   .preferredLocalParallelism(2)
+                                   .build());
 
         Job job = invokeJob(hz, pipeline);
         AtomicInteger totalCount = new AtomicInteger(0);
@@ -195,10 +195,10 @@ public class MongoDBSinkResilienceTest extends SimpleTestInClusterSupport {
                         .append("key", doc.getKey())
                         .append("value", doc.getValue())
                 ).setLocalParallelism(2)
-                .writeTo(MongoDBSinks.builder("mongoSink", Document.class, () -> mongoClient(connectionViaToxi))
-                                     .into(databaseName, collectionName)
-                                     .preferredLocalParallelism(2)
-                                     .build());
+                .writeTo(MongoSinks.builder("mongoSink", Document.class, () -> mongoClient(connectionViaToxi))
+                                   .into(databaseName, collectionName)
+                                   .preferredLocalParallelism(2)
+                                   .build());
 
         Job job = invokeJob(hz, pipeline);
         final AtomicBoolean continueCounting = new AtomicBoolean(true);

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSinkTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSinkTest.java
@@ -51,8 +51,8 @@ import java.util.Objects;
 import java.util.concurrent.CompletionException;
 
 import static com.hazelcast.core.EntryEventType.ADDED;
-import static com.hazelcast.jet.mongodb.MongoDBSinks.builder;
-import static com.hazelcast.jet.mongodb.MongoDBSinks.mongodb;
+import static com.hazelcast.jet.mongodb.MongoSinks.builder;
+import static com.hazelcast.jet.mongodb.MongoSinks.mongodb;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
 import static com.hazelcast.jet.pipeline.Sources.mapJournal;
 import static com.hazelcast.jet.pipeline.test.TestSources.items;
@@ -64,7 +64,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParametrizedRunner.class)
 @Category({QuickTest.class})
-public class MongoDBSinkTest extends AbstractMongoDBTest {
+public class MongoSinkTest extends AbstractMongoTest {
 
     private static final long COUNT = 4;
     private static final long HALF = COUNT / 2;
@@ -271,7 +271,7 @@ public class MongoDBSinkTest extends AbstractMongoDBTest {
     public void test_whenServerNotAvailable() {
         String defaultDatabase = defaultDatabase();
         String collectionName = testName.getMethodName();
-        Sink<Document> sink = MongoDBSinks
+        Sink<Document> sink = MongoSinks
                 .builder(SINK_NAME, Document.class, () -> mongoClient("non-existing-server", 0))
                 .into(defaultDatabase, collectionName)
                 .identifyDocumentBy("_id", (doc) -> doc.get("_id"))

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceResilienceTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceResilienceTest.java
@@ -60,7 +60,7 @@ import java.util.function.Consumer;
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
-import static com.hazelcast.jet.mongodb.AbstractMongoDBTest.TEST_MONGO_VERSION;
+import static com.hazelcast.jet.mongodb.AbstractMongoTest.TEST_MONGO_VERSION;
 import static com.hazelcast.jet.pipeline.Sinks.map;
 import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static eu.rekawek.toxiproxy.model.ToxicDirection.DOWNSTREAM;
@@ -70,8 +70,8 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({NightlyTest.class})
-public class MongoDBSourceResilienceTest extends SimpleTestInClusterSupport {
-    private static final ILogger logger = Logger.getLogger(MongoDBSourceResilienceTest.class);
+public class MongoSourceResilienceTest extends SimpleTestInClusterSupport {
+    private static final ILogger logger = Logger.getLogger(MongoSourceResilienceTest.class);
 
     @Rule
     public Network network = Network.newNetwork();
@@ -233,7 +233,7 @@ public class MongoDBSourceResilienceTest extends SimpleTestInClusterSupport {
     private static Pipeline buildIngestPipeline(String mongoContainerConnectionString, String sinkName,
                                                 String databaseName, String collectionName) {
         Pipeline pipeline = Pipeline.create();
-        pipeline.readFrom(MongoDBSourceBuilder
+        pipeline.readFrom(MongoSourceBuilder
                         .stream("mongo source", () -> mongoClient(mongoContainerConnectionString))
                         .database(databaseName)
                         .collection(collectionName)

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceTest.java
@@ -20,8 +20,8 @@ import com.google.common.collect.Sets;
 import com.hazelcast.collection.IList;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
-import com.hazelcast.jet.mongodb.MongoDBSourceBuilder.Batch;
-import com.hazelcast.jet.mongodb.MongoDBSourceBuilder.Stream;
+import com.hazelcast.jet.mongodb.MongoSourceBuilder.Batch;
+import com.hazelcast.jet.mongodb.MongoSourceBuilder.Stream;
 import com.hazelcast.jet.mongodb.impl.Mappers;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
-import static com.hazelcast.jet.mongodb.MongoDBSources.batch;
+import static com.hazelcast.jet.mongodb.MongoSources.batch;
 import static com.hazelcast.jet.mongodb.impl.Mappers.streamToClass;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
@@ -60,7 +60,7 @@ import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParametrizedRunner.class)
 @Category({QuickTest.class})
-public class MongoDBSourceTest extends AbstractMongoDBTest {
+public class MongoSourceTest extends AbstractMongoTest {
 
     private static final int COUNT_IN_BATCH = 10;
     private static final int FILTERED_BOUND = 5;
@@ -179,7 +179,7 @@ public class MongoDBSourceTest extends AbstractMongoDBTest {
         String connectionString = mongoContainer.getConnectionString();
 
         Pipeline pipeline = Pipeline.create();
-        pipeline.readFrom(MongoDBSources.stream(SOURCE_NAME, connectionString, defaultDatabase(), methodName, null, null))
+        pipeline.readFrom(MongoSources.stream(SOURCE_NAME, connectionString, defaultDatabase(), methodName, null, null))
                 .withNativeTimestamps(0)
                 .setLocalParallelism(1)
                 .writeTo(Sinks.list(list));
@@ -200,9 +200,9 @@ public class MongoDBSourceTest extends AbstractMongoDBTest {
     public void testStreamOneCollection() {
         IList<Object> list = instance().getList(testName.getMethodName());
         String connectionString = mongoContainer.getConnectionString();
-        Stream<?> sourceBuilder = MongoDBSources.stream(SOURCE_NAME, () -> mongoClient(connectionString))
-                                                      .database(defaultDatabase())
-                                                      .collection(testName.getMethodName(), Document.class);
+        Stream<?> sourceBuilder = MongoSources.stream(SOURCE_NAME, () -> mongoClient(connectionString))
+                                              .database(defaultDatabase())
+                                              .collection(testName.getMethodName(), Document.class);
         sourceBuilder = streamFilters(sourceBuilder);
 
         Pipeline pipeline = Pipeline.create();
@@ -232,7 +232,7 @@ public class MongoDBSourceTest extends AbstractMongoDBTest {
 
         String connectionString = mongoContainer.getConnectionString();
 
-        Stream<?> builder = MongoDBSourceBuilder
+        Stream<?> builder = MongoSourceBuilder
                 .stream(SOURCE_NAME, () -> MongoClients.create(connectionString))
                 .database(defaultDatabase());
         builder = streamFilters(builder);
@@ -272,7 +272,7 @@ public class MongoDBSourceTest extends AbstractMongoDBTest {
 
         String connectionString = mongoContainer.getConnectionString();
 
-        Stream<?> builder = MongoDBSourceBuilder.stream(SOURCE_NAME, () -> MongoClients.create(connectionString));
+        Stream<?> builder = MongoSourceBuilder.stream(SOURCE_NAME, () -> MongoClients.create(connectionString));
         builder = streamFilters(builder);
 
         Pipeline pipeline = Pipeline.create();

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceVariousIdTypesTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceVariousIdTypesTest.java
@@ -33,12 +33,12 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
-import static com.hazelcast.jet.mongodb.MongoDBSources.batch;
+import static com.hazelcast.jet.mongodb.MongoSources.batch;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParametrizedRunner.class)
 @Category({QuickTest.class})
-public class MongoDBSourceVariousIdTypesTest extends AbstractMongoDBTest {
+public class MongoSourceVariousIdTypesTest extends AbstractMongoTest {
 
     @Parameter(0)
     public Object id1;

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourcesWindowedTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourcesWindowedTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class})
-public class MongoDBSourcesWindowedTest extends AbstractMongoDBTest {
+public class MongoSourcesWindowedTest extends AbstractMongoTest {
 
     @BeforeClass
     public static void beforeClass() {
@@ -50,10 +50,10 @@ public class MongoDBSourcesWindowedTest extends AbstractMongoDBTest {
 
     @Test
     public void testWindows() {
-        StreamSource<? extends Document> streamSource = MongoDBSources.stream("src", mongoContainer.getConnectionString(),
+        StreamSource<? extends Document> streamSource = MongoSources.stream("src", mongoContainer.getConnectionString(),
                 defaultDatabase(), testName.getMethodName(),
                 null, null)
-                .setPartitionIdleTimeout(1000);
+                                                                    .setPartitionIdleTimeout(1000);
 
         IList<WindowResult<Long>> result = instance().getList("result");
 


### PR DESCRIPTION
Simple change of MongoDB* class prefix to Mongo* for better clarity.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
