### PR TITLE
Add HazelcastDataLink and support it in remoteMapJournal [HZ-1433]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/datalink/HazelcastDataLink.java
+++ b/hazelcast/src/main/java/com/hazelcast/datalink/HazelcastDataLink.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.datalink;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.config.DataLinkConfig;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.map.IMap;
+import com.hazelcast.spi.annotation.Beta;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static com.hazelcast.jet.impl.util.ImdgUtil.asClientConfig;
+import static com.hazelcast.jet.impl.util.ImdgUtil.asClientConfigFromYaml;
+
+/**
+ * Creates a HazelcastInstance that is shared to connect to a remote cluster.
+ * <p>
+ * Set the client XML as property using {@link HazelcastDataLink#CLIENT_XML} as property key or
+ * Set the client YAML as property using {@link HazelcastDataLink#CLIENT_YML} as property key
+ *
+ * @since 5.3
+ */
+@Beta
+public class HazelcastDataLink extends DataLinkBase implements DataLink {
+
+    /**
+     * The constant to be used as property key for XML
+     */
+    public static final String CLIENT_XML = "client_xml";
+
+    /**
+     * The constant to be used as property key for YAML
+     */
+    public static final String CLIENT_YML = "client_yml";
+
+    private final ClientConfig clientConfig;
+
+    /**
+     * The cached client instance
+     */
+    private volatile HazelcastClientProxy proxy;
+
+    public HazelcastDataLink(@Nonnull DataLinkConfig dataLinkConfig) {
+        super(dataLinkConfig);
+        this.clientConfig = buildClientConfig();
+
+        if (dataLinkConfig.isShared()) {
+            HazelcastClientProxy proxy = (HazelcastClientProxy) HazelcastClient.newHazelcastClient(clientConfig);
+            this.proxy = new HazelcastClientProxy(proxy.client) {
+                @Override
+                public void shutdown() {
+                    release();
+                }
+            };
+        }
+    }
+
+    private ClientConfig buildClientConfig() {
+        ClientConfig clientConfig = null;
+        String clientXml = getConfig().getProperty(CLIENT_XML);
+        if (!StringUtil.isNullOrEmpty(clientXml)) {
+            // Read ClientConfig from XML
+            clientConfig = asClientConfig(clientXml);
+        }
+
+        String clientYaml = getConfig().getProperty(CLIENT_YML);
+        if (!StringUtil.isNullOrEmpty(clientYaml)) {
+            // Read ClientConfig from Yaml
+            clientConfig = asClientConfigFromYaml(clientYaml);
+        }
+
+        if (clientConfig == null) {
+            throw new HazelcastException("HazelcastDataLink with name '" + getConfig().getName()
+                    + "' could not be created, provide either client_xml or client_yml property "
+                    + "with the client configuration.");
+        }
+        return clientConfig;
+    }
+
+    @Nonnull
+    @Override
+    public Collection<DataLinkResource> listResources() {
+        HazelcastInstance instance = getClient();
+        try {
+            return instance.getDistributedObjects()
+                           .stream()
+                           .filter(o -> o instanceof IMap)
+                           .map(o -> new DataLinkResource("IMap", o.getName()))
+                           .collect(Collectors.toList());
+        } finally {
+            instance.shutdown();
+        }
+    }
+
+    /**
+     * Return a client {@link HazelcastInstance} based on this DataLink configuration.
+     * <p>
+     * Depending on the {@link DataLinkConfig#isShared()} config the HazelcastInstance is
+     * - shared=true -> a single instance is created
+     * - shared=false -> a new instance is created each time the method is called
+     * <p>
+     * The caller must call `shutdown` on the instance when finished to allow correct
+     * release of the underlying resources. In case of a shared instance, the instance
+     * is shut down when all users call the shutdown method and this DataLink is released.
+     * In case of a non-shared instance, the instance is shutdown immediately
+     * when the shutdown method is called.
+     */
+    @Nonnull
+    public HazelcastInstance getClient() {
+        if (getConfig().isShared()) {
+            retain();
+            return proxy;
+        } else {
+            return HazelcastClient.newHazelcastClient(clientConfig);
+        }
+    }
+
+    @Override
+    public synchronized void destroy() {
+        if (proxy != null) {
+            // the proxy has overridden shutdown method, need to close real client
+            proxy.client.shutdown();
+            proxy = null;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/datalink/impl/HazelcastDataLinkRegistration.java
+++ b/hazelcast/src/main/java/com/hazelcast/datalink/impl/HazelcastDataLinkRegistration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.datalink.impl;
+
+import com.hazelcast.datalink.DataLink;
+import com.hazelcast.datalink.DataLinkRegistration;
+import com.hazelcast.datalink.HazelcastDataLink;
+
+/**
+ * Registration for {@link HazelcastDataLink}
+ */
+public class HazelcastDataLinkRegistration implements DataLinkRegistration {
+
+    @Override
+    public String type() {
+        return "HZ";
+    }
+
+    @Override
+    public Class<? extends DataLink> clazz() {
+        return HazelcastDataLink.class;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -196,7 +196,7 @@ public final class SourceProcessors {
     ) {
         String clientXml = asXmlString(clientConfig);
         return StreamEventJournalP.streamRemoteMapSupplier(
-                mapName, clientXml, predicateFn, projectionFn, initialPos, eventTimePolicy);
+                mapName, null, clientXml, predicateFn, projectionFn, initialPos, eventTimePolicy);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
@@ -391,12 +391,12 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
 
         @Override
         public int preferredLocalParallelism() {
-            return dataLinkName != null || clientXml != null ? 1 : 2;
+            return isRemote(dataLinkName, clientXml) ? 1 : 2;
         }
 
         @Override
         public void init(@Nonnull Context context) {
-            if (dataLinkName != null || clientXml != null) {
+            if (isRemote(dataLinkName, clientXml)) {
                 initRemote(context);
             } else {
                 PermissionsUtil.checkPermission(eventJournalReaderSupplier, context);
@@ -439,10 +439,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
 
         @Override
         public Permission getRequiredPermission() {
-            if (dataLinkName != null) {
-                return null;
-            }
-            if (clientXml != null) {
+            if (isRemote(dataLinkName, clientXml)) {
                 return null;
             }
             return permissionFn.get();
@@ -502,7 +499,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
 
             // The order is important.
             // If dataLinkConfig is specified prefer it to clientXml
-            if (dataLinkName != null || clientXml != null) {
+            if (isRemote(dataLinkName, clientXml)) {
                 client = createRemoteClient(context, dataLinkName, clientXml);
                 instance = client;
             }
@@ -555,6 +552,10 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         } else {
             return newHazelcastClient(asClientConfig(clientXml));
         }
+    }
+
+    private static boolean isRemote(String dataLinkName, String clientXml) {
+        return dataLinkName != null || clientXml != null;
     }
 
     public static <K, V, T> ProcessorMetaSupplier streamMapSupplier(

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
@@ -21,9 +21,9 @@ import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.datalink.HazelcastDataLink;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.PredicateEx;
-import com.hazelcast.security.impl.function.SecuredFunctions;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.internal.journal.EventJournalInitialSubscriberState;
@@ -48,6 +48,7 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.partition.Partition;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.security.PermissionsUtil;
+import com.hazelcast.security.impl.function.SecuredFunctions;
 import com.hazelcast.security.permission.CachePermission;
 import com.hazelcast.security.permission.MapPermission;
 
@@ -75,10 +76,10 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 import static com.hazelcast.jet.impl.util.ImdgUtil.asClientConfig;
 import static com.hazelcast.jet.impl.util.ImdgUtil.maybeUnwrapImdgFunction;
 import static com.hazelcast.jet.impl.util.ImdgUtil.maybeUnwrapImdgPredicate;
-import static com.hazelcast.jet.impl.util.Util.distributeObjects;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFinest;
 import static com.hazelcast.jet.impl.util.Util.arrayIndexOf;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
+import static com.hazelcast.jet.impl.util.Util.distributeObjects;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_CURRENT;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
@@ -349,6 +350,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         static final long serialVersionUID = 1L;
 
         private final String clientXml;
+        private final String dataLinkName;
         private final FunctionEx<? super HazelcastInstance, ? extends EventJournalReader<E>>
                 eventJournalReaderSupplier;
         private final PredicateEx<? super E> predicate;
@@ -358,9 +360,13 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         private final SupplierEx<Permission> permissionFn;
 
         private transient int remotePartitionCount;
+
+        //Key : Address of the local or remote member
+        //Value : List of partitions ids on this member
         private transient Map<Address, List<Integer>> addrToPartitions;
 
         ClusterMetaSupplier(
+                @Nullable String dataLinkName,
                 @Nullable String clientXml,
                 @Nonnull FunctionEx<? super HazelcastInstance, ? extends EventJournalReader<E>>
                         eventJournalReaderSupplier,
@@ -369,7 +375,11 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
                 @Nonnull JournalInitialPosition initialPos,
                 @Nonnull EventTimePolicy<? super T> eventTimePolicy,
                 @Nonnull SupplierEx<Permission> permissionFn
-                ) {
+        ) {
+            if (dataLinkName != null && clientXml != null) {
+                throw new IllegalArgumentException("Only one of dataLinkName or clientXml should be provided");
+            }
+            this.dataLinkName = dataLinkName;
             this.clientXml = clientXml;
             this.eventJournalReaderSupplier = eventJournalReaderSupplier;
             this.predicate = predicate;
@@ -381,21 +391,21 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
 
         @Override
         public int preferredLocalParallelism() {
-            return clientXml != null ? 1 : 2;
+            return dataLinkName != null || clientXml != null ? 1 : 2;
         }
 
         @Override
         public void init(@Nonnull Context context) {
-            if (clientXml != null) {
-                initRemote();
+            if (dataLinkName != null || clientXml != null) {
+                initRemote(context);
             } else {
                 PermissionsUtil.checkPermission(eventJournalReaderSupplier, context);
                 initLocal(context.hazelcastInstance().getPartitionService().getPartitions());
             }
         }
 
-        private void initRemote() {
-            HazelcastInstance client = newHazelcastClient(asClientConfig(clientXml));
+        private void initRemote(Context context) {
+            HazelcastInstance client = createRemoteClient(context, dataLinkName, clientXml);
             try {
                 HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
                 remotePartitionCount = clientProxy.client.getClientPartitionService().getPartitionCount();
@@ -413,20 +423,25 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         @Override
         @Nonnull
         public Function<Address, ProcessorSupplier> get(@Nonnull List<Address> addresses) {
+            // If addrToPartitions is null it means that we are connecting to remote cluster
             if (addrToPartitions == null) {
-                // assign each remote partition to a member
+                // assign each remote partition id to a local member address
                 addrToPartitions = range(0, remotePartitionCount)
                         .boxed()
                         .collect(groupingBy(partition -> addresses.get(partition % addresses.size())));
             }
 
+            // Return a new factory per member owning the given partitions
             return address -> new ClusterProcessorSupplier<>(addrToPartitions.get(address),
-                    clientXml, eventJournalReaderSupplier, predicate, projection, initialPos,
+                    dataLinkName, clientXml, eventJournalReaderSupplier, predicate, projection, initialPos,
                     eventTimePolicy);
         }
 
         @Override
         public Permission getRequiredPermission() {
+            if (dataLinkName != null) {
+                return null;
+            }
             if (clientXml != null) {
                 return null;
             }
@@ -440,6 +455,8 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
 
         @Nonnull
         private final List<Integer> ownedPartitions;
+        @Nullable
+        private final String dataLinkName;
         @Nullable
         private final String clientXml;
         @Nonnull
@@ -459,6 +476,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
 
         ClusterProcessorSupplier(
                 @Nonnull List<Integer> ownedPartitions,
+                @Nullable String dataLinkName,
                 @Nullable String clientXml,
                 @Nonnull FunctionEx<? super HazelcastInstance, ? extends EventJournalReader<E>>
                         eventJournalReaderSupplier,
@@ -468,6 +486,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
                 @Nonnull EventTimePolicy<? super T> eventTimePolicy
         ) {
             this.ownedPartitions = ownedPartitions;
+            this.dataLinkName = dataLinkName;
             this.clientXml = clientXml;
             this.eventJournalReaderSupplier = eventJournalReaderSupplier;
             this.predicate = predicate;
@@ -478,16 +497,26 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
 
         @Override
         public void init(@Nonnull Context context) {
+            // Default is HazelcastInstance for member
             HazelcastInstance instance = context.hazelcastInstance();
-            if (clientXml != null) {
-                client = newHazelcastClient(asClientConfig(clientXml));
+
+            // The order is important.
+            // If dataLinkConfig is specified prefer it to clientXml
+            if (dataLinkName != null || clientXml != null) {
+                client = createRemoteClient(context, dataLinkName, clientXml);
                 instance = client;
             }
+            // Create a new EventJournalReader
+            // The eventJournalReaderSupplier is using the Hazelcast client to create an EventJournalReader
+            // Hazelcast client is thread safe.
+            // So we can create EventJournalReader in a thread-safe manner
             eventJournalReader = eventJournalReaderSupplier.apply(instance);
         }
 
         @Override
         public void close(Throwable error) {
+            // In the processor factory, if client is not null
+            // we need to shut it down
             if (client != null) {
                 client.shutdown();
             }
@@ -510,7 +539,24 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         }
     }
 
-    @SuppressWarnings("unchecked")
+    private static HazelcastInstance createRemoteClient(
+            ProcessorMetaSupplier.Context context, String dataLinkName, String clientXml) {
+        // The order is important.
+        // If dataLinkConfig is specified prefer it to clientXml
+        if (dataLinkName != null) {
+            HazelcastDataLink hazelcastDataLink = context
+                    .dataLinkService()
+                    .getAndRetainDataLink(dataLinkName, HazelcastDataLink.class);
+            try {
+                return hazelcastDataLink.getClient();
+            } finally {
+                hazelcastDataLink.release();
+            }
+        } else {
+            return newHazelcastClient(asClientConfig(clientXml));
+        }
+    }
+
     public static <K, V, T> ProcessorMetaSupplier streamMapSupplier(
             @Nonnull String mapName,
             @Nonnull PredicateEx<? super EventJournalMapEvent<K, V>> predicate,
@@ -521,16 +567,16 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         checkSerializable(predicate, "predicate");
         checkSerializable(projection, "projection");
 
-        return new ClusterMetaSupplier<>(null,
+        return new ClusterMetaSupplier<>(null, null,
                 SecuredFunctions.mapEventJournalReaderFn(mapName),
                 predicate, projection, initialPos, eventTimePolicy,
                 () -> new MapPermission(mapName, ACTION_CREATE, ACTION_READ));
     }
 
-    @SuppressWarnings("unchecked")
     public static <K, V, T> ProcessorMetaSupplier streamRemoteMapSupplier(
             @Nonnull String mapName,
-            @Nonnull String clientXml,
+            @Nullable String dataLinkName,
+            @Nullable String clientXml,
             @Nonnull PredicateEx<? super EventJournalMapEvent<K, V>> predicate,
             @Nonnull FunctionEx<? super EventJournalMapEvent<K, V>, ? extends T> projection,
             @Nonnull JournalInitialPosition initialPos,
@@ -538,13 +584,12 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         checkSerializable(predicate, "predicate");
         checkSerializable(projection, "projection");
 
-        return new ClusterMetaSupplier<>(clientXml,
+        return new ClusterMetaSupplier<>(dataLinkName, clientXml,
                 SecuredFunctions.mapEventJournalReaderFn(mapName),
                 predicate, projection, initialPos, eventTimePolicy,
                 () -> new MapPermission(mapName, ACTION_CREATE, ACTION_READ));
     }
 
-    @SuppressWarnings("unchecked")
     public static <K, V, T> ProcessorMetaSupplier streamCacheSupplier(
             @Nonnull String cacheName,
             @Nonnull PredicateEx<? super EventJournalCacheEvent<K, V>> predicate,
@@ -554,13 +599,16 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         checkSerializable(predicate, "predicate");
         checkSerializable(projection, "projection");
 
-        return new ClusterMetaSupplier<>(null,
+        return new ClusterMetaSupplier<>(null, null,
                 SecuredFunctions.cacheEventJournalReaderFn(cacheName),
                 predicate, projection, initialPos, eventTimePolicy,
                 () -> new CachePermission(cacheName, ACTION_CREATE, ACTION_READ));
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * ProcessorMetaSupplier for CacheJournal that uses the given XML to access remote cluster
+     */
+    // remoteCacheJournal processor that uses the given clientXml
     public static <K, V, T> ProcessorMetaSupplier streamRemoteCacheSupplier(
             @Nonnull String cacheName,
             @Nonnull String clientXml,
@@ -571,7 +619,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         checkSerializable(predicate, "predicate");
         checkSerializable(projection, "projection");
 
-        return new ClusterMetaSupplier<>(clientXml,
+        return new ClusterMetaSupplier<>(null, clientXml,
                 SecuredFunctions.cacheEventJournalReaderFn(cacheName),
                 predicate, projection, initialPos, eventTimePolicy,
                 () -> new CachePermission(cacheName, ACTION_CREATE, ACTION_READ));

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ImdgUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ImdgUtil.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.util;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientConfigXmlGenerator;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.config.YamlClientConfigBuilder;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.core.HazelcastInstance;
@@ -87,6 +88,15 @@ public final class ImdgUtil {
     public static ClientConfig asClientConfig(String xml) {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
         return new XmlClientConfigBuilder(inputStream).build();
+    }
+
+    /**
+     * Converts client-config yaml string to {@link ClientConfig} using {@link
+     * YamlClientConfigBuilder}.
+     */
+    public static ClientConfig asClientConfigFromYaml(String yaml) {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+        return new YamlClientConfigBuilder(inputStream).build();
     }
 
     public static <T> PredicateEx<T> wrapImdgPredicate(Predicate<T> predicate) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.collection.IList;
 import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.datalink.HazelcastDataLink;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.PredicateEx;
 import com.hazelcast.function.SupplierEx;
@@ -656,7 +657,75 @@ public final class Sources {
         String clientXml = asXmlString(clientConfig);
         return streamFromProcessorWithWatermarks("remoteMapJournalSource(" + mapName + ')',
                 false, w -> StreamEventJournalP.streamRemoteMapSupplier(
-                        mapName, clientXml, predicateFn, projectionFn, initialPos, w));
+                        mapName, null, clientXml, predicateFn, projectionFn, initialPos, w));
+    }
+
+    /**
+     * The same as the {@link #remoteMapJournal(String, ClientConfig, JournalInitialPosition, FunctionEx, PredicateEx)}
+     * method. The only difference is instead of a ClientConfig parameter that
+     * is used to connect to remote cluster, this method receives a
+     * DataLinkConfig.
+     * <p>
+     * The DataLinkConfig caches the connection to remote cluster, so that it
+     * can be re-used
+     * <p>
+     * (Prerequisite) External dataLink configuration:
+     * Use {@link HazelcastDataLink#CLIENT_XML} for XML or
+     * use {@link HazelcastDataLink#CLIENT_YML} for YAML string.
+     * <pre>{@code
+     * Config config = ...;
+     * String xmlString = ...;
+     * DataLinkConfig dataLinkConfig = new DataLinkConfig()
+     *     .setName("my-hzclient-datalink")
+     *     .setClassName(HzClientDataLinkFactory.class.getName())
+     *     .setProperty(HzClientDataLinkFactory.CLIENT_XML, xmlString);
+     * config.addDataLinkConfig(dataLinkConfig);
+     *  }</pre>
+     * <p>
+     * Pipeline configuration
+     * <pre>{@code
+     * PredicateEx<EventJournalMapEvent<String, Integer>> predicate = ...;
+     * p.readFrom(Sources.remoteMapJournal(
+     *     mapName,
+     *     DataLinkRef.dataLinkRef("my-hzclient-datalink"),
+     *     JournalInitialPosition.START_FROM_OLDEST,
+     *     EventJournalMapEvent::getNewValue,
+     *     predicate
+     *  ));
+     *  }</pre>
+     *
+     * @param mapName the name of the map
+     * @param dataLinkRef the reference to DataLinkConfig
+     * @param initialPos describes which event to start receiving from
+     * @param projectionFn the projection to map the events. If the projection returns a {@code
+     *                      null} for an item, that item will be filtered out. You may use {@link
+     *                      Util#mapEventToEntry()} to extract just the key and
+     *                      the new value. It must be stateless and {@linkplain
+     *                      Processor#isCooperative() cooperative}.
+     * @param predicateFn the predicate to filter the events. If you want to specify just the
+     *                      projection, use {@link Util#mapPutEvents} to pass
+     *                      only {@link EntryEventType#ADDED ADDED} and
+     *                      {@link EntryEventType#UPDATED UPDATED} events. It must be stateless and
+     *                      {@linkplain Processor#isCooperative() cooperative}.
+     * @param <T> is the return type of the stream
+     * @param <K> is the key type of EventJournalMapEvent
+     * @param <V> is the vale type of EventJournalMapEvent
+     * @return a stream that can be used as a source
+     * @since 5.3
+     */
+    @Nonnull
+    @Beta
+    public static <T, K, V> StreamSource<T> remoteMapJournal(
+            @Nonnull String mapName,
+            @Nonnull DataLinkRef dataLinkRef,
+            @Nonnull JournalInitialPosition initialPos,
+            @Nonnull FunctionEx<? super EventJournalMapEvent<K, V>, ? extends T> projectionFn,
+            @Nonnull PredicateEx<? super EventJournalMapEvent<K, V>> predicateFn
+    ) {
+        return streamFromProcessorWithWatermarks("remoteMapJournalSource(" + mapName + ')',
+                false,
+                w -> StreamEventJournalP.streamRemoteMapSupplier(
+                        mapName, dataLinkRef.getName(), null, predicateFn, projectionFn, initialPos, w));
     }
 
     /**
@@ -672,6 +741,23 @@ public final class Sources {
             @Nonnull JournalInitialPosition initialPos
     ) {
         return remoteMapJournal(mapName, clientConfig, initialPos, mapEventToEntry(), mapPutEvents());
+    }
+
+    /**
+     * Convenience for {@link #remoteMapJournal(String, DataLinkRef, JournalInitialPosition, FunctionEx, PredicateEx)}
+     * which will pass only {@link EntryEventType#ADDED ADDED}
+     * and {@link EntryEventType#UPDATED UPDATED} events and will
+     * project the event's key and new value into a {@code Map.Entry}.
+     * @since 5.3
+     */
+    @Nonnull
+    @Beta
+    public static <K, V> StreamSource<Entry<K, V>> remoteMapJournal(
+            @Nonnull String mapName,
+            @Nonnull DataLinkRef dataLinkRef,
+            @Nonnull JournalInitialPosition initialPos
+    ) {
+        return remoteMapJournal(mapName, dataLinkRef, initialPos, mapEventToEntry(), mapPutEvents());
     }
 
     /**

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.datalink.DataLinkRegistration
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.datalink.DataLinkRegistration
@@ -15,3 +15,4 @@
 #
 
 com.hazelcast.datalink.impl.JdbcDataLinkRegistration
+com.hazelcast.datalink.impl.HazelcastDataLinkRegistration

--- a/hazelcast/src/test/java/com/hazelcast/datalink/HazelcastDataLinkTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datalink/HazelcastDataLinkTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.datalink;
+
+import com.hazelcast.config.DataLinkConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Collection;
+
+import static java.nio.file.Files.readAllBytes;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class HazelcastDataLinkTest extends HazelcastTestSupport {
+
+    private static HazelcastInstance instance;
+    private HazelcastDataLink hazelcastDataLink;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        instance = Hazelcast.newHazelcastInstance();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        if (instance != null) {
+            instance.shutdown();
+            instance = null;
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (hazelcastDataLink != null) {
+            hazelcastDataLink.release();
+        }
+    }
+
+    @Test
+    public void list_resources_should_return_map() throws Exception {
+        IMap<Integer, String> map = instance.getMap("my_map");
+        map.put(42, "42");
+
+        DataLinkConfig dataLinkConfig = sharedDataLinkConfig();
+
+        hazelcastDataLink = new HazelcastDataLink(dataLinkConfig);
+        Collection<DataLinkResource> resources = hazelcastDataLink.listResources();
+
+        assertThat(resources).contains(new DataLinkResource("IMap", "my_map"));
+    }
+
+    @Test
+    public void list_resources_should_not_return_system_maps() throws Exception {
+        DataLinkConfig dataLinkConfig = sharedDataLinkConfig();
+
+        hazelcastDataLink = new HazelcastDataLink(dataLinkConfig);
+        Collection<DataLinkResource> resources = hazelcastDataLink.listResources();
+
+        assertThat(resources).isEmpty();
+    }
+
+    @Test
+    public void should_throw_with_missing_config() {
+        DataLinkConfig dataLinkConfig = new DataLinkConfig("data-link-name")
+                .setClassName(HazelcastDataLink.class.getName())
+                .setShared(true);
+
+        assertThatThrownBy(() -> hazelcastDataLink = new HazelcastDataLink(dataLinkConfig))
+                .isInstanceOf(HazelcastException.class)
+                .hasMessage("HazelcastDataLink with name 'data-link-name' "
+                        + "could not be created, provide either client_xml or client_yml property "
+                        + "with the client configuration.");
+    }
+
+    @Test
+    public void shared_client_should_return_same_instance() {
+        DataLinkConfig dataLinkConfig = sharedDataLinkConfig();
+        hazelcastDataLink = new HazelcastDataLink(dataLinkConfig);
+        HazelcastInstance c1 = hazelcastDataLink.getClient();
+        HazelcastInstance c2 = hazelcastDataLink.getClient();
+
+        try {
+            assertThat(c1).isSameAs(c2);
+        } finally {
+            c1.shutdown();
+            c2.shutdown();
+        }
+    }
+
+    @Test
+    public void non_shared_client_should_return_new_client_instance() {
+        DataLinkConfig dataLinkConfig = nonSharedDataLinkConfig();
+        hazelcastDataLink = new HazelcastDataLink(dataLinkConfig);
+        HazelcastInstance c1 = hazelcastDataLink.getClient();
+        HazelcastInstance c2 = hazelcastDataLink.getClient();
+
+        try {
+            assertThat(c1).isNotSameAs(c2);
+        } finally {
+            c1.shutdown();
+            c2.shutdown();
+        }
+    }
+
+    private static DataLinkConfig nonSharedDataLinkConfig() {
+        return sharedDataLinkConfig()
+                .setShared(false);
+    }
+    @Nonnull
+    private static DataLinkConfig sharedDataLinkConfig() {
+        DataLinkConfig dataLinkConfig = new DataLinkConfig("data-link-name")
+                .setClassName(HazelcastDataLink.class.getName())
+                .setShared(true);
+        try {
+            byte[] bytes = readAllBytes(Paths.get("src", "test", "resources", "hazelcast-client-test-external.xml"));
+            String xmlString = new String(bytes, StandardCharsets.UTF_8);
+            dataLinkConfig.setProperty(HazelcastDataLink.CLIENT_XML, xmlString);
+            return dataLinkConfig;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
@@ -22,7 +22,9 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.collection.IList;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.DataLinkConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.datalink.HazelcastDataLink;
 import com.hazelcast.function.PredicateEx;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.jet.Job;
@@ -35,8 +37,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -45,7 +50,9 @@ import java.util.stream.Stream;
 import static com.hazelcast.function.Functions.entryValue;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.Util.mapPutEvents;
+import static com.hazelcast.jet.pipeline.DataLinkRef.dataLinkRef;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
+import static java.nio.file.Files.readAllBytes;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -58,16 +65,42 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
     private static HazelcastInstance remoteHz;
     private static ClientConfig clientConfig;
 
+    private static final String HZ_CLIENT_EXTERNAL_REF = "hzclientexternalref";
+
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws IOException {
+        String clusterName = randomName();
+
         Config config = new Config();
-        config.setClusterName(randomName());
+        config.setClusterName(clusterName);
         config.addCacheConfig(new CacheSimpleConfig().setName("*"));
         config.getMapConfig(JOURNALED_MAP_PREFIX + '*').getEventJournalConfig().setEnabled(true);
         config.getCacheConfig(JOURNALED_CACHE_PREFIX + '*').getEventJournalConfig().setEnabled(true);
 
+        DataLinkConfig dataLinkConfig = new DataLinkConfig(HZ_CLIENT_EXTERNAL_REF);
+        dataLinkConfig.setClassName(HazelcastDataLink.class.getName());
+
+        // Read XML and set as DataLinkConfig
+        String xmlString = readClusterConfig("hazelcast-client-test-external.xml", clusterName);
+        dataLinkConfig.setProperty(HazelcastDataLink.CLIENT_XML, xmlString);
+
+        // Read YAML and set as DataLinkConfig
+        String yamlString = readClusterConfig("hazelcast-client-test-external.yaml", clusterName);
+        dataLinkConfig.setProperty(HazelcastDataLink.CLIENT_YML, yamlString);
+
         remoteHz = createRemoteCluster(config, 2).get(0);
         clientConfig = getClientConfigForRemoteCluster(remoteHz);
+
+        for (HazelcastInstance hazelcastInstance : allHazelcastInstances()) {
+            Config hazelcastInstanceConfig = hazelcastInstance.getConfig();
+            hazelcastInstanceConfig.addDataLinkConfig(dataLinkConfig);
+        }
+    }
+
+    private static String readClusterConfig(String file, String clusterName) throws IOException {
+        byte[] bytes = readAllBytes(Paths.get("src", "test", "resources", file));
+        return new String(bytes, StandardCharsets.UTF_8)
+                .replace("$CLUSTER_NAME$", clusterName);
     }
 
     @AfterClass
@@ -101,6 +134,7 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
         testMapJournal(map, source);
     }
 
+    // Test with ClientConfig
     @Test
     public void remoteMapJournal() {
         // Given
@@ -110,6 +144,42 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
         // When
         StreamSource<Entry<String, Integer>> source = Sources.remoteMapJournal(
                 mapName, clientConfig, START_FROM_OLDEST);
+
+        // Then
+        testMapJournal(map, source);
+    }
+
+    // Test remoteMapJournal() using default parameters with DataLinkRef
+    @Test
+    public void remoteMapJournal_withExternalConfig() {
+        // Given
+        String mapName = JOURNALED_MAP_PREFIX + randomName();
+        IMap<String, Integer> map = remoteHz.getMap(mapName);
+
+        // When
+        StreamSource<Entry<String, Integer>> source = Sources.remoteMapJournal(
+                mapName, dataLinkRef(HZ_CLIENT_EXTERNAL_REF), START_FROM_OLDEST);
+
+        // Then
+        testMapJournal(map, source);
+    }
+
+    // Test remoteMapJournal() using default parameters with DataLinkRef
+    @Test
+    public void remoteMapJournal_withExternalConfigYaml() {
+        for (HazelcastInstance hazelcastInstance : allHazelcastInstances()) {
+            Config config = hazelcastInstance.getConfig();
+            DataLinkConfig dataLinkConfig = config.getDataLinkConfig(HZ_CLIENT_EXTERNAL_REF);
+            // Make XML empty, so that we use yaml in the test
+            dataLinkConfig.setProperty(HazelcastDataLink.CLIENT_XML, "");
+        }
+        // Given
+        String mapName = JOURNALED_MAP_PREFIX + randomName();
+        IMap<String, Integer> map = remoteHz.getMap(mapName);
+
+        // When
+        StreamSource<Entry<String, Integer>> source = Sources.remoteMapJournal(
+                mapName, dataLinkRef(HZ_CLIENT_EXTERNAL_REF), START_FROM_OLDEST);
 
         // Then
         testMapJournal(map, source);
@@ -281,6 +351,7 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
         testMapJournal_withPredicateAndProjection(map, source);
     }
 
+    // Test with ClientConfig
     @Test
     public void remoteMapJournal_withPredicateAndProjectionFn() {
         // Given
@@ -291,6 +362,22 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
         // When
         StreamSource<Integer> source = Sources.remoteMapJournal(
                 mapName, clientConfig, START_FROM_OLDEST, EventJournalMapEvent::getNewValue, p);
+
+        // Then
+        testMapJournal_withPredicateAndProjection(map, source);
+    }
+
+    // Test remoteMapJournal() using all  parameters with DataLinkRef
+    @Test
+    public void remoteMapJournal_withExternalConfigPredicateAndProjectionFn() {
+        // Given
+        String mapName = JOURNALED_MAP_PREFIX + randomName();
+        IMap<String, Integer> map = remoteHz.getMap(mapName);
+        PredicateEx<EventJournalMapEvent<String, Integer>> p = e -> e.getNewValue() % 2 == 0;
+
+        // When
+        StreamSource<Integer> source = Sources.remoteMapJournal(
+                mapName, dataLinkRef(HZ_CLIENT_EXTERNAL_REF), START_FROM_OLDEST, EventJournalMapEvent::getNewValue, p);
 
         // Then
         testMapJournal_withPredicateAndProjection(map, source);
@@ -332,25 +419,26 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
         URL jarResource = Thread.currentThread().getContextClassLoader()
                                 .getResource("deployment/sample-pojo-1.0-car.jar");
         assertNotNull("jar not found", jarResource);
-        ClassLoader cl = new URLClassLoader(new URL[]{jarResource});
-        Class<?> carClz = cl.loadClass("com.sample.pojo.car.Car");
-        Object car = carClz.getConstructor(String.class, String.class)
-                                 .newInstance("make", "model");
-        IMap<String, Object> map = remoteHz.getMap(srcName);
-        // the class of the value is unknown to the remote IMDG member, it will be only known to Jet
-        map.put("key", car);
+        try (URLClassLoader cl = new URLClassLoader(new URL[]{jarResource})) {
+            Class<?> carClz = cl.loadClass("com.sample.pojo.car.Car");
+            Object car = carClz.getConstructor(String.class, String.class)
+                    .newInstance("make", "model");
+            IMap<String, Object> map = remoteHz.getMap(srcName);
+            // the class of the value is unknown to the remote IMDG member, it will be only known to Jet
+            map.put("key", car);
 
-        // When
-        StreamSource<Entry<Object, Object>> source = Sources.remoteMapJournal(srcName, clientConfig, START_FROM_OLDEST);
+            // When
+            StreamSource<Entry<Object, Object>> source = Sources.remoteMapJournal(srcName, clientConfig, START_FROM_OLDEST);
 
-        // Then
-        p.readFrom(source).withoutTimestamps().map(en -> en.getValue().toString()).writeTo(sink);
-        JobConfig jobConfig = new JobConfig();
-        jobConfig.addJar(jarResource);
-        Job job = hz().getJet().newJob(p, jobConfig);
-        List<Object> expected = singletonList(car.toString());
-        assertTrueEventually(() -> assertEquals(expected, new ArrayList<>(sinkList)), 10);
-        job.cancel();
+            // Then
+            p.readFrom(source).withoutTimestamps().map(en -> en.getValue().toString()).writeTo(sink);
+            JobConfig jobConfig = new JobConfig();
+            jobConfig.addJar(jarResource);
+            Job job = hz().getJet().newJob(p, jobConfig);
+            List<Object> expected = singletonList(car.toString());
+            assertTrueEventually(() -> assertEquals(expected, new ArrayList<>(sinkList)), 10);
+            job.cancel();
+        }
     }
 
     @Test
@@ -486,26 +574,27 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
         URL jarResource = Thread.currentThread().getContextClassLoader()
                                 .getResource("deployment/sample-pojo-1.0-car.jar");
         assertNotNull("jar not found", jarResource);
-        ClassLoader cl = new URLClassLoader(new URL[]{jarResource});
-        Class<?> carClz = cl.loadClass("com.sample.pojo.car.Car");
-        Object car = carClz.getConstructor(String.class, String.class)
-                                 .newInstance("make", "model");
-        String cacheName = JOURNALED_CACHE_PREFIX + randomName();
-        ICache<String, Object> cache = remoteHz.getCacheManager().getCache(cacheName);
-        // the class of the value is unknown to the remote IMDG member, it will be only known to Jet
-        cache.put("key", car);
+        try (URLClassLoader cl = new URLClassLoader(new URL[]{jarResource})) {
+            Class<?> carClz = cl.loadClass("com.sample.pojo.car.Car");
+            Object car = carClz.getConstructor(String.class, String.class)
+                    .newInstance("make", "model");
+            String cacheName = JOURNALED_CACHE_PREFIX + randomName();
+            ICache<String, Object> cache = remoteHz.getCacheManager().getCache(cacheName);
+            // the class of the value is unknown to the remote IMDG member, it will be only known to Jet
+            cache.put("key", car);
 
-        // When
-        StreamSource<Entry<Object, Object>> source =
-                Sources.remoteCacheJournal(cacheName, clientConfig, START_FROM_OLDEST);
+            // When
+            StreamSource<Entry<Object, Object>> source =
+                    Sources.remoteCacheJournal(cacheName, clientConfig, START_FROM_OLDEST);
 
-        // Then
-        p.readFrom(source).withoutTimestamps().map(en -> en.getValue().toString()).writeTo(sink);
-        JobConfig jobConfig = new JobConfig();
-        jobConfig.addJar(jarResource);
-        Job job = hz().getJet().newJob(p, jobConfig);
-        List<Object> expected = singletonList(car.toString());
-        assertTrueEventually(() -> assertEquals(expected, new ArrayList<>(sinkList)), 10);
-        job.cancel();
+            // Then
+            p.readFrom(source).withoutTimestamps().map(en -> en.getValue().toString()).writeTo(sink);
+            JobConfig jobConfig = new JobConfig();
+            jobConfig.addJar(jarResource);
+            Job job = hz().getJet().newJob(p, jobConfig);
+            List<Object> expected = singletonList(car.toString());
+            assertTrueEventually(() -> assertEquals(expected, new ArrayList<>(sinkList)), 10);
+            job.cancel();
+        }
     }
 }

--- a/hazelcast/src/test/resources/hazelcast-client-test-external.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-test-external.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.3.xsd">
+    <cluster-name>$CLUSTER_NAME$</cluster-name>
+    <network>
+        <cluster-members>
+            <address>127.0.0.1:5701</address>
+        </cluster-members>
+    </network>
+</hazelcast-client>

--- a/hazelcast/src/test/resources/hazelcast-client-test-external.yaml
+++ b/hazelcast/src/test/resources/hazelcast-client-test-external.yaml
@@ -1,0 +1,6 @@
+hazelcast-client:
+  cluster-name: $CLUSTER_NAME$
+  network:
+    cluster-members:
+      - 127.0.0.1:5701
+


### PR DESCRIPTION
When map journal of a remote cluster is used within a Jet job, each job instance on a member creates a new Hazelcast client instance.

This PR adds
- DataLink for remote Hazelcast client
- support for the DataLink in remoteMapJournal, allowing re-use of the Hazelcast client instance

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
