### PR TITLE
[ALTO] Minor NioAsyncSocket improvements

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocket.java
@@ -88,7 +88,7 @@ public final class NioAsyncSocket extends AsyncSocket {
             }
             this.writeThrough = builder.writeThrough;
             this.regularSchedule = builder.regularSchedule;
-            this.writeQueue = new MpmcArrayQueue<>(builder.unflushedBufsCapacity);
+            this.writeQueue = new MpmcArrayQueue<>(builder.writeQueueCapacity);
             this.handler = new Handler(builder);
             this.key = socketChannel.register(reactor.selector, 0, handler);
             this.readHandler = builder.readHandler;

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocket.java
@@ -53,7 +53,7 @@ public final class NioAsyncSocket extends AsyncSocket {
 
     private final NioAsyncSocketOptions options;
     private final AtomicReference<Thread> flushThread = new AtomicReference<>();
-    private final MpmcArrayQueue<IOBuffer> unflushedBufs;
+    private final MpmcArrayQueue<IOBuffer> writeQueue;
     private final Handler handler;
     private final SocketChannel socketChannel;
     private final NioReactor reactor;
@@ -88,7 +88,7 @@ public final class NioAsyncSocket extends AsyncSocket {
             }
             this.writeThrough = builder.writeThrough;
             this.regularSchedule = builder.regularSchedule;
-            this.unflushedBufs = new MpmcArrayQueue<>(builder.unflushedBufsCapacity);
+            this.writeQueue = new MpmcArrayQueue<>(builder.unflushedBufsCapacity);
             this.handler = new Handler(builder);
             this.key = socketChannel.register(reactor.selector, 0, handler);
             this.readHandler = builder.readHandler;
@@ -273,7 +273,7 @@ public final class NioAsyncSocket extends AsyncSocket {
     private void resetFlushed() {
         flushThread.set(null);
 
-        if (!unflushedBufs.isEmpty()) {
+        if (!writeQueue.isEmpty()) {
             if (flushThread.compareAndSet(null, Thread.currentThread())) {
                 reactor.offer(handler);
             }
@@ -282,12 +282,12 @@ public final class NioAsyncSocket extends AsyncSocket {
 
     @Override
     public boolean write(IOBuffer buf) {
-        return unflushedBufs.add(buf);
+        return writeQueue.add(buf);
     }
 
     @Override
     public boolean writeAll(Collection<IOBuffer> bufs) {
-        return unflushedBufs.addAll(bufs);
+        return writeQueue.addAll(bufs);
     }
 
     @Override
@@ -311,19 +311,19 @@ public final class NioAsyncSocket extends AsyncSocket {
                 if (ioVector.offer(buf)) {
                     result = true;
                 } else {
-                    result = unflushedBufs.offer(buf);
+                    result = writeQueue.offer(buf);
                 }
             } else {
-                result = unflushedBufs.offer(buf);
+                result = writeQueue.offer(buf);
             }
         } else if (currentFlushThread == eventloopThread) {
             if (ioVector.offer(buf)) {
                 result = true;
             } else {
-                result = unflushedBufs.offer(buf);
+                result = writeQueue.offer(buf);
             }
         } else {
-            result = unflushedBufs.offer(buf);
+            result = writeQueue.offer(buf);
             flush();
         }
         return result;
@@ -410,9 +410,15 @@ public final class NioAsyncSocket extends AsyncSocket {
 
             writeEvents.inc();
 
-            ioVector.populate(unflushedBufs);
+            ioVector.populate(writeQueue);
 
-            long written = ioVector.write(socketChannel);
+            ByteBuffer[] srcs = ioVector.array();
+            int length = ioVector.length();
+            long written = length == 1
+                    ? socketChannel.write(srcs[0])
+                    : socketChannel.write(srcs, 0, length);
+
+            ioVector.compact(written);
 
             bytesWritten.inc(written);
             //System.out.println(NioAsyncSocket.this + " bytes written:" + written);

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncSocketBuilder.java
@@ -34,7 +34,7 @@ import static com.hazelcast.internal.tpc.util.Preconditions.checkPositive;
  * A {@link AsyncSocketBuilder} specific to the {@link NioAsyncSocket}.
  */
 public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
-    static final int DEFAULT_UNFLUSHED_BUFS_CAPACITY = 2 << 16;
+    static final int DEFAULT_WRITE_QUEUE_CAPACITY = 2 << 16;
 
     final NioReactor reactor;
     final SocketChannel socketChannel;
@@ -43,7 +43,7 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
     boolean regularSchedule = true;
     boolean writeThrough;
     boolean receiveBufferIsDirect = true;
-    int unflushedBufsCapacity = DEFAULT_UNFLUSHED_BUFS_CAPACITY;
+    int writeQueueCapacity = DEFAULT_WRITE_QUEUE_CAPACITY;
     ReadHandler readHandler;
     NioAsyncSocketOptions options;
     private boolean build;
@@ -81,10 +81,10 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
         return this;
     }
 
-    public NioAsyncSocketBuilder setUnflushedBufsCapacity(int unflushedBufsCapacity) {
+    public NioAsyncSocketBuilder setWriteQueueCapacity(int writeQueueCapacity) {
         verifyNotBuild();
 
-        this.unflushedBufsCapacity = checkPositive(unflushedBufsCapacity, "unflushedBufsCapacity");
+        this.writeQueueCapacity = checkPositive(writeQueueCapacity, "writeQueueCapacity");
         return this;
     }
 

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioReactor.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioReactor.java
@@ -17,9 +17,6 @@
 package com.hazelcast.internal.tpc.nio;
 
 import com.hazelcast.internal.tpc.AcceptRequest;
-import com.hazelcast.internal.tpc.AsyncServerSocketBuilder;
-import com.hazelcast.internal.tpc.AsyncSocketBuilder;
-import com.hazelcast.internal.tpc.Eventloop;
 import com.hazelcast.internal.tpc.Reactor;
 import com.hazelcast.internal.tpc.ReactorBuilder;
 
@@ -44,14 +41,14 @@ public final class NioReactor extends Reactor {
     }
 
     @Override
-    public AsyncSocketBuilder newAsyncSocketBuilder() {
+    public NioAsyncSocketBuilder newAsyncSocketBuilder() {
         verifyRunning();
 
         return new NioAsyncSocketBuilder(this, null);
     }
 
     @Override
-    public AsyncSocketBuilder newAsyncSocketBuilder(AcceptRequest acceptRequest) {
+    public NioAsyncSocketBuilder newAsyncSocketBuilder(AcceptRequest acceptRequest) {
         verifyRunning();
 
         NioAcceptRequest nioAcceptRequest = checkInstanceOf(NioAcceptRequest.class, acceptRequest, "acceptRequest");
@@ -59,14 +56,14 @@ public final class NioReactor extends Reactor {
     }
 
     @Override
-    public AsyncServerSocketBuilder newAsyncServerSocketBuilder() {
+    public NioAsyncServerSocketBuilder newAsyncServerSocketBuilder() {
         verifyRunning();
 
         return new NioAsyncServerSocketBuilder(this);
     }
 
     @Override
-    protected Eventloop newEventloop(ReactorBuilder builder) {
+    protected NioEventloop newEventloop(ReactorBuilder builder) {
         return new NioEventloop(this, (NioReactorBuilder) builder);
     }
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncSocketBuilderTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncSocketBuilderTest.java
@@ -23,7 +23,9 @@ import com.hazelcast.internal.tpc.Reactor;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class NioAsyncSocketBuilderTest extends AsyncSocketBuilderTest {
 
@@ -41,7 +43,7 @@ public class NioAsyncSocketBuilderTest extends AsyncSocketBuilderTest {
     }
 
     @Test
-    public void test_setWriteQueueCapacity__whenZero() {
+    public void test_setWriteQueueCapacity_whenZero() {
         NioReactor reactor = (NioReactor) newReactor();
         NioAsyncSocketBuilder builder = reactor.newAsyncSocketBuilder();
 
@@ -49,13 +51,13 @@ public class NioAsyncSocketBuilderTest extends AsyncSocketBuilderTest {
     }
 
     @Test
-    public void test_setWriteQueueCapacity__whenAlreadyBuild() {
+    public void test_setWriteQueueCapacity_whenAlreadyBuild() {
         NioReactor reactor = (NioReactor) newReactor();
         NioAsyncSocketBuilder builder = reactor.newAsyncSocketBuilder();
         builder.setReadHandler(new DevNullReadHandler());
         AsyncSocket socket = builder.build();
 
-        assertThrows(IllegalStateException.class, builder::build);
+        assertThrows(IllegalStateException.class, ()->builder.setWriteQueueCapacity(1024));
     }
 
     @Test
@@ -65,5 +67,27 @@ public class NioAsyncSocketBuilderTest extends AsyncSocketBuilderTest {
         builder.setWriteQueueCapacity(16384);
 
         assertEquals(16384, builder.writeQueueCapacity);
+    }
+
+    @Test
+    public void test_setReceiveBufferIsDirect_whenAlreadyBuild() {
+        NioReactor reactor = (NioReactor) newReactor();
+        NioAsyncSocketBuilder builder = reactor.newAsyncSocketBuilder();
+        builder.setReadHandler(new DevNullReadHandler());
+        AsyncSocket socket = builder.build();
+
+        assertThrows(IllegalStateException.class, builder::build);
+    }
+
+    @Test
+    public void test_setReceiveBufferIsDirect() {
+        Reactor reactor = newReactor();
+        NioAsyncSocketBuilder builder = (NioAsyncSocketBuilder) reactor.newAsyncSocketBuilder();
+
+        builder.setReceiveBufferIsDirect(false);
+        assertFalse(builder.receiveBufferIsDirect);
+
+        builder.setReceiveBufferIsDirect(true);
+        assertTrue(builder.receiveBufferIsDirect);
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncSocketBuilderTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncSocketBuilderTest.java
@@ -57,7 +57,7 @@ public class NioAsyncSocketBuilderTest extends AsyncSocketBuilderTest {
         builder.setReadHandler(new DevNullReadHandler());
         AsyncSocket socket = builder.build();
 
-        assertThrows(IllegalStateException.class, ()->builder.setWriteQueueCapacity(1024));
+        assertThrows(IllegalStateException.class, () -> builder.setWriteQueueCapacity(1024));
     }
 
     @Test

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncSocketBuilderTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/nio/NioAsyncSocketBuilderTest.java
@@ -16,12 +16,54 @@
 
 package com.hazelcast.internal.tpc.nio;
 
+import com.hazelcast.internal.tpc.AsyncSocket;
 import com.hazelcast.internal.tpc.AsyncSocketBuilderTest;
-import com.hazelcast.internal.tpc.ReactorBuilder;
+import com.hazelcast.internal.tpc.DevNullReadHandler;
+import com.hazelcast.internal.tpc.Reactor;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class NioAsyncSocketBuilderTest extends AsyncSocketBuilderTest {
+
     @Override
-    public ReactorBuilder newReactorBuilder() {
+    public NioReactorBuilder newReactorBuilder() {
         return new NioReactorBuilder();
+    }
+
+    @Test
+    public void test_setWriteQueueCapacity_whenNegative() {
+        NioReactor reactor = (NioReactor) newReactor();
+        NioAsyncSocketBuilder builder = reactor.newAsyncSocketBuilder();
+
+        assertThrows(IllegalArgumentException.class, () -> builder.setWriteQueueCapacity(-1));
+    }
+
+    @Test
+    public void test_setWriteQueueCapacity__whenZero() {
+        NioReactor reactor = (NioReactor) newReactor();
+        NioAsyncSocketBuilder builder = reactor.newAsyncSocketBuilder();
+
+        assertThrows(IllegalArgumentException.class, () -> builder.setWriteQueueCapacity(0));
+    }
+
+    @Test
+    public void test_setWriteQueueCapacity__whenAlreadyBuild() {
+        NioReactor reactor = (NioReactor) newReactor();
+        NioAsyncSocketBuilder builder = reactor.newAsyncSocketBuilder();
+        builder.setReadHandler(new DevNullReadHandler());
+        AsyncSocket socket = builder.build();
+
+        assertThrows(IllegalStateException.class, builder::build);
+    }
+
+    @Test
+    public void test_setWriteQueueCapacity() {
+        Reactor reactor = newReactor();
+        NioAsyncSocketBuilder builder = (NioAsyncSocketBuilder) reactor.newAsyncSocketBuilder();
+        builder.setWriteQueueCapacity(16384);
+
+        assertEquals(16384, builder.writeQueueCapacity);
     }
 }


### PR DESCRIPTION
- Renamed the unflushedBufs to writeQueue.

- Simplified the IOVector: it can't write to the socket any longer. This is moved to the NioAsyncSocket. The reason behind this is that the primitive functions to access the IOVector and to compact, need to be exposed for SSL as well.
