### PR TITLE
Update testcontainers to 1.17.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <mockito.version>3.6.0</mockito.version>
         <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
-        <testcontainers.version>1.17.3</testcontainers.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
         <archunit.version>0.22.0</archunit.version>
         <errorprone.version>2.15.0</errorprone.version>
         <awaitility.version>4.1.1</awaitility.version>


### PR DESCRIPTION
Update testcontainers version from 1.17.3 to 1.17.6
The same version is currently in the master branch.

Fixes https://github.com/hazelcast/hazelcast/issues/23703

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible