### PR TITLE
Reduce number of keys in SqlOrderByTest [HZ-1697]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlOrderByTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlOrderByTest.java
@@ -663,7 +663,7 @@ public class SqlOrderByTest extends HazelcastTestSupport {
         ExecutorService executor = Executors.newFixedThreadPool(10);
 
         int threadsCount = 10;
-        int keysPerThread = serializationMode == SERIALIZABLE ? 2500 : 5000;
+        int keysPerThread = 2500;
         CountDownLatch latch = new CountDownLatch(threadsCount);
         AtomicReference<Throwable> exception = new AtomicReference<>();
 


### PR DESCRIPTION
Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/5346