### PR TITLE
[ALTO] Wait for connections to properly established in ClientAltoTests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/alto/ClientAltoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/alto/ClientAltoTest.java
@@ -73,7 +73,7 @@ public class ClientAltoTest extends ClientTestSupport {
         HazelcastInstance client = HazelcastClient.newHazelcastClient(getClientConfig());
 
         Collection<ClientConnection> connections = getConnectionManager(client).getActiveConnections();
-        assertEquals(2, connections.size());
+        assertTrueEventually(() -> assertEquals(2, connections.size()));
 
         assertClientConnectsAllAltoPortsEventually(connections, config.getAltoConfig().getEventloopCount());
     }
@@ -132,6 +132,7 @@ public class ClientAltoTest extends ClientTestSupport {
 
         ClientConnectionManager connectionManager = getConnectionManager(client);
         Collection<ClientConnection> connections = connectionManager.getActiveConnections();
+        assertTrueEventually(() -> assertEquals(2, connections.size()));
 
         assertClientConnectsAllAltoPortsEventually(connections, config.getAltoConfig().getEventloopCount());
 
@@ -313,7 +314,8 @@ public class ClientAltoTest extends ClientTestSupport {
 
         ClientConnectionManager connectionManager = getConnectionManager(client);
         Collection<ClientConnection> connections = connectionManager.getActiveConnections();
-        assertEquals(2, connections.size());
+        assertTrueEventually(() -> assertEquals(2, connections.size()));
+
         assertNoConnectionToAltoPortsAllTheTime(connections);
 
         map.put("42", "42");
@@ -331,7 +333,8 @@ public class ClientAltoTest extends ClientTestSupport {
 
         ClientConnectionManager connectionManager = getConnectionManager(client);
         Collection<ClientConnection> connections = connectionManager.getActiveConnections();
-        assertEquals(2, connections.size());
+        assertTrueEventually(() -> assertEquals(2, connections.size()));
+
         assertNoConnectionToAltoPortsAllTheTime(connections);
 
         map.put("42", "42");


### PR DESCRIPTION
This PR makes the assertions about the connection sizes to multi-member clusters eventually, so that the test can run correctly, even if the connection to one of the members is done later.

closes https://github.com/hazelcast/hazelcast/issues/23868
closes https://github.com/hazelcast/hazelcast/issues/23903
