### PR TITLE
[ALTO] Cleaned up AsyncSocket metrics

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncServerSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncServerSocket.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.internal.tpc;
 
-import com.hazelcast.internal.tpc.util.ProgressIndicator;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.SocketAddress;
@@ -29,21 +27,28 @@ import java.util.function.Consumer;
  */
 public abstract class AsyncServerSocket extends AbstractAsyncSocket {
 
-    protected final ProgressIndicator accepted = new ProgressIndicator();
+    protected final AsyncServerSocketMetrics metrics = new AsyncServerSocketMetrics();
 
     protected AsyncServerSocket() {
     }
 
-    public abstract AsyncSocketOptions options();
+    /**
+     * Returns the AsyncServerSocketMetrics of this AsyncServerSocket.
+     * <p/>
+     * This call can always be made no matter the state of the socket.
+     *
+     * @return the metrics.
+     */
+    public AsyncServerSocketMetrics metrics() {
+        return metrics;
+    }
 
     /**
-     * Returns the number of sockets that have been accepted.
+     * Gets the AsyncSocketOptions for this AsyncServerSocket.
      *
-     * @return the number of accepted sockets.
+     * @return the options.
      */
-    public long getAccepted() {
-        return accepted.get();
-    }
+    public abstract AsyncSocketOptions options();
 
     /**
      * Gets the local address: the socket address that this channel's socket is bound to.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncServerSocketMetrics.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncServerSocketMetrics.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc;
+
+import com.hazelcast.internal.tpc.util.UnsafeLocator;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+
+@SuppressWarnings("checkstyle:ConstantName")
+public class AsyncServerSocketMetrics {
+
+    private static final Unsafe UNSAFE = UnsafeLocator.UNSAFE;
+    private static final long OFFSET_accepted;
+    private volatile long accepted;
+
+    static {
+        try {
+            OFFSET_accepted = getOffset("accepted");
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static long getOffset(String fieldName) throws NoSuchFieldException {
+        Field field = AsyncServerSocketMetrics.class.getDeclaredField(fieldName);
+        return UNSAFE.objectFieldOffset(field);
+    }
+
+    /**
+     * Gets the current value.
+     *
+     * @return the current value.
+     */
+    public long accepted() {
+        return accepted;
+    }
+
+    public void incAccepted() {
+        UNSAFE.putOrderedLong(this, OFFSET_accepted, accepted + 1);
+    }
+}

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncSocket.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.tpc;
 
 import com.hazelcast.internal.tpc.iobuffer.IOBuffer;
-import com.hazelcast.internal.tpc.util.ProgressIndicator;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -33,71 +32,22 @@ public abstract class AsyncSocket extends AbstractAsyncSocket {
 
     protected volatile SocketAddress remoteAddress;
     protected volatile SocketAddress localAddress;
-
+    protected AsyncSocketMetrics metrics = new AsyncSocketMetrics();
     protected final boolean clientSide;
-    protected final ProgressIndicator ioBuffersWritten = new ProgressIndicator();
-    protected final ProgressIndicator ioBuffersRead = new ProgressIndicator();
-    protected final ProgressIndicator bytesRead = new ProgressIndicator();
-    protected final ProgressIndicator bytesWritten = new ProgressIndicator();
-    protected final ProgressIndicator writeEvents = new ProgressIndicator();
-    protected final ProgressIndicator readEvents = new ProgressIndicator();
 
     protected AsyncSocket(boolean clientSide) {
         this.clientSide = clientSide;
     }
 
     /**
-     * Gets the number of bytes read.
+     * Return the metrics of this AsyncSocket.
+     * <p/>
+     * This call can always be made no matter the state of the socket.
      *
-     * @return number of bytes read.
+     * @return the metrics.
      */
-    public final long getBytesRead() {
-        return bytesRead.get();
-    }
-
-    /**
-     * Gets the number of bytes written.
-     *
-     * @return number of bytes written.
-     */
-    public final long getBytesWritten() {
-        return bytesWritten.get();
-    }
-
-    /**
-     * Gets the number of IOBuffers read.
-     *
-     * @return the number of IOBuffers read.
-     */
-    public final long getIoBuffersRead() {
-        return ioBuffersRead.get();
-    }
-
-    /**
-     * Gets the number of IOBuffers written.
-     *
-     * @return the number of IOBuffers written.
-     */
-    public final long getIoBuffersWritten() {
-        return ioBuffersWritten.get();
-    }
-
-    /**
-     * Gets the number of write events.
-     *
-     * @return the number of write events.
-     */
-    public final long getWriteEvents() {
-        return writeEvents.get();
-    }
-
-    /**
-     * Gets the number of read events.
-     *
-     * @return the number of read events.
-     */
-    public final long getReadEvents() {
-        return readEvents.get();
+    public final AsyncSocketMetrics metrics() {
+        return metrics;
     }
 
     /**
@@ -140,7 +90,7 @@ public abstract class AsyncSocket extends AbstractAsyncSocket {
         return localAddress;
     }
 
-   /**
+    /**
      * Configures if this AsyncSocket is readable or not. If there is no change in the
      * readable status, the call is ignored.
      * <p/>

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncSocketMetrics.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/AsyncSocketMetrics.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc;
+
+import com.hazelcast.internal.tpc.util.UnsafeLocator;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+
+@SuppressWarnings("checkstyle:ConstantName")
+public class AsyncSocketMetrics {
+    private static final Unsafe UNSAFE = UnsafeLocator.UNSAFE;
+    private static final long OFFSET_bytesRead;
+    private static final long OFFSET_bytesWritten;
+    private static final long OFFSET_writeEvents;
+    private static final long OFFSET_readEvents;
+
+    private volatile long bytesRead;
+    private volatile long bytesWritten;
+    private volatile long writeEvents;
+    private volatile long readEvents;
+
+    static {
+        try {
+            OFFSET_bytesRead = getOffset("bytesRead");
+            OFFSET_bytesWritten = getOffset("bytesWritten");
+            OFFSET_writeEvents = getOffset("writeEvents");
+            OFFSET_readEvents = getOffset("readEvents");
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static long getOffset(String fieldName) throws NoSuchFieldException {
+        Field field = AsyncSocketMetrics.class.getDeclaredField(fieldName);
+        return UNSAFE.objectFieldOffset(field);
+    }
+
+    public long bytesRead() {
+        return bytesRead;
+    }
+
+    public void incBytesRead(long delta) {
+        UNSAFE.putOrderedLong(this, OFFSET_bytesRead, bytesRead + delta);
+    }
+
+    public long bytesWritten() {
+        // In the future we could use an opaque read.
+        return bytesWritten;
+    }
+
+    public void incBytesWritten(long delta) {
+        UNSAFE.putOrderedLong(this, OFFSET_bytesWritten, bytesWritten + delta);
+    }
+
+    public long writeEvents() {
+        return writeEvents;
+    }
+
+    public void incWriteEvents() {
+        UNSAFE.putOrderedLong(this, OFFSET_writeEvents, writeEvents + 1);
+    }
+
+    public long readEvents() {
+        return readEvents;
+    }
+
+    public void incReadEvents() {
+        UNSAFE.putOrderedLong(this, OFFSET_readEvents, readEvents + 1);
+    }
+}

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpc/nio/NioAsyncServerSocket.java
@@ -158,7 +158,7 @@ public final class NioAsyncServerSocket extends AsyncServerSocket {
             }
 
             SocketChannel socketChannel = serverSocketChannel.accept();
-            accepted.inc();
+            metrics.incAccepted();
             if (logger.isInfoEnabled()) {
                 logger.info(NioAsyncServerSocket.this + " accepted: " + socketChannel.getRemoteAddress()
                         + "->" + socketChannel.getLocalAddress());

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncServerSocketMetricsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncServerSocketMetricsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class AsyncServerSocketMetricsTest {
+
+    @Test
+    public void test_writeEvents() {
+        AsyncServerSocketMetrics metrics = new AsyncServerSocketMetrics();
+
+        metrics.incAccepted();
+        assertEquals(1, metrics.accepted());
+
+        metrics.incAccepted();
+        assertEquals(2, metrics.accepted());
+    }
+}

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncServerSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncServerSocketTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import static com.hazelcast.internal.tpc.TpcTestSupport.assertCompletesEventually;
 import static com.hazelcast.internal.tpc.TpcTestSupport.terminate;
 import static com.hazelcast.internal.tpc.TpcTestSupport.terminateAll;
+import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -61,6 +62,7 @@ public abstract class AsyncServerSocketTest {
                 })
                 .build();
         assertSame(reactor, socket.getReactor());
+        assertNotNull(socket.metrics());
     }
 
     @Test
@@ -181,7 +183,7 @@ public abstract class AsyncServerSocketTest {
             assertCompletesEventually(connect);
         }
 
-        assertEquals(clients, serverSocket.getAccepted());
+        assertEquals(clients, serverSocket.metrics.accepted());
     }
 
     @Test

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocketMetricsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocketMetricsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class AsyncSocketMetricsTest {
+
+    @Test
+    public void test_bytesRead() {
+        AsyncSocketMetrics metrics = new AsyncSocketMetrics();
+
+        metrics.incBytesRead(10);
+        assertEquals(10, metrics.bytesRead());
+
+        metrics.incBytesRead(5);
+        assertEquals(15, metrics.bytesRead());
+    }
+
+    @Test
+    public void test_bytesWritten() {
+        AsyncSocketMetrics metrics = new AsyncSocketMetrics();
+
+        metrics.incBytesWritten(10);
+        assertEquals(10, metrics.bytesWritten());
+
+        metrics.incBytesWritten(5);
+        assertEquals(15, metrics.bytesWritten());
+    }
+
+    @Test
+    public void test_writeEvents() {
+        AsyncSocketMetrics metrics = new AsyncSocketMetrics();
+
+        metrics.incWriteEvents();
+        assertEquals(1, metrics.writeEvents());
+
+        metrics.incWriteEvents();
+        assertEquals(2, metrics.writeEvents());
+    }
+
+    @Test
+    public void test_readEvents() {
+        AsyncSocketMetrics metrics = new AsyncSocketMetrics();
+
+        metrics.incReadEvents();
+        assertEquals(1, metrics.readEvents());
+
+        metrics.incReadEvents();
+        assertEquals(2, metrics.readEvents());
+    }
+}

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocketTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletionException;
 
 import static com.hazelcast.internal.tpc.TpcTestSupport.assertCompletesEventually;
 import static com.hazelcast.internal.tpc.TpcTestSupport.terminateAll;
+import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -50,6 +51,18 @@ public abstract class AsyncSocketTest {
     @After
     public void after() throws InterruptedException {
         terminateAll(reactors);
+    }
+
+    @Test
+    public void test_construction() {
+        Reactor reactor = newReactor();
+        AsyncSocketBuilder socketBuilder = reactor
+                .newAsyncSocketBuilder()
+                .setReadHandler(new DevNullReadHandler());
+        AsyncSocket socket = socketBuilder.build();
+
+        assertNotNull(socket.metrics());
+        assertNotNull(socket.context());
     }
 
     @Test

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_ReadableTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpc/AsyncSocket_ReadableTest.java
@@ -83,20 +83,20 @@ public abstract class AsyncSocket_ReadableTest {
         // disable remote socket readable, send data, and verify the data is not received.
         remoteSocket.setReadable(false);
         localSocket.writeAndFlush(newSingleLongBuffer());
-        assertTrueTwoSeconds(() -> assertEquals(0, remoteSocket.bytesRead.get()));
+        assertTrueTwoSeconds(() -> assertEquals(0, remoteSocket.metrics().bytesRead()));
 
         // enable remote socket readable and verify the data is received eventually.
         remoteSocket.setReadable(true);
-        assertTrueEventually(() -> assertEquals(SIZEOF_LONG, remoteSocket.bytesRead.get()));
+        assertTrueEventually(() -> assertEquals(SIZEOF_LONG, remoteSocket.metrics().bytesRead()));
 
         // disable remote socket readable, send more data, and verify the data is not received.
         remoteSocket.setReadable(false);
         localSocket.writeAndFlush(newSingleLongBuffer());
-        assertTrueTwoSeconds(() -> assertEquals(SIZEOF_LONG, remoteSocket.bytesRead.get()));
+        assertTrueTwoSeconds(() -> assertEquals(SIZEOF_LONG, remoteSocket.metrics().bytesRead()));
 
         // enable remote socket readable and verify the data is received eventually.
         remoteSocket.setReadable(true);
-        assertTrueEventually(() -> assertEquals(2 * SIZEOF_LONG, remoteSocket.bytesRead.get()));
+        assertTrueEventually(() -> assertEquals(2 * SIZEOF_LONG, remoteSocket.metrics().bytesRead()));
     }
 
     private static IOBuffer newSingleLongBuffer() {


### PR DESCRIPTION
Introduced dedicated AsyncSocketMetrics and AsyncSocketServerMetrics. This way we can keep the AsyncSocket/AsyncServerSocket API cleaner because all metrics is moved to its own object; just like AsyncSocketOptions.

It also reduced the number of objects associated with a socket and will help to improve the cache hit rate.