### PR TITLE
[ALTO] Close connection on congestion.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -301,7 +301,7 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
                 // number of packets on the write-queue to prevent running into OOME.
                 // So if the response can't be send, we close the connection to indicate
                 // that the connection was congested.
-                connection.close("Closing connection: response could not be send due to congested socket "
+                connection.close("Response could not be send due to congested socket "
                         + asyncSocket, null);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -55,7 +55,6 @@ import java.util.Set;
 
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.SIZE_OF_FRAME_LENGTH_AND_FLAGS;
-import static com.hazelcast.internal.tpcengine.util.BufferUtil.upcast;
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
 
 /**


### PR DESCRIPTION
If the response for a client can't be sent due to a congested socket, the connection is closed.

With classic networking, there is no bound on the write queue for a socket and hence a single slow client can cause a whole cluster to go OOME.

With TPC all sockets have buffers with a bound. In this particular case, we need to deal with the fact that a response to the client can't be sent when the socket is congested. So when that is detected, the whole connection (including all the async sockets) is closed to indicate that there was a problem.
