### PR TITLE
Make Jet not overwrite default wildcard IMap config [HZ-2130] [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
@@ -158,15 +158,14 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
         config.addMapConfig(internalMapConfig)
                 .addMapConfig(resultsMapConfig)
                 .addMapConfig(metricsMapConfig)
-                .addMapConfig(initializeSqlCatalog(new MapConfig()));
+                .addMapConfig(initializeSqlCatalog());
     }
 
     // visible for tests
-    static MapConfig initializeSqlCatalog(MapConfig config) {
+    static MapConfig initializeSqlCatalog() {
         // TODO HZ-1743 when implemented properly align this with the chosen
         //  approach that HZ-1743 follows
-        return config
-                .setName(SQL_CATALOG_MAP_NAME)
+        return new MapConfig(SQL_CATALOG_MAP_NAME)
                 .setBackupCount(MapConfig.MAX_BACKUP_COUNT)
                 .setAsyncBackupCount(MapConfig.MIN_BACKUP_COUNT)
                 .setTimeToLiveSeconds(DISABLED_TTL_SECONDS)

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
@@ -158,15 +158,13 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
         config.addMapConfig(internalMapConfig)
                 .addMapConfig(resultsMapConfig)
                 .addMapConfig(metricsMapConfig)
-                .addMapConfig(initializeSqlCatalog(config.getMapConfig(SQL_CATALOG_MAP_NAME)));
+                .addMapConfig(initializeSqlCatalog(new MapConfig()));
     }
 
+    // visible for tests
     static MapConfig initializeSqlCatalog(MapConfig config) {
         // TODO HZ-1743 when implemented properly align this with the chosen
         //  approach that HZ-1743 follows
-        // disabling tiered store configuration for the __sql.catalog map to
-        // prevent unnecessarily increasing tstore's memory demand
-        config.getTieredStoreConfig().setEnabled(false);
         return config
                 .setName(SQL_CATALOG_MAP_NAME)
                 .setBackupCount(MapConfig.MAX_BACKUP_COUNT)

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
@@ -158,11 +158,11 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
         config.addMapConfig(internalMapConfig)
                 .addMapConfig(resultsMapConfig)
                 .addMapConfig(metricsMapConfig)
-                .addMapConfig(initializeSqlCatalog());
+                .addMapConfig(createSqlCatalogConfig());
     }
 
     // visible for tests
-    static MapConfig initializeSqlCatalog() {
+    static MapConfig createSqlCatalogConfig() {
         // TODO HZ-1743 when implemented properly align this with the chosen
         //  approach that HZ-1743 follows
         return new MapConfig(SQL_CATALOG_MAP_NAME)

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JetServiceBackendTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JetServiceBackendTest.java
@@ -45,7 +45,7 @@ public class JetServiceBackendTest extends JetTestSupport {
         config.getJetConfig().setEnabled(true);
         HazelcastInstance instance = createHazelcastInstance(config);
         MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
-        assertEquals(initializeSqlCatalog(new MapConfig()), mapConfig);
+        assertEquals(initializeSqlCatalog(), mapConfig);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class JetServiceBackendTest extends JetTestSupport {
         HazelcastInstance instance = createHazelcastInstance(config);
         MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
         assertEquals(new DataPersistenceConfig(), mapConfig.getDataPersistenceConfig());
-        assertEquals(initializeSqlCatalog(new MapConfig(SQL_CATALOG_MAP_NAME)), mapConfig);
+        assertEquals(initializeSqlCatalog(), mapConfig);
 
         MapConfig otherMapConfig = ((MapProxyImpl) instance.getMap("otherMap")).getMapConfig();
         assertFalse(otherMapConfig.getDataPersistenceConfig().isEnabled());
@@ -76,7 +76,7 @@ public class JetServiceBackendTest extends JetTestSupport {
         HazelcastInstance instance = createHazelcastInstance(config);
         MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
         assertEquals(new DataPersistenceConfig(), mapConfig.getDataPersistenceConfig());
-        assertEquals(initializeSqlCatalog(new MapConfig(SQL_CATALOG_MAP_NAME)), mapConfig);
+        assertEquals(initializeSqlCatalog(), mapConfig);
     }
 
     @Test
@@ -104,7 +104,7 @@ public class JetServiceBackendTest extends JetTestSupport {
         HazelcastInstance instance = createHazelcastInstance(config);
         MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
         assertEquals(new DataPersistenceConfig(), mapConfig.getDataPersistenceConfig());
-        assertEquals(initializeSqlCatalog(new MapConfig(SQL_CATALOG_MAP_NAME)), mapConfig);
+        assertEquals(initializeSqlCatalog(), mapConfig);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JetServiceBackendTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JetServiceBackendTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.DataPersistenceConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -28,9 +29,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.config.MapConfig.DEFAULT_BACKUP_COUNT;
 import static com.hazelcast.jet.impl.JetServiceBackend.SQL_CATALOG_MAP_NAME;
 import static com.hazelcast.jet.impl.JetServiceBackend.initializeSqlCatalog;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -45,20 +49,79 @@ public class JetServiceBackendTest extends JetTestSupport {
     }
 
     @Test
-    public void when_instanceIsCreatedWithOverriddenConfiguration_then_sqlCatalogConfigIsMerged() {
+    public void when_instanceIsCreatedWithOverriddenConfiguration_then_sqlCatalogConfigIsNotMerged() {
         Config config = new Config();
         DataPersistenceConfig dataPersistenceConfig = new DataPersistenceConfig();
         dataPersistenceConfig.setEnabled(true);
-        config.addMapConfig(getMapConfig(dataPersistenceConfig));
+        config.addMapConfig(getMapConfig(SQL_CATALOG_MAP_NAME, dataPersistenceConfig));
         config.getJetConfig().setEnabled(true);
 
         HazelcastInstance instance = createHazelcastInstance(config);
         MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
-        assertEquals(dataPersistenceConfig, mapConfig.getDataPersistenceConfig());
-        assertEquals(initializeSqlCatalog(new MapConfig(SQL_CATALOG_MAP_NAME).setDataPersistenceConfig(dataPersistenceConfig)), mapConfig);
+        assertEquals(new DataPersistenceConfig(), mapConfig.getDataPersistenceConfig());
+        assertEquals(initializeSqlCatalog(new MapConfig(SQL_CATALOG_MAP_NAME)), mapConfig);
+
+        MapConfig otherMapConfig = ((MapProxyImpl) instance.getMap("otherMap")).getMapConfig();
+        assertFalse(otherMapConfig.getDataPersistenceConfig().isEnabled());
     }
 
-    private static MapConfig getMapConfig(DataPersistenceConfig dataPersistenceConfig) {
-        return new MapConfig(SQL_CATALOG_MAP_NAME).setDataPersistenceConfig(dataPersistenceConfig);
+    @Test
+    public void when_instanceIsCreatedWithOverriddenDefaultConfiguration_then_sqlCatalogConfigIsNotMerged() {
+        Config config = new Config();
+        DataPersistenceConfig dataPersistenceConfig = new DataPersistenceConfig();
+        dataPersistenceConfig.setEnabled(true);
+        config.addMapConfig(getMapConfig("default", dataPersistenceConfig));
+        config.getJetConfig().setEnabled(true);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
+        assertEquals(new DataPersistenceConfig(), mapConfig.getDataPersistenceConfig());
+        assertEquals(initializeSqlCatalog(new MapConfig(SQL_CATALOG_MAP_NAME)), mapConfig);
+    }
+
+    @Test
+    public void when_instanceIsCreatedWithOverriddenDefaultConfiguration_then_defaultConfigurationIsNotChanged() {
+        Config config = new Config();
+        DataPersistenceConfig dataPersistenceConfig = new DataPersistenceConfig();
+        dataPersistenceConfig.setEnabled(true);
+        config.addMapConfig(getMapConfig("default", dataPersistenceConfig));
+        config.getJetConfig().setEnabled(true);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        MapConfig otherMapConfig = ((MapProxyImpl) instance.getMap("otherMap")).getMapConfig();
+        assertTrue(otherMapConfig.getDataPersistenceConfig().isEnabled());
+        assertEquals(DEFAULT_BACKUP_COUNT, otherMapConfig.getBackupCount());
+    }
+
+    @Test
+    public void when_instanceIsCreatedWithOverriddenDefaultWildcardConfiguration_then_sqlCatalogConfigIsNotMerged() {
+        Config config = new Config();
+        DataPersistenceConfig dataPersistenceConfig = new DataPersistenceConfig();
+        dataPersistenceConfig.setEnabled(true);
+        config.addMapConfig(getMapConfig("*", dataPersistenceConfig));
+        config.getJetConfig().setEnabled(true);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
+        assertEquals(new DataPersistenceConfig(), mapConfig.getDataPersistenceConfig());
+        assertEquals(initializeSqlCatalog(new MapConfig(SQL_CATALOG_MAP_NAME)), mapConfig);
+    }
+
+    @Test
+    public void when_instanceIsCreatedWithOverriddenDefaultWildcardConfiguration_then_defaultConfigurationIsNotChanged() {
+        Config config = new Config();
+        DataPersistenceConfig dataPersistenceConfig = new DataPersistenceConfig();
+        dataPersistenceConfig.setEnabled(true);
+        config.addMapConfig(getMapConfig("*", dataPersistenceConfig));
+        config.getJetConfig().setEnabled(true);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        MapConfig otherMapConfig = ((MapProxyImpl) instance.getMap("otherMap")).getMapConfig();
+        assertTrue(otherMapConfig.getDataPersistenceConfig().isEnabled());
+        assertEquals(DEFAULT_BACKUP_COUNT, otherMapConfig.getBackupCount());
+    }
+
+    private static MapConfig getMapConfig(String mapName, DataPersistenceConfig dataPersistenceConfig) {
+        return new MapConfig(mapName).setDataPersistenceConfig(dataPersistenceConfig);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JetServiceBackendTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JetServiceBackendTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 
 import static com.hazelcast.config.MapConfig.DEFAULT_BACKUP_COUNT;
 import static com.hazelcast.jet.impl.JetServiceBackend.SQL_CATALOG_MAP_NAME;
-import static com.hazelcast.jet.impl.JetServiceBackend.initializeSqlCatalog;
+import static com.hazelcast.jet.impl.JetServiceBackend.createSqlCatalogConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -45,7 +45,7 @@ public class JetServiceBackendTest extends JetTestSupport {
         config.getJetConfig().setEnabled(true);
         HazelcastInstance instance = createHazelcastInstance(config);
         MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
-        assertEquals(initializeSqlCatalog(), mapConfig);
+        assertEquals(createSqlCatalogConfig(), mapConfig);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class JetServiceBackendTest extends JetTestSupport {
         HazelcastInstance instance = createHazelcastInstance(config);
         MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
         assertEquals(new DataPersistenceConfig(), mapConfig.getDataPersistenceConfig());
-        assertEquals(initializeSqlCatalog(), mapConfig);
+        assertEquals(createSqlCatalogConfig(), mapConfig);
 
         MapConfig otherMapConfig = ((MapProxyImpl) instance.getMap("otherMap")).getMapConfig();
         assertFalse(otherMapConfig.getDataPersistenceConfig().isEnabled());
@@ -76,7 +76,7 @@ public class JetServiceBackendTest extends JetTestSupport {
         HazelcastInstance instance = createHazelcastInstance(config);
         MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
         assertEquals(new DataPersistenceConfig(), mapConfig.getDataPersistenceConfig());
-        assertEquals(initializeSqlCatalog(), mapConfig);
+        assertEquals(createSqlCatalogConfig(), mapConfig);
     }
 
     @Test
@@ -104,7 +104,7 @@ public class JetServiceBackendTest extends JetTestSupport {
         HazelcastInstance instance = createHazelcastInstance(config);
         MapConfig mapConfig = instance.getConfig().getMapConfig(JetServiceBackend.SQL_CATALOG_MAP_NAME);
         assertEquals(new DataPersistenceConfig(), mapConfig.getDataPersistenceConfig());
-        assertEquals(initializeSqlCatalog(), mapConfig);
+        assertEquals(createSqlCatalogConfig(), mapConfig);
     }
 
     @Test


### PR DESCRIPTION
Jet used to overwrite settings in IMap config with wildcard `*`, because Config.getMapConfig() clones only the `default` config but not the wildcard configuration if they match requested map name.

Fixes HZ-2130
Backport of: #23848

Breaking changes (list specific methods/types/messages):
* it was possible, however undocumented, to set default configuration for SQL catalog (eg. persistence). It will not be possible anymore until HZ-1743 is implemented. 

Fixes HZ-2130

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
