### PR TITLE
Create Kubernetes Client only for API discovery mode

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/DnsEndpointResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/DnsEndpointResolver.java
@@ -46,8 +46,9 @@ final class DnsEndpointResolver
     private final int serviceDnsTimeout;
     private final RawLookupProvider rawLookupProvider;
 
-    DnsEndpointResolver(ILogger logger, String serviceDns, int port, int serviceDnsTimeout) {
-        this(logger, serviceDns, port, serviceDnsTimeout, InetAddress::getAllByName);
+    DnsEndpointResolver(ILogger logger, KubernetesConfig config) {
+        this(logger, config.getServiceDns(), config.getServicePort(),
+                config.getServiceDnsTimeout(), InetAddress::getAllByName);
     }
 
     /**
@@ -61,7 +62,8 @@ final class DnsEndpointResolver
         this.rawLookupProvider = rawLookupProvider;
     }
 
-    List<DiscoveryNode> resolve() {
+    @Override
+    List<DiscoveryNode> resolveNodes() {
         try {
             return lookup();
         } catch (TimeoutException e) {

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -29,13 +29,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.hazelcast.internal.util.HostnameUtil.getLocalHostname;
-
 final class HazelcastKubernetesDiscoveryStrategy
         extends AbstractDiscoveryStrategy {
-    private final KubernetesClient client;
     private final EndpointResolver endpointResolver;
-    private final KubernetesConfig config;
 
     private final Map<String, String> memberMetadata = new HashMap<>();
 
@@ -43,106 +39,40 @@ final class HazelcastKubernetesDiscoveryStrategy
                                          ClusterTopologyIntentTracker clusterTopologyIntentTracker) {
         super(logger, properties);
 
-        config = new KubernetesConfig(properties);
+        KubernetesConfig config = new KubernetesConfig(properties);
         logger.info(config.toString());
 
-        client = buildKubernetesClient(config, clusterTopologyIntentTracker);
-
         if (DiscoveryMode.DNS_LOOKUP.equals(config.getMode())) {
-            endpointResolver = new DnsEndpointResolver(logger, config.getServiceDns(), config.getServicePort(),
-                    config.getServiceDnsTimeout());
+            endpointResolver = new DnsEndpointResolver(logger, config);
         } else {
-            endpointResolver = new KubernetesApiEndpointResolver(logger, config.getServiceName(), config.getServicePort(),
-                    config.getServiceLabelName(), config.getServiceLabelValue(),
-                    config.getPodLabelName(), config.getPodLabelValue(),
-                    config.isResolveNotReadyAddresses(), client);
+            endpointResolver = new KubernetesApiEndpointResolver(logger, config, clusterTopologyIntentTracker);
         }
 
         logger.info("Kubernetes Discovery activated with mode: " + config.getMode().name());
     }
 
-    private static KubernetesClient buildKubernetesClient(KubernetesConfig config,
-                                                          ClusterTopologyIntentTracker tracker) {
-        return new KubernetesClient(config.getNamespace(), config.getKubernetesMasterUrl(), config.getTokenProvider(),
-                config.getKubernetesCaCertificate(), config.getKubernetesApiRetries(), config.getExposeExternallyMode(),
-                config.isUseNodeNameAsExternalAddress(), config.getServicePerPodLabelName(),
-                config.getServicePerPodLabelValue(), tracker);
-    }
-
+    @Override
     public void start() {
-        client.start();
         endpointResolver.start();
     }
 
     @Override
     public Map<String, String> discoverLocalMetadata() {
         if (memberMetadata.isEmpty()) {
-            memberMetadata.put(PartitionGroupMetaData.PARTITION_GROUP_ZONE, discoverZone());
-            memberMetadata.put("hazelcast.partition.group.node", discoverNodeName());
+            memberMetadata.put(PartitionGroupMetaData.PARTITION_GROUP_ZONE, endpointResolver.resolveCurrentZone());
+            memberMetadata.put("hazelcast.partition.group.node", endpointResolver.resolveCurrentNodeName());
         }
         return memberMetadata;
     }
 
-    /**
-     * Discovers the availability zone in which the current Hazelcast member is running.
-     * <p>
-     * Note: ZONE_AWARE is available only for the Kubernetes API Mode.
-     */
-    private String discoverZone() {
-        if (DiscoveryMode.KUBERNETES_API.equals(config.getMode())) {
-            try {
-                String zone = client.zone(podName());
-                if (zone != null) {
-                    getLogger().info(String.format("Kubernetes plugin discovered availability zone: %s", zone));
-                    return zone;
-                }
-            } catch (Exception e) {
-                // only log the exception and the message, Hazelcast should still start
-                getLogger().finest(e);
-            }
-            getLogger().info("Cannot fetch the current zone, ZONE_AWARE feature is disabled");
-        }
-        return "unknown";
-    }
-
-    /**
-     * Discovers the name of the node which the current Hazelcast member pod is running on.
-     * <p>
-     * Note: NODE_AWARE is available only for the Kubernetes API Mode.
-     */
-    private String discoverNodeName() {
-        if (DiscoveryMode.KUBERNETES_API.equals(config.getMode())) {
-            try {
-                String nodeName = client.nodeName(podName());
-                if (nodeName != null) {
-                    getLogger().info(String.format("Kubernetes plugin discovered node name: %s", nodeName));
-                    return nodeName;
-                }
-            } catch (Exception e) {
-                // only log the exception and the message, Hazelcast should still start
-                getLogger().finest(e);
-            }
-            getLogger().warning("Cannot fetch name of the node, NODE_AWARE feature is disabled");
-        }
-        return "unknown";
-    }
-
-    private String podName() {
-        String podName = System.getenv("POD_NAME");
-        if (podName == null) {
-            podName = getLocalHostname();
-        }
-        return podName;
+    @Override
+    public Iterable<DiscoveryNode> discoverNodes() {
+        return endpointResolver.resolveNodes();
     }
 
     @Override
-    public Iterable<DiscoveryNode> discoverNodes() {
-        return endpointResolver.resolve();
-    }
-
     public void destroy() {
         endpointResolver.destroy();
-        client.destroy();
     }
 
     abstract static class EndpointResolver {
@@ -152,7 +82,25 @@ final class HazelcastKubernetesDiscoveryStrategy
             this.logger = logger;
         }
 
-        abstract List<DiscoveryNode> resolve();
+        abstract List<DiscoveryNode> resolveNodes();
+
+        /**
+         * Discovers the availability zone in which the current Hazelcast member is running.
+         * <p>
+         * Note: ZONE_AWARE is available only for the Kubernetes API Mode.
+         */
+        String resolveCurrentZone() {
+            return "unknown";
+        }
+
+        /**
+         * Discovers the name of the node which the current Hazelcast member pod is running on.
+         * <p>
+         * Note: NODE_AWARE is available only for the Kubernetes API Mode.
+         */
+        String resolveCurrentNodeName() {
+            return "unknown";
+        }
 
         void start() {
         }

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
@@ -17,6 +17,7 @@
 package com.hazelcast.kubernetes;
 
 import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.instance.impl.ClusterTopologyIntentTracker;
 import com.hazelcast.kubernetes.KubernetesClient.Endpoint;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.cluster.Address;
@@ -27,6 +28,8 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+
+import static com.hazelcast.internal.util.HostnameUtil.getLocalHostname;
 
 class KubernetesApiEndpointResolver
         extends HazelcastKubernetesDiscoveryStrategy.EndpointResolver {
@@ -40,12 +43,19 @@ class KubernetesApiEndpointResolver
     private final int port;
     private final KubernetesClient client;
 
+    KubernetesApiEndpointResolver(ILogger logger, KubernetesConfig config, ClusterTopologyIntentTracker tracker) {
+        this(logger, config.getServiceName(), config.getServicePort(), config.getServiceLabelName(),
+                config.getServiceLabelValue(), config.getPodLabelName(), config.getPodLabelValue(),
+                config.isResolveNotReadyAddresses(), buildKubernetesClient(config, tracker));
+    }
+
+    /**
+     * Used externally only for testing
+     */
     KubernetesApiEndpointResolver(ILogger logger, String serviceName, int port,
                                   String serviceLabel, String serviceLabelValue, String podLabel, String podLabelValue,
                                   Boolean resolveNotReadyAddresses, KubernetesClient client) {
-
         super(logger);
-
         this.serviceName = serviceName;
         this.port = port;
         this.serviceLabel = serviceLabel;
@@ -56,8 +66,15 @@ class KubernetesApiEndpointResolver
         this.client = client;
     }
 
+    private static KubernetesClient buildKubernetesClient(KubernetesConfig config, ClusterTopologyIntentTracker tracker) {
+        return new KubernetesClient(config.getNamespace(), config.getKubernetesMasterUrl(), config.getTokenProvider(),
+                config.getKubernetesCaCertificate(), config.getKubernetesApiRetries(), config.getExposeExternallyMode(),
+                config.isUseNodeNameAsExternalAddress(), config.getServicePerPodLabelName(),
+                config.getServicePerPodLabelValue(), tracker);
+    }
+
     @Override
-    List<DiscoveryNode> resolve() {
+    List<DiscoveryNode> resolveNodes() {
         if (serviceName != null && !serviceName.isEmpty()) {
             logger.fine("Using service name to discover nodes.");
             return getSimpleDiscoveryNodes(client.endpointsByName(serviceName));
@@ -122,5 +139,55 @@ class KubernetesApiEndpointResolver
             return this.port;
         }
         return NetworkConfig.DEFAULT_PORT;
+    }
+
+    @Override
+    String resolveCurrentZone() {
+        try {
+            String zone = client.zone(podName());
+            if (zone != null) {
+                logger.info(String.format("Kubernetes plugin discovered availability zone: %s", zone));
+                return zone;
+            }
+        } catch (Exception e) {
+            // only log the exception and the message, Hazelcast should still start
+            logger.finest(e);
+        }
+        logger.info("Cannot fetch the current zone, ZONE_AWARE feature is disabled");
+        return "unknown";
+    }
+
+    @Override
+    String resolveCurrentNodeName() {
+        try {
+            String nodeName = client.nodeName(podName());
+            if (nodeName != null) {
+                logger.info(String.format("Kubernetes plugin discovered node name: %s", nodeName));
+                return nodeName;
+            }
+        } catch (Exception e) {
+            // only log the exception and the message, Hazelcast should still start
+            logger.finest(e);
+        }
+        logger.warning("Cannot fetch name of the node, NODE_AWARE feature is disabled");
+        return "unknown";
+    }
+
+    private String podName() {
+        String podName = System.getenv("POD_NAME");
+        if (podName == null) {
+            podName = getLocalHostname();
+        }
+        return podName;
+    }
+
+    @Override
+    void start() {
+        client.start();
+    }
+
+    @Override
+    void destroy() {
+        client.destroy();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/DnsEndpointResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/DnsEndpointResolverTest.java
@@ -64,7 +64,7 @@ public class DnsEndpointResolverTest {
         DnsEndpointResolver dnsEndpointResolver = new DnsEndpointResolver(LOGGER, SERVICE_DNS, UNSET_PORT, DEFAULT_SERVICE_DNS_TIMEOUT_SECONDS, lookupProvider);
 
         // when
-        List<DiscoveryNode> result = dnsEndpointResolver.resolve();
+        List<DiscoveryNode> result = dnsEndpointResolver.resolveNodes();
 
         // then
 
@@ -81,7 +81,7 @@ public class DnsEndpointResolverTest {
         DnsEndpointResolver dnsEndpointResolver = new DnsEndpointResolver(LOGGER, SERVICE_DNS, CUSTOM_PORT, DEFAULT_SERVICE_DNS_TIMEOUT_SECONDS, lookupProvider);
 
         // when
-        List<DiscoveryNode> result = dnsEndpointResolver.resolve();
+        List<DiscoveryNode> result = dnsEndpointResolver.resolveNodes();
 
         // then
 
@@ -92,14 +92,13 @@ public class DnsEndpointResolverTest {
     }
 
     @Test
-    public void resolveException() throws Exception {
+    public void resolveException() {
         // given
         ILogger logger = mock(ILogger.class);
-        RawLookupProvider lookupProvider = nonResolvingLookupProvider();
         DnsEndpointResolver dnsEndpointResolver = new DnsEndpointResolver(logger, SERVICE_DNS, UNSET_PORT, DEFAULT_SERVICE_DNS_TIMEOUT_SECONDS, nonResolvingLookupProvider());
 
         // when
-        List<DiscoveryNode> result = dnsEndpointResolver.resolve();
+        List<DiscoveryNode> result = dnsEndpointResolver.resolveNodes();
 
         // then
         assertEquals(0, result.size());
@@ -108,13 +107,13 @@ public class DnsEndpointResolverTest {
     }
 
     @Test
-    public void resolveNotFound() throws Exception {
+    public void resolveNotFound() {
         // given
         RawLookupProvider lookupProvider = staticLookupProvider(SERVICE_DNS);
         DnsEndpointResolver dnsEndpointResolver = new DnsEndpointResolver(LOGGER, SERVICE_DNS, UNSET_PORT, DEFAULT_SERVICE_DNS_TIMEOUT_SECONDS, lookupProvider);
 
         // when
-        List<DiscoveryNode> result = dnsEndpointResolver.resolve();
+        List<DiscoveryNode> result = dnsEndpointResolver.resolveNodes();
 
         // then
         assertEquals(0, result.size());
@@ -127,7 +126,7 @@ public class DnsEndpointResolverTest {
         DnsEndpointResolver dnsEndpointResolver = new DnsEndpointResolver(logger, SERVICE_DNS, UNSET_PORT, TEST_DNS_TIMEOUT_SECONDS, timingOutLookupProvider());
 
         // when
-        List<DiscoveryNode> result = dnsEndpointResolver.resolve();
+        List<DiscoveryNode> result = dnsEndpointResolver.resolveNodes();
 
         // then
         assertEquals(0, result.size());

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolverTest.java
@@ -57,7 +57,7 @@ public class KubernetesApiEndpointResolverTest {
         KubernetesApiEndpointResolver sut = new KubernetesApiEndpointResolver(LOGGER, null, 0, null, null, null, null, null, client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(0, nodes.size());
@@ -82,7 +82,7 @@ public class KubernetesApiEndpointResolverTest {
                 client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(1, nodes.size());
@@ -99,7 +99,7 @@ public class KubernetesApiEndpointResolverTest {
                 null, null, null, client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(1, nodes.size());
@@ -116,7 +116,7 @@ public class KubernetesApiEndpointResolverTest {
                 POD_LABEL, POD_LABEL_VALUE, null, client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(1, nodes.size());
@@ -133,7 +133,7 @@ public class KubernetesApiEndpointResolverTest {
                 null, null, RESOLVE_NOT_READY_ADDRESSES, client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(1, nodes.size());
@@ -149,7 +149,7 @@ public class KubernetesApiEndpointResolverTest {
                 client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(0, nodes.size());


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

Logic specific for Kubernetes API discovery mode including `KubernetesClient` build moved to `KubernetesAPIEndpointResolver`. It should resolve an issue with unexpected requests to Kube API when DNS discovery mode is chosen.

Fixes #23208 

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
