### PR TITLE
Renamed CLientAsyncReadHandler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/bootstrap/ClientReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/bootstrap/ClientReadHandler.java
@@ -30,14 +30,18 @@ import java.util.Collection;
 import java.util.UUID;
 
 
-public class ClientAsyncReadHandler extends ReadHandler {
+/**
+ * A {@link ReadHandler} that reads incoming traffic from clients. The main
+ * payloads being the {@link ClientMessage}.
+ */
+public class ClientReadHandler extends ReadHandler {
 
     private final ClientEngine clientEngine;
     private final ClientMessageReader clientMessageReader = new ClientMessageReader(0);
     private boolean protocolBytesReceived;
     private Connection connection;
 
-    public ClientAsyncReadHandler(ClientEngine clientEngine) {
+    public ClientReadHandler(ClientEngine clientEngine) {
         this.clientEngine = clientEngine;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/bootstrap/TpcServerBootstrap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/bootstrap/TpcServerBootstrap.java
@@ -187,7 +187,7 @@ public class TpcServerBootstrap {
             Reactor reactor = tpcEngine.reactor(k);
 
             Supplier<ReadHandler> readHandlerSupplier =
-                    () -> new ClientAsyncReadHandler(nodeEngine.getNode().clientEngine);
+                    () -> new ClientReadHandler(nodeEngine.getNode().clientEngine);
             readHandlerSuppliers.put(reactor, readHandlerSupplier);
 
             AsyncServerSocket serverSocket = reactor.newAsyncServerSocketBuilder()


### PR DESCRIPTION
I believe this is based on an old name of the ReadHandler which was AsyncReadHandler.

The new name is ClientReadHandler.
