### PR TITLE
Resolve InvocationConstants before super.complete [HZ-2051]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -1240,8 +1240,9 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     protected void onComplete() {
-        if (state instanceof ExceptionalResult) {
-            super.completeExceptionally(((ExceptionalResult) state).getCause());
+        if (isCompletedExceptionally()) {
+            ExceptionalResult resolved = (ExceptionalResult) resolve(state);
+            super.completeExceptionally(resolved.getCause());
         } else {
             super.complete((V) state);
         }


### PR DESCRIPTION
`AbstractInvocationFuture.onComplete` takes care of completing the `CompletableFuture` superclass, which is required for interoperability with plain JDK `CompletableFuture`s.
Previously, `onComplete` was not resolving the state before completion; therefore InvocationFutures completed normally with an InvocationConstant that signals exceptional completion were completed normally from JDK's CompletableFuture point of view, breaking interop with CompletableFuture. e.g. this code was broken:

```
InvocationFuture f = newInvocationFuture();
CompletableFuture cf = CompletableFuture.allOf(f); 
.complete(InvocationConstant.CALL_TIMEOUT);
// bug: does not throw because f seems complete normally
cf.get;
```

Fixes #23632 

Checklist:
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
