### PR TITLE
Exclude new CompletionStage Async methods from checker for Java 8 compatibility

### DIFF
--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/CompletableFutureUsageCondition.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/CompletableFutureUsageCondition.java
@@ -24,6 +24,8 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -54,6 +56,12 @@ public class CompletableFutureUsageCondition extends ArchCondition<JavaClass> {
             .collect(toSet());
 
     private static final Set<String> SYNC_AND_ASYNC_METHODS = collectSyncAndAsyncCounterpartMethods();
+    //TODO Remove Java 8 compatibility code after JDK upgrade
+    static {
+        Collection<String> excludedSyncMethodsForJava8Compatibility
+                = Arrays.asList("exceptionally");
+        SYNC_AND_ASYNC_METHODS.removeAll(excludedSyncMethodsForJava8Compatibility);
+    }
 
     CompletableFutureUsageCondition() {
         super("use only CompletableFuture async methods with explicit executor service");


### PR DESCRIPTION
CompletableFutureAsyncUsage checker failed on Java 8+ version due to new Async methods being added to JDK.

Fixes https://github.com/hazelcast/hazelcast/issues/23866

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
