### PR TITLE
Fix InvocationFuture with ArbitraryArityConstruction

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -831,6 +831,11 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
         return value;
     }
 
+    protected ExceptionalResult toExceptionalResult(Object object) {
+        assert object instanceof ExceptionalResult;
+        return (ExceptionalResult) object;
+    }
+
     protected V resolveAndThrowWithJoinConvention(Object state) {
         Object value = resolve(state);
         return returnOrThrowWithJoinConventions(value);
@@ -1240,8 +1245,8 @@ public abstract class AbstractInvocationFuture<V> extends InternalCompletableFut
     }
 
     protected void onComplete() {
-        if (state instanceof ExceptionalResult) {
-            super.completeExceptionally(((ExceptionalResult) state).getCause());
+        if (isCompletedExceptionally()) {
+            super.completeExceptionally(toExceptionalResult(state).getCause());
         } else {
             super.complete((V) state);
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -127,13 +127,8 @@ public final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
     protected Object resolve(Object unresolved) {
         if (unresolved == null) {
             return null;
-        } else if (unresolved == INTERRUPTED) {
-            return new ExceptionalResult(
-                    new InterruptedException(invocation.op.getClass().getSimpleName() + " was interrupted. " + invocation));
-        } else if (unresolved == CALL_TIMEOUT) {
-            return new ExceptionalResult(newOperationTimeoutException(false));
-        } else if (unresolved == HEARTBEAT_TIMEOUT) {
-            return new ExceptionalResult(newOperationTimeoutException(true));
+        } else if (unresolved == INTERRUPTED || unresolved == CALL_TIMEOUT || unresolved == HEARTBEAT_TIMEOUT) {
+            return toExceptionalResult(unresolved);
         } else if (unresolved.getClass() == Packet.class) {
             NormalResponse response = invocation.context.serializationService.toObject(unresolved);
             unresolved = response.getValue();
@@ -159,6 +154,20 @@ public final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
         }
 
         return value;
+    }
+
+    @Override
+    protected ExceptionalResult toExceptionalResult(Object object) {
+        if (object == INTERRUPTED) {
+            return new ExceptionalResult(
+                    new InterruptedException(invocation.op.getClass().getSimpleName() + " was interrupted. " + invocation));
+        } else if (object == CALL_TIMEOUT) {
+            return new ExceptionalResult(newOperationTimeoutException(false));
+        } else if (object == HEARTBEAT_TIMEOUT) {
+            return new ExceptionalResult(newOperationTimeoutException(true));
+        }
+
+        return super.toExceptionalResult(object);
     }
 
     private OperationTimeoutException newOperationTimeoutException(boolean heartbeatTimeout) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ArbitraryArityConstructionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ArbitraryArityConstructionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.impl.operationservice.OperationService;
+import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static com.hazelcast.spi.properties.ClusterProperty.OPERATION_CALL_TIMEOUT_MILLIS;
+import static com.hazelcast.test.Accessors.getOperationService;
+import static com.hazelcast.test.Accessors.getSerializationService;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class Invocation_ArbitraryArityConstructionTest extends HazelcastTestSupport {
+
+    private static final Object RESPONSE = "someresponse";
+    private final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+
+    private HazelcastInstance local;
+    private HazelcastInstance remote;
+    private InvocationFuture<Object> f1;
+    private InvocationFuture<Object> f2;
+
+    @Before
+    public void setUp() throws Exception {
+        long callTimeoutMillis = 200;
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
+        config.setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + callTimeoutMillis);
+
+        local = factory.newHazelcastInstance(config);
+        remote = factory.newHazelcastInstance(config);
+        warmUpPartitions(local, remote);
+
+        OperationService opService = getOperationService(local);
+
+        // block the partition thread
+        f1 = opService.invokeOnPartition(
+                null,
+                new SlowOperation(callTimeoutMillis * 2, RESPONSE),
+                getPartitionId(remote)
+        );
+
+        // this future will timeout since partition thread is blocked
+        f2 = opService.invokeOnPartition(
+                null,
+                new DummyOperation(),
+                getPartitionId(remote)
+        );
+    }
+
+    @Test
+    public void testAllOf_whenTimeout() {
+        CompletableFuture<Void> allOf = CompletableFuture.allOf(f1, f2);
+
+        // should throw since f2 will time out
+        assertThrows(CompletionException.class, f2::join);
+        assertThrows(CompletionException.class, allOf::join);
+    }
+
+    @Test
+    public void testAnyOf_whenSomeTimeout() {
+        CompletableFuture<Object> anyOf = CompletableFuture.anyOf(f1, f2);
+
+        // should not throw since f1 will complete
+        assertEquals(RESPONSE, f1.join());
+        assertThrows(CompletionException.class, f2::join);
+
+        // This isn't ideal, but I don't see a good way for us to get results
+        // of anyOf future. So this test is here to document the behavior.
+        assertThrows(AssertionError.class, () -> assertEquals(RESPONSE, anyOf.join()));
+        assertEquals(RESPONSE, getSerializationService(local).<NormalResponse>toObject(anyOf.join()).getValue());
+    }
+
+    @Test
+    public void testAnyOf_whenAllTimeout() {
+        // this future will also time out since partition thread is blocked
+        InvocationFuture<Object> f3 = getOperationService(local).invokeOnPartition(
+                null,
+                new DummyOperation(),
+                getPartitionId(remote)
+        );
+
+        CompletableFuture<Object> anyOf = CompletableFuture.anyOf(f2, f3);
+
+        // should throw since f2 and f3 will throw
+        assertThrows(CompletionException.class, f2::join);
+        assertThrows(CompletionException.class, f3::join);
+        assertThrows(CompletionException.class, anyOf::join);
+    }
+}


### PR DESCRIPTION
This PR aims to make `CompletableFuture.allOf()` and
`CompletableFuture.anyOf()` usage with `InvocationFuture`'s more
user-friendly.

Fixes: https://github.com/hazelcast/hazelcast/issues/23632