### PR TITLE
Update Kafka to 3.4.0 to fix CVE-2023-25194 [5.2.z]

### DIFF
--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/ResumeTransactionUtil.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/ResumeTransactionUtil.java
@@ -52,11 +52,11 @@ final class ResumeTransactionUtil {
 
         Object transactionManager = getTransactionManager(producer);
         synchronized (transactionManager) {
-            Object topicPartitionBookkeeper =
-                    getField(transactionManager, "topicPartitionBookkeeper");
+            Object txnPartitionMap =
+                    getField(transactionManager, "txnPartitionMap");
 
             transitionTransactionManagerStateTo(transactionManager, "INITIALIZING");
-            invoke(topicPartitionBookkeeper, "reset");
+            invoke(txnPartitionMap, "reset");
 
             setField(
                     transactionManager,

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <json-surfer.version>0.11</json-surfer.version>
         <jsr107.api.version>1.1.1</jsr107.api.version> <!-- JCache -->
         <jsr250.api.version>1.2</jsr250.api.version> <!-- javax.annotations -->
-        <kafka.version>2.8.2</kafka.version>
+        <kafka.version>3.4.0</kafka.version>
         <kotlin.version>1.7.10</kotlin.version>
         <log4j.version>1.2.17.redhat-00008</log4j.version>
         <log4j2.version>2.18.0</log4j2.version>


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/23786

Backport of https://github.com/hazelcast/hazelcast/pull/23906

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
