### PR TITLE
[TPC] OS utility + socketbuilders improvements and build failure fixes

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilder.java
@@ -37,9 +37,24 @@ public interface AsyncServerSocketBuilder {
      * @param <T> the type of the option/value
      * @throws NullPointerException when option or value is <code>null</code>.
      * @throws IllegalStateException when build already has been called
+     * @throws UnsupportedOperationException if the option isn't supported.
      * @throws java.io.UncheckedIOException when something failed while configuring the underlying socket.
      */
     <T> AsyncServerSocketBuilder set(Option<T> option, T value);
+
+    /**
+     * Sets the option on the underlying socket if that option is supported.
+     * If the option isn't supported, the call is ignored.
+     *
+     * @param option the option
+     * @param value the value
+     * @return this
+     * @param <T> the type of the option/value
+     * @throws NullPointerException when option or value is null.
+     * @throws IllegalStateException when build already has been called
+     * @throws java.io.UncheckedIOException when something failed while configuring the underlying socket.
+     */
+    <T> AsyncServerSocketBuilder setIfSupported(Option<T> option, T value);
 
     /**
      * Sets the consumer for accept requests.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilder.java
@@ -32,36 +32,41 @@ public interface AsyncServerSocketBuilder {
      * Sets the option on the underlying socket.
      *
      * @param option the option
-     * @param value the value
+     * @param value  the value
+     * @param <T>    the type of the option/value
      * @return this
-     * @param <T> the type of the option/value
-     * @throws NullPointerException when option or value is <code>null</code>.
-     * @throws IllegalStateException when build already has been called
+     * @throws NullPointerException          when option or value is null.
+     * @throws IllegalStateException         when build already has been called
      * @throws UnsupportedOperationException if the option isn't supported.
-     * @throws java.io.UncheckedIOException when something failed while configuring the underlying socket.
+     * @throws java.io.UncheckedIOException  when something failed while configuring the underlying socket.
      */
-    <T> AsyncServerSocketBuilder set(Option<T> option, T value);
+    default <T> AsyncServerSocketBuilder set(Option<T> option, T value) {
+        if (setIfSupported(option, value)) {
+            return this;
+        } else {
+            throw new UnsupportedOperationException("'" + option.name() + "' not supported");
+        }
+    }
 
     /**
      * Sets the option on the underlying socket if that option is supported.
-     * If the option isn't supported, the call is ignored.
      *
      * @param option the option
-     * @param value the value
-     * @return this
-     * @param <T> the type of the option/value
-     * @throws NullPointerException when option or value is null.
-     * @throws IllegalStateException when build already has been called
+     * @param value  the value
+     * @param <T>    the type of the option/value
+     * @return true if the option was supported, false otherwise.
+     * @throws NullPointerException         when option or value is null.
+     * @throws IllegalStateException        when build already has been called
      * @throws java.io.UncheckedIOException when something failed while configuring the underlying socket.
      */
-    <T> AsyncServerSocketBuilder setIfSupported(Option<T> option, T value);
+    <T> boolean setIfSupported(Option<T> option, T value);
 
     /**
      * Sets the consumer for accept requests.
      *
      * @param consumer the consumer
      * @return this
-     * @throws NullPointerException if consumer is <code>null</code>.
+     * @throws NullPointerException  if consumer is null.
      * @throws IllegalStateException when build already has been called.
      */
     AsyncServerSocketBuilder setAcceptConsumer(Consumer<AcceptRequest> consumer);
@@ -70,8 +75,8 @@ public interface AsyncServerSocketBuilder {
      * Builds the AsyncServerSocket.
      *
      * @return the build AsyncServerSocket.
-     * @throws IllegalStateException when the build already has been called or when the builder
-     *                               has not been properly configured.
+     * @throws IllegalStateException        when the build already has been called or when the builder
+     *                                      has not been properly configured.
      * @throws java.io.UncheckedIOException when the socket could not be build.
      */
     AsyncServerSocket build();

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilder.java
@@ -35,7 +35,7 @@ public interface AsyncServerSocketBuilder {
      * @param value  the value
      * @param <T>    the type of the option/value
      * @return this
-     * @throws NullPointerException          when option or value is null.
+     * @throws NullPointerException          when option or value is <code>null</code>.
      * @throws IllegalStateException         when build already has been called
      * @throws UnsupportedOperationException if the option isn't supported.
      * @throws java.io.UncheckedIOException  when something failed while configuring the underlying socket.
@@ -55,7 +55,7 @@ public interface AsyncServerSocketBuilder {
      * @param value  the value
      * @param <T>    the type of the option/value
      * @return true if the option was supported, false otherwise.
-     * @throws NullPointerException         when option or value is null.
+     * @throws NullPointerException         when option or value is <code>null</code>.
      * @throws IllegalStateException        when build already has been called
      * @throws java.io.UncheckedIOException when something failed while configuring the underlying socket.
      */

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilder.java
@@ -66,7 +66,7 @@ public interface AsyncServerSocketBuilder {
      *
      * @param consumer the consumer
      * @return this
-     * @throws NullPointerException  if consumer is null.
+     * @throws NullPointerException  if consumer is <code>null</code>.
      * @throws IllegalStateException when build already has been called.
      */
     AsyncServerSocketBuilder setAcceptConsumer(Consumer<AcceptRequest> consumer);

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketBuilder.java
@@ -57,7 +57,6 @@ public interface AsyncSocketBuilder {
      * @return true if the option was supported, false otherwise.
      * @throws NullPointerException          when option or value is null.
      * @throws IllegalStateException         when build already has been called
-     * @throws UnsupportedOperationException if the option isn't supported.
      * @throws java.io.UncheckedIOException  when something failed while configuring
      *                                       the underlying socket.
      */

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketBuilder.java
@@ -34,29 +34,34 @@ public interface AsyncSocketBuilder {
      * @param value  the value
      * @param <T>    the type of the option/value
      * @return this
-     * @throws NullPointerException         when option or value is null.
-     * @throws IllegalStateException        when build already has been called
+     * @throws NullPointerException          when option or value is null.
+     * @throws IllegalStateException         when build already has been called
      * @throws UnsupportedOperationException if the option isn't supported.
-     * @throws java.io.UncheckedIOException when something failed while configuring
-     *                                      the underlying socket.
+     * @throws java.io.UncheckedIOException  when something failed while configuring
+     *                                       the underlying socket.
      */
-    <T> AsyncSocketBuilder set(Option<T> option, T value);
+    default <T> AsyncSocketBuilder set(Option<T> option, T value) {
+        if (setIfSupported(option, value)) {
+            return this;
+        } else {
+            throw new UnsupportedOperationException("'" + option.name() + "' not supported");
+        }
+    }
 
     /**
      * Sets the option on the underlying if that option is supported.
-     * If the option isn't supported, the call is ignored.
      *
      * @param option the option
      * @param value  the value
      * @param <T>    the type of the option/value
-     * @return this
-     * @throws NullPointerException         when option or value is null.
-     * @throws IllegalStateException        when build already has been called
+     * @return true if the option was supported, false otherwise.
+     * @throws NullPointerException          when option or value is null.
+     * @throws IllegalStateException         when build already has been called
      * @throws UnsupportedOperationException if the option isn't supported.
-     * @throws java.io.UncheckedIOException when something failed while configuring
-     *                                      the underlying socket.
+     * @throws java.io.UncheckedIOException  when something failed while configuring
+     *                                       the underlying socket.
      */
-    <T> AsyncSocketBuilder setIfSupported(Option<T> option, T value);
+    <T> boolean setIfSupported(Option<T> option, T value);
 
     /**
      * Sets the ReadHandler.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketBuilder.java
@@ -36,10 +36,27 @@ public interface AsyncSocketBuilder {
      * @return this
      * @throws NullPointerException         when option or value is null.
      * @throws IllegalStateException        when build already has been called
+     * @throws UnsupportedOperationException if the option isn't supported.
      * @throws java.io.UncheckedIOException when something failed while configuring
      *                                      the underlying socket.
      */
     <T> AsyncSocketBuilder set(Option<T> option, T value);
+
+    /**
+     * Sets the option on the underlying if that option is supported.
+     * If the option isn't supported, the call is ignored.
+     *
+     * @param option the option
+     * @param value  the value
+     * @param <T>    the type of the option/value
+     * @return this
+     * @throws NullPointerException         when option or value is null.
+     * @throws IllegalStateException        when build already has been called
+     * @throws UnsupportedOperationException if the option isn't supported.
+     * @throws java.io.UncheckedIOException when something failed while configuring
+     *                                      the underlying socket.
+     */
+    <T> AsyncSocketBuilder setIfSupported(Option<T> option, T value);
 
     /**
      * Sets the ReadHandler.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketOptions.java
@@ -79,7 +79,7 @@ public interface AsyncSocketOptions {
      *
      * @param option the option
      * @return true if supported, false otherwise
-     * @throws NullPointerException if option or value is null.
+     * @throws NullPointerException if option is <code>null</code>.
      */
     boolean isSupported(Option option);
 

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketOptions.java
@@ -73,6 +73,16 @@ public interface AsyncSocketOptions {
      */
     Option<Integer> TCP_KEEPCOUNT = new Option<>("TCP_KEEPCOUNT", Integer.class);
 
+
+    /**
+     * Checks if the option is supported.
+     *
+     * @param option the option
+     * @return true if supported, false otherwise
+     * @throws NullPointerException if option or value is null.
+     */
+    boolean isSupported(Option option);
+
     /**
      * Sets an option value.
      *
@@ -100,7 +110,6 @@ public interface AsyncSocketOptions {
      * @throws java.io.UncheckedIOException if the value could not be set.
      */
     <T> boolean setIfSupported(Option<T> option, T value);
-
 
     /**
      * Gets an option value if that option is supported. If option not supported,

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocketOptions.java
@@ -23,7 +23,6 @@ package com.hazelcast.internal.tpcengine;
  * and java.net.SocketOptions.
  */
 public interface AsyncSocketOptions {
-
     /**
      * See {@link java.net.SocketOptions#SO_RCVBUF}.
      */
@@ -80,18 +79,55 @@ public interface AsyncSocketOptions {
      * @param option the option
      * @param value  the value
      * @param <T>    the type of the value
+     * @throws NullPointerException          if option or value is null.
+     * @throws UnsupportedOperationException if the option isn't supported.
+     * @throws java.io.UncheckedIOException  if the value could not be set.
+     */
+    default <T> void set(Option<T> option, T value) {
+        if (!setIfSupported(option, value)) {
+            throw new UnsupportedOperationException("'" + option.name() + "' not supported");
+        }
+    }
+
+    /**
+     * Sets an option value if that option is supported.
+     *
+     * @param option the option
+     * @param value  the value
+     * @param <T>    the type of the value
+     * @return true if the option was supported, false otherwise.
      * @throws NullPointerException         if option or value is null.
      * @throws java.io.UncheckedIOException if the value could not be set.
      */
-    <T> void set(Option<T> option, T value);
+    <T> boolean setIfSupported(Option<T> option, T value);
+
 
     /**
-     * Gets an option value.
+     * Gets an option value if that option is supported. If option not supported,
+     * <code>null</code> is returned.
      *
      * @param option the option
      * @param <T>    the type of the value
      * @return null if value is null.
      * @throws java.io.UncheckedIOException if the value could not be get.
      */
-    <T> T get(Option<T> option);
+    <T> T getIfSupported(Option<T> option);
+
+    /**
+     * Gets an option value.
+     *
+     * @param option the option
+     * @param <T>    the type of the value
+     * @return the value for the option
+     * @throws UnsupportedOperationException if the option isn't supported.
+     * @throws java.io.UncheckedIOException  if the value could not be get.
+     */
+    default <T> T get(Option<T> option) {
+        T value = getIfSupported(option);
+        if (value == null) {
+            throw new UnsupportedOperationException("'" + option.name() + "' not supported");
+        } else {
+            return value;
+        }
+    }
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketBuilder.java
@@ -61,19 +61,10 @@ public class NioAsyncServerSocketBuilder implements AsyncServerSocketBuilder {
     }
 
     @Override
-    public <T> NioAsyncServerSocketBuilder set(Option<T> option, T value) {
+    public <T> boolean setIfSupported(Option<T> option, T value) {
         verifyNotBuild();
 
-        options.set(option, value);
-        return this;
-    }
-
-    @Override
-    public <T> AsyncServerSocketBuilder setIfSupported(Option<T> option, T value) {
-        verifyNotBuild();
-
-        options.setIfSupported(option, value);
-        return this;
+        return options.setIfSupported(option, value);
     }
 
     @SuppressWarnings("java:S1181")

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketBuilder.java
@@ -68,6 +68,14 @@ public class NioAsyncServerSocketBuilder implements AsyncServerSocketBuilder {
         return this;
     }
 
+    @Override
+    public <T> AsyncServerSocketBuilder setIfSupported(Option<T> option, T value) {
+        verifyNotBuild();
+
+        options.setIfSupported(option, value);
+        return this;
+    }
+
     @SuppressWarnings("java:S1181")
     @Override
     public AsyncServerSocket build() {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptions.java
@@ -60,6 +60,10 @@ public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
         checkNotNull(option, "option");
 
         SocketOption socketOption = toSocketOption(option);
+        return isSupported(socketOption);
+    }
+
+    private boolean isSupported(SocketOption socketOption) {
         return socketOption != null && serverSocketChannel.supportedOptions().contains(socketOption);
     }
 
@@ -70,11 +74,11 @@ public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
 
         try {
             SocketOption socketOption = toSocketOption(option);
-            if (socketOption == null || !serverSocketChannel.supportedOptions().contains(socketOption)) {
-                return false;
-            } else {
+            if (isSupported(socketOption)) {
                 serverSocketChannel.setOption(socketOption, value);
                 return true;
+            } else {
+                return false;
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to set " + option.name() + " with value [" + value + "]", e);
@@ -87,10 +91,10 @@ public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
 
         try {
             SocketOption socketOption = toSocketOption(option);
-            if (socketOption == null || !serverSocketChannel.supportedOptions().contains(socketOption)) {
-                return null;
-            } else {
+            if (isSupported(socketOption)) {
                 return (T) serverSocketChannel.getOption(socketOption);
+            } else {
+                return null;
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to get option " + option.name(), e);

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptions.java
@@ -56,6 +56,14 @@ public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
     }
 
     @Override
+    public boolean isSupported(Option option) {
+        checkNotNull(option, "option");
+
+        SocketOption socketOption = toSocketOption(option);
+        return socketOption != null && serverSocketChannel.supportedOptions().contains(socketOption);
+    }
+
+    @Override
     public <T> boolean setIfSupported(Option<T> option, T value) {
         checkNotNull(option, "option");
         checkNotNull(value, "value");

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptions.java
@@ -18,15 +18,12 @@ package com.hazelcast.internal.tpcengine.nio;
 
 import com.hazelcast.internal.tpcengine.AsyncSocketOptions;
 import com.hazelcast.internal.tpcengine.Option;
-import com.hazelcast.internal.tpcengine.logging.TpcLogger;
-import com.hazelcast.internal.tpcengine.logging.TpcLoggerLocator;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.nio.channels.ServerSocketChannel;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.internal.tpcengine.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.tpcengine.util.ReflectionUtil.findStaticFieldValue;
@@ -36,13 +33,9 @@ import static com.hazelcast.internal.tpcengine.util.ReflectionUtil.findStaticFie
  */
 public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
 
-    private static final AtomicBoolean SO_REUSE_PORT_PRINTED = new AtomicBoolean();
-
     // This option is available since Java 9, so we need to use reflection.
-    private static final SocketOption<Boolean> JAVA_NET_SO_REUSEPORT
+    private static final SocketOption<Boolean> STD_SOCK_OPT_SO_REUSEPORT
             = findStaticFieldValue(StandardSocketOptions.class, "SO_REUSEPORT");
-
-    private final TpcLogger logger = TpcLoggerLocator.getLogger(getClass());
 
     private final ServerSocketChannel serverSocketChannel;
 
@@ -50,27 +43,30 @@ public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
         this.serverSocketChannel = serverSocketChannel;
     }
 
+    private static SocketOption toSocketOption(Option option) {
+        if (SO_RCVBUF.equals(option)) {
+            return StandardSocketOptions.SO_RCVBUF;
+        } else if (SO_REUSEADDR.equals(option)) {
+            return StandardSocketOptions.SO_REUSEADDR;
+        } else if (SO_REUSEPORT.equals(option)) {
+            return STD_SOCK_OPT_SO_REUSEPORT;
+        } else {
+            return null;
+        }
+    }
+
     @Override
-    public <T> void set(Option<T> option, T value) {
+    public <T> boolean setIfSupported(Option<T> option, T value) {
         checkNotNull(option, "option");
         checkNotNull(value, "value");
 
         try {
-            if (SO_RCVBUF.equals(option)) {
-                serverSocketChannel.setOption(StandardSocketOptions.SO_RCVBUF, (Integer) value);
-            } else if (SO_REUSEADDR.equals(option)) {
-                serverSocketChannel.setOption(StandardSocketOptions.SO_REUSEADDR, (Boolean) value);
-            } else if (SO_REUSEPORT.equals(option)) {
-                if (JAVA_NET_SO_REUSEPORT == null) {
-                    if (SO_REUSE_PORT_PRINTED.compareAndSet(false, true)) {
-                        logger.warning("Ignoring SO_REUSEPORT."
-                                + "Please upgrade to Java 9+ to enable the SO_REUSEPORT option.");
-                    }
-                } else {
-                    serverSocketChannel.setOption(JAVA_NET_SO_REUSEPORT, (Boolean) value);
-                }
+            SocketOption socketOption = toSocketOption(option);
+            if (socketOption == null || !serverSocketChannel.supportedOptions().contains(socketOption)) {
+                return false;
             } else {
-                throw new UnsupportedOperationException("Unrecognized option " + option);
+                serverSocketChannel.setOption(socketOption, value);
+                return true;
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to set " + option.name() + " with value [" + value + "]", e);
@@ -78,22 +74,15 @@ public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
     }
 
     @Override
-    public <T> T get(Option<T> option) {
+    public <T> T getIfSupported(Option<T> option) {
         checkNotNull(option, "option");
 
         try {
-            if (SO_RCVBUF.equals(option)) {
-                return (T) serverSocketChannel.getOption(StandardSocketOptions.SO_RCVBUF);
-            } else if (SO_REUSEADDR.equals(option)) {
-                return (T) serverSocketChannel.getOption(StandardSocketOptions.SO_REUSEADDR);
-            } else if (SO_REUSEPORT.equals(option)) {
-                if (JAVA_NET_SO_REUSEPORT == null) {
-                    return (T) Boolean.FALSE;
-                } else {
-                    return (T) serverSocketChannel.getOption(JAVA_NET_SO_REUSEPORT);
-                }
+            SocketOption socketOption = toSocketOption(option);
+            if (socketOption == null || !serverSocketChannel.supportedOptions().contains(socketOption)) {
+                return null;
             } else {
-                throw new UnsupportedOperationException("Unrecognized option:" + option);
+                return (T) serverSocketChannel.getOption(socketOption);
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to get option " + option.name(), e);

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketBuilder.java
@@ -66,7 +66,6 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
         }
     }
 
-
     @Override
     public <T> boolean setIfSupported(Option<T> option, T value) {
         verifyNotBuild();

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketBuilder.java
@@ -66,20 +66,12 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
         }
     }
 
-    @Override
-    public <T> NioAsyncSocketBuilder set(Option<T> option, T value) {
-        verifyNotBuild();
-
-        options.set(option, value);
-        return this;
-    }
 
     @Override
-    public <T> AsyncSocketBuilder setIfSupported(Option<T> option, T value) {
+    public <T> boolean setIfSupported(Option<T> option, T value) {
         verifyNotBuild();
 
-        options.setIfSupported(option, value);
-        return this;
+        return options.setIfSupported(option, value);
     }
 
     public NioAsyncSocketBuilder setReceiveBufferIsDirect(boolean receiveBufferIsDirect) {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketBuilder.java
@@ -74,6 +74,14 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
         return this;
     }
 
+    @Override
+    public <T> AsyncSocketBuilder setIfSupported(Option<T> option, T value) {
+        verifyNotBuild();
+
+        options.setIfSupported(option, value);
+        return this;
+    }
+
     public NioAsyncSocketBuilder setReceiveBufferIsDirect(boolean receiveBufferIsDirect) {
         verifyNotBuild();
 

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -81,7 +81,7 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
     }
 
     private boolean isSupported(SocketOption socketOption) {
-        return socketOption != null & socketChannel.supportedOptions().contains(socketOption);
+        return socketOption != null && socketChannel.supportedOptions().contains(socketOption);
     }
 
     @Override

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -76,8 +76,12 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
             return true;
         } else {
             SocketOption socketOption = toSocketOption(option);
-            return socketOption != null && socketChannel.supportedOptions().contains(socketOption);
+            return isSupported(socketOption);
         }
+    }
+
+    private boolean isSupported(SocketOption socketOption) {
+        return socketOption != null & socketChannel.supportedOptions().contains(socketOption);
     }
 
     @Override
@@ -89,16 +93,17 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
                 return (T) (Integer) socketChannel.socket().getSoTimeout();
             } else {
                 SocketOption socketOption = toSocketOption(option);
-                if (socketOption == null || !socketChannel.supportedOptions().contains(socketOption)) {
-                    return null;
-                } else {
+                if (isSupported(socketOption)) {
                     return (T) socketChannel.getOption(socketOption);
+                } else {
+                    return null;
                 }
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
+
 
     @Override
     public <T> boolean setIfSupported(Option<T> option, T value) {
@@ -111,11 +116,11 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
                 return true;
             } else {
                 SocketOption socketOption = toSocketOption(option);
-                if (socketOption == null || !socketChannel.supportedOptions().contains(socketOption)) {
-                    return false;
-                } else {
+                if (isSupported(socketOption)) {
                     socketChannel.setOption(socketOption, value);
                     return true;
+                } else {
+                    return false;
                 }
             }
         } catch (IOException e) {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -104,7 +104,6 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
         }
     }
 
-
     @Override
     public <T> boolean setIfSupported(Option<T> option, T value) {
         checkNotNull(option, "option");

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -116,64 +116,76 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
             } else if (SO_TIMEOUT.equals(option)) {
                 channel.socket().setSoTimeout((Integer) value);
             } else if (TCP_KEEPCOUNT.equals(option)) {
-                if (JDK_NET_TCP_KEEPCOUNT == null) {
-                    if (TCP_KEEPCOUNT_PRINTED.compareAndSet(false, true)) {
-                        if (OS.isLinux()) {
-                            logger.warning("Ignoring TCP_KEEPCOUNT. "
-                                    + "Please upgrade to Java 11+ configure tcp_keepalive_probes in the kernel: "
-                                    + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
-                                    + "If this isn't dealt with, idle connections could be closed prematurely.");
-                        } else if (OS.isWindows()) {
-                            logger.warning("Ignoring TCP_KEEPCOUNT. This option is not supported on Windows.");
-                        } else {
-                            logger.warning("Ignoring TCP_KEEPCOUNT. The option either isn't supported by the OS "
-                                    + "or by the JVM (Java 11+ required).");
-                        }
-                    }
-                } else {
-                    channel.setOption(JDK_NET_TCP_KEEPCOUNT, (Integer) value);
-                }
+                setTcpKeepCount((Integer) value);
             } else if (TCP_KEEPIDLE.equals(option)) {
-                if (JDK_NET_TCP_KEEPIDLE == null) {
-                    if (TCP_KEEPIDLE_PRINTED.compareAndSet(false, true)) {
-                        if (OS.isLinux()) {
-                            logger.warning("Ignoring TCP_KEEPIDLE. "
-                                    + "Please upgrade to Java 11+ configure tcp_keepalive_time in the kernel. "
-                                    + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
-                                    + "If this isn't dealt with, idle connections could be closed prematurely.");
-                        } else if (OS.isWindows()) {
-                            logger.warning("Ignoring TCP_KEEPIDLE. This option is not supported on Windows.");
-                        } else {
-                            logger.warning("Ignoring TCP_KEEPIDLE. The option either isn't supported by the OS "
-                                    + "or by the JVM (Java 11+ required).");
-                        }
-                    }
-                } else {
-                    channel.setOption(JDK_NET_TCP_KEEPIDLE, (Integer) value);
-                }
+                setTcpKeepIdle((Integer) value);
             } else if (TCP_KEEPINTERVAL.equals(option)) {
-                if (JDK_NET_TCP_KEEPINTERVAL == null) {
-                    if (TCP_KEEPINTERVAL_PRINTED.compareAndSet(false, true)) {
-                        if (OS.isLinux()) {
-                            logger.warning("Ignoring TCP_KEEPINTERVAL. "
-                                    + "Please upgrade to Java 11+ and Linux or configure tcp_keepalive_intvl in the kernel. "
-                                    + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
-                                    + "If this isn't dealt with, idle connections could be closed prematurely.");
-                        } else if (OS.isWindows()) {
-                            logger.warning("Ignoring TCP_KEEPINTERVAL. This option is not supported on Windows.");
-                        } else {
-                            logger.warning("Ignoring TCP_KEEPINTERVAL. The option either isn't supported by the OS "
-                                    + "or by the JVM (Java 11+ required).");
-                        }
-                    }
-                } else {
-                    channel.setOption(JDK_NET_TCP_KEEPINTERVAL, (Integer) value);
-                }
+                setTcpKeepInterval((Integer) value);
             } else {
                 throw new UnsupportedOperationException("Unrecognized option:" + option);
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to setOption [" + option.name() + "] with value [" + value + "]", e);
+        }
+    }
+
+    private <T> void setTcpKeepInterval(Integer value) throws IOException {
+        if (JDK_NET_TCP_KEEPINTERVAL == null) {
+            if (TCP_KEEPINTERVAL_PRINTED.compareAndSet(false, true)) {
+                if (OS.isLinux()) {
+                    logger.warning("Ignoring TCP_KEEPINTERVAL. "
+                            + "Please upgrade to Java 11+ and Linux or configure tcp_keepalive_intvl in the kernel. "
+                            + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
+                            + "If this isn't dealt with, idle connections could be closed prematurely.");
+                } else if (OS.isWindows()) {
+                    logger.warning("Ignoring TCP_KEEPINTERVAL. This option is not supported on Windows.");
+                } else {
+                    logger.warning("Ignoring TCP_KEEPINTERVAL. The option either isn't supported by the OS "
+                            + "or by the JVM (Java 11+ required).");
+                }
+            }
+        } else {
+            channel.setOption(JDK_NET_TCP_KEEPINTERVAL, value);
+        }
+    }
+
+    private <T> void setTcpKeepIdle(Integer value) throws IOException {
+        if (JDK_NET_TCP_KEEPIDLE == null) {
+            if (TCP_KEEPIDLE_PRINTED.compareAndSet(false, true)) {
+                if (OS.isLinux()) {
+                    logger.warning("Ignoring TCP_KEEPIDLE. "
+                            + "Please upgrade to Java 11+ configure tcp_keepalive_time in the kernel. "
+                            + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
+                            + "If this isn't dealt with, idle connections could be closed prematurely.");
+                } else if (OS.isWindows()) {
+                    logger.warning("Ignoring TCP_KEEPIDLE. This option is not supported on Windows.");
+                } else {
+                    logger.warning("Ignoring TCP_KEEPIDLE. The option either isn't supported by the OS "
+                            + "or by the JVM (Java 11+ required).");
+                }
+            }
+        } else {
+            channel.setOption(JDK_NET_TCP_KEEPIDLE, value);
+        }
+    }
+
+    private <T> void setTcpKeepCount(Integer value) throws IOException {
+        if (JDK_NET_TCP_KEEPCOUNT == null) {
+            if (TCP_KEEPCOUNT_PRINTED.compareAndSet(false, true)) {
+                if (OS.isLinux()) {
+                    logger.warning("Ignoring TCP_KEEPCOUNT. "
+                            + "Please upgrade to Java 11+ configure tcp_keepalive_probes in the kernel: "
+                            + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
+                            + "If this isn't dealt with, idle connections could be closed prematurely.");
+                } else if (OS.isWindows()) {
+                    logger.warning("Ignoring TCP_KEEPCOUNT. This option is not supported on Windows.");
+                } else {
+                    logger.warning("Ignoring TCP_KEEPCOUNT. The option either isn't supported by the OS "
+                            + "or by the JVM (Java 11+ required).");
+                }
+            }
+        } else {
+            channel.setOption(JDK_NET_TCP_KEEPCOUNT, value);
         }
     }
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -130,6 +130,21 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
     }
 
     private <T> void setTcpKeepInterval(Integer value) throws IOException {
+        boolean unsupported = false;
+        if (JDK_NET_TCP_KEEPINTERVAL == null || TCP_KEEPINTERVAL_PRINTED.get()) {
+            unsupported = true;
+        } else {
+            try {
+                channel.setOption(JDK_NET_TCP_KEEPINTERVAL, value);
+            } catch (UnsupportedOperationException e) {
+                unsupported = true;
+            }
+        }
+
+        if(unsupported && TCP_KEEPCOUNT_PRINTED.compareAndSet(false,true)){
+
+        }
+
         if (OS.isWindows()) {
             if (TCP_KEEPINTERVAL_PRINTED.compareAndSet(false, true)) {
                 logger.warning("Ignoring TCP_KEEPINTERVAL. This option is not supported on Windows.");

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.tpcengine.AsyncSocketOptions;
 import com.hazelcast.internal.tpcengine.Option;
 import com.hazelcast.internal.tpcengine.logging.TpcLogger;
 import com.hazelcast.internal.tpcengine.logging.TpcLoggerLocator;
+import com.hazelcast.internal.tpcengine.util.OS;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -117,10 +118,17 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
             } else if (TCP_KEEPCOUNT.equals(option)) {
                 if (JDK_NET_TCP_KEEPCOUNT == null) {
                     if (TCP_KEEPCOUNT_PRINTED.compareAndSet(false, true)) {
-                        logger.warning("Ignoring TCP_KEEPCOUNT. "
-                                + "Please upgrade to Java 11+ or configure tcp_keepalive_probes in the kernel: "
-                                + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
-                                + "If this isn't dealt with, idle connections could be closed prematurely.");
+                        if (OS.isLinux()) {
+                            logger.warning("Ignoring TCP_KEEPCOUNT. "
+                                    + "Please upgrade to Java 11+ configure tcp_keepalive_probes in the kernel: "
+                                    + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
+                                    + "If this isn't dealt with, idle connections could be closed prematurely.");
+                        } else if (OS.isWindows()) {
+                            logger.warning("Ignoring TCP_KEEPCOUNT. This option is not supported on Windows.");
+                        } else {
+                            logger.warning("Ignoring TCP_KEEPCOUNT. The option either isn't supported by the OS "
+                                    + "or by the JVM (Java 11+ required).");
+                        }
                     }
                 } else {
                     channel.setOption(JDK_NET_TCP_KEEPCOUNT, (Integer) value);
@@ -128,10 +136,17 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
             } else if (TCP_KEEPIDLE.equals(option)) {
                 if (JDK_NET_TCP_KEEPIDLE == null) {
                     if (TCP_KEEPIDLE_PRINTED.compareAndSet(false, true)) {
-                        logger.warning("Ignoring TCP_KEEPIDLE. "
-                                + "Please upgrade to Java 11+ or configure tcp_keepalive_time in the kernel. "
-                                + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
-                                + "If this isn't dealt with, idle connections could be closed prematurely.");
+                        if (OS.isLinux()) {
+                            logger.warning("Ignoring TCP_KEEPIDLE. "
+                                    + "Please upgrade to Java 11+ configure tcp_keepalive_time in the kernel. "
+                                    + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
+                                    + "If this isn't dealt with, idle connections could be closed prematurely.");
+                        } else if (OS.isWindows()) {
+                            logger.warning("Ignoring TCP_KEEPIDLE. This option is not supported on Windows.");
+                        } else {
+                            logger.warning("Ignoring TCP_KEEPIDLE. The option either isn't supported by the OS "
+                                    + "or by the JVM (Java 11+ required).");
+                        }
                     }
                 } else {
                     channel.setOption(JDK_NET_TCP_KEEPIDLE, (Integer) value);
@@ -139,10 +154,17 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
             } else if (TCP_KEEPINTERVAL.equals(option)) {
                 if (JDK_NET_TCP_KEEPINTERVAL == null) {
                     if (TCP_KEEPINTERVAL_PRINTED.compareAndSet(false, true)) {
-                        logger.warning("Ignoring TCP_KEEPINTERVAL. "
-                                + "Please upgrade to Java 11+ or configure tcp_keepalive_intvl in the kernel. "
-                                + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
-                                + "If this isn't dealt with, idle connections could be closed prematurely.");
+                        if (OS.isLinux()) {
+                            logger.warning("Ignoring TCP_KEEPINTERVAL. "
+                                    + "Please upgrade to Java 11+ and Linux or configure tcp_keepalive_intvl in the kernel. "
+                                    + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
+                                    + "If this isn't dealt with, idle connections could be closed prematurely.");
+                        } else if (OS.isWindows()) {
+                            logger.warning("Ignoring TCP_KEEPINTERVAL. This option is not supported on Windows.");
+                        } else {
+                            logger.warning("Ignoring TCP_KEEPINTERVAL. The option either isn't supported by the OS "
+                                    + "or by the JVM (Java 11+ required).");
+                        }
                     }
                 } else {
                     channel.setOption(JDK_NET_TCP_KEEPINTERVAL, (Integer) value);

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -69,6 +69,18 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
     }
 
     @Override
+    public boolean isSupported(Option option) {
+        checkNotNull(option, "option");
+
+        if (option.equals(SO_TIMEOUT)) {
+            return true;
+        } else {
+            SocketOption socketOption = toSocketOption(option);
+            return socketOption != null && socketChannel.supportedOptions().contains(socketOption);
+        }
+    }
+
+    @Override
     public <T> T getIfSupported(Option<T> option) {
         checkNotNull(option, "option");
 

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -19,15 +19,12 @@ package com.hazelcast.internal.tpcengine.nio;
 
 import com.hazelcast.internal.tpcengine.AsyncSocketOptions;
 import com.hazelcast.internal.tpcengine.Option;
-import com.hazelcast.internal.tpcengine.logging.TpcLogger;
-import com.hazelcast.internal.tpcengine.logging.TpcLoggerLocator;
-import com.hazelcast.internal.tpcengine.util.OS;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.nio.channels.SocketChannel;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.internal.tpcengine.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.tpcengine.util.ReflectionUtil.findStaticFieldValue;
@@ -35,176 +32,82 @@ import static com.hazelcast.internal.tpcengine.util.ReflectionUtil.findStaticFie
 @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:returncount", "java:S3776"})
 public class NioAsyncSocketOptions implements AsyncSocketOptions {
 
-    private static final java.net.SocketOption<Integer> JDK_NET_TCP_KEEPCOUNT
+    private static final java.net.SocketOption<Integer> EXT_SOCK_OPTS_TCP_KEEPCOUNT
             = findStaticFieldValue("jdk.net.ExtendedSocketOptions", "TCP_KEEPCOUNT");
-    private static final java.net.SocketOption<Integer> JDK_NET_TCP_KEEPIDLE
+    private static final java.net.SocketOption<Integer> EXT_SOCK_OPTS_TCP_KEEPIDLE
             = findStaticFieldValue("jdk.net.ExtendedSocketOptions", "TCP_KEEPIDLE");
-    private static final java.net.SocketOption<Integer> JDK_NET_TCP_KEEPINTERVAL
+    private static final java.net.SocketOption<Integer> EXT_SO_OPTS_TCP_KEEPINTERVAL
             = findStaticFieldValue("jdk.net.ExtendedSocketOptions", "TCP_KEEPINTERVAL");
 
-    private static final AtomicBoolean TCP_KEEPCOUNT_PRINTED = new AtomicBoolean();
-    private static final AtomicBoolean TCP_KEEPIDLE_PRINTED = new AtomicBoolean();
-    private static final AtomicBoolean TCP_KEEPINTERVAL_PRINTED = new AtomicBoolean();
+    private final SocketChannel socketChannel;
 
-    private final SocketChannel channel;
-    private final TpcLogger logger = TpcLoggerLocator.getLogger(getClass());
+    NioAsyncSocketOptions(SocketChannel socketChannel) {
+        this.socketChannel = socketChannel;
+    }
 
-    NioAsyncSocketOptions(SocketChannel channel) {
-        this.channel = channel;
+    // SO_TIMEOUT unfortunately doesn't have a SocketOption version.
+    private static SocketOption toSocketOption(Option option) {
+        if (TCP_NODELAY.equals(option)) {
+            return StandardSocketOptions.TCP_NODELAY;
+        } else if (SO_RCVBUF.equals(option)) {
+            return StandardSocketOptions.SO_RCVBUF;
+        } else if (SO_SNDBUF.equals(option)) {
+            return StandardSocketOptions.SO_SNDBUF;
+        } else if (SO_KEEPALIVE.equals(option)) {
+            return StandardSocketOptions.SO_KEEPALIVE;
+        } else if (SO_REUSEADDR.equals(option)) {
+            return StandardSocketOptions.SO_REUSEADDR;
+        } else if (TCP_KEEPCOUNT.equals(option)) {
+            return EXT_SOCK_OPTS_TCP_KEEPCOUNT;
+        } else if (TCP_KEEPINTERVAL.equals(option)) {
+            return EXT_SO_OPTS_TCP_KEEPINTERVAL;
+        } else if (TCP_KEEPIDLE.equals(option)) {
+            return EXT_SOCK_OPTS_TCP_KEEPIDLE;
+        } else {
+            return null;
+        }
     }
 
     @Override
-    public <T> T get(Option<T> option) {
+    public <T> T getIfSupported(Option<T> option) {
         checkNotNull(option, "option");
 
         try {
-            if (TCP_NODELAY.equals(option)) {
-                return (T) channel.getOption(StandardSocketOptions.TCP_NODELAY);
-            } else if (SO_RCVBUF.equals(option)) {
-                return (T) channel.getOption(StandardSocketOptions.SO_RCVBUF);
-            } else if (SO_SNDBUF.equals(option)) {
-                return (T) channel.getOption(StandardSocketOptions.SO_SNDBUF);
-            } else if (SO_KEEPALIVE.equals(option)) {
-                return (T) channel.getOption(StandardSocketOptions.SO_KEEPALIVE);
-            } else if (SO_REUSEADDR.equals(option)) {
-                return (T) channel.getOption(StandardSocketOptions.SO_REUSEADDR);
-            } else if (SO_TIMEOUT.equals(option)) {
-                return (T) (Integer) channel.socket().getSoTimeout();
-            } else if (TCP_KEEPCOUNT.equals(option)) {
-                if (JDK_NET_TCP_KEEPCOUNT == null) {
-                    return (T) Integer.valueOf(0);
-                } else {
-                    return (T) channel.getOption(JDK_NET_TCP_KEEPCOUNT);
-                }
-            } else if (TCP_KEEPINTERVAL.equals(option)) {
-                if (JDK_NET_TCP_KEEPINTERVAL == null) {
-                    return (T) Integer.valueOf(0);
-                } else {
-                    return (T) channel.getOption(JDK_NET_TCP_KEEPINTERVAL);
-                }
-            } else if (TCP_KEEPIDLE.equals(option)) {
-                if (JDK_NET_TCP_KEEPIDLE == null) {
-                    return (T) Integer.valueOf(0);
-                } else {
-                    return (T) channel.getOption(JDK_NET_TCP_KEEPIDLE);
-                }
+            if (option.equals(SO_TIMEOUT)) {
+                return (T) (Integer) socketChannel.socket().getSoTimeout();
             } else {
-                throw new UnsupportedOperationException("Unrecognized option:" + option);
+                SocketOption socketOption = toSocketOption(option);
+                if (socketOption == null || !socketChannel.supportedOptions().contains(socketOption)) {
+                    return null;
+                } else {
+                    return (T) socketChannel.getOption(socketOption);
+                }
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     @Override
-    public <T> void set(Option<T> option, T value) {
+    public <T> boolean setIfSupported(Option<T> option, T value) {
         checkNotNull(option, "option");
         checkNotNull(value, "value");
 
         try {
-            if (TCP_NODELAY.equals(option)) {
-                channel.setOption(StandardSocketOptions.TCP_NODELAY, (Boolean) value);
-            } else if (SO_RCVBUF.equals(option)) {
-                channel.setOption(StandardSocketOptions.SO_RCVBUF, (Integer) value);
-            } else if (SO_SNDBUF.equals(option)) {
-                channel.setOption(StandardSocketOptions.SO_SNDBUF, (Integer) value);
-            } else if (SO_KEEPALIVE.equals(option)) {
-                channel.setOption(StandardSocketOptions.SO_KEEPALIVE, (Boolean) value);
-            } else if (SO_REUSEADDR.equals(option)) {
-                channel.setOption(StandardSocketOptions.SO_REUSEADDR, (Boolean) value);
-            } else if (SO_TIMEOUT.equals(option)) {
-                channel.socket().setSoTimeout((Integer) value);
-            } else if (TCP_KEEPCOUNT.equals(option)) {
-                setTcpKeepCount((Integer) value);
-            } else if (TCP_KEEPIDLE.equals(option)) {
-                setTcpKeepIdle((Integer) value);
-            } else if (TCP_KEEPINTERVAL.equals(option)) {
-                setTcpKeepInterval((Integer) value);
+            if (option.equals(SO_TIMEOUT)) {
+                socketChannel.socket().setSoTimeout((Integer) value);
+                return true;
             } else {
-                throw new UnsupportedOperationException("Unrecognized option:" + option);
+                SocketOption socketOption = toSocketOption(option);
+                if (socketOption == null || !socketChannel.supportedOptions().contains(socketOption)) {
+                    return false;
+                } else {
+                    socketChannel.setOption(socketOption, value);
+                    return true;
+                }
             }
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to setOption [" + option.name() + "] with value [" + value + "]", e);
-        }
-    }
-
-    private <T> void setTcpKeepInterval(Integer value) throws IOException {
-        boolean unsupported = false;
-        if (JDK_NET_TCP_KEEPINTERVAL == null || TCP_KEEPINTERVAL_PRINTED.get()) {
-            unsupported = true;
-        } else {
-            try {
-                channel.setOption(JDK_NET_TCP_KEEPINTERVAL, value);
-            } catch (UnsupportedOperationException e) {
-                unsupported = true;
-            }
-        }
-
-        if(unsupported && TCP_KEEPCOUNT_PRINTED.compareAndSet(false,true)){
-
-        }
-
-        if (OS.isWindows()) {
-            if (TCP_KEEPINTERVAL_PRINTED.compareAndSet(false, true)) {
-                logger.warning("Ignoring TCP_KEEPINTERVAL. This option is not supported on Windows.");
-            }
-        } else {
-            if (JDK_NET_TCP_KEEPINTERVAL == null) {
-                if (TCP_KEEPINTERVAL_PRINTED.compareAndSet(false, true)) {
-                    if (OS.isLinux()) {
-                        logger.warning("Ignoring TCP_KEEPINTERVAL. "
-                                + "Please upgrade to Java 11+ or configure tcp_keepalive_intvl in the kernel. "
-                                + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
-                                + "If this isn't dealt with, idle connections could be closed prematurely.");
-                    } else {
-                        logger.warning("Ignoring TCP_KEEPINTERVAL. The option either isn't supported by the OS "
-                                + "or by the JVM (Java 11+ required).");
-                    }
-                }
-            } else {
-                channel.setOption(JDK_NET_TCP_KEEPINTERVAL, value);
-            }
-        }
-    }
-
-    private <T> void setTcpKeepIdle(Integer value) throws IOException {
-        if (JDK_NET_TCP_KEEPIDLE == null) {
-            if (TCP_KEEPIDLE_PRINTED.compareAndSet(false, true)) {
-                if (OS.isLinux()) {
-                    logger.warning("Ignoring TCP_KEEPIDLE. "
-                            + "Please upgrade to Java 11+ configure tcp_keepalive_time in the kernel. "
-                            + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
-                            + "If this isn't dealt with, idle connections could be closed prematurely.");
-                } else if (OS.isWindows()) {
-                    logger.warning("Ignoring TCP_KEEPIDLE. This option is not supported on Windows.");
-                } else {
-                    logger.warning("Ignoring TCP_KEEPIDLE. The option either isn't supported by the OS "
-                            + "or by the JVM (Java 11+ required).");
-                }
-            }
-        } else {
-            channel.setOption(JDK_NET_TCP_KEEPIDLE, value);
-        }
-    }
-
-    private <T> void setTcpKeepCount(Integer value) throws IOException {
-        if (JDK_NET_TCP_KEEPCOUNT == null) {
-            if (TCP_KEEPCOUNT_PRINTED.compareAndSet(false, true)) {
-                if (OS.isLinux()) {
-                    logger.warning("Ignoring TCP_KEEPCOUNT. "
-                            + "Please upgrade to Java 11+ configure tcp_keepalive_probes in the kernel: "
-                            + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
-                            + "If this isn't dealt with, idle connections could be closed prematurely.");
-                } else if (OS.isWindows()) {
-                    logger.warning("Ignoring TCP_KEEPCOUNT. This option is not supported on Windows.");
-                } else {
-                    logger.warning("Ignoring TCP_KEEPCOUNT. The option either isn't supported by the OS "
-                            + "or by the JVM (Java 11+ required).");
-                }
-            }
-        } else {
-            channel.setOption(JDK_NET_TCP_KEEPCOUNT, value);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -130,22 +130,26 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
     }
 
     private <T> void setTcpKeepInterval(Integer value) throws IOException {
-        if (JDK_NET_TCP_KEEPINTERVAL == null) {
+        if (OS.isWindows()) {
             if (TCP_KEEPINTERVAL_PRINTED.compareAndSet(false, true)) {
-                if (OS.isLinux()) {
-                    logger.warning("Ignoring TCP_KEEPINTERVAL. "
-                            + "Please upgrade to Java 11+ and Linux or configure tcp_keepalive_intvl in the kernel. "
-                            + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
-                            + "If this isn't dealt with, idle connections could be closed prematurely.");
-                } else if (OS.isWindows()) {
-                    logger.warning("Ignoring TCP_KEEPINTERVAL. This option is not supported on Windows.");
-                } else {
-                    logger.warning("Ignoring TCP_KEEPINTERVAL. The option either isn't supported by the OS "
-                            + "or by the JVM (Java 11+ required).");
-                }
+                logger.warning("Ignoring TCP_KEEPINTERVAL. This option is not supported on Windows.");
             }
         } else {
-            channel.setOption(JDK_NET_TCP_KEEPINTERVAL, value);
+            if (JDK_NET_TCP_KEEPINTERVAL == null) {
+                if (TCP_KEEPINTERVAL_PRINTED.compareAndSet(false, true)) {
+                    if (OS.isLinux()) {
+                        logger.warning("Ignoring TCP_KEEPINTERVAL. "
+                                + "Please upgrade to Java 11+ or configure tcp_keepalive_intvl in the kernel. "
+                                + "For more info see https://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/. "
+                                + "If this isn't dealt with, idle connections could be closed prematurely.");
+                    } else {
+                        logger.warning("Ignoring TCP_KEEPINTERVAL. The option either isn't supported by the OS "
+                                + "or by the JVM (Java 11+ required).");
+                    }
+                }
+            } else {
+                channel.setOption(JDK_NET_TCP_KEEPINTERVAL, value);
+            }
         }
     }
 

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/util/OS.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/util/OS.java
@@ -20,13 +20,14 @@ package com.hazelcast.internal.tpcengine.util;
  * Utility methods for OS specific functionality.
  */
 @SuppressWarnings("checkstyle:MethodName")
+// https://lopica.sourceforge.net/os.html
+// https://memorynotfound.com/detect-os-name-version-java/
 public final class OS {
 
     private static final String OS_NAME = System.getProperty("os.name", "?");
     private static final String OS_VERSION = System.getProperty("os.version", "?");
     private static final boolean IS_LINUX = isLinux0(OS_NAME);
     private static final boolean IS_WINDOWS = isWindows0(OS_NAME);
-    private static final boolean IS_UNIX_FAMILY = isUnixFamily0(OS_NAME);
     private static final boolean IS_MAC = isMac0(OS_NAME);
 
     private static final int LINUX_KERNEL_MAJOR_VERSION = linuxMajorVersion0(OS_VERSION, IS_LINUX);
@@ -50,11 +51,6 @@ public final class OS {
     static boolean isWindows0(String osName) {
         osName = osName.toLowerCase();
         return osName.contains("windows");
-    }
-
-    static boolean isUnixFamily0(String osName) {
-        osName = osName.toLowerCase();
-        return (osName.contains("nix") || osName.contains("nux") || osName.contains("aix"));
     }
 
     static boolean isMac0(String osName) {
@@ -181,15 +177,6 @@ public final class OS {
     }
 
     /**
-     * Returns {@code true} if the system is from Unix family.
-     *
-     * @return {@code true} if the current system is Unix/Linux/AIX.
-     */
-    public static boolean isUnixFamily() {
-        return IS_UNIX_FAMILY;
-    }
-
-    /**
      * Returns {@code true} if the system is a Mac OS.
      *
      * @return {@code true} if the current system is Mac.
@@ -206,5 +193,4 @@ public final class OS {
     public static boolean isWindows() {
         return IS_WINDOWS;
     }
-
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/util/OS.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/util/OS.java
@@ -25,6 +25,10 @@ public final class OS {
     private static final String OS_NAME = System.getProperty("os.name", "?");
     private static final String OS_VERSION = System.getProperty("os.version", "?");
     private static final boolean IS_LINUX = isLinux0(OS_NAME);
+    private static final boolean IS_WINDOWS = isWindows0(OS_NAME);
+    private static final boolean IS_UNIX_FAMILY = isUnixFamily(OS_NAME);
+    private static final boolean IS_MAC = isMac(OS_NAME);
+
     private static final int LINUX_KERNEL_MAJOR_VERSION = linuxMajorVersion0(OS_VERSION, IS_LINUX);
     private static final int LINUX_KERNEL_MINOR_VERSION = linuxMinorVersion0(OS_VERSION, IS_LINUX);
     private static final int PAGE_SIZE = UnsafeLocator.UNSAFE.pageSize();
@@ -41,6 +45,21 @@ public final class OS {
 
     static boolean isLinux0(String osName) {
         return osName.toLowerCase().startsWith("linux");
+    }
+
+    static boolean isWindows0(String osName) {
+        osName = osName.toLowerCase();
+        return osName.contains("windows");
+    }
+
+    static boolean isUnixFamily(String osName) {
+        osName = osName.toLowerCase();
+        return (osName.contains("nix") || osName.contains("nux") || osName.contains("aix"));
+    }
+
+    static boolean isMac(String osName) {
+        osName = osName.toLowerCase();
+        return (osName.contains("mac") || osName.contains("darwin"));
     }
 
     static int linuxMajorVersion0(String version, boolean isLinux) {
@@ -161,5 +180,31 @@ public final class OS {
         return IS_64BIT;
     }
 
+    /**
+     * Returns {@code true} if the system is from Unix family.
+     *
+     * @return {@code true} if the current system is Unix/Linux/AIX.
+     */
+    public static boolean isUnixFamily() {
+        return IS_UNIX_FAMILY;
+    }
+
+    /**
+     * Returns {@code true} if the system is a Mac OS.
+     *
+     * @return {@code true} if the current system is Mac.
+     */
+    public static boolean isMac() {
+        return IS_MAC;
+    }
+
+    /**
+     * Returns {@code true} if the system is a Windows.
+     *
+     * @return {@code true} if the current system is a Windows one.
+     */
+    public static boolean isWindows() {
+        return IS_WINDOWS;
+    }
 
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/util/OS.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/util/OS.java
@@ -26,8 +26,8 @@ public final class OS {
     private static final String OS_VERSION = System.getProperty("os.version", "?");
     private static final boolean IS_LINUX = isLinux0(OS_NAME);
     private static final boolean IS_WINDOWS = isWindows0(OS_NAME);
-    private static final boolean IS_UNIX_FAMILY = isUnixFamily(OS_NAME);
-    private static final boolean IS_MAC = isMac(OS_NAME);
+    private static final boolean IS_UNIX_FAMILY = isUnixFamily0(OS_NAME);
+    private static final boolean IS_MAC = isMac0(OS_NAME);
 
     private static final int LINUX_KERNEL_MAJOR_VERSION = linuxMajorVersion0(OS_VERSION, IS_LINUX);
     private static final int LINUX_KERNEL_MINOR_VERSION = linuxMinorVersion0(OS_VERSION, IS_LINUX);
@@ -52,12 +52,12 @@ public final class OS {
         return osName.contains("windows");
     }
 
-    static boolean isUnixFamily(String osName) {
+    static boolean isUnixFamily0(String osName) {
         osName = osName.toLowerCase();
         return (osName.contains("nix") || osName.contains("nux") || osName.contains("aix"));
     }
 
-    static boolean isMac(String osName) {
+    static boolean isMac0(String osName) {
         osName = osName.toLowerCase();
         return (osName.contains("mac") || osName.contains("darwin"));
     }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilderTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilderTest.java
@@ -27,8 +27,10 @@ import java.util.List;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminateAll;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AsyncServerSocketBuilderTest {
+    private static final Option<String> UNKNOwN_OPTION = new Option<>("banana", String.class);
 
     private final List<Reactor> reactors = new ArrayList<>();
 
@@ -47,28 +49,49 @@ public abstract class AsyncServerSocketBuilderTest {
     }
 
     @Test
-    public void setOption_whenNullOption() {
+    public void test_setIfSupported_whenNullOption() {
         Reactor reactor = newReactor();
         AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
-        assertThrows(NullPointerException.class, () -> builder.set(null, 1));
+        assertThrows(NullPointerException.class, () -> builder.setIfSupported(null, 1));
     }
 
     @Test
-    public void setOption_whenNullValue() {
+    public void test_setIfSupported_whenNullValue() {
         Reactor reactor = newReactor();
         AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
-        assertThrows(NullPointerException.class, () -> builder.set(AsyncSocketOptions.SO_RCVBUF, null));
+        assertThrows(NullPointerException.class, () -> builder.setIfSupported(AsyncSocketOptions.SO_RCVBUF, null));
     }
 
     @Test
-    public void whenAcceptConsumerNotSet() {
+    public void test_setIfSupported_whenNotSupported() {
+        Reactor reactor = newReactor();
+        AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
+        assertFalse(builder.setIfSupported(UNKNOwN_OPTION, "banana"));
+    }
+
+    @Test
+    public void test_setIfSupported_whenSuccess() {
+        Reactor reactor = newReactor();
+        AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
+        assertTrue(builder.setIfSupported(AsyncSocketOptions.SO_RCVBUF, 10));
+    }
+
+    @Test
+    public void test_set_whenNotSupported() {
+        Reactor reactor = newReactor();
+        AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
+        assertThrows(UnsupportedOperationException.class, () -> builder.set(UNKNOwN_OPTION, "banana"));
+    }
+
+    @Test
+    public void test_whenAcceptConsumerNotSet() {
         Reactor reactor = newReactor();
         AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
         assertThrows(IllegalStateException.class, builder::build);
     }
 
     @Test
-    public void whenReactorNotStarted() {
+    public void test_whenReactorNotStarted() {
         Reactor reactor = newReactorBuilder().build();
         reactors.add(reactor);
 
@@ -76,7 +99,7 @@ public abstract class AsyncServerSocketBuilderTest {
     }
 
     @Test
-    public void whenSuccess() {
+    public void test_whenSuccess() {
         Reactor reactor = newReactor();
 
         AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncServerSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncServerSocketOptionsTest.java
@@ -58,7 +58,7 @@ public abstract class AsyncServerSocketOptionsTest {
     }
 
     @Test
-    public void test_set_nullOption() {
+    public void set_nullOption() {
         AsyncServerSocket serverSocket = newServerSocket();
         AsyncSocketOptions options = serverSocket.options();
         assertThrows(NullPointerException.class, () -> options.set(null, 1));

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketBuilderTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketBuilderTest.java
@@ -22,9 +22,12 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AsyncSocketBuilderTest {
+    private static final Option<String> UNKNOwN_OPTION = new Option<>("banana", String.class);
 
     private final List<Reactor> reactors = new ArrayList<>();
 
@@ -40,6 +43,41 @@ public abstract class AsyncSocketBuilderTest {
     @After
     public void after() {
         TpcTestSupport.terminateAll(reactors);
+    }
+
+    @Test
+    public void test_setIfSupported_whenNullOption() {
+        Reactor reactor = newReactor();
+        AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
+        assertThrows(NullPointerException.class, () -> builder.setIfSupported(null, 1));
+    }
+
+    @Test
+    public void test_setIfSupported_whenNullValue() {
+        Reactor reactor = newReactor();
+        AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
+        assertThrows(NullPointerException.class, () -> builder.setIfSupported(AsyncSocketOptions.SO_RCVBUF, null));
+    }
+
+    @Test
+    public void test_setIfSupported_whenNotSupported() {
+        Reactor reactor = newReactor();
+        AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
+        assertFalse(builder.setIfSupported(UNKNOwN_OPTION, "banana"));
+    }
+
+    @Test
+    public void test_test_setIfSupported_whenSuccess() {
+        Reactor reactor = newReactor();
+        AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
+        assertTrue(builder.setIfSupported(AsyncSocketOptions.SO_RCVBUF, 10));
+    }
+
+    @Test
+    public void test_set_whenNotSupported() {
+        Reactor reactor = newReactor();
+        AsyncServerSocketBuilder builder = reactor.newAsyncServerSocketBuilder();
+        assertThrows(UnsupportedOperationException.class, () -> builder.set(UNKNOwN_OPTION, "banana"));
     }
 
     @Test

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.tpcengine;
 
 import com.hazelcast.internal.tpcengine.nio.NioAsyncSocketOptionsTest;
 import com.hazelcast.internal.tpcengine.util.JVM;
+import com.hazelcast.internal.tpcengine.util.OS;
 import org.junit.After;
 import org.junit.Test;
 
@@ -144,9 +145,10 @@ public abstract class AsyncSocketOptionsTest {
         assertEquals(Boolean.FALSE, options.get(SO_KEEPALIVE));
     }
 
-    private void assumeIfNioThenJava11Plus() {
+    private void assumeIfNioThenJava11PlusAndLinux() {
         if (this instanceof NioAsyncSocketOptionsTest) {
             assumeTrue(JVM.getMajorVersion() >= 11);
+            assumeTrue(OS.isLinux());
         }
     }
 
@@ -160,7 +162,7 @@ public abstract class AsyncSocketOptionsTest {
 
     @Test
     public void test_TCP_KEEPCOUNT() {
-        assumeIfNioThenJava11Plus();
+        assumeIfNioThenJava11PlusAndLinux();
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
         options.set(TCP_KEEPCOUNT, 100);
@@ -169,7 +171,7 @@ public abstract class AsyncSocketOptionsTest {
 
     @Test
     public void test_TCP_KEEPIDLE() {
-        assumeIfNioThenJava11Plus();
+        assumeIfNioThenJava11PlusAndLinux();
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
         options.set(TCP_KEEPIDLE, 100);
@@ -178,7 +180,7 @@ public abstract class AsyncSocketOptionsTest {
 
     @Test
     public void test_TCP_KEEPINTERVAL() {
-        assumeIfNioThenJava11Plus();
+        assumeIfNioThenJava11PlusAndLinux();
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
         options.set(TCP_KEEPINTERVAL, 100);

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
@@ -16,9 +16,6 @@
 
 package com.hazelcast.internal.tpcengine;
 
-import com.hazelcast.internal.tpcengine.nio.NioAsyncSocketOptionsTest;
-import com.hazelcast.internal.tpcengine.util.JVM;
-import com.hazelcast.internal.tpcengine.util.OS;
 import org.junit.After;
 import org.junit.Test;
 
@@ -36,8 +33,9 @@ import static com.hazelcast.internal.tpcengine.AsyncSocketOptions.TCP_KEEPINTERV
 import static com.hazelcast.internal.tpcengine.AsyncSocketOptions.TCP_NODELAY;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminateAll;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assume.assumeTrue;
 
 public abstract class AsyncSocketOptionsTest {
 
@@ -85,10 +83,24 @@ public abstract class AsyncSocketOptionsTest {
     }
 
     @Test
+    public void test_setIfUnsupported_unsupportedOption() {
+        AsyncSocket socket = newSocket();
+        AsyncSocketOptions options = socket.options();
+        assertFalse(options.setIfSupported(UNKNOwN_OPTION, ""));
+    }
+
+    @Test
     public void test_get_unsupportedOption() {
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
         assertThrows(UnsupportedOperationException.class, () -> options.get(UNKNOwN_OPTION));
+    }
+
+    @Test
+    public void test_getIfUnsupported_unsupportedOption() {
+        AsyncSocket socket = newSocket();
+        AsyncSocketOptions options = socket.options();
+        assertNull(options.getIfSupported(UNKNOwN_OPTION));
     }
 
     @Test
@@ -144,13 +156,6 @@ public abstract class AsyncSocketOptionsTest {
         assertEquals(Boolean.FALSE, options.get(SO_KEEPALIVE));
     }
 
-    private void assumeIfNioThenJava11PlusAndLinux() {
-        if (this instanceof NioAsyncSocketOptionsTest) {
-            assumeTrue(JVM.getMajorVersion() >= 11);
-            assumeTrue(OS.isLinux());
-        }
-    }
-
     @Test
     public void test_SO_TIMEOUT() {
         AsyncSocket socket = newSocket();
@@ -161,31 +166,40 @@ public abstract class AsyncSocketOptionsTest {
 
     @Test
     public void test_TCP_KEEPCOUNT() {
-        assumeIfNioThenJava11PlusAndLinux();
-
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
-        options.set(TCP_KEEPCOUNT, 100);
-        assertEquals(Integer.valueOf(100), options.get(TCP_KEEPCOUNT));
+        if (options.isSupported(TCP_KEEPCOUNT)) {
+            options.set(TCP_KEEPCOUNT, 100);
+            assertEquals(Integer.valueOf(100), options.get(TCP_KEEPCOUNT));
+        } else {
+            assertFalse(options.setIfSupported(TCP_KEEPCOUNT, 100));
+            assertNull(options.getIfSupported(TCP_KEEPCOUNT));
+        }
     }
 
     @Test
     public void test_TCP_KEEPIDLE() {
-        assumeIfNioThenJava11PlusAndLinux();
-
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
-        options.set(TCP_KEEPIDLE, 100);
-        assertEquals(Integer.valueOf(100), options.get(TCP_KEEPIDLE));
+        if (options.isSupported(TCP_KEEPIDLE)) {
+            options.set(TCP_KEEPIDLE, 100);
+            assertEquals(Integer.valueOf(100), options.get(TCP_KEEPIDLE));
+        } else {
+            assertFalse(options.setIfSupported(TCP_KEEPIDLE, 100));
+            assertNull(options.getIfSupported(TCP_KEEPIDLE));
+        }
     }
 
     @Test
     public void test_TCP_KEEPINTERVAL() {
-        assumeIfNioThenJava11PlusAndLinux();
-
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
-        options.set(TCP_KEEPINTERVAL, 100);
-        assertEquals(Integer.valueOf(100), options.get(TCP_KEEPINTERVAL));
+        if (options.isSupported(TCP_KEEPINTERVAL)) {
+            options.set(TCP_KEEPINTERVAL, 100);
+            assertEquals(Integer.valueOf(100), options.get(TCP_KEEPINTERVAL));
+        } else {
+            assertFalse(options.setIfSupported(TCP_KEEPINTERVAL, 100));
+            assertNull(options.getIfSupported(TCP_KEEPINTERVAL));
+        }
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
@@ -58,10 +58,9 @@ public abstract class AsyncSocketOptionsTest {
         reactors.add(reactor);
         reactor.start();
 
-        AsyncSocket socket = reactor.newAsyncSocketBuilder()
+        return reactor.newAsyncSocketBuilder()
                 .setReadHandler(new DevNullReadHandler())
                 .build();
-        return socket;
     }
 
     @Test

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertThrows;
 
 public abstract class AsyncSocketOptionsTest {
 
-    public static final Option<String> UNKNOwN_OPTION = new Option<>("banana", String.class);
+    private static final Option<String> UNKNOwN_OPTION = new Option<>("banana", String.class);
 
     private final List<Reactor> reactors = new ArrayList<>();
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
@@ -162,6 +162,7 @@ public abstract class AsyncSocketOptionsTest {
     @Test
     public void test_TCP_KEEPCOUNT() {
         assumeIfNioThenJava11PlusAndLinux();
+
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
         options.set(TCP_KEEPCOUNT, 100);
@@ -171,6 +172,7 @@ public abstract class AsyncSocketOptionsTest {
     @Test
     public void test_TCP_KEEPIDLE() {
         assumeIfNioThenJava11PlusAndLinux();
+
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
         options.set(TCP_KEEPIDLE, 100);
@@ -180,6 +182,7 @@ public abstract class AsyncSocketOptionsTest {
     @Test
     public void test_TCP_KEEPINTERVAL() {
         assumeIfNioThenJava11PlusAndLinux();
+
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
         options.set(TCP_KEEPINTERVAL, 100);

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
@@ -186,16 +186,4 @@ public abstract class AsyncSocketOptionsTest {
         options.set(TCP_KEEPINTERVAL, 100);
         assertEquals(Integer.valueOf(100), options.get(TCP_KEEPINTERVAL));
     }
-
-
-//    @Test
-//    public void test_TcpKeepAliveProbes() {
-//        assumeIfNioThenJava11Plus();
-//
-//        Reactor reactor = newReactor();
-//        AsyncSocket socket = reactor.openTcpAsyncSocket();
-//
-//        socket.setTcpKeepAliveProbes(5);
-//        assertEquals(5, socket.getTcpKeepaliveProbes());
-//    }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/util/OSTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/util/OSTest.java
@@ -35,6 +35,30 @@ public class OSTest {
     }
 
     @Test
+    public void test_isWindows0() {
+        assertTrue(OS.isWindows0("Windows"));
+        assertTrue(OS.isWindows0("wInDoWs"));
+        assertTrue(OS.isWindows0("Windows 10"));
+        assertTrue(OS.isWindows0("Windows 11"));
+        assertFalse(OS.isWindows0("LINUX"));
+        assertFalse(OS.isWindows0("LiNuX"));
+        assertFalse(OS.isWindows0("linux"));
+        assertFalse(OS.isWindows0("Mac OS X"));
+    }
+
+    @Test
+    public void test_isMac() {
+        assertFalse(OS.isMac0("Windows"));
+        assertFalse(OS.isMac0("wInDoWs"));
+        assertFalse(OS.isMac0("Windows 10"));
+        assertFalse(OS.isMac0("Windows 11"));
+        assertFalse(OS.isMac0("LINUX"));
+        assertFalse(OS.isMac0("LiNuX"));
+        assertFalse(OS.isMac0("linux"));
+        assertTrue(OS.isMac0("Mac OS X"));
+    }
+
+    @Test
     public void test_linuxMajorVersion0_whenIsLinux() {
         assertEquals(5, OS.linuxMajorVersion0("5.16.12-200.fc35.x86_64", true));
     }


### PR DESCRIPTION
The following functions were added.

- Check isWindows
- Check isMac
- Extracting the OS name.

The missing functionality comes from the OsHelper class which eventually will be removed once we have the commons module.

Code also has been optimized so the actual getters just return a static final boolean; so the analysis is only done once.

Also fixed the following bug:
https://github.com/hazelcast/hazelcast/issues/23918

There is also a cleanup of the AsyncSocketOptions. There is better support for unsupported options. There is no more secret ignoring of properties when not supported. Now you have full control.