### PR TITLE
Allow multiple actions in InstancePermission only when granting them [HZ-2116]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/SqlPlanImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/SqlPlanImpl.java
@@ -47,6 +47,7 @@ import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.core.TableModify.Operation;
 
 import java.security.Permission;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -85,9 +86,9 @@ abstract class SqlPlanImpl extends SqlPlan {
             return;
         }
         for (Vertex vertex : dag) {
-            Permission permission = vertex.getMetaSupplier().getRequiredPermission();
-            if (permission != null) {
-                context.checkPermission(permission);
+            Permission[] permissions = vertex.getMetaSupplier().getRequiredPermissions();
+            if (permissions != null) {
+                Arrays.stream(permissions).forEach(context::checkPermission);
             }
         }
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/SqlPlanImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/SqlPlanImpl.java
@@ -261,7 +261,8 @@ abstract class SqlPlanImpl extends SqlPlan {
         @Override
         public void checkPermissions(SqlSecurityContext context) {
             if (isReplace()) {
-                context.checkPermission(new SqlPermission(name, ACTION_CREATE_LINK, ACTION_DROP_LINK));
+                context.checkPermission(new SqlPermission(name, ACTION_CREATE_LINK));
+                context.checkPermission(new SqlPermission(name, ACTION_DROP_LINK));
             } else {
                 context.checkPermission(new SqlPermission(name, ACTION_CREATE_LINK));
             }
@@ -308,7 +309,8 @@ abstract class SqlPlanImpl extends SqlPlan {
 
         @Override
         public void checkPermissions(SqlSecurityContext context) {
-            context.checkPermission(new SqlPermission(name, ACTION_VIEW_LINK, ACTION_DROP_LINK));
+            context.checkPermission(new SqlPermission(name, ACTION_VIEW_LINK));
+            context.checkPermission(new SqlPermission(name, ACTION_DROP_LINK));
         }
 
         @Override
@@ -1189,7 +1191,8 @@ abstract class SqlPlanImpl extends SqlPlan {
 
         @Override
         public void checkPermissions(SqlSecurityContext context) {
-            context.checkPermission(new MapPermission(mapName, ACTION_CREATE, ACTION_READ));
+            context.checkPermission(new MapPermission(mapName, ACTION_CREATE));
+            context.checkPermission(new MapPermission(mapName, ACTION_READ));
             permissions.forEach(context::checkPermission);
         }
 
@@ -1263,7 +1266,8 @@ abstract class SqlPlanImpl extends SqlPlan {
 
         @Override
         public void checkPermissions(SqlSecurityContext context) {
-            context.checkPermission(new MapPermission(mapName, ACTION_CREATE, ACTION_PUT));
+            context.checkPermission(new MapPermission(mapName, ACTION_CREATE));
+            context.checkPermission(new MapPermission(mapName, ACTION_PUT));
             permissions.forEach(context::checkPermission);
         }
 
@@ -1329,7 +1333,9 @@ abstract class SqlPlanImpl extends SqlPlan {
 
         @Override
         public void checkPermissions(SqlSecurityContext context) {
-            context.checkPermission(new MapPermission(mapName, ACTION_CREATE, ACTION_PUT, ACTION_REMOVE));
+            context.checkPermission(new MapPermission(mapName, ACTION_CREATE));
+            context.checkPermission(new MapPermission(mapName, ACTION_PUT));
+            context.checkPermission(new MapPermission(mapName, ACTION_REMOVE));
             permissions.forEach(context::checkPermission);
         }
 
@@ -1411,7 +1417,10 @@ abstract class SqlPlanImpl extends SqlPlan {
         @Override
         public void checkPermissions(SqlSecurityContext context) {
             // We are checking ACTION_CREATE and ACTION_READ permissions to align with DmlPlan.
-            context.checkPermission(new MapPermission(mapName, ACTION_CREATE, ACTION_READ, ACTION_PUT, ACTION_REMOVE));
+            context.checkPermission(new MapPermission(mapName, ACTION_CREATE));
+            context.checkPermission(new MapPermission(mapName, ACTION_READ));
+            context.checkPermission(new MapPermission(mapName, ACTION_PUT));
+            context.checkPermission(new MapPermission(mapName, ACTION_REMOVE));
             permissions.forEach(context::checkPermission);
         }
 
@@ -1486,7 +1495,10 @@ abstract class SqlPlanImpl extends SqlPlan {
         @Override
         public void checkPermissions(SqlSecurityContext context) {
             // We are checking ACTION_CREATE and ACTION_READ permissions to align with DmlPlan.
-            context.checkPermission(new MapPermission(mapName, ACTION_CREATE, ACTION_READ, ACTION_PUT, ACTION_REMOVE));
+            context.checkPermission(new MapPermission(mapName, ACTION_CREATE));
+            context.checkPermission(new MapPermission(mapName, ACTION_READ));
+            context.checkPermission(new MapPermission(mapName, ACTION_PUT));
+            context.checkPermission(new MapPermission(mapName, ACTION_REMOVE));
             permissions.forEach(context::checkPermission);
         }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/InsertProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/InsertProcessorSupplier.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_PUT;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 final class InsertProcessorSupplier implements ProcessorSupplier, DataSerializable {
@@ -81,7 +82,7 @@ final class InsertProcessorSupplier implements ProcessorSupplier, DataSerializab
 
     @Override
     public List<Permission> permissions() {
-        return singletonList(new MapPermission(mapName, ACTION_CREATE, ACTION_PUT));
+        return asList(MapPermission.create(mapName, ACTION_CREATE, ACTION_PUT));
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinByEquiJoinProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinByEquiJoinProcessorSupplier.java
@@ -57,7 +57,7 @@ import static com.hazelcast.jet.Traversers.singleton;
 import static com.hazelcast.jet.Traversers.traverseIterable;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 @SuppressFBWarnings(
         value = {"SE_BAD_FIELD", "SE_NO_SERIALVERSIONID"},
@@ -180,7 +180,7 @@ final class JoinByEquiJoinProcessorSupplier implements ProcessorSupplier, DataSe
 
     @Override
     public List<Permission> permissions() {
-        return singletonList(new MapPermission(mapName, ACTION_CREATE, ACTION_READ));
+        return asList(MapPermission.create(mapName, ACTION_CREATE, ACTION_READ));
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinByPrimitiveKeyProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinByPrimitiveKeyProcessorSupplier.java
@@ -44,7 +44,7 @@ import java.util.List;
 import static com.hazelcast.jet.Traversers.singleton;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 @SuppressFBWarnings(
@@ -141,7 +141,7 @@ final class JoinByPrimitiveKeyProcessorSupplier implements ProcessorSupplier, Da
 
     @Override
     public List<Permission> permissions() {
-        return singletonList(new MapPermission(mapName, ACTION_CREATE, ACTION_READ));
+        return asList(MapPermission.create(mapName, ACTION_CREATE, ACTION_READ));
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinScanProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinScanProcessorSupplier.java
@@ -47,7 +47,7 @@ import java.util.Map.Entry;
 import static com.hazelcast.jet.Traversers.traverseIterable;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 @SuppressFBWarnings(
         value = {"SE_BAD_FIELD", "SE_NO_SERIALVERSIONID"},
@@ -156,7 +156,7 @@ final class JoinScanProcessorSupplier implements ProcessorSupplier, DataSerializ
 
     @Override
     public List<Permission> permissions() {
-        return singletonList(new MapPermission(mapName, ACTION_CREATE, ACTION_READ));
+        return asList(MapPermission.create(mapName, ACTION_CREATE, ACTION_READ));
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MapIndexScanP.java
@@ -67,8 +67,8 @@ import static com.hazelcast.jet.impl.util.Util.getNodeEngine;
 import static com.hazelcast.query.impl.getters.GetterCache.SIMPLE_GETTER_CACHE_SUPPLIER;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 
@@ -471,7 +471,7 @@ final class MapIndexScanP extends AbstractProcessor {
 
         @Override
         public List<Permission> permissions() {
-            return singletonList(new MapPermission(metadata.getMapName(), ACTION_CREATE, ACTION_READ));
+            return asList(MapPermission.create(metadata.getMapName(), ACTION_CREATE, ACTION_READ));
         }
 
         @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorSupplier.java
@@ -43,7 +43,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_PUT;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 final class UpdateProcessorSupplier implements ProcessorSupplier, DataSerializable {
 
@@ -103,7 +103,7 @@ final class UpdateProcessorSupplier implements ProcessorSupplier, DataSerializab
 
     @Override
     public List<Permission> permissions() {
-        return singletonList(new MapPermission(mapName, ACTION_CREATE, ACTION_PUT));
+        return asList(MapPermission.create(mapName, ACTION_CREATE, ACTION_PUT));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/SecureRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/SecureRequest.java
@@ -20,7 +20,18 @@ import java.security.Permission;
 
 public interface SecureRequest {
 
-    Permission getRequiredPermission();
+    Permission[] EMPTY_PERMISSIONS = new Permission[0];
+
+    default Permission getRequiredPermission() {
+        throw new IllegalStateException(
+                "At least one of the getRequiredPermission() and getRequiredPermissions() methods has to be implemented in "
+                        + getClass().getName());
+    }
+
+    default Permission[] getRequiredPermissions() {
+        Permission permission = getRequiredPermission();
+        return permission == null ? EMPTY_PERMISSIONS : new Permission[] { permission };
+    }
 
     /**
      * Used for {@link com.hazelcast.security.SecurityInterceptor}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -240,9 +240,11 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
     private void checkPermissions(ClientEndpoint endpoint) {
         SecurityContext securityContext = clientEngine.getSecurityContext();
         if (securityContext != null) {
-            Permission permission = getRequiredPermission();
-            if (permission != null) {
-                securityContext.checkPermission(endpoint.getSubject(), permission);
+            Permission[] permissions = getRequiredPermissions();
+            if (permissions != null) {
+                for (Permission permission : permissions) {
+                    securityContext.checkPermission(endpoint.getSubject(), permission);
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSubmitToKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSubmitToKeyMessageTask.java
@@ -63,8 +63,8 @@ public class MapSubmitToKeyMessageTask
     }
 
     @Override
-    public Permission getRequiredPermission() {
-        return new MapPermission(parameters.name, ActionConstants.ACTION_PUT, ActionConstants.ACTION_REMOVE);
+    public Permission[] getRequiredPermissions() {
+        return MapPermission.create(parameters.name, ActionConstants.ACTION_PUT, ActionConstants.ACTION_REMOVE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
@@ -98,6 +98,16 @@ public interface ProcessorMetaSupplier extends Serializable {
     }
 
     /**
+     * Returns the required permissions to execute the vertex which has
+     * this ProcessorMetaSupplier. This is an Enterprise feature.
+     */
+    @Nullable
+    default Permission[] getRequiredPermissions() {
+        Permission permission = getRequiredPermission();
+        return permission == null ? null : new Permission[] { permission };
+    }
+
+    /**
      * Returns the metadata on this supplier, a string-to-string map. There is
      * no predefined metadata; this facility exists to allow the DAG vertices
      * to contribute some information to the execution planning phase.

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -376,9 +376,10 @@ public class JobCoordinationService {
             return;
         }
         for (Vertex vertex : dag) {
-            Permission requiredPermission = vertex.getMetaSupplier().getRequiredPermission();
-            if (requiredPermission != null) {
-                securityContext.checkPermission(subject, requiredPermission);
+            Permission[] requiredPermissions = vertex.getMetaSupplier().getRequiredPermissions();
+            if (requiredPermissions != null) {
+                Arrays.stream(requiredPermissions)
+                        .forEach(requiredPermission -> securityContext.checkPermission(subject, requiredPermission));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
@@ -357,7 +357,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         private final FunctionEx<? super E, ? extends T> projection;
         private final JournalInitialPosition initialPos;
         private final EventTimePolicy<? super T> eventTimePolicy;
-        private final SupplierEx<Permission> permissionFn;
+        private final SupplierEx<Permission[]> permissionFn;
 
         private transient int remotePartitionCount;
 
@@ -374,7 +374,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
                 @Nonnull FunctionEx<? super E, ? extends T> projection,
                 @Nonnull JournalInitialPosition initialPos,
                 @Nonnull EventTimePolicy<? super T> eventTimePolicy,
-                @Nonnull SupplierEx<Permission> permissionFn
+                @Nonnull SupplierEx<Permission[]> permissionFn
         ) {
             if (dataLinkName != null && clientXml != null) {
                 throw new IllegalArgumentException("Only one of dataLinkName or clientXml should be provided");
@@ -438,7 +438,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         }
 
         @Override
-        public Permission getRequiredPermission() {
+        public Permission[] getRequiredPermissions() {
             if (isRemote(dataLinkName, clientXml)) {
                 return null;
             }
@@ -571,7 +571,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         return new ClusterMetaSupplier<>(null, null,
                 SecuredFunctions.mapEventJournalReaderFn(mapName),
                 predicate, projection, initialPos, eventTimePolicy,
-                () -> new MapPermission(mapName, ACTION_CREATE, ACTION_READ));
+                () -> MapPermission.create(mapName, ACTION_CREATE, ACTION_READ));
     }
 
     public static <K, V, T> ProcessorMetaSupplier streamRemoteMapSupplier(
@@ -588,7 +588,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         return new ClusterMetaSupplier<>(dataLinkName, clientXml,
                 SecuredFunctions.mapEventJournalReaderFn(mapName),
                 predicate, projection, initialPos, eventTimePolicy,
-                () -> new MapPermission(mapName, ACTION_CREATE, ACTION_READ));
+                () -> MapPermission.create(mapName, ACTION_CREATE, ACTION_READ));
     }
 
     public static <K, V, T> ProcessorMetaSupplier streamCacheSupplier(
@@ -603,7 +603,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         return new ClusterMetaSupplier<>(null, null,
                 SecuredFunctions.cacheEventJournalReaderFn(cacheName),
                 predicate, projection, initialPos, eventTimePolicy,
-                () -> new CachePermission(cacheName, ACTION_CREATE, ACTION_READ));
+                () -> CachePermission.create(cacheName, ACTION_CREATE, ACTION_READ));
     }
 
     /**
@@ -623,6 +623,6 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
         return new ClusterMetaSupplier<>(null, clientXml,
                 SecuredFunctions.cacheEventJournalReaderFn(cacheName),
                 predicate, projection, initialPos, eventTimePolicy,
-                () -> new CachePermission(cacheName, ACTION_CREATE, ACTION_READ));
+                () -> CachePermission.create(cacheName, ACTION_CREATE, ACTION_READ));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplier.java
@@ -96,6 +96,11 @@ public final class WrappingProcessorMetaSupplier implements ProcessorMetaSupplie
     }
 
     @Override
+    public Permission[] getRequiredPermissions() {
+        return wrapped.getRequiredPermissions();
+    }
+
+    @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(wrapped);
         out.writeObject(wrapperSupplier);

--- a/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunctions.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunctions.java
@@ -71,6 +71,7 @@ import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_PUBLISH;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_WRITE;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 /**
@@ -91,7 +92,7 @@ public final class SecuredFunctions {
 
             @Override
             public List<Permission> permissions() {
-                return singletonList(new MapPermission(name, ACTION_CREATE, ACTION_READ));
+                return asList(MapPermission.create(name, ACTION_CREATE, ACTION_READ));
             }
         };
     }
@@ -107,7 +108,7 @@ public final class SecuredFunctions {
 
             @Override
             public List<Permission> permissions() {
-                return singletonList(new MapPermission(name, ACTION_CREATE, ACTION_READ));
+                return asList(MapPermission.create(name, ACTION_CREATE, ACTION_READ));
             }
         };
     }
@@ -123,7 +124,7 @@ public final class SecuredFunctions {
 
             @Override
             public List<Permission> permissions() {
-                return singletonList(new CachePermission(name, ACTION_CREATE, ACTION_READ));
+                return asList(CachePermission.create(name, ACTION_CREATE, ACTION_READ));
             }
         };
     }
@@ -137,7 +138,7 @@ public final class SecuredFunctions {
 
             @Override
             public List<Permission> permissions() {
-                return singletonList(new ReplicatedMapPermission(name, ACTION_CREATE, ACTION_READ));
+                return asList(ReplicatedMapPermission.create(name, ACTION_CREATE, ACTION_READ));
             }
         };
     }
@@ -165,7 +166,7 @@ public final class SecuredFunctions {
 
             @Override
             public List<Permission> permissions() {
-                return singletonList(new ReliableTopicPermission(name, ACTION_CREATE, ACTION_PUBLISH));
+                return asList(ReliableTopicPermission.create(name, ACTION_CREATE, ACTION_PUBLISH));
             }
         };
     }

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/CachePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/CachePermission.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.security.permission;
 
+import java.security.Permission;
+import java.util.Arrays;
+
 public class CachePermission extends InstancePermission {
 
     private static final int PUT = 4;
@@ -52,4 +55,9 @@ public class CachePermission extends InstancePermission {
         }
         return mask;
     }
+
+    public static Permission[] create(String name, String... actions) {
+        return Arrays.stream(actions).map(a -> new CachePermission(name, a)).toArray(Permission[]::new);
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
@@ -66,8 +66,8 @@ public abstract class InstancePermission extends ClusterPermission {
         InstancePermission that = (InstancePermission) permission;
 
         if (that.actions != null && that.actions.indexOf(' ') >= 0) {
-            throw new IllegalStateException(
-                    "An InstancePermission with multiple actions is being checked! Multiple permissions with single action must be used instead!");
+            throw new IllegalStateException("An InstancePermission with multiple actions is being checked!"
+                    + " Multiple permissions with single action must be used instead!");
         }
 
         boolean maskTest = ((this.mask & that.mask) == that.mask);

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
@@ -65,6 +65,11 @@ public abstract class InstancePermission extends ClusterPermission {
 
         InstancePermission that = (InstancePermission) permission;
 
+        if (that.actions != null && that.actions.indexOf(' ') >= 0) {
+            throw new IllegalStateException(
+                    "An InstancePermission with multiple actions is being checked! Multiple permissions with single action must be used instead!");
+        }
+
         boolean maskTest = ((this.mask & that.mask) == that.mask);
         if (!maskTest) {
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
@@ -65,11 +65,6 @@ public abstract class InstancePermission extends ClusterPermission {
 
         InstancePermission that = (InstancePermission) permission;
 
-        if (that.actions != null && that.actions.indexOf(' ') >= 0) {
-            throw new IllegalStateException("An InstancePermission with multiple actions is being checked!"
-                    + " Multiple permissions with single action must be used instead!");
-        }
-
         boolean maskTest = ((this.mask & that.mask) == that.mask);
         if (!maskTest) {
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MapPermission.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.security.permission;
 
+import java.security.Permission;
+import java.util.Arrays;
+
 public class MapPermission extends InstancePermission {
 
     private static final int PUT = 4;
@@ -60,5 +63,9 @@ public class MapPermission extends InstancePermission {
             }
         }
         return mask;
+    }
+
+    public static Permission[] create(String name, String... actions) {
+        return Arrays.stream(actions).map(a -> new MapPermission(name, a)).toArray(MapPermission[]::new);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MapPermission.java
@@ -66,6 +66,6 @@ public class MapPermission extends InstancePermission {
     }
 
     public static Permission[] create(String name, String... actions) {
-        return Arrays.stream(actions).map(a -> new MapPermission(name, a)).toArray(MapPermission[]::new);
+        return Arrays.stream(actions).map(a -> new MapPermission(name, a)).toArray(Permission[]::new);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ReliableTopicPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ReliableTopicPermission.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.security.permission;
 
+import java.security.Permission;
+import java.util.Arrays;
+
 public class ReliableTopicPermission extends InstancePermission {
 
     private static final int PUBLISH = 4;
@@ -45,5 +48,9 @@ public class ReliableTopicPermission extends InstancePermission {
             }
         }
         return mask;
+    }
+
+    public static Permission[] create(String name, String... actions) {
+        return Arrays.stream(actions).map(a -> new ReliableTopicPermission(name, a)).toArray(Permission[]::new);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ReplicatedMapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ReplicatedMapPermission.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.security.permission;
 
+import java.security.Permission;
+import java.util.Arrays;
+
 public class ReplicatedMapPermission extends InstancePermission {
 
     private static final int PUT = 4;
@@ -61,4 +64,9 @@ public class ReplicatedMapPermission extends InstancePermission {
         }
         return mask;
     }
+
+    public static Permission[] create(String name, String... actions) {
+        return Arrays.stream(actions).map(a -> new ReplicatedMapPermission(name, a)).toArray(Permission[]::new);
+    }
+
 }


### PR DESCRIPTION
Don't allow multiple actions in checked client permissions as it can lead to a false denial.