### PR TITLE
Update lastAccessTime and expirationTime in executeOnEntries for HD IMap [HZ-2149]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -195,6 +195,9 @@ public class PartitionWideEntryOperation extends MapOperation
                 outComes.add(eventType);
                 outComes.add(operator.getEntry().getNewTtl());
                 outComes.add(operator.getEntry().isChangeExpiryOnUpdate());
+            } else {
+                // when event type is null, it means that there was no modification
+                operator.doPostOperateOps();
             }
         }, false);
 


### PR DESCRIPTION
Fixes HZ-2149

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/5801

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
