### PR TITLE
Fix a NPE when calling array getters on a DeserializedGenericRecord

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/DeserializedGenericRecord.java
@@ -219,6 +219,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_BOOLEAN, ARRAY_OF_NULLABLE_BOOLEAN);
         if (fieldKind == ARRAY_OF_NULLABLE_BOOLEAN) {
             Boolean[] array = (Boolean[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             boolean[] result = new boolean[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
@@ -237,6 +240,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_INT8, ARRAY_OF_NULLABLE_INT8);
         if (fieldKind == ARRAY_OF_NULLABLE_INT8) {
             Byte[] array = (Byte[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             byte[] result = new byte[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
@@ -261,6 +267,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_FLOAT64, ARRAY_OF_NULLABLE_FLOAT64);
         if (fieldKind == ARRAY_OF_NULLABLE_FLOAT64) {
             Double[] array = (Double[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             double[] result = new double[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
@@ -279,6 +288,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_FLOAT32, ARRAY_OF_NULLABLE_FLOAT32);
         if (fieldKind == ARRAY_OF_NULLABLE_FLOAT32) {
             Float[] array = (Float[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             float[] result = new float[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
@@ -297,6 +309,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_INT32, ARRAY_OF_NULLABLE_INT32);
         if (fieldKind == ARRAY_OF_NULLABLE_INT32) {
             Integer[] array = (Integer[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             int[] result = new int[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
@@ -315,6 +330,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_INT64, ARRAY_OF_NULLABLE_INT64);
         if (fieldKind == ARRAY_OF_NULLABLE_INT64) {
             Long[] array = (Long[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             long[] result = new long[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
@@ -333,6 +351,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16);
         if (fieldKind == ARRAY_OF_NULLABLE_INT16) {
             Short[] array = (Short[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             short[] result = new short[array.length];
             for (int i = 0; i < array.length; i++) {
                 if (array[i] == null) {
@@ -435,6 +456,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_BOOLEAN, ARRAY_OF_NULLABLE_BOOLEAN);
         if (fieldKind == ARRAY_OF_BOOLEAN) {
             boolean[] array = (boolean[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             Boolean[] result = new Boolean[array.length];
             Arrays.setAll(result, i -> array[i]);
             return result;
@@ -448,6 +472,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_INT8, ARRAY_OF_NULLABLE_INT8);
         if (fieldKind == ARRAY_OF_INT8) {
             byte[] array = (byte[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             Byte[] result = new Byte[array.length];
             Arrays.setAll(result, i -> array[i]);
             return result;
@@ -461,6 +488,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_FLOAT64, ARRAY_OF_NULLABLE_FLOAT64);
         if (fieldKind == ARRAY_OF_FLOAT64) {
             double[] array = (double[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             Double[] result = new Double[array.length];
             Arrays.setAll(result, i -> array[i]);
             return result;
@@ -474,6 +504,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_FLOAT32, ARRAY_OF_NULLABLE_FLOAT32);
         if (fieldKind == ARRAY_OF_FLOAT32) {
             float[] array = (float[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             Float[] result = new Float[array.length];
             Arrays.setAll(result, i -> array[i]);
             return result;
@@ -487,6 +520,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_INT32, ARRAY_OF_NULLABLE_INT32);
         if (fieldKind == ARRAY_OF_INT32) {
             int[] array = (int[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             Integer[] result = new Integer[array.length];
             Arrays.setAll(result, i -> array[i]);
             return result;
@@ -500,6 +536,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_INT64, ARRAY_OF_NULLABLE_INT64);
         if (fieldKind == ARRAY_OF_INT64) {
             long[] array = (long[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             Long[] result = new Long[array.length];
             Arrays.setAll(result, i -> array[i]);
             return result;
@@ -513,6 +552,9 @@ public class DeserializedGenericRecord extends CompactGenericRecord {
         FieldKind fieldKind = check(fieldName, ARRAY_OF_INT16, ARRAY_OF_NULLABLE_INT16);
         if (fieldKind == ARRAY_OF_INT16) {
             short[] array = (short[]) objects.get(fieldName);
+            if (array == null) {
+                return null;
+            }
             Short[] result = new Short[array.length];
             Arrays.setAll(result, i -> array[i]);
             return result;

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
@@ -51,6 +51,7 @@ import static com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder
 import static com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder.portable;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -382,5 +383,45 @@ public class GenericRecordTest {
         Schema schema = schemaWriter.build();
         GenericRecordBuilder builder = new DeserializedSchemaBoundGenericRecordBuilder(schema);
         builder.setArrayOfGenericRecord("f", new GenericRecord[]{aPortable, aCompact});
+    }
+
+    @Test
+    public void testGetArrayFieldAsNullableArrayField_whenFieldIsNull() {
+        GenericRecord record = compact("foo")
+                .setArrayOfBoolean("b", null)
+                .setArrayOfInt8("b8", null)
+                .setArrayOfInt16("s", null)
+                .setArrayOfInt32("i", null)
+                .setArrayOfInt64("l", null)
+                .setArrayOfFloat32("f", null)
+                .setArrayOfFloat64("d", null)
+                .build();
+        assertNull(record.getArrayOfNullableBoolean("b"));
+        assertNull(record.getArrayOfNullableInt8("b8"));
+        assertNull(record.getArrayOfNullableInt16("s"));
+        assertNull(record.getArrayOfNullableInt32("i"));
+        assertNull(record.getArrayOfNullableInt64("l"));
+        assertNull(record.getArrayOfNullableFloat32("f"));
+        assertNull(record.getArrayOfNullableFloat64("d"));
+    }
+
+    @Test
+    public void testGetArrayOfNullableFieldAsPrimitiveArrayField_whenFieldIsNull() {
+        GenericRecord record = compact("foo")
+                .setArrayOfNullableBoolean("b", null)
+                .setArrayOfNullableInt8("b8", null)
+                .setArrayOfNullableInt16("s", null)
+                .setArrayOfNullableInt32("i", null)
+                .setArrayOfNullableInt64("l", null)
+                .setArrayOfNullableFloat32("f", null)
+                .setArrayOfNullableFloat64("d", null)
+                .build();
+        assertNull(record.getArrayOfBoolean("b"));
+        assertNull(record.getArrayOfInt8("b8"));
+        assertNull(record.getArrayOfInt16("s"));
+        assertNull(record.getArrayOfInt32("i"));
+        assertNull(record.getArrayOfInt64("l"));
+        assertNull(record.getArrayOfFloat32("f"));
+        assertNull(record.getArrayOfFloat64("d"));
     }
 }


### PR DESCRIPTION
The problem was happening when a primitive array is tried to be read as a nullable array or vice versa. The array getters were not checking if the actual array was null in these conditions.

Fixes API-1870

Breaking changes (list specific methods/types/messages):
- None 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
