### PR TITLE
Multiple Mongo SQL connector fixes

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSourceBuilder.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSourceBuilder.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.mongodb;
 
+import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
@@ -355,7 +356,7 @@ public final class MongoSourceBuilder {
             this.name = name;
             this.params = new ReadMongoParams<>(true);
             this.params.setClientSupplier(clientSupplier);
-            this.params.setMapStreamFn((FunctionEx<ChangeStreamDocument<Document>, T>) streamToClass(Document.class));
+            this.params.setMapStreamFn((BiFunctionEx<ChangeStreamDocument<Document>, Long, T>) streamToClass(Document.class));
         }
         @SuppressWarnings("unchecked")
         private Stream(
@@ -366,7 +367,7 @@ public final class MongoSourceBuilder {
             this.name = name;
             this.params = new ReadMongoParams<>(true);
             this.params.setDataLinkRef(dataLinkRef);
-            this.params.setMapStreamFn((FunctionEx<ChangeStreamDocument<Document>, T>) streamToClass(Document.class));
+            this.params.setMapStreamFn((BiFunctionEx<ChangeStreamDocument<Document>, Long, T>) streamToClass(Document.class));
         }
 
         /**
@@ -476,13 +477,13 @@ public final class MongoSourceBuilder {
 
         /**
          * @param mapFn   transforms the queried document to the desired output
-         *                object
+         *                object. Second parameter will be the event timestamp.
          * @param <T_NEW> type of the emitted object
          * @return this builder
          */
         @Nonnull
         @SuppressWarnings("unchecked")
-        public <T_NEW> Stream<T_NEW> mapFn(@Nonnull FunctionEx<ChangeStreamDocument<Document>, T_NEW> mapFn) {
+        public <T_NEW> Stream<T_NEW> mapFn(@Nonnull BiFunctionEx<ChangeStreamDocument<Document>, Long, T_NEW> mapFn) {
             checkSerializable(mapFn, "mapFn");
             Stream<T_NEW> newThis = (Stream<T_NEW>) this;
             newThis.params.setMapStreamFn(mapFn);

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSourceBuilder.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSourceBuilder.java
@@ -356,7 +356,8 @@ public final class MongoSourceBuilder {
             this.name = name;
             this.params = new ReadMongoParams<>(true);
             this.params.setClientSupplier(clientSupplier);
-            this.params.setMapStreamFn((BiFunctionEx<ChangeStreamDocument<Document>, Long, T>) streamToClass(Document.class));
+            this.params.setMapStreamFn(
+                    (BiFunctionEx<ChangeStreamDocument<Document>, Long, T>) streamToClass(Document.class));
         }
         @SuppressWarnings("unchecked")
         private Stream(
@@ -367,7 +368,8 @@ public final class MongoSourceBuilder {
             this.name = name;
             this.params = new ReadMongoParams<>(true);
             this.params.setDataLinkRef(dataLinkRef);
-            this.params.setMapStreamFn((BiFunctionEx<ChangeStreamDocument<Document>, Long, T>) streamToClass(Document.class));
+            this.params.setMapStreamFn(
+                    (BiFunctionEx<ChangeStreamDocument<Document>, Long, T>) streamToClass(Document.class));
         }
 
         /**

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSources.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSources.java
@@ -310,7 +310,7 @@ public final class MongoSources {
                 .stream(name, () -> MongoClients.create(connectionString))
                 .database(database)
                 .collection(collection)
-                .mapFn(ChangeStreamDocument::getFullDocument);
+                .mapFn((d, t) -> d.getFullDocument());
         if (projection != null) {
             builder.project(projection);
         }

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSources.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSources.java
@@ -25,7 +25,6 @@ import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.spi.annotation.Beta;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
-import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/Mappers.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/Mappers.java
@@ -15,6 +15,7 @@
  */
 package com.hazelcast.jet.mongodb.impl;
 
+import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
@@ -75,8 +76,8 @@ public final class Mappers {
     }
 
     @Nonnull
-    public static <T> FunctionEx<ChangeStreamDocument<Document>, T> streamToClass(Class<T> type) {
-        return doc -> {
+    public static <T> BiFunctionEx<ChangeStreamDocument<Document>, Long, T> streamToClass(Class<T> type) {
+        return (doc, ts) -> {
             assert doc.getFullDocument() != null;
             return map(doc.getFullDocument(), type);
         };

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
@@ -39,6 +39,10 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public final class MongoUtilities {
+    /**
+     * 1 millisecond converted to nanoseconds.
+     */
+    @SuppressWarnings("checkstyle:MagicNumber")
     private static final int MILLIS_TO_NANOS = 1000 * 1000;
 
     private MongoUtilities() {
@@ -115,12 +119,16 @@ public final class MongoUtilities {
      * Converts given bson timest1amp to unix epoch.
      */
     @Nullable
+    @SuppressWarnings("checkstyle:MagicNumber")
     public static LocalDateTime bsonTimestampToLocalDateTime(@Nullable BsonTimestamp time) {
         if (time == null) {
             return null;
         }
         long v = time.getValue();
-        int nanoOfSecond = (int) (v % 1000) * MILLIS_TO_NANOS;
+        // gets last 3 digits - millisecond in the epoch timestamp - and converts it to nanoseconds
+        int millisOfSecond = (int) (v % 1000);
+        int nanoOfSecond = millisOfSecond * MILLIS_TO_NANOS;
         return LocalDateTime.ofEpochSecond(v / 1000, nanoOfSecond, ZoneOffset.UTC);
     }
+
 }

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
@@ -18,12 +18,16 @@ package com.hazelcast.jet.mongodb.impl;
 import com.mongodb.client.model.Field;
 import com.mongodb.client.model.Filters;
 import org.bson.BsonArray;
+import org.bson.BsonDateTime;
 import org.bson.BsonString;
 import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +36,7 @@ import static com.mongodb.client.model.Aggregates.match;
 import static com.mongodb.client.model.Aggregates.unset;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public final class MongoUtilities {
 
@@ -93,5 +98,27 @@ public final class MongoUtilities {
      */
     public static BsonTimestamp bsonTimestampFromTimeMillis(long time) {
         return new BsonTimestamp((int) MILLISECONDS.toSeconds(time), 0);
+    }
+    /**
+     * Converts given bson timestamp to unix epoch.
+     */
+    @Nullable
+    public static LocalDateTime bsonDateTimeToLocalDateTime(@Nullable BsonDateTime time) {
+        if (time == null) {
+            return null;
+        }
+        Instant instant = Instant.ofEpochMilli(time.getValue());
+        return LocalDateTime.from(instant);
+    }
+    /**
+     * Converts given bson timest1amp to unix epoch.
+     */
+    @Nullable
+    public static LocalDateTime bsonTimestampToLocalDateTime(@Nullable BsonTimestamp time) {
+        if (time == null) {
+            return null;
+        }
+        Instant instant = Instant.ofEpochMilli(SECONDS.toMillis(time.getTime()));
+        return LocalDateTime.from(instant);
     }
 }

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
@@ -28,6 +28,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,9 +37,9 @@ import static com.mongodb.client.model.Aggregates.match;
 import static com.mongodb.client.model.Aggregates.unset;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public final class MongoUtilities {
+    private static final int MILLIS_TO_NANOS = 1000 * 1000;
 
     private MongoUtilities() {
     }
@@ -118,7 +119,8 @@ public final class MongoUtilities {
         if (time == null) {
             return null;
         }
-        Instant instant = Instant.ofEpochMilli(SECONDS.toMillis(time.getTime()));
-        return LocalDateTime.from(instant);
+        long v = time.getValue();
+        int nanoOfSecond = (int) (v % 1000) * MILLIS_TO_NANOS;
+        return LocalDateTime.ofEpochSecond(v / 1000, nanoOfSecond, ZoneOffset.UTC);
     }
 }

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoParams.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoParams.java
@@ -15,6 +15,7 @@
  */
 package com.hazelcast.jet.mongodb.impl;
 
+import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.core.EventTimePolicy;
@@ -47,7 +48,7 @@ public class ReadMongoParams<I> implements Serializable {
 
     Long startAtTimestamp;
     EventTimePolicy<? super I> eventTimePolicy;
-    FunctionEx<ChangeStreamDocument<Document>, I> mapStreamFn;
+    BiFunctionEx<ChangeStreamDocument<Document>, Long, I> mapStreamFn;
 
     public ReadMongoParams(boolean stream) {
         this.stream = stream;
@@ -151,11 +152,11 @@ public class ReadMongoParams<I> implements Serializable {
         return this;
     }
 
-    public FunctionEx<ChangeStreamDocument<Document>, I> getMapStreamFn() {
+    public BiFunctionEx<ChangeStreamDocument<Document>, Long, I> getMapStreamFn() {
         return mapStreamFn;
     }
 
-    public ReadMongoParams<I> setMapStreamFn(FunctionEx<ChangeStreamDocument<Document>, I> mapStreamFn) {
+    public ReadMongoParams<I> setMapStreamFn(BiFunctionEx<ChangeStreamDocument<Document>, Long, I> mapStreamFn) {
         this.mapStreamFn = mapStreamFn;
         return this;
     }

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceResilienceTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceResilienceTest.java
@@ -34,7 +34,6 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import org.bson.BsonTimestamp;

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceResilienceTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceResilienceTest.java
@@ -237,7 +237,7 @@ public class MongoSourceResilienceTest extends SimpleTestInClusterSupport {
                         .stream("mongo source", () -> mongoClient(mongoContainerConnectionString))
                         .database(databaseName)
                         .collection(collectionName)
-                        .mapFn(ChangeStreamDocument::getFullDocument)
+                        .mapFn((d, t) -> d.getFullDocument())
                         .startAtOperationTime(new BsonTimestamp(System.currentTimeMillis()))
                         .build())
                 .withNativeTimestamps(0)

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/BsonTypes.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/BsonTypes.java
@@ -40,7 +40,6 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Date;
@@ -50,6 +49,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.jet.mongodb.impl.MongoUtilities.bsonTimestampToLocalDateTime;
 import static java.util.Locale.ROOT;
 import static java.util.stream.Collectors.toList;
 
@@ -60,8 +60,6 @@ final class BsonTypes {
 
     private static final Map<String, BsonType> BSON_NAME_TO_TYPE = generateBsonNameToBsonTypeMapping();
     private static final Map<Class<?>, BsonType> JAVA_TYPE_TO_BSON_TYPE = generateJavaClassToBsonTypeMapping();
-
-    private static final int MILLIS_TO_NANOS = 1000 * 1000;
 
     private BsonTypes() {
     }
@@ -176,7 +174,7 @@ final class BsonTypes {
             return LocalDateTime.from(new Date(v.getValue()).toInstant());
         }
         if (value instanceof BsonTimestamp) {
-            return timestampToLocalDateTime((BsonTimestamp) value);
+            return bsonTimestampToLocalDateTime((BsonTimestamp) value);
         }
         if (value instanceof BsonJavaScript) {
             return ((BsonJavaScript) value).getCode();
@@ -209,13 +207,6 @@ final class BsonTypes {
             return Document.parse(((HazelcastJsonValue) value).getValue());
         }
         return orElse.apply(value);
-    }
-
-    @SuppressWarnings("checkstyle:MagicNumber")
-    private static LocalDateTime timestampToLocalDateTime(BsonTimestamp value) {
-        long v = value.getValue();
-        int nanoOfSecond = (int) (v % 1000) * MILLIS_TO_NANOS;
-        return LocalDateTime.ofEpochSecond(v / 1000, nanoOfSecond, ZoneOffset.UTC);
     }
 
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/BsonTypes.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/BsonTypes.java
@@ -70,6 +70,14 @@ final class BsonTypes {
         return bsonType;
     }
 
+    static BsonType resolveTypeFromJavaClass(Class<?> clazz) {
+        BsonType bsonType = JAVA_TYPE_TO_BSON_TYPE.get(clazz);
+        if (bsonType == null) {
+            throw new IllegalArgumentException("BSON type " + clazz + " is not known");
+        }
+        return bsonType;
+    }
+
     static BsonType resolveTypeByName(String bsonTypeName) {
         BsonType bsonType = BSON_NAME_TO_TYPE.get(bsonTypeName.toLowerCase(ROOT));
         if (bsonType == null) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolver.java
@@ -30,23 +30,20 @@ import org.bson.Document;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.function.Predicate;
 
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
+import static com.hazelcast.jet.sql.impl.connector.mongodb.BsonTypes.getBsonType;
 import static com.hazelcast.jet.sql.impl.connector.mongodb.BsonTypes.resolveTypeFromJava;
 import static com.hazelcast.jet.sql.impl.connector.mongodb.Options.CONNECTION_STRING_OPTION;
 import static com.hazelcast.jet.sql.impl.connector.mongodb.Options.DATA_LINK_REF_OPTION;
 import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
 import static com.mongodb.client.model.Filters.eq;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 
 class FieldResolver {
 
@@ -221,34 +218,6 @@ class FieldResolver {
             }
         }
         return fields;
-    }
-
-    private static BsonType getBsonType(Document props) {
-        Object bsonType = props.get("bsonType");
-        if (bsonType instanceof String) {
-            String bsonTypeName = (String) bsonType;
-            return BsonTypes.resolveTypeByName(bsonTypeName);
-        }
-        if (bsonType instanceof Collection) {
-            return BsonType.DOCUMENT;
-        } else if (bsonType == null) {
-            Object enumValues = props.get("enum");
-            checkNotNull(enumValues, "either bsonType or enum should be provided");
-            Collection<?> col = (Collection<?>) enumValues;
-            List<? extends Class<?>> classes =
-                    col.stream()
-                       .filter(Objects::nonNull)
-                       .map(Object::getClass)
-                       .distinct()
-                       .collect(toList());
-
-            if (classes.size() != 1) {
-                return BsonType.DOCUMENT;
-            } else {
-                return BsonTypes.resolveTypeFromJavaClass(classes.get(0));
-            }
-        }
-        throw new UnsupportedOperationException("Cannot infer BSON type from schema");
     }
 
     private Document getIgnoringNulls(@Nonnull Document doc, @Nonnull String... options) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolver.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -235,7 +236,11 @@ class FieldResolver {
             checkNotNull(enumValues, "either bsonType or enum should be provided");
             Collection<?> col = (Collection<?>) enumValues;
             List<? extends Class<?>> classes =
-                    col.stream().map(Object::getClass).distinct().collect(toList());
+                    col.stream()
+                       .filter(Objects::nonNull)
+                       .map(Object::getClass)
+                       .distinct()
+                       .collect(toList());
 
             if (classes.size() != 1) {
                 return BsonType.DOCUMENT;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
@@ -15,8 +15,6 @@
  */
 package com.hazelcast.jet.sql.impl.connector.mongodb;
 
-import com.hazelcast.internal.util.StringUtil;
-import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.mongodb.datalink.MongoDataLink;
 import com.hazelcast.jet.mongodb.impl.MongoUtilities;
 import com.hazelcast.spi.impl.NodeEngine;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
@@ -15,15 +15,20 @@
  */
 package com.hazelcast.jet.sql.impl.connector.mongodb;
 
+import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.mongodb.datalink.MongoDataLink;
 import com.hazelcast.jet.mongodb.impl.MongoUtilities;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.schema.MappingField;
 import org.bson.BsonTimestamp;
 
 import java.time.Instant;
 import java.util.Map;
 import java.util.function.Predicate;
+
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 
 final class Options {
 
@@ -38,6 +43,9 @@ final class Options {
 
     static BsonTimestamp startAt(Map<String, String> options) {
         String startAtValue = options.get(START_AT_OPTION);
+        if (isNullOrEmpty(startAtValue)) {
+            throw QueryException.error("startAt property is required for MongoDB stream");
+        }
         if ("now".equalsIgnoreCase(startAtValue)) {
             return MongoUtilities.bsonTimestampFromTimeMillis(System.currentTimeMillis());
         } else {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/RexToMongo.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/RexToMongo.java
@@ -97,6 +97,16 @@ public final class RexToMongo {
 
             case IS_NOT_FALSE:
                 return Filters.ne((String) operands[0], false);
+            case IS_NULL:
+                return Filters.or(
+                        Filters.exists((String) operands[0], false),
+                        Filters.eq((String) operands[0], null)
+                );
+            case IS_NOT_NULL:
+                return Filters.and(
+                        Filters.exists((String) operands[0]),
+                        Filters.ne((String) operands[0], null)
+                );
             default:
                 throw new UnsupportedOperationException();
         }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolverTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolverTest.java
@@ -72,6 +72,9 @@ public class FieldResolverTest {
                             "        \"firstName\": { \"bsonType\": \"string\" }\n" +
                             "        \"lastName\": { \"bsonType\": \"string\" }\n" +
                             "        \"birthYear\": { \"bsonType\": \"int\" }\n" +
+                            "        \"title\": { \"enum\": [ \"Bsc\", \"Msc\", \"PhD\" ] }\n" +
+                            "        \"intOrString\": { \"enum\": [ \"String\", 1 ] }\n" +
+                            "        \"unionType\": { \"bsonType\": [ 'int', 'string' ] }\n" +
                             "      }\n" +
                             "    }\n" +
                             "  }\n"
@@ -85,11 +88,15 @@ public class FieldResolverTest {
             readOpts.put("connectionString", mongoContainer.getConnectionString());
             readOpts.put("database", databaseName);
             Map<String, DocumentField> fields = resolver.readFields(collectionName, readOpts, false);
-            assertThat(fields).containsOnlyKeys("firstName", "lastName", "birthYear");
+            assertThat(fields).containsOnlyKeys("firstName", "lastName", "birthYear", "title", "unionType", "intOrString");
             assertThat(fields.get("lastName").columnType).isEqualTo(BsonType.STRING);
             assertThat(fields.get("birthYear").columnType).isEqualTo(BsonType.INT32);
+            assertThat(fields.get("title").columnType).isEqualTo(BsonType.STRING);
+            assertThat(fields.get("intOrString").columnType).isEqualTo(BsonType.DOCUMENT);
+            assertThat(fields.get("unionType").columnType).isEqualTo(BsonType.DOCUMENT);
         }
     }
+
 
     @Test
     public void testResolvesFieldsViaSample() {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoBatchSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoBatchSqlConnectorTest.java
@@ -81,6 +81,7 @@ public class MongoBatchSqlConnectorTest extends MongoSqlTest {
         collection.insertOne(new Document("firstName", "Luke").append("lastName", "Skywalker").append("jedi", true));
         collection.insertOne(new Document("firstName", "Han").append("lastName", "Solo").append("jedi", false));
         collection.insertOne(new Document("firstName", "Anakin").append("lastName", "Skywalker").append("jedi", true));
+        collection.insertOne(new Document("firstName", "Rey").append("jedi", true));
 
         execute("CREATE MAPPING " + collectionName
                 + " ("
@@ -97,11 +98,12 @@ public class MongoBatchSqlConnectorTest extends MongoSqlTest {
 
         String force = forceTwoSteps ? " and cast(jedi as varchar) = 'true' " : "";
         assertRowsAnyOrder("select firstName, lastName from " + collectionName
-                        + " where lastName = ? and jedi=true" + force,
+                        + " where (lastName = ? or lastName is null) and jedi=true" + force,
                 singletonList("Skywalker"),
                 asList(
                         new Row("Luke", "Skywalker"),
-                        new Row("Anakin", "Skywalker")
+                        new Row("Anakin", "Skywalker"),
+                        new Row("Rey", null)
                 )
         );
         assertEquals(forceTwoSteps, projectAndFilterFound.get());

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlTest.java
@@ -32,6 +32,8 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.MongoDBContainer;
 
+import static org.testcontainers.containers.wait.strategy.Wait.forListeningPort;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class})
 public abstract class MongoSqlTest extends SqlTestSupport {
@@ -51,7 +53,7 @@ public abstract class MongoSqlTest extends SqlTestSupport {
     public final TestName testName = new TestName();
 
     @BeforeClass
-    public static void beforeClass() {
+    public static void beforeClass() throws InterruptedException {
         initialize(1, null);
         sqlService = instance().getSql();
         mongoClient = MongoClients.create(mongoContainer.getConnectionString());

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlTest.java
@@ -32,8 +32,6 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.MongoDBContainer;
 
-import static org.testcontainers.containers.wait.strategy.Wait.forListeningPort;
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class})
 public abstract class MongoSqlTest extends SqlTestSupport {

--- a/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -71,6 +71,7 @@ public abstract class SimpleTestInClusterSupport extends JetTestSupport {
         for (int i = 0; i < memberCount; i++) {
             instances[i] = factory.newHazelcastInstance(config);
         }
+        assertEqualsEventually(() -> instance().getLifecycleService().isRunning(), true);
     }
 
     protected static void initializeWithClient(


### PR DESCRIPTION
1. There was no event timestamp exposed and no wall time / cluster time from changeStreamDocument.
2. Returned row was not of the projection size, but document size - if field was missing, we got an error.
3. there was no `is null` / `is not null` support.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [?] Send backports/forwardports if fix needs to be applied to past/future releases