### PR TITLE
Stop retries when node stops

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/executor/CachedExecutorServiceDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/executor/CachedExecutorServiceDelegate.java
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 public final class CachedExecutorServiceDelegate implements ExecutorService, ManagedExecutorService {
@@ -220,7 +219,7 @@ public final class CachedExecutorServiceDelegate implements ExecutorService, Man
                 }
                 while (r != null);
             } catch (InterruptedException ignored) {
-                ignore(ignored);
+                Thread.currentThread().interrupt();
             } finally {
                 exit();
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
@@ -55,14 +55,10 @@ public class MapManagedService implements ManagedService {
 
     @Override
     public void shutdown(boolean terminate) {
-        if (!terminate) {
-            // in case of a graceful shutdown flush map-stores to prevent data-loss.
-            mapServiceContext.flushMaps();
-            mapServiceContext.destroyMapStores();
-        }
-
-        // clear internal resources, these are the resources wholly managed by hazelcast,
-        // means they have no external interaction like map-stores.
+        mapServiceContext.shutdownMapStores(terminate);
+        // clear internal resources, these are the resources
+        // wholly managed by hazelcast, means they have
+        // no external interaction like map-stores.
         mapServiceContext.shutdown();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -142,7 +142,11 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport,
 
     void destroyMapStores();
 
-    void flushMaps();
+    /**
+     * @param terminate {@code true} if immediate
+     * ungraceful shutdown of hazelcast instance is asked.
+     */
+    void shutdownMapStores(boolean terminate);
 
     void destroyMap(String mapName);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -420,6 +420,10 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public void flushMaps() {
+        for (MapContainer mapContainer : mapContainers.values()) {
+            mapContainer.getMapStoreContext().stop();
+        }
+
         for (PartitionContainer partitionContainer : partitionContainers) {
             for (String mapName : mapContainers.keySet()) {
                 RecordStore recordStore = partitionContainer.getExistingRecordStore(mapName);
@@ -430,9 +434,6 @@ class MapServiceContextImpl implements MapServiceContext {
             }
         }
 
-        for (MapContainer mapContainer : mapContainers.values()) {
-            mapContainer.getMapStoreContext().stop();
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -420,10 +420,6 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public void flushMaps() {
-        for (MapContainer mapContainer : mapContainers.values()) {
-            mapContainer.getMapStoreContext().stop();
-        }
-
         for (PartitionContainer partitionContainer : partitionContainers) {
             for (String mapName : mapContainers.keySet()) {
                 RecordStore recordStore = partitionContainer.getExistingRecordStore(mapName);
@@ -434,6 +430,9 @@ class MapServiceContextImpl implements MapServiceContext {
             }
         }
 
+        for (MapContainer mapContainer : mapContainers.values()) {
+            mapContainer.getMapStoreContext().stop();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -420,18 +420,18 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public void flushMaps() {
+        for (MapContainer mapContainer : mapContainers.values()) {
+            mapContainer.getMapStoreContext().stop();
+        }
+
         for (PartitionContainer partitionContainer : partitionContainers) {
             for (String mapName : mapContainers.keySet()) {
                 RecordStore recordStore = partitionContainer.getExistingRecordStore(mapName);
                 if (recordStore != null) {
                     MapDataStore mapDataStore = recordStore.getMapDataStore();
-                    mapDataStore.hardFlush();
+                    mapDataStore.hardFlushOnShutDown();
                 }
             }
-        }
-
-        for (MapContainer mapContainer : mapContainers.values()) {
-            mapContainer.getMapStoreContext().stop();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -420,10 +420,6 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public void flushMaps() {
-        for (MapContainer mapContainer : mapContainers.values()) {
-            mapContainer.getMapStoreContext().stop();
-        }
-
         for (PartitionContainer partitionContainer : partitionContainers) {
             for (String mapName : mapContainers.keySet()) {
                 RecordStore recordStore = partitionContainer.getExistingRecordStore(mapName);
@@ -432,6 +428,10 @@ class MapServiceContextImpl implements MapServiceContext {
                     mapDataStore.hardFlush();
                 }
             }
+        }
+
+        for (MapContainer mapContainer : mapContainers.values()) {
+            mapContainer.getMapStoreContext().stop();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/EmptyMapDataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/EmptyMapDataStore.java
@@ -85,7 +85,7 @@ class EmptyMapDataStore implements MapDataStore {
     }
 
     @Override
-    public void hardFlush() {
+    public void hardFlushOnShutDown() {
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStore.java
@@ -127,7 +127,7 @@ public interface MapDataStore<K, V> {
      *
      * @see com.hazelcast.map.impl.MapManagedService#shutdown(boolean)
      */
-    void hardFlush();
+    void hardFlushOnShutDown();
 
     /**
      * Flushes the supplied key to the map-store.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/AbstractWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/AbstractWriteBehindProcessor.java
@@ -91,34 +91,30 @@ abstract class AbstractWriteBehindProcessor<T> implements WriteBehindProcessor<T
 
         DELETE {
             @Override
-            boolean processSingle(Object key, Object value, MapStore mapStore) {
+            void processSingle(Object key, Object value, MapStore mapStore) {
                 mapStore.delete(key);
-                return true;
             }
 
             @Override
-            boolean processBatch(Map map, MapStore mapStore) {
+            void processBatch(Map map, MapStore mapStore) {
                 mapStore.deleteAll(map.keySet());
-                return true;
             }
         },
 
         WRITE {
             @Override
-            boolean processSingle(Object key, Object value, MapStore mapStore) {
+            void processSingle(Object key, Object value, MapStore mapStore) {
                 mapStore.store(key, value);
-                return true;
             }
 
             @Override
-            boolean processBatch(Map map, MapStore mapStore) {
+            void processBatch(Map map, MapStore mapStore) {
                 mapStore.storeAll(map);
-                return true;
             }
         };
 
-        abstract boolean processSingle(Object key, Object value, MapStore mapStore);
+        abstract void processSingle(Object key, Object value, MapStore mapStore);
 
-        abstract boolean processBatch(Map map, MapStore mapStore);
+        abstract void processBatch(Map map, MapStore mapStore);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/AbstractWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/AbstractWriteBehindProcessor.java
@@ -17,11 +17,11 @@
 package com.hazelcast.map.impl.mapstore.writebehind;
 
 import com.hazelcast.config.MapStoreConfig;
-import com.hazelcast.map.MapStore;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.MapStore;
 import com.hazelcast.map.impl.MapStoreWrapper;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
-import com.hazelcast.internal.serialization.SerializationService;
 
 import java.util.List;
 import java.util.Map;
@@ -33,15 +33,17 @@ import java.util.Map;
  */
 abstract class AbstractWriteBehindProcessor<T> implements WriteBehindProcessor<T> {
 
+    protected final boolean writeCoalescing;
     protected final int writeBatchSize;
 
-    protected final boolean writeCoalescing;
-
     protected final ILogger logger;
-
     protected final MapStoreWrapper mapStore;
+    protected final SerializationService serializationService;
 
-    private final SerializationService serializationService;
+    /**
+     * Flag to indicate this processor must be stopped.
+     */
+    protected volatile boolean stopped;
 
     AbstractWriteBehindProcessor(MapStoreContext mapStoreContext) {
         this.serializationService = mapStoreContext.getSerializationService();
@@ -50,6 +52,11 @@ abstract class AbstractWriteBehindProcessor<T> implements WriteBehindProcessor<T
         MapStoreConfig mapStoreConfig = mapStoreContext.getMapStoreConfig();
         this.writeBatchSize = mapStoreConfig.getWriteBatchSize();
         this.writeCoalescing = mapStoreConfig.isWriteCoalescing();
+    }
+
+    @Override
+    public void stop() {
+        stopped = true;
     }
 
     protected Object toObject(Object obj) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -100,7 +100,7 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
         return failuresByPartition;
     }
 
-    private void addFailsTo(Map<Integer, List<DelayedEntry>> failsPerPartition, List<DelayedEntry> fails) {
+    private static void addFailsTo(Map<Integer, List<DelayedEntry>> failsPerPartition, List<DelayedEntry> fails) {
         if (fails == null || fails.isEmpty()) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindManager.java
@@ -50,6 +50,7 @@ public class WriteBehindManager implements MapStoreManager {
     @Override
     public void stop() {
         storeWorker.stop();
+        writeBehindProcessor.stop();
     }
 
     //todo get this via constructor function.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessor.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.map.impl.mapstore.writebehind;
 
+import com.hazelcast.map.impl.mapstore.writebehind.entry.DelayedEntry;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -32,9 +34,10 @@ public interface WriteBehindProcessor<E> {
      * Process store operations and returns failed operation per partition map.
      *
      * @param delayedEntries to be written to store.
+     * @param onShutDown
      * @return failed store operations per partition.
      */
-    Map<Integer, List<E>> process(List<E> delayedEntries);
+    Map<Integer, List<E>> process(List<DelayedEntry> delayedEntries, boolean onShutDown);
 
     void callAfterStoreListeners(Collection<E> entries);
 
@@ -47,7 +50,7 @@ public interface WriteBehindProcessor<E> {
      *
      * @param queue supplied {@link WriteBehindQueue} for flush.
      */
-    void flush(WriteBehindQueue queue);
+    void hardFlushOnShutDown(WriteBehindQueue queue);
 
     /**
      * Flushes a key directly to map store.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessor.java
@@ -55,4 +55,9 @@ public interface WriteBehindProcessor<E> {
      * @param key to be flushed.
      */
     void flush(E key);
+
+    /**
+     * Contains stopping logic for this processor like stopping retries.
+     */
+    void stop();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
@@ -347,12 +347,12 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
     }
 
     @Override
-    public void hardFlush() {
+    public void hardFlushOnShutDown() {
         if (writeBehindQueue.size() == 0) {
             return;
         }
 
-        writeBehindProcessor.flush(writeBehindQueue);
+        writeBehindProcessor.hardFlushOnShutDown(writeBehindQueue);
     }
 
     public WriteBehindQueue<DelayedEntry> getWriteBehindQueue() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/WriteThroughStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/WriteThroughStore.java
@@ -100,7 +100,7 @@ public class WriteThroughStore extends AbstractMapDataStore<Data, Object> {
     }
 
     @Override
-    public void hardFlush() {
+    public void hardFlushOnShutDown() {
         // Only write-behind configured map-stores are flushable.
     }
 


### PR DESCRIPTION
**Issue:**
When a store operation fails while writing to map-store, we re-queue it by adding failed store operation to the **head** of the queue and then retry to store. If node is shutdown when doing these retries, node lives more than expected in memory, this is a temporary situation but if you do many quick node start and shut-down, memory need increase and OOME can be seen.

**Is this a new issue?**
Probably offloading mechanism made it easily visible since in a mixed test setup, which uses both write-through and write-behind maps, no map blocks other maps and we see increased throughput.

**Modifications:**
- To stop retrying on node stop, added a new flag to write-behind-processor so it can take actions to stop 
   retrying.
- Some polishing to make code more readable.

- [ ] backport to 5.2