### PR TITLE
Migrate from log4j to reload4j (#23953) [5.1.z]

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -550,8 +550,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <jsr250.api.version>1.2</jsr250.api.version> <!-- javax.annotations -->
         <kafka.version>2.2.2</kafka.version>
         <kotlin.version>1.5.32</kotlin.version>
-        <log4j.version>1.2.17.redhat-00008</log4j.version>
+        <reload4j.version>1.2.24</reload4j.version>
         <log4j2.version>2.17.1</log4j2.version>
         <mysql.connector.version>8.0.20</mysql.connector.version>
         <netty.version>4.1.86.Final</netty.version>
@@ -1775,9 +1775,9 @@
                 <version>${jackson.mapper.asl.version}</version>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>${log4j.version}</version>
+                <groupId>ch.qos.reload4j</groupId>
+                <artifactId>reload4j</artifactId>
+                <version>${reload4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.lz4</groupId>


### PR DESCRIPTION
To mitigate CVE-2020-9493, see
https://github.com/hazelcast/hazelcast/security/dependabot/30

Backport of https://github.com/hazelcast/hazelcast/pull/23953

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc

(cherry picked from commit ab8567aa1e10c46911efcc33e915ae3500989465)
