### PR TITLE
Migrate from log4j to reload4j (#23953) [4.2.z]

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -384,9 +384,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,9 @@
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
         <owasp.dependency-check.version>6.1.5</owasp.dependency-check.version>
         <codehause.license.plugin.version>2.0.0</codehause.license.plugin.version>
-
-        <log4j.version>1.2.17</log4j.version>
-
+        <reload4j.version>1.2.24</reload4j.version>
         <log4j2.version>2.17.0</log4j2.version>
         <slf4j.version>1.7.30</slf4j.version>
-
         <jackson.version>2.14.0</jackson.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -1406,6 +1403,11 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.reload4j</groupId>
+                <artifactId>reload4j</artifactId>
+                <version>${reload4j.version}</version>
             </dependency>
             <!--
             The following are test dependencies, they are not in the final distribution.


### PR DESCRIPTION
To mitigate CVE-2020-9493, see
https://github.com/hazelcast/hazelcast/security/dependabot/30

Backport of https://github.com/hazelcast/hazelcast/pull/23953

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc

(cherry picked from commit ab8567aa1e10c46911efcc33e915ae3500989465)
