### PR TITLE
Bump everit-json-schema to mitigate CVE-2022-45688

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -508,7 +508,7 @@
         <dependency>
             <groupId>com.github.erosb</groupId>
             <artifactId>everit-json-schema</artifactId>
-            <version>1.14.1</version>
+            <version>1.14.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.re2j</groupId>


### PR DESCRIPTION
Related to https://github.com/hazelcast/hazelcast/issues/23565

Forward port of https://github.com/hazelcast/hazelcast/pull/23935

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
