### PR TITLE
Add suppressions to owasp checks

### DIFF
--- a/owasp-check-suppressions.xml
+++ b/owasp-check-suppressions.xml
@@ -111,4 +111,47 @@
         <packageUrl regex="true">^pkg:maven/com\.google\.http\-client/google\-http\-client\-gson@.*$</packageUrl>
         <cpe>cpe:/a:google:gson</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        False positive - snakeyaml incorrectly identified as go-yaml project.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cpe>cpe:/a:yaml_project:yaml</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        False positive - json-utils incorrectly identified as json-java and random personal utils script.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/software\.amazon\.awssdk/json\-utils@.*$</packageUrl>
+        <cpe>cpe:/a:json-java_project:json-java</cpe>
+        <cpe>cpe:/a:utils_project:utils</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        False positive - json-smart incorrectly identified as json-java.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/net\.minidev/json\-smart@.*$</packageUrl>
+        <cpe>cpe:/a:json-java_project:json-java</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        False positive - json-path incorrectly identified as json-java.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.jayway\.jsonpath/json\-path@.*$</packageUrl>
+        <cpe>cpe:/a:json-java_project:json-java</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        False positive - json version 20230227 have already fix for listed CVE.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.json/json@20230227.*$</packageUrl>
+        <cve>CVE-2022-45688</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        False positive - woodstox:stax2-api identified as fasterxml:woodstox.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.codehaus\.woodstox/stax2\-api@.*$</packageUrl>
+        <cpe>cpe:/a:fasterxml:woodstox</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Add suppressions to owasp checks for already fixed CVE and incorrectly mapped dependencies

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases - **_needs to be done for master_**