### PR TITLE
[TPC] Minor cleanups

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/Option.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/Option.java
@@ -34,6 +34,7 @@ public final class Option<T> {
      *
      * @param name the name of the Option
      * @param type the type of the Option
+     * @throws NullPointerException if name of type is <code>null</code>.
      */
     public Option(String name, Class<T> type) {
         this.name = checkNotNull(name, "name");

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioReactor.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioReactor.java
@@ -31,11 +31,7 @@ public final class NioReactor extends Reactor {
 
     final Selector selector;
 
-    public NioReactor() {
-        this(new NioReactorBuilder());
-    }
-
-    public NioReactor(NioReactorBuilder builder) {
+    NioReactor(NioReactorBuilder builder) {
         super(builder);
         this.selector = ((NioEventloop) eventloop()).selector;
     }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioReactorBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioReactorBuilder.java
@@ -21,10 +21,13 @@ import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import com.hazelcast.internal.tpcengine.ReactorType;
 
 /**
- * A builder for a {@link NioReactor}.
+ * A {@link ReactorBuilder} that builds a {@link NioReactor}.
  */
 public class NioReactorBuilder extends ReactorBuilder {
 
+    /**
+     * Creates a new NioReactorBuilder.
+     */
     public NioReactorBuilder() {
         super(ReactorType.NIO);
     }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketOptionsTest.java
@@ -57,10 +57,9 @@ public abstract class AsyncSocketOptionsTest {
         reactors.add(reactor);
         reactor.start();
 
-        AsyncSocket socket = reactor.newAsyncSocketBuilder()
+        return reactor.newAsyncSocketBuilder()
                 .setReadHandler(new DevNullReadHandler())
                 .build();
-        return socket;
     }
 
     @Test

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
@@ -46,12 +46,12 @@ public abstract class AsyncSocket_LargePayloadTest {
     private Reactor clientReactor;
     private Reactor serverReactor;
 
-    public abstract Reactor newReactor();
+    public abstract ReactorBuilder newReactorBuilder();
 
     @Before
     public void before() {
-        clientReactor = newReactor();
-        serverReactor = newReactor();
+        clientReactor = newReactorBuilder().build().start();
+        serverReactor = newReactorBuilder().build().start();
     }
 
     @After

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_ReadableTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_ReadableTest.java
@@ -42,12 +42,12 @@ public abstract class AsyncSocket_ReadableTest {
     private Reactor clientReactor;
     private Reactor serverReactor;
 
-    public abstract Reactor newReactor();
+    public abstract ReactorBuilder newReactorBuilder();
 
     @Before
     public void before() {
-        clientReactor = newReactor();
-        serverReactor = newReactor();
+        clientReactor = newReactorBuilder().build().start();
+        serverReactor = newReactorBuilder().build().start();
     }
 
     @After

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_RpcTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_RpcTest.java
@@ -58,12 +58,12 @@ public abstract class AsyncSocket_RpcTest {
     private Reactor clientReactor;
     private Reactor serverReactor;
 
-    public abstract Reactor newReactor();
+    public abstract ReactorBuilder newReactorBuilder();
 
     @Before
     public void before() {
-        clientReactor = newReactor();
-        serverReactor = newReactor();
+        clientReactor = newReactorBuilder().build().start();
+        serverReactor = newReactorBuilder().build().start();
     }
 
     @After

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/PromiseTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/PromiseTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.tpcengine;
 
-import com.hazelcast.internal.tpcengine.nio.NioReactor;
+import com.hazelcast.internal.tpcengine.nio.NioReactorBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,13 +35,12 @@ import static org.junit.Assert.assertTrue;
 
 public class PromiseTest {
 
-    private NioReactor reactor;
+    private Reactor reactor;
     private PromiseAllocator promiseAllocator;
 
     @Before
     public void before() {
-        reactor = new NioReactor();
-        reactor.start();
+        reactor = new NioReactorBuilder().build().start();
 
         promiseAllocator = new PromiseAllocator(reactor.eventloop, 1024);
     }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_LargePayloadTest.java
@@ -17,12 +17,12 @@
 package com.hazelcast.internal.tpcengine.nio;
 
 import com.hazelcast.internal.tpcengine.AsyncSocket_LargePayloadTest;
-import com.hazelcast.internal.tpcengine.Reactor;
+import com.hazelcast.internal.tpcengine.ReactorBuilder;
 
 public class NioAsyncSocket_LargePayloadTest extends AsyncSocket_LargePayloadTest {
 
     @Override
-    public Reactor newReactor() {
-        return new NioReactor().start();
+    public ReactorBuilder newReactorBuilder() {
+        return new NioReactorBuilder();
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_ReadableTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_ReadableTest.java
@@ -17,12 +17,12 @@
 package com.hazelcast.internal.tpcengine.nio;
 
 import com.hazelcast.internal.tpcengine.AsyncSocket_ReadableTest;
-import com.hazelcast.internal.tpcengine.Reactor;
+import com.hazelcast.internal.tpcengine.ReactorBuilder;
 
 public class NioAsyncSocket_ReadableTest extends AsyncSocket_ReadableTest {
 
     @Override
-    public Reactor newReactor() {
-        return new NioReactor().start();
+    public ReactorBuilder newReactorBuilder() {
+        return new NioReactorBuilder();
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_RpcTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_RpcTest.java
@@ -17,12 +17,12 @@
 package com.hazelcast.internal.tpcengine.nio;
 
 import com.hazelcast.internal.tpcengine.AsyncSocket_RpcTest;
-import com.hazelcast.internal.tpcengine.Reactor;
+import com.hazelcast.internal.tpcengine.ReactorBuilder;
 
 public class NioAsyncSocket_RpcTest extends AsyncSocket_RpcTest {
 
     @Override
-    public Reactor newReactor() {
-        return new NioReactor().start();
+    public ReactorBuilder newReactorBuilder() {
+        return new NioReactorBuilder();
     }
 }


### PR DESCRIPTION
- tests start reactors based on newReactorBuilder. So a test subclasses only needs to return a reactorbuilder and the test takes care of building/starting.

- No more direct creation of NioReactor. Always go through builder.

- Minor doc improvements.
