### PR TITLE
Revert Bump nexus-staging-maven-plugin from 1.6.8 to 1.6.10 (#20817)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1167,7 +1167,8 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.10</version>
+                        <!-- do not update to 1.6.10, it blocks release process -->
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>release-repository</serverId>


### PR DESCRIPTION
Details are described here - https://github.com/hazelcast/hazelcast/pull/20797