### PR TITLE
Update lastAccessTime and expirationTime in executeOnEntries for HD IMap [HZ-2149] [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -195,6 +195,9 @@ public class PartitionWideEntryOperation extends MapOperation
                 outComes.add(eventType);
                 outComes.add(operator.getEntry().getNewTtl());
                 outComes.add(operator.getEntry().isChangeExpiryOnUpdate());
+            } else {
+                // when event type is null, it means that there was no modification
+                operator.doPostOperateOps();
             }
         }, false);
 


### PR DESCRIPTION
Fixes [HZ-2149]
Backport of: #23926

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible


[HZ-2149]: https://hazelcast.atlassian.net/browse/HZ-2149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ