### PR TITLE
[TPC] Tests less sensitive to dangling sockets.

### DIFF
--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilderTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncServerSocketBuilderTest.java
@@ -112,7 +112,7 @@ public abstract class AsyncServerSocketBuilderTest {
         });
 
         AsyncServerSocket serverSocket = builder.build();
-        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
+        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 0);
         serverSocket.bind(serverAddress);
         serverSocket.start();
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncServerSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncServerSocketTest.java
@@ -117,9 +117,7 @@ public abstract class AsyncServerSocketTest {
                 })
                 .build();
 
-        SocketAddress local = new InetSocketAddress("127.0.0.1", 5000);
-
-        assertThrows(IllegalArgumentException.class, () -> socket.bind(local, -1));
+        assertThrows(IllegalArgumentException.class, () -> socket.bind(new InetSocketAddress("127.0.0.1", 0), -1));
     }
 
     @Test
@@ -149,9 +147,8 @@ public abstract class AsyncServerSocketTest {
                 })
                 .build();
 
-        SocketAddress local = new InetSocketAddress("127.0.0.1", 5000);
-        socket.bind(local);
-        assertThrows(UncheckedIOException.class, () -> socket.bind(local));
+        socket.bind(new InetSocketAddress("127.0.0.1", 0));
+        assertThrows(UncheckedIOException.class, () -> socket.bind(new InetSocketAddress("127.0.0.1", 0)));
 
         socket.close();
     }
@@ -168,8 +165,7 @@ public abstract class AsyncServerSocketTest {
                 })
                 .build();
 
-        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
-        serverSocket.bind(serverAddress);
+        serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
         serverSocket.start();
 
         int clients = 5;
@@ -179,7 +175,7 @@ public abstract class AsyncServerSocketTest {
                     .build();
             clientSocket.start();
 
-            CompletableFuture<Void> connect = clientSocket.connect(serverAddress);
+            CompletableFuture<Void> connect = clientSocket.connect(serverSocket.getLocalAddress());
             assertCompletesEventually(connect);
         }
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketTest.java
@@ -103,8 +103,7 @@ public abstract class AsyncSocketTest {
                 })
                 .build();
 
-        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
-        serverSocket.bind(serverAddress);
+        serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
         serverSocket.start();
 
         AsyncSocket clientSocket = reactor.newAsyncSocketBuilder()
@@ -112,11 +111,11 @@ public abstract class AsyncSocketTest {
                 .build();
         clientSocket.start();
 
-        CompletableFuture<Void> connect = clientSocket.connect(serverAddress);
+        CompletableFuture<Void> connect = clientSocket.connect(serverSocket.getLocalAddress());
 
         assertCompletesEventually(connect);
         assertNull(connect.join());
-        assertEquals(serverAddress, clientSocket.getRemoteAddress());
+        assertEquals(serverSocket.getLocalAddress(), clientSocket.getRemoteAddress());
     }
 
 
@@ -128,11 +127,7 @@ public abstract class AsyncSocketTest {
                 .build();
         clientSocket.start();
 
-        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
-        CompletableFuture<Void> connect = clientSocket.connect(serverAddress);
-
-
-        CompletableFuture<Void> future = clientSocket.connect(new InetSocketAddress(50000));
+        CompletableFuture<Void> future = clientSocket.connect(new InetSocketAddress("127.0.0.1", 5000));
 
         assertThrows(CompletionException.class, () -> future.join());
     }
@@ -185,8 +180,7 @@ public abstract class AsyncSocketTest {
                     socket.start();
                 }).build();
 
-        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
-        serverSocket.bind(serverAddress);
+        serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
         serverSocket.start();
 
         AsyncSocket clientSocket = reactor.newAsyncSocketBuilder()
@@ -194,11 +188,11 @@ public abstract class AsyncSocketTest {
                 .build();
         clientSocket.start();
 
-        CompletableFuture<Void> connect = clientSocket.connect(serverAddress);
+        CompletableFuture<Void> connect = clientSocket.connect(serverSocket.getLocalAddress());
 
         assertCompletesEventually(connect);
         assertNull(connect.join());
-        assertEquals(serverAddress, clientSocket.getRemoteAddress());
+        assertEquals(serverSocket.getLocalAddress(), clientSocket.getRemoteAddress());
 
         assertTrue(clientSocket.isReadable());
         clientSocket.setReadable(false);

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
@@ -191,13 +191,11 @@ public abstract class AsyncSocket_LargePayloadTest {
     }
 
     public void test(int payloadSize, int concurrency) throws InterruptedException {
-        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
-
-        AsyncServerSocket serverSocket = newServer(serverAddress);
+        AsyncServerSocket serverSocket = newServer();
 
         CountDownLatch completionLatch = new CountDownLatch(concurrency);
 
-        AsyncSocket clientSocket = newClient(serverAddress, completionLatch);
+        AsyncSocket clientSocket = newClient(serverSocket.getLocalAddress(), completionLatch);
 
         System.out.println("Starting");
 
@@ -230,7 +228,7 @@ public abstract class AsyncSocket_LargePayloadTest {
         return clientSocket;
     }
 
-    private AsyncServerSocket newServer(SocketAddress serverAddress) {
+    private AsyncServerSocket newServer() {
         AsyncServerSocket serverSocket = serverReactor.newAsyncServerSocketBuilder()
                 .set(SO_RCVBUF, SOCKET_BUFFER_SIZE)
                 .setAcceptConsumer(acceptRequest -> {
@@ -243,7 +241,7 @@ public abstract class AsyncSocket_LargePayloadTest {
                     socket.start();
                 })
                 .build();
-        serverSocket.bind(serverAddress);
+        serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
         serverSocket.start();
         return serverSocket;
     }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_ReadableTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_ReadableTest.java
@@ -22,7 +22,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
@@ -58,7 +57,6 @@ public abstract class AsyncSocket_ReadableTest {
 
     @Test
     public void test() {
-        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
         CompletableFuture<AsyncSocket> remoteSocketFuture = new CompletableFuture<>();
         AsyncServerSocket serverSocket = serverReactor.newAsyncServerSocketBuilder()
                 .setAcceptConsumer(acceptRequest -> {
@@ -69,14 +67,14 @@ public abstract class AsyncSocket_ReadableTest {
                     remoteSocketFuture.complete(asyncSocket);
                 })
                 .build();
-        serverSocket.bind(serverAddress);
+        serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
         serverSocket.start();
 
         AsyncSocket localSocket = clientReactor.newAsyncSocketBuilder()
                 .setReadHandler(new NullReadHandler())
                 .build();
         localSocket.start();
-        localSocket.connect(serverAddress).join();
+        localSocket.connect(serverSocket.getLocalAddress()).join();
 
         AsyncSocket remoteSocket = remoteSocketFuture.join();
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_RpcTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_RpcTest.java
@@ -228,11 +228,9 @@ public abstract class AsyncSocket_RpcTest {
     }
 
     public void test(int payloadSize, int concurrency) throws InterruptedException {
-        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
+        AsyncServerSocket serverSocket = newServer();
 
-        AsyncServerSocket serverSocket = newServer(serverAddress);
-
-        AsyncSocket clientSocket = newClient(serverAddress);
+        AsyncSocket clientSocket = newClient(serverSocket.getLocalAddress());
 
         AtomicLong callIdGenerator = new AtomicLong();
         List<LoadGeneratorThread> threads = new ArrayList<>();
@@ -261,7 +259,7 @@ public abstract class AsyncSocket_RpcTest {
         return clientSocket;
     }
 
-    private AsyncServerSocket newServer(SocketAddress serverAddress) {
+    private AsyncServerSocket newServer() {
         AsyncServerSocket serverSocket = serverReactor.newAsyncServerSocketBuilder()
                 .set(SO_RCVBUF, SOCKET_BUFFER_SIZE)
                 .setAcceptConsumer(acceptRequest -> {
@@ -275,7 +273,7 @@ public abstract class AsyncSocket_RpcTest {
                 })
                 .build();
 
-        serverSocket.bind(serverAddress);
+        serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
         serverSocket.start();
         return serverSocket;
     }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/ReactorTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/ReactorTest.java
@@ -20,7 +20,6 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -193,8 +192,7 @@ public abstract class ReactorTest {
                 })
                 .build();
 
-        SocketAddress local = new InetSocketAddress("127.0.0.1", 5000);
-        serverSocket.bind(local);
+        serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
         serverSocket.start();
 
         reactor.shutdown();
@@ -210,8 +208,7 @@ public abstract class ReactorTest {
                 })
                 .build();
 
-        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
-        serverSocket.bind(serverAddress);
+        serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
         serverSocket.start();
 
         Reactor clientReactor = newReactor();
@@ -224,7 +221,7 @@ public abstract class ReactorTest {
                 })
                 .build();
         clientSocket.start();
-        clientSocket.connect(serverAddress);
+        clientSocket.connect(serverSocket.getLocalAddress());
 
         clientReactor.shutdown();
         assertTrueEventually(() -> assertTrue(clientSocket.isClosed()));


### PR DESCRIPTION
Instead of always binding to port 5000, 'bind' for most tests is done with port=0, meaning that the OS will look up a free port.

This makes the tests less sensitive if a socket is not yet properly closed by a previous test. In certain cases, it can happen that the OS keeps a socket around for a bit (e.g. time_wait state).