### PR TITLE
[TPC] Increase timeout to take nightly tests into account

### DIFF
--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
@@ -215,7 +215,7 @@ public abstract class AsyncSocket_LargePayloadTest {
         }
         clientSocket.flush();
 
-        assertOpenEventually(completionLatch, TimeUnit.MINUTES.toSeconds(5));
+        assertOpenEventually(completionLatch, TimeUnit.MINUTES.toSeconds(4));
     }
 
     private AsyncSocket newClient(SocketAddress serverAddress, CountDownLatch completionLatch) {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
@@ -27,6 +27,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.internal.tpcengine.AsyncSocketOptions.SO_RCVBUF;
 import static com.hazelcast.internal.tpcengine.AsyncSocketOptions.SO_SNDBUF;
@@ -214,7 +215,7 @@ public abstract class AsyncSocket_LargePayloadTest {
         }
         clientSocket.flush();
 
-        assertOpenEventually(completionLatch);
+        assertOpenEventually(completionLatch, TimeUnit.MINUTES.toSeconds(5));
     }
 
     private AsyncSocket newClient(SocketAddress serverAddress, CountDownLatch completionLatch) {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_LargePayloadTest_Nightly.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_LargePayloadTest_Nightly.java
@@ -17,10 +17,14 @@
 package com.hazelcast.internal.tpcengine.nio;
 
 import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Rule;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 
 @Category(NightlyTest.class)
 public class NioAsyncSocket_LargePayloadTest_Nightly extends NioAsyncSocket_LargePayloadTest {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(8 * 60);
 
     public NioAsyncSocket_LargePayloadTest_Nightly() {
         iterations = 20000;

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_LargePayloadTest_Nightly.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_LargePayloadTest_Nightly.java
@@ -17,14 +17,10 @@
 package com.hazelcast.internal.tpcengine.nio;
 
 import com.hazelcast.test.annotation.NightlyTest;
-import org.junit.Rule;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.Timeout;
 
 @Category(NightlyTest.class)
 public class NioAsyncSocket_LargePayloadTest_Nightly extends NioAsyncSocket_LargePayloadTest {
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(8 * 60);
 
     public NioAsyncSocket_LargePayloadTest_Nightly() {
         iterations = 20000;


### PR DESCRIPTION
Default 2 minutes were used for nightly tests as well, which may be not enough if Jenkins is overloaded.

Fixes #24019
Fixes #24016

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible