### PR TITLE
[TPC] Renamed NioAsyncServerSocketConfigTest.

### DIFF
--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptionsTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.tpcengine.nio;
 import com.hazelcast.internal.tpcengine.AsyncServerSocketOptionsTest;
 import com.hazelcast.internal.tpcengine.ReactorBuilder;
 
-public class NioAsyncServerSocketConfigTest extends AsyncServerSocketOptionsTest {
+public class NioAsyncServerSocketOptionsTest extends AsyncServerSocketOptionsTest {
 
     @Override
     public ReactorBuilder newReactorBuilder() {


### PR DESCRIPTION
It is based on the AsyncServerSocketOptionsTest and therefore it should be named NioAsyncServerSocketOptionsTest.

Apparently, I forgot to rename this class when I refactored the options functionality.