### PR TITLE
[TPC] AcceptRequest closing.

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AcceptRequest.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AcceptRequest.java
@@ -26,6 +26,6 @@ import java.util.function.Consumer;
  * (e.g. the accepted SocketChannel) to the constructor of the AsyncSocket in a typesafe
  * manner.
  */
-public interface AcceptRequest {
+public interface AcceptRequest extends AutoCloseable {
 
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAcceptRequest.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAcceptRequest.java
@@ -29,4 +29,9 @@ class NioAcceptRequest implements AcceptRequest {
     NioAcceptRequest(SocketChannel socketChannel) {
         this.socketChannel = checkNotNull(socketChannel, "socketChannel");
     }
+
+    @Override
+    public void close() throws Exception {
+        socketChannel.close();
+    }
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocket.java
@@ -164,8 +164,13 @@ public final class NioAsyncServerSocket extends AsyncServerSocket {
                         + "->" + socketChannel.getLocalAddress());
             }
 
-            // todo: we need to think about rejection.
-            consumer.accept(new NioAcceptRequest(socketChannel));
+            NioAcceptRequest acceptRequest = new NioAcceptRequest(socketChannel);
+            try {
+                consumer.accept(acceptRequest);
+            } catch (Throwable t) {
+                closeQuietly(acceptRequest);
+                throw sneakyThrow(t);
+            }
         }
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncServerSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncServerSocketTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.tpcengine;
 
+import com.hazelcast.internal.tpcengine.util.CloseUtil;
 import org.junit.After;
 import org.junit.Test;
 
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertCompletesEventually;
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertTrueEventually;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminate;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminateAll;
 import static junit.framework.TestCase.assertNotNull;
@@ -34,6 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 
 public abstract class AsyncServerSocketTest {
@@ -184,6 +187,52 @@ public abstract class AsyncServerSocketTest {
         }
 
         assertEquals(clients, serverSocket.metrics.accepted());
+    }
+
+    @Test
+    public void test_accept_withException() {
+        Reactor reactor = newReactor();
+        AsyncServerSocket serverSocket = reactor.newAsyncServerSocketBuilder()
+                .setAcceptConsumer(acceptRequest -> {
+                    throw new RuntimeException();
+                })
+                .build();
+
+        SocketAddress serverAddress = new InetSocketAddress("127.0.0.1", 5000);
+        serverSocket.bind(serverAddress);
+        serverSocket.start();
+
+        AsyncSocket clientSocket = reactor.newAsyncSocketBuilder()
+                .setReadHandler(new DevNullReadHandler())
+                .build();
+        clientSocket.start();
+
+        CompletableFuture<Void> connect = clientSocket.connect(serverAddress);
+        assertCompletesEventually(connect);
+        assertTrueEventually(() -> assertTrue(clientSocket.isClosed()));
+    }
+
+    @Test
+    public void test_acceptWithExplicitClose() {
+        Reactor reactor = newReactor();
+        SocketAddress serverAddress;
+        try (AsyncServerSocket serverSocket = reactor.newAsyncServerSocketBuilder()
+                .setAcceptConsumer(CloseUtil::closeQuietly)
+                .build()) {
+
+            serverAddress = new InetSocketAddress("127.0.0.1", 5000);
+            serverSocket.bind(serverAddress);
+            serverSocket.start();
+        }
+
+        AsyncSocket clientSocket = reactor.newAsyncSocketBuilder()
+                .setReadHandler(new DevNullReadHandler())
+                .build();
+        clientSocket.start();
+
+        CompletableFuture<Void> connect = clientSocket.connect(serverAddress);
+        assertCompletesEventually(connect);
+        assertTrueEventually(() -> assertTrue(clientSocket.isClosed()));
     }
 
     @Test


### PR DESCRIPTION
Functionality has been added for closing the 'accepted' socket from the AcceptRequest.

So the AcceptRequest (and the underlying socket) can be explicitly closed by calling the close on the AcceptRequest or by throwing an exception from the 'acceptConsumer'.

This is useful for 2 situations:

1) You want to prevent that a socket is 'properly' accepted. Maybe the maximum number of sockets has been reached. So you can now call acceptRequest.close to close the socket for the accept request.

2) There was a problem processing the accept request and we need to ensure that the socket is properly closed instead of ending up in some zombie state where the socket is created at the OS level, but not known at the application level (end hence doesn't get closed). This is especially a problem with testing where the acceptance of a socket can be rejected if the reactor has been shut down.
