### PR TITLE
Create Kubernetes Client only for API discovery mode [5.1.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/DnsEndpointResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/DnsEndpointResolver.java
@@ -46,8 +46,9 @@ final class DnsEndpointResolver
     private final int serviceDnsTimeout;
     private final RawLookupProvider rawLookupProvider;
 
-    DnsEndpointResolver(ILogger logger, String serviceDns, int port, int serviceDnsTimeout) {
-        this(logger, serviceDns, port, serviceDnsTimeout, InetAddress::getAllByName);
+    DnsEndpointResolver(ILogger logger, KubernetesConfig config) {
+        this(logger, config.getServiceDns(), config.getServicePort(),
+                config.getServiceDnsTimeout(), InetAddress::getAllByName);
     }
 
     /**
@@ -61,7 +62,8 @@ final class DnsEndpointResolver
         this.rawLookupProvider = rawLookupProvider;
     }
 
-    List<DiscoveryNode> resolve() {
+    @Override
+    List<DiscoveryNode> resolveNodes() {
         try {
             return lookup();
         } catch (TimeoutException e) {

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -30,39 +30,26 @@ import java.util.Map;
 
 final class HazelcastKubernetesDiscoveryStrategy
         extends AbstractDiscoveryStrategy {
-    private final KubernetesClient client;
     private final EndpointResolver endpointResolver;
-    private final KubernetesConfig config;
 
     private final Map<String, String> memberMetadata = new HashMap<>();
 
     HazelcastKubernetesDiscoveryStrategy(ILogger logger, Map<String, Comparable> properties) {
         super(logger, properties);
 
-        config = new KubernetesConfig(properties);
+        KubernetesConfig config = new KubernetesConfig(properties);
         logger.info(config.toString());
 
-        client = buildKubernetesClient(config);
-
         if (DiscoveryMode.DNS_LOOKUP.equals(config.getMode())) {
-            endpointResolver = new DnsEndpointResolver(logger, config.getServiceDns(), config.getServicePort(),
-                    config.getServiceDnsTimeout());
+            endpointResolver = new DnsEndpointResolver(logger, config);
         } else {
-            endpointResolver = new KubernetesApiEndpointResolver(logger, config.getServiceName(), config.getServicePort(),
-                    config.getServiceLabelName(), config.getServiceLabelValue(),
-                    config.getPodLabelName(), config.getPodLabelValue(),
-                    config.isResolveNotReadyAddresses(), client);
+            endpointResolver = new KubernetesApiEndpointResolver(logger, config);
         }
 
         logger.info("Kubernetes Discovery activated with mode: " + config.getMode().name());
     }
 
-    private static KubernetesClient buildKubernetesClient(KubernetesConfig config) {
-        return new KubernetesClient(config.getNamespace(), config.getKubernetesMasterUrl(), config.getTokenProvider(),
-                config.getKubernetesCaCertificate(), config.getKubernetesApiRetries(), config.getExposeExternallyMode(),
-                config.isUseNodeNameAsExternalAddress(), config.getServicePerPodLabelName(), config.getServicePerPodLabelValue());
-    }
-
+    @Override
     public void start() {
         endpointResolver.start();
     }
@@ -70,72 +57,18 @@ final class HazelcastKubernetesDiscoveryStrategy
     @Override
     public Map<String, String> discoverLocalMetadata() {
         if (memberMetadata.isEmpty()) {
-            memberMetadata.put(PartitionGroupMetaData.PARTITION_GROUP_ZONE, discoverZone());
-            memberMetadata.put("hazelcast.partition.group.node", discoverNodeName());
+            memberMetadata.put(PartitionGroupMetaData.PARTITION_GROUP_ZONE, endpointResolver.resolveCurrentZone());
+            memberMetadata.put("hazelcast.partition.group.node", endpointResolver.resolveCurrentNodeName());
         }
         return memberMetadata;
     }
 
-    /**
-     * Discovers the availability zone in which the current Hazelcast member is running.
-     * <p>
-     * Note: ZONE_AWARE is available only for the Kubernetes API Mode.
-     */
-    private String discoverZone() {
-        if (DiscoveryMode.KUBERNETES_API.equals(config.getMode())) {
-            try {
-                String zone = client.zone(podName());
-                if (zone != null) {
-                    getLogger().info(String.format("Kubernetes plugin discovered availability zone: %s", zone));
-                    return zone;
-                }
-            } catch (Exception e) {
-                // only log the exception and the message, Hazelcast should still start
-                getLogger().finest(e);
-            }
-            getLogger().info("Cannot fetch the current zone, ZONE_AWARE feature is disabled");
-        }
-        return "unknown";
-    }
-
-    /**
-     * Discovers the name of the node which the current Hazelcast member pod is running on.
-     * <p>
-     * Note: NODE_AWARE is available only for the Kubernetes API Mode.
-     */
-    private String discoverNodeName() {
-        if (DiscoveryMode.KUBERNETES_API.equals(config.getMode())) {
-            try {
-                String nodeName = client.nodeName(podName());
-                if (nodeName != null) {
-                    getLogger().info(String.format("Kubernetes plugin discovered node name: %s", nodeName));
-                    return nodeName;
-                }
-            } catch (Exception e) {
-                // only log the exception and the message, Hazelcast should still start
-                getLogger().finest(e);
-            }
-            getLogger().warning("Cannot fetch name of the node, NODE_AWARE feature is disabled");
-        }
-        return "unknown";
-    }
-
-    private String podName() throws UnknownHostException {
-        String podName = System.getenv("POD_NAME");
-        if (podName == null) {
-            podName = System.getenv("HOSTNAME");
-        }
-        if (podName == null) {
-            podName = InetAddress.getLocalHost().getHostName();
-        }
-        return podName;
+    @Override
+    public Iterable<DiscoveryNode> discoverNodes() {
+        return endpointResolver.resolveNodes();
     }
 
     @Override
-    public Iterable<DiscoveryNode> discoverNodes() {
-        return endpointResolver.resolve();
-    }
-
     public void destroy() {
         endpointResolver.destroy();
     }
@@ -147,7 +80,25 @@ final class HazelcastKubernetesDiscoveryStrategy
             this.logger = logger;
         }
 
-        abstract List<DiscoveryNode> resolve();
+        abstract List<DiscoveryNode> resolveNodes();
+
+        /**
+         * Discovers the availability zone in which the current Hazelcast member is running.
+         * <p>
+         * Note: ZONE_AWARE is available only for the Kubernetes API Mode.
+         */
+        String resolveCurrentZone() {
+            return "unknown";
+        }
+
+        /**
+         * Discovers the name of the node which the current Hazelcast member pod is running on.
+         * <p>
+         * Note: NODE_AWARE is available only for the Kubernetes API Mode.
+         */
+        String resolveCurrentNodeName() {
+            return "unknown";
+        }
 
         void start() {
         }

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/DnsEndpointResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/DnsEndpointResolverTest.java
@@ -64,7 +64,7 @@ public class DnsEndpointResolverTest {
         DnsEndpointResolver dnsEndpointResolver = new DnsEndpointResolver(LOGGER, SERVICE_DNS, UNSET_PORT, DEFAULT_SERVICE_DNS_TIMEOUT_SECONDS, lookupProvider);
 
         // when
-        List<DiscoveryNode> result = dnsEndpointResolver.resolve();
+        List<DiscoveryNode> result = dnsEndpointResolver.resolveNodes();
 
         // then
 
@@ -81,7 +81,7 @@ public class DnsEndpointResolverTest {
         DnsEndpointResolver dnsEndpointResolver = new DnsEndpointResolver(LOGGER, SERVICE_DNS, CUSTOM_PORT, DEFAULT_SERVICE_DNS_TIMEOUT_SECONDS, lookupProvider);
 
         // when
-        List<DiscoveryNode> result = dnsEndpointResolver.resolve();
+        List<DiscoveryNode> result = dnsEndpointResolver.resolveNodes();
 
         // then
 
@@ -92,14 +92,13 @@ public class DnsEndpointResolverTest {
     }
 
     @Test
-    public void resolveException() throws Exception {
+    public void resolveException() {
         // given
         ILogger logger = mock(ILogger.class);
-        RawLookupProvider lookupProvider = nonResolvingLookupProvider();
         DnsEndpointResolver dnsEndpointResolver = new DnsEndpointResolver(logger, SERVICE_DNS, UNSET_PORT, DEFAULT_SERVICE_DNS_TIMEOUT_SECONDS, nonResolvingLookupProvider());
 
         // when
-        List<DiscoveryNode> result = dnsEndpointResolver.resolve();
+        List<DiscoveryNode> result = dnsEndpointResolver.resolveNodes();
 
         // then
         assertEquals(0, result.size());
@@ -108,13 +107,13 @@ public class DnsEndpointResolverTest {
     }
 
     @Test
-    public void resolveNotFound() throws Exception {
+    public void resolveNotFound() {
         // given
         RawLookupProvider lookupProvider = staticLookupProvider(SERVICE_DNS);
         DnsEndpointResolver dnsEndpointResolver = new DnsEndpointResolver(LOGGER, SERVICE_DNS, UNSET_PORT, DEFAULT_SERVICE_DNS_TIMEOUT_SECONDS, lookupProvider);
 
         // when
-        List<DiscoveryNode> result = dnsEndpointResolver.resolve();
+        List<DiscoveryNode> result = dnsEndpointResolver.resolveNodes();
 
         // then
         assertEquals(0, result.size());
@@ -127,7 +126,7 @@ public class DnsEndpointResolverTest {
         DnsEndpointResolver dnsEndpointResolver = new DnsEndpointResolver(logger, SERVICE_DNS, UNSET_PORT, TEST_DNS_TIMEOUT_SECONDS, timingOutLookupProvider());
 
         // when
-        List<DiscoveryNode> result = dnsEndpointResolver.resolve();
+        List<DiscoveryNode> result = dnsEndpointResolver.resolveNodes();
 
         // then
         assertEquals(0, result.size());

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolverTest.java
@@ -57,7 +57,7 @@ public class KubernetesApiEndpointResolverTest {
         KubernetesApiEndpointResolver sut = new KubernetesApiEndpointResolver(LOGGER, null, 0, null, null, null, null, null, client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(0, nodes.size());
@@ -82,7 +82,7 @@ public class KubernetesApiEndpointResolverTest {
                 client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(1, nodes.size());
@@ -99,7 +99,7 @@ public class KubernetesApiEndpointResolverTest {
                 null, null, null, client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(1, nodes.size());
@@ -116,7 +116,7 @@ public class KubernetesApiEndpointResolverTest {
                 POD_LABEL, POD_LABEL_VALUE, null, client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(1, nodes.size());
@@ -133,7 +133,7 @@ public class KubernetesApiEndpointResolverTest {
                 null, null, RESOLVE_NOT_READY_ADDRESSES, client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(1, nodes.size());
@@ -149,7 +149,7 @@ public class KubernetesApiEndpointResolverTest {
                 client);
 
         // when
-        List<DiscoveryNode> nodes = sut.resolve();
+        List<DiscoveryNode> nodes = sut.resolveNodes();
 
         // then
         assertEquals(0, nodes.size());


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

Logic specific for Kubernetes API discovery mode including KubernetesClient build moved to KubernetesAPIEndpointResolver. It should resolve an issue with unexpected requests to Kube API when DNS discovery mode is chosen.

Fixes #23208 

Backport of: #23883

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
