### PR TITLE
[TPC] Fixes the TpcIntegrationTest by reducing nr-operations.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/tpc/TpcIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/tpc/TpcIntegrationTest.java
@@ -25,10 +25,8 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.After;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.internal.tpc.TpcServerBootstrap.TPC_ENABLED;
@@ -36,13 +34,11 @@ import static com.hazelcast.internal.tpc.TpcServerBootstrap.TPC_EVENTLOOP_COUNT;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
 public class TpcIntegrationTest extends HazelcastTestSupport {
-    private static final int COUNT = 100_000;
-    private static final int PRINT_PROGRESS_TIMES = 100;
+    private static final int PRINT_PROGRESS_INTERVAL = 100;
 
+    public int iterations = 1_000;
     private final ILogger logger = Logger.getLogger(getClass());
-
     private HazelcastInstance server;
     private HazelcastInstance client;
 
@@ -71,17 +67,17 @@ public class TpcIntegrationTest extends HazelcastTestSupport {
 
         long startTime = System.currentTimeMillis();
 
-        for (int k = 0; k < COUNT; k++) {
-            if (k % (COUNT / PRINT_PROGRESS_TIMES) == 0) {
+        for (int k = 0; k < iterations; k++) {
+            if (k % (iterations / PRINT_PROGRESS_INTERVAL) == 0) {
                 logger.info(">> At:" + k);
             }
             map.put(k, k);
         }
 
         long duration = System.currentTimeMillis() - startTime;
-        double throughput = COUNT * 1000f / duration;
+        double throughput = iterations * 1000f / duration;
         logger.info(">> Throughput:" + throughput + " op/s");
 
-        assertEquals(COUNT, map.size());
+        assertEquals(iterations, map.size());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/tpc/TpcIntegrationTest_Nightly.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/tpc/TpcIntegrationTest_Nightly.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class TpcIntegrationTest_Nightly extends TpcIntegrationTest {
+    public TpcIntegrationTest_Nightly() {
+        iterations = 10_000;
+    }
+}


### PR DESCRIPTION
From one of the test failures, it was clear that the tpc test failed to process the number of operations within the given window. The test was slow, it didn't crash.

The following changes have been made:
- The TpcIntegrationTest is not a nightly test. We want failures with tpc integration as part of the daily tests.
- The TpcIntegrationTest does 1k instead of 100k iterations
- The TpcIntegrationTest_Nightly has been added which does 10k iteration

Fixes https://github.com/hazelcast/hazelcast/issues/24017
