### PR TITLE
Add keep-alive socket options for unified network [HZ-1672]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/EndpointConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EndpointConfig.java
@@ -39,7 +39,7 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
  *
  * @since 3.12
  */
-@SuppressWarnings({"checkstyle:methodcount", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:methodcount")
 public class EndpointConfig implements NamedConfig {
 
     /**
@@ -340,7 +340,7 @@ public class EndpointConfig implements NamedConfig {
      *
      * @return the configured value of Keep-Alive idle time.
      * @since 5.3.0
-     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPIDLE>
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPIDLE">
      *     jdk.net.ExtendedSocketOptions#TCP_KEEPIDLE</a>
      */
     public int getSocketKeepIdleSeconds() {
@@ -354,7 +354,7 @@ public class EndpointConfig implements NamedConfig {
      * <a href="https://bugs.openjdk.org/browse/JDK-8194298">JDK support</a>.
      *
      * @since 5.3.0
-     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPIDLE>
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPIDLE">
      *      jdk.net.ExtendedSocketOptions#TCP_KEEPIDLE</a>
      */
     public EndpointConfig setSocketKeepIdleSeconds(int socketKeepIdleSeconds) {
@@ -370,7 +370,8 @@ public class EndpointConfig implements NamedConfig {
      *
      * @return the configured value of Keep-Alive interval time.
      * @since 5.3.0
-     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPINTERVAL>
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/
+     ExtendedSocketOptions.html#TCP_KEEPINTERVAL">
      *     jdk.net.ExtendedSocketOptions#TCP_KEEPINTERVAL</a>
      */
     public int getSocketKeepIntervalSeconds() {
@@ -385,7 +386,8 @@ public class EndpointConfig implements NamedConfig {
      * <a href="https://bugs.openjdk.org/browse/JDK-8194298">JDK support</a>.
      *
      * @since 5.3.0
-     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPINTERVAL>
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/
+     ExtendedSocketOptions.html#TCP_KEEPINTERVAL">
      *     jdk.net.ExtendedSocketOptions#TCP_KEEPINTERVAL</a>
      */
     public EndpointConfig setSocketKeepIntervalSeconds(int socketKeepIntervalSeconds) {
@@ -402,7 +404,7 @@ public class EndpointConfig implements NamedConfig {
      *
      * @return the configured value of Keep-Alive probe count.
      * @since 5.3.0
-     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPCOUNT>
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPCOUNT">
      *     jdk.net.ExtendedSocketOptions#TCP_KEEPCOUNT</a>
      */
     public int getSocketKeepCount() {
@@ -417,7 +419,7 @@ public class EndpointConfig implements NamedConfig {
      * <a href="https://bugs.openjdk.org/browse/JDK-8194298">JDK support</a>.
      *
      * @since 5.3.0
-     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPCOUNT>
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPCOUNT">
      *     jdk.net.ExtendedSocketOptions#TCP_KEEPCOUNT</a>
      */
     public EndpointConfig setSocketKeepCount(int socketKeepCount) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DelegatingAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DelegatingAddressPicker.java
@@ -26,6 +26,7 @@ import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.MemberAddressProvider;
+import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -35,6 +36,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
+import static com.hazelcast.instance.impl.DefaultAddressPicker.endpointConfigFromProperties;
 import static com.hazelcast.instance.impl.ServerSocketHelper.createServerSocketChannel;
 
 /**
@@ -54,6 +56,7 @@ final class DelegatingAddressPicker
     private final Config config;
     private final ILogger logger;
     private final boolean usesAdvancedNetworkConfig;
+    private final HazelcastProperties properties;
 
     DelegatingAddressPicker(MemberAddressProvider memberAddressProvider, Config config, ILogger logger) {
         super();
@@ -61,6 +64,7 @@ final class DelegatingAddressPicker
         this.config = config;
         this.memberAddressProvider = memberAddressProvider;
         this.usesAdvancedNetworkConfig = config.getAdvancedNetworkConfig().isEnabled();
+        this.properties = new HazelcastProperties(config);
     }
 
     @Override
@@ -101,7 +105,8 @@ final class DelegatingAddressPicker
         publicAddress = memberAddressProvider.getPublicAddress();
         validatePublicAddress(publicAddress);
 
-        serverSocketChannel = createServerSocketChannel(logger, null, bindAddress.getAddress(),
+        serverSocketChannel = createServerSocketChannel(logger,
+                endpointConfigFromProperties(properties), bindAddress.getAddress(),
                 bindAddress.getPort() == 0 ? networkConfig.getPort() : bindAddress.getPort(), networkConfig.getPortCount(),
                 networkConfig.isPortAutoIncrement(), networkConfig.isReuseAddress(), false);
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/ServerSocketHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/ServerSocketHelper.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.logging.ILogger;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -62,7 +63,8 @@ final class ServerSocketHelper {
      * @param bindAny               when {@code true} bind any local address otherwise bind given {@code bindAddress}
      * @return actual port number that created {@code ServerSocketChannel} is bound to
      */
-    static ServerSocketChannel createServerSocketChannel(ILogger logger, EndpointConfig endpointConfig, InetAddress bindAddress,
+    static ServerSocketChannel createServerSocketChannel(ILogger logger, @Nonnull EndpointConfig endpointConfig,
+                                                         InetAddress bindAddress,
                                                          int port, int portCount, boolean isPortAutoIncrement,
                                                          boolean isReuseAddress, boolean bindAny) {
         logger.finest("inet reuseAddress:" + isReuseAddress);
@@ -85,7 +87,8 @@ final class ServerSocketHelper {
         }
     }
 
-    private static ServerSocketChannel tryOpenServerSocketChannel(EndpointConfig endpointConfig, InetAddress bindAddress,
+    private static ServerSocketChannel tryOpenServerSocketChannel(@Nonnull EndpointConfig endpointConfig,
+                                                                  InetAddress bindAddress,
                                                           int initialPort, boolean isReuseAddress,  int portTrialCount,
                                                           boolean bindAny, ILogger logger)
             throws IOException {
@@ -109,8 +112,9 @@ final class ServerSocketHelper {
         throw error;
     }
 
-    private static ServerSocketChannel openServerSocketChannel(EndpointConfig endpointConfig, InetSocketAddress socketBindAddress,
-                                                        boolean reuseAddress, ILogger logger)
+    private static ServerSocketChannel openServerSocketChannel(@Nonnull EndpointConfig endpointConfig,
+                                                               InetSocketAddress socketBindAddress,
+                                                               boolean reuseAddress, ILogger logger)
             throws IOException {
 
         ServerSocket serverSocket = null;
@@ -128,10 +132,10 @@ final class ServerSocketHelper {
             serverSocket.setReuseAddress(reuseAddress);
             serverSocket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
 
-            if (endpointConfig != null) {
+            if (endpointConfig.isSocketKeepAlive()) {
                 IOUtil.setKeepAliveOptionsIfNotDefault(serverSocketChannel, endpointConfig, logger);
-                serverSocket.setReceiveBufferSize(endpointConfig.getSocketRcvBufferSizeKb() * KILO_BYTE);
             }
+            serverSocket.setReceiveBufferSize(endpointConfig.getSocketRcvBufferSizeKb() * KILO_BYTE);
 
             logger.fine("Trying to bind inet socket address: " + socketBindAddress);
             serverSocket.bind(socketBindAddress, SOCKET_BACKLOG_LENGTH);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedChannelInitializer.java
@@ -27,10 +27,16 @@ import static com.hazelcast.internal.networking.ChannelOption.SO_KEEPALIVE;
 import static com.hazelcast.internal.networking.ChannelOption.SO_LINGER;
 import static com.hazelcast.internal.networking.ChannelOption.SO_RCVBUF;
 import static com.hazelcast.internal.networking.ChannelOption.SO_SNDBUF;
+import static com.hazelcast.internal.networking.ChannelOption.TCP_KEEPCOUNT;
+import static com.hazelcast.internal.networking.ChannelOption.TCP_KEEPIDLE;
+import static com.hazelcast.internal.networking.ChannelOption.TCP_KEEPINTERVAL;
 import static com.hazelcast.internal.networking.ChannelOption.TCP_NODELAY;
 import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_BUFFER_DIRECT;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_KEEP_ALIVE;
+import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_KEEP_COUNT;
+import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_KEEP_IDLE;
+import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_KEEP_INTERVAL;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_LINGER_SECONDS;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_NO_DELAY;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_RECEIVE_BUFFER_SIZE;
@@ -60,7 +66,10 @@ public class UnifiedChannelInitializer
                 .setOption(SO_KEEPALIVE, props.getBoolean(SOCKET_KEEP_ALIVE))
                 .setOption(SO_SNDBUF, props.getInteger(SOCKET_SEND_BUFFER_SIZE) * KILO_BYTE)
                 .setOption(SO_RCVBUF, props.getInteger(SOCKET_RECEIVE_BUFFER_SIZE) * KILO_BYTE)
-                .setOption(SO_LINGER, props.getSeconds(SOCKET_LINGER_SECONDS));
+                .setOption(SO_LINGER, props.getSeconds(SOCKET_LINGER_SECONDS))
+                .setOption(TCP_KEEPIDLE, props.getInteger(SOCKET_KEEP_IDLE))
+                .setOption(TCP_KEEPCOUNT, props.getInteger(SOCKET_KEEP_COUNT))
+                .setOption(TCP_KEEPINTERVAL, props.getInteger(SOCKET_KEEP_INTERVAL));
 
         UnifiedProtocolEncoder encoder = new UnifiedProtocolEncoder(serverContext);
         UnifiedProtocolDecoder decoder = new UnifiedProtocolDecoder(serverContext, encoder);

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -209,6 +209,63 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.socket.keep.alive", true);
 
     /**
+     * Keep-Alive idle time: the number of seconds of idle time before keep-alive initiates a probe.
+     * <p/>
+     * Caveats:
+     * <ul>
+     *     <li>This option is only applicable to member-side sockets when {@link #SOCKET_KEEP_ALIVE keep alive is true}.</li>
+     *     <li>When using {@link AdvancedNetworkConfig}, set the respective socket option in {@link EndpointConfig}.</li>
+     *     <li>Requires a recent JDK 8, JDK 11 or greater version that includes the required
+     *     <a href="https://bugs.openjdk.org/browse/JDK-8194298">JDK support</a>.</li>
+     * </ul>
+     *
+     * @since 5.3.0
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPIDLE">
+     *     jdk.net.ExtendedSocketOptions#TCP_KEEPIDLE</a>
+     */
+    public static final HazelcastProperty SOCKET_KEEP_IDLE
+            = new HazelcastProperty("hazelcast.socket.keep.idle", 7200);
+
+    /**
+     * Keep-Alive interval: the number of seconds between keep-alive probes.
+     * <p/>
+     * Caveats:
+     * <ul>
+     *     <li>This option is only applicable to member-side sockets when {@link #SOCKET_KEEP_ALIVE keep alive is true}.</li>
+     *     <li>When using {@link AdvancedNetworkConfig}, set the respective socket option in {@link EndpointConfig}.</li>
+     *     <li>Requires a recent JDK 8, JDK 11 or greater version that includes the required
+     *     <a href="https://bugs.openjdk.org/browse/JDK-8194298">JDK support</a>.</li>
+     * </ul>
+     *
+     * @since 5.3.0
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/
+     ExtendedSocketOptions.html#TCP_KEEPINTERVAL">
+     *     jdk.net.ExtendedSocketOptions#TCP_KEEPINTERVAL</a>
+     */
+    public static final HazelcastProperty SOCKET_KEEP_INTERVAL
+            = new HazelcastProperty("hazelcast.socket.keep.interval", 75);
+
+    /**
+     * Keep-Alive count: the maximum number of TCP keep-alive probes to send before giving up and closing the connection if no
+     * response is obtained from the other side.
+     * <p/>
+     * Caveats:
+     * <ul>
+     *     <li>This option is only applicable to member-side sockets when {@link #SOCKET_KEEP_ALIVE keep alive is true}.</li>
+     *     <li>When using {@link AdvancedNetworkConfig}, set the respective socket option in {@link EndpointConfig}.</li>
+     *     <li>Requires a recent JDK 8, JDK 11 or greater version that includes the required
+     *     <a href="https://bugs.openjdk.org/browse/JDK-8194298">JDK support</a>.</li>
+     * </ul>
+     *
+     * @return the configured value of Keep-Alive probe count.
+     * @since 5.3.0
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/ExtendedSocketOptions.html#TCP_KEEPCOUNT">
+     *     jdk.net.ExtendedSocketOptions#TCP_KEEPCOUNT</a>
+     */
+    public static final HazelcastProperty SOCKET_KEEP_COUNT
+            = new HazelcastProperty("hazelcast.socket.keep.count", 8);
+
+    /**
      * Socket set TCP no delay.
      */
     public static final HazelcastProperty SOCKET_NO_DELAY

--- a/hazelcast/src/test/java/com/hazelcast/config/AdvancedNetworkConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AdvancedNetworkConfigTest.java
@@ -36,6 +36,7 @@ import java.util.IdentityHashMap;
 
 import static com.hazelcast.instance.EndpointQualifier.CLIENT;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
+import static java.lang.Integer.parseInt;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -57,10 +58,16 @@ public class AdvancedNetworkConfigTest extends HazelcastTestSupport {
         assertEquals(ServerSocketEndpointConfig.DEFAULT_PORT, defaultEndpointConfig.getPort());
         assertEquals(ServerSocketEndpointConfig.PORT_AUTO_INCREMENT, defaultEndpointConfig.getPortCount());
         assertTrue(defaultEndpointConfig.isPortAutoIncrement());
-        assertEquals(Integer.parseInt(ClusterProperty.SOCKET_RECEIVE_BUFFER_SIZE.getDefaultValue()),
+        assertEquals(parseInt(ClusterProperty.SOCKET_RECEIVE_BUFFER_SIZE.getDefaultValue()),
                 defaultEndpointConfig.getSocketRcvBufferSizeKb());
-        assertEquals(Integer.parseInt(ClusterProperty.SOCKET_SEND_BUFFER_SIZE.getDefaultValue()),
+        assertEquals(parseInt(ClusterProperty.SOCKET_SEND_BUFFER_SIZE.getDefaultValue()),
                 defaultEndpointConfig.getSocketSendBufferSizeKb());
+        assertEquals(parseInt(ClusterProperty.SOCKET_KEEP_IDLE.getDefaultValue()),
+                defaultEndpointConfig.getSocketKeepIdleSeconds());
+        assertEquals(parseInt(ClusterProperty.SOCKET_KEEP_COUNT.getDefaultValue()),
+                defaultEndpointConfig.getSocketKeepCount());
+        assertEquals(parseInt(ClusterProperty.SOCKET_KEEP_INTERVAL.getDefaultValue()),
+                defaultEndpointConfig.getSocketKeepIntervalSeconds());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.instance.impl;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.instance.impl.DefaultAddressPicker.AddressDefinition;
 import com.hazelcast.instance.impl.DefaultAddressPicker.InterfaceDefinition;
@@ -25,6 +26,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
@@ -44,6 +46,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
+import java.util.Properties;
 
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV4_STACK;
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV6_ADDRESSES;
@@ -52,6 +55,7 @@ import static com.hazelcast.test.OverridePropertyRule.set;
 import static com.hazelcast.internal.util.AddressUtil.getAddressHolder;
 import static java.net.InetAddress.getByName;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -96,6 +100,23 @@ public class DefaultAddressPickerTest {
         if (addressPicker != null) {
             IOUtil.closeResource(addressPicker.getServerSocketChannel(null));
         }
+    }
+
+    @Test
+    public void testEndpointConfigFromClusterProperty() {
+        Config config = new Config();
+        config.setProperty(ClusterProperty.SOCKET_KEEP_ALIVE.getName(), "false");
+        config.setProperty(ClusterProperty.SOCKET_KEEP_IDLE.getName(), "30");
+        config.setProperty(ClusterProperty.SOCKET_KEEP_COUNT.getName(), "5");
+        config.setProperty(ClusterProperty.SOCKET_KEEP_INTERVAL.getName(), "6");
+        config.setProperty(ClusterProperty.SOCKET_RECEIVE_BUFFER_SIZE.getName(), "512");
+        HazelcastProperties properties = new HazelcastProperties(config);
+        EndpointConfig endpointConfig = DefaultAddressPicker.endpointConfigFromProperties(properties);
+        assertFalse(endpointConfig.isSocketKeepAlive());
+        assertEquals(30, endpointConfig.getSocketKeepIdleSeconds());
+        assertEquals(5, endpointConfig.getSocketKeepCount());
+        assertEquals(6, endpointConfig.getSocketKeepIntervalSeconds());
+        assertEquals(512, endpointConfig.getSocketRcvBufferSizeKb());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
@@ -16,15 +16,15 @@
 
 package com.hazelcast.instance.impl;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.instance.impl.DefaultAddressPicker.AddressDefinition;
 import com.hazelcast.instance.impl.DefaultAddressPicker.InterfaceDefinition;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.ChangeLoggingRule;
@@ -46,13 +46,12 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
-import java.util.Properties;
 
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV4_STACK;
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV6_ADDRESSES;
+import static com.hazelcast.internal.util.AddressUtil.getAddressHolder;
 import static com.hazelcast.test.OverridePropertyRule.clear;
 import static com.hazelcast.test.OverridePropertyRule.set;
-import static com.hazelcast.internal.util.AddressUtil.getAddressHolder;
 import static java.net.InetAddress.getByName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NetworkTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NetworkTestUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.networking.nio;
+
+import com.hazelcast.internal.nio.IOUtil;
+import org.junit.Assume;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.channels.ServerSocketChannel;
+
+public class NetworkTestUtil {
+
+    private NetworkTestUtil() {
+    }
+
+    public static void assumeKeepAlivePerSocketOptionsNotSupported() throws Throwable {
+        Assume.assumeFalse(socketSupportsKeepAliveOptions());
+    }
+
+    public static void assumeKeepAlivePerSocketOptionsSupported() throws Throwable {
+        Assume.assumeTrue(socketSupportsKeepAliveOptions());
+    }
+
+    public static boolean socketSupportsKeepAliveOptions() throws Throwable {
+        try (ServerSocketChannel serverSocketChannel = buildServerSocket()) {
+            return IOUtil.supportsKeepAliveOptions(serverSocketChannel);
+        }
+    }
+
+    private static ServerSocketChannel buildServerSocket() throws IOException {
+        InetSocketAddress socketAddress = new InetSocketAddress("127.0.0.1", 0);
+        ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+        ServerSocket server = serverSocketChannel.socket();
+        server.bind(socketAddress);
+        return serverSocketChannel;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/UnifiedNetworkIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/UnifiedNetworkIntegrationTest.java
@@ -44,6 +44,7 @@ import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
 public class UnifiedNetworkIntegrationTest {
     @Rule
     public ExpectedException expect = ExpectedException.none();
@@ -54,7 +55,6 @@ public class UnifiedNetworkIntegrationTest {
     }
 
     @Test
-    @Category(QuickTest.class)
     public void testKeepAliveSocketOptions() throws Throwable {
         assumeKeepAlivePerSocketOptionsSupported();
         Config config = getConfig();
@@ -84,7 +84,6 @@ public class UnifiedNetworkIntegrationTest {
     }
 
     @Test
-    @Category(QuickTest.class)
     public void testKeepAliveSocketOptions_whenNotSupported() throws Throwable {
         assumeKeepAlivePerSocketOptionsNotSupported();
         // ensure that even though options are configured and setting them fails, no exceptions are thrown

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/UnifiedNetworkIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/UnifiedNetworkIntegrationTest.java
@@ -95,7 +95,7 @@ public class UnifiedNetworkIntegrationTest {
         assertClusterSizeEventually(2, hz);
     }
 
-    private Config getConfig() {
+    protected Config getConfig() {
         Config config = smallInstanceConfig();
         config.setProperty(ClusterProperty.SOCKET_KEEP_IDLE.getName(), "5");
         config.setProperty(ClusterProperty.SOCKET_KEEP_INTERVAL.getName(), "1");

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/UnifiedNetworkIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/UnifiedNetworkIntegrationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.networking.nio;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.server.ServerConnection;
+import com.hazelcast.internal.server.tcp.ServerSocketRegistry;
+import com.hazelcast.internal.server.tcp.TcpServer;
+import com.hazelcast.internal.server.tcp.TcpServerConnection;
+import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.Accessors;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.core.Hazelcast.newHazelcastInstance;
+import static com.hazelcast.internal.networking.nio.NetworkTestUtil.assumeKeepAlivePerSocketOptionsNotSupported;
+import static com.hazelcast.internal.networking.nio.NetworkTestUtil.assumeKeepAlivePerSocketOptionsSupported;
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class UnifiedNetworkIntegrationTest {
+    @Rule
+    public ExpectedException expect = ExpectedException.none();
+
+    @After
+    public void tearDown() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    @Category(QuickTest.class)
+    public void testKeepAliveSocketOptions() throws Throwable {
+        assumeKeepAlivePerSocketOptionsSupported();
+        Config config = getConfig();
+
+        HazelcastInstance hz = newHazelcastInstance(config);
+        newHazelcastInstance(config);
+
+        assertClusterSizeEventually(2, hz);
+
+        TcpServer tcpServer = (TcpServer) Accessors.getNode(hz).getServer();
+        ServerSocketRegistry registry = tcpServer.getRegistry();
+        for (ServerSocketRegistry.Pair pair : registry) {
+            if (EndpointQualifier.MEMBER.equals(pair.getQualifier())) {
+                assertEquals(2, (int) pair.getChannel().getOption(IOUtil.JDK_NET_TCP_KEEPCOUNT));
+                assertEquals(1, (int) pair.getChannel().getOption(IOUtil.JDK_NET_TCP_KEEPINTERVAL));
+                assertEquals(5, (int) pair.getChannel().getOption(IOUtil.JDK_NET_TCP_KEEPIDLE));
+            }
+        }
+
+        for (ServerConnection c : tcpServer.getConnectionManager(EndpointQualifier.MEMBER).getConnections()) {
+            TcpServerConnection cxn = (TcpServerConnection) c;
+            AbstractChannel ch = (AbstractChannel) cxn.getChannel();
+            assertEquals(2, (int) ch.socketChannel().getOption(IOUtil.JDK_NET_TCP_KEEPCOUNT));
+            assertEquals(1, (int) ch.socketChannel().getOption(IOUtil.JDK_NET_TCP_KEEPINTERVAL));
+            assertEquals(5, (int) ch.socketChannel().getOption(IOUtil.JDK_NET_TCP_KEEPIDLE));
+        }
+    }
+
+    @Test
+    @Category(QuickTest.class)
+    public void testKeepAliveSocketOptions_whenNotSupported() throws Throwable {
+        assumeKeepAlivePerSocketOptionsNotSupported();
+        // ensure that even though options are configured and setting them fails, no exceptions are thrown
+        Config config = getConfig();
+
+        HazelcastInstance hz = newHazelcastInstance(config);
+        newHazelcastInstance(config);
+
+        assertClusterSizeEventually(2, hz);
+    }
+
+    private Config getConfig() {
+        Config config = smallInstanceConfig();
+        config.setProperty(ClusterProperty.SOCKET_KEEP_IDLE.getName(), "5");
+        config.setProperty(ClusterProperty.SOCKET_KEEP_INTERVAL.getName(), "1");
+        config.setProperty(ClusterProperty.SOCKET_KEEP_COUNT.getName(), "2");
+        return config;
+    }
+}


### PR DESCRIPTION
Follow up to #23816, adding socket options for keep alive with unified (classic) network config, based on [internal feedback](https://hazelcast.slack.com/archives/CFL9NM4NR/p1679413827042419?thread_ts=1679411564.141089&cid=CFL9NM4NR).
