### PR TITLE
Explicitly set default value of disk-tier-enabled to false in xsd/json config schema [HZ-2094]

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.3.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.3.xsd
@@ -4894,7 +4894,7 @@
                 Defines configuration for the disk tier of a tiered store.
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="enabled" type="xs:boolean" use="required">
+        <xs:attribute name="enabled" type="xs:boolean" use="required" default="false">
             <xs:annotation>
                 <xs:documentation>
                     True to enable using disk as the second memory tier, false otherwise.

--- a/hazelcast/src/main/resources/hazelcast-config-5.3.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.3.json
@@ -1565,6 +1565,7 @@
                 "properties": {
                   "enabled": {
                     "type": "boolean",
+                    "default": "false",
                     "description": "True to enable using disk as the second memory tier, false otherwise."
                   },
                   "device-name": {

--- a/hazelcast/src/main/resources/hazelcast-config-5.3.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.3.xsd
@@ -4353,7 +4353,7 @@
                 Defines configuration for the disk tier of a tiered store.
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="enabled" type="xs:boolean" use="required">
+        <xs:attribute name="enabled" type="xs:boolean" use="required" default="false">
             <xs:annotation>
                 <xs:documentation>
                     True to enable using disk as the second memory tier, false otherwise.


### PR DESCRIPTION
Fixes HZ-2094
Follow-up of https://github.com/hazelcast/hazelcast-enterprise/pull/5751

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
