### PR TITLE
Bump json-smart from to 2.4.10 to fix CVE-2023-1370

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1901,7 +1901,7 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>2.4.9</version>
+                <version>2.4.10</version>
             </dependency>
             <dependency>
               <groupId>org.wildfly.openssl</groupId>


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/24056

Forwadport of: https://github.com/hazelcast/hazelcast/pull/24058

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
