### PR TITLE
Add AbstractHazelcastInstanceProxy to avoid duplication

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestSpringClientFailoverContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestSpringClientFailoverContext.java
@@ -52,7 +52,7 @@ public class TestSpringClientFailoverContext {
     @Test
     public void testBlueGreenClient() {
         HazelcastClientProxy blueGreenClient = applicationContext.getBean("blueGreenClient", HazelcastClientProxy.class);
-        ClientFailoverConfig failoverConfig = blueGreenClient.target().getFailoverConfig();
+        ClientFailoverConfig failoverConfig = blueGreenClient.getTargetOrNull().getFailoverConfig();
         List<ClientConfig> clientConfigs = failoverConfig.getClientConfigs();
         assertEquals(2, clientConfigs.size());
         assertEquals("spring-cluster", clientConfigs.get(0).getClusterName());

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestSpringClientFailoverContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestSpringClientFailoverContext.java
@@ -52,7 +52,7 @@ public class TestSpringClientFailoverContext {
     @Test
     public void testBlueGreenClient() {
         HazelcastClientProxy blueGreenClient = applicationContext.getBean("blueGreenClient", HazelcastClientProxy.class);
-        ClientFailoverConfig failoverConfig = blueGreenClient.client.getFailoverConfig();
+        ClientFailoverConfig failoverConfig = blueGreenClient.target().getFailoverConfig();
         List<ClientConfig> clientConfigs = failoverConfig.getClientConfigs();
         assertEquals(2, clientConfigs.size());
         assertEquals("spring-cluster", clientConfigs.get(0).getClusterName());

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/MCMessageTasksTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/MCMessageTasksTest.java
@@ -134,7 +134,7 @@ public class MCMessageTasksTest extends SqlTestSupport {
     }
 
     private HazelcastClientInstanceImpl getClientImpl() {
-        return ((HazelcastClientProxy) client()).client;
+        return ((HazelcastClientProxy) client()).getTarget();
     }
 
     private String getMappingDdl(String name, String partitionKey) throws InterruptedException, ExecutionException, TimeoutException {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -75,7 +75,7 @@ public class HazelcastServerCacheManager extends AbstractHazelcastCacheManager {
          * by this cache manager itself.
          */
         if (hazelcastInstance instanceof HazelcastInstanceProxy) {
-            instance = ((HazelcastInstanceProxy) hazelcastInstance).getOriginal();
+            instance = ((HazelcastInstanceProxy) hazelcastInstance).getTarget();
         } else {
             instance = (HazelcastInstanceImpl) hazelcastInstance;
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -320,11 +320,11 @@ public final class HazelcastClient {
         for (InstanceFuture<HazelcastClientProxy> future : CLIENTS.values()) {
             try {
                 HazelcastClientProxy proxy = future.get();
-                HazelcastClientInstanceImpl client = proxy.client;
+                HazelcastClientInstanceImpl client = proxy.target();
                 if (client == null) {
                     continue;
                 }
-                proxy.client = null;
+                proxy.target(null);
                 client.shutdown();
             } catch (Throwable ignored) {
                 EmptyStatement.ignore(ignored);
@@ -342,11 +342,11 @@ public final class HazelcastClient {
     public static void shutdown(HazelcastInstance instance) {
         if (instance instanceof HazelcastClientProxy) {
             final HazelcastClientProxy proxy = (HazelcastClientProxy) instance;
-            HazelcastClientInstanceImpl client = proxy.client;
+            HazelcastClientInstanceImpl client = proxy.target();
             if (client == null) {
                 return;
             }
-            proxy.client = null;
+            proxy.target(null);
             CLIENTS.remove(client.getName());
 
             try {
@@ -371,11 +371,11 @@ public final class HazelcastClient {
         }
 
         HazelcastClientProxy proxy = future.get();
-        HazelcastClientInstanceImpl client = proxy.client;
+        HazelcastClientInstanceImpl client = proxy.target();
         if (client == null) {
             return;
         }
-        proxy.client = null;
+        proxy.target(null);
         try {
             client.shutdown();
         } catch (Throwable ignored) {

--- a/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -320,11 +320,11 @@ public final class HazelcastClient {
         for (InstanceFuture<HazelcastClientProxy> future : CLIENTS.values()) {
             try {
                 HazelcastClientProxy proxy = future.get();
-                HazelcastClientInstanceImpl client = proxy.target();
+                HazelcastClientInstanceImpl client = proxy.getTargetOrNull();
                 if (client == null) {
                     continue;
                 }
-                proxy.target(null);
+                proxy.setTarget(null);
                 client.shutdown();
             } catch (Throwable ignored) {
                 EmptyStatement.ignore(ignored);
@@ -342,11 +342,11 @@ public final class HazelcastClient {
     public static void shutdown(HazelcastInstance instance) {
         if (instance instanceof HazelcastClientProxy) {
             final HazelcastClientProxy proxy = (HazelcastClientProxy) instance;
-            HazelcastClientInstanceImpl client = proxy.target();
+            HazelcastClientInstanceImpl client = proxy.getTargetOrNull();
             if (client == null) {
                 return;
             }
-            proxy.target(null);
+            proxy.setTarget(null);
             CLIENTS.remove(client.getName());
 
             try {
@@ -371,11 +371,11 @@ public final class HazelcastClient {
         }
 
         HazelcastClientProxy proxy = future.get();
-        HazelcastClientInstanceImpl client = proxy.target();
+        HazelcastClientInstanceImpl client = proxy.getTargetOrNull();
         if (client == null) {
             return;
         }
-        proxy.target(null);
+        proxy.setTarget(null);
         try {
             client.shutdown();
         } catch (Throwable ignored) {

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -64,7 +64,7 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
          * by this cache manager itself.
          */
         if (hazelcastInstance instanceof HazelcastClientProxy) {
-            client = ((HazelcastClientProxy) hazelcastInstance).target();
+            client = ((HazelcastClientProxy) hazelcastInstance).getTargetOrNull();
         } else {
             client = ((HazelcastClientInstanceImpl) hazelcastInstance);
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -64,7 +64,7 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
          * by this cache manager itself.
          */
         if (hazelcastInstance instanceof HazelcastClientProxy) {
-            client = ((HazelcastClientProxy) hazelcastInstance).client;
+            client = ((HazelcastClientProxy) hazelcastInstance).target();
         } else {
             client = ((HazelcastClientInstanceImpl) hazelcastInstance);
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -611,7 +611,7 @@ public class HazelcastCommandLine implements Runnable {
 
     protected static HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance client) {
         if (client instanceof HazelcastClientProxy) {
-            return ((HazelcastClientProxy) client).client;
+            return ((HazelcastClientProxy) client).target();
         } else if (client instanceof HazelcastClientInstanceImpl) {
             return ((HazelcastClientInstanceImpl) client);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -611,7 +611,7 @@ public class HazelcastCommandLine implements Runnable {
 
     protected static HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance client) {
         if (client instanceof HazelcastClientProxy) {
-            return ((HazelcastClientProxy) client).target();
+            return ((HazelcastClientProxy) client).getTargetOrNull();
         } else if (client instanceof HazelcastClientInstanceImpl) {
             return ((HazelcastClientInstanceImpl) client);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
@@ -16,223 +16,26 @@
 
 package com.hazelcast.client.impl.clientside;
 
-import com.hazelcast.cardinality.CardinalityEstimator;
-import com.hazelcast.client.Client;
-import com.hazelcast.client.ClientService;
 import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.cluster.Cluster;
-import com.hazelcast.collection.IList;
-import com.hazelcast.collection.IQueue;
-import com.hazelcast.collection.ISet;
-import com.hazelcast.config.Config;
-import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ICacheManager;
-import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.LifecycleService;
-import com.hazelcast.cp.CPSubsystem;
-import com.hazelcast.crdt.pncounter.PNCounter;
-import com.hazelcast.durableexecutor.DurableExecutorService;
-import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.instance.impl.AbstractHazelcastInstanceProxy;
 import com.hazelcast.instance.impl.TerminatedLifecycleService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.jet.JetService;
-import com.hazelcast.logging.LoggingService;
-import com.hazelcast.map.IMap;
-import com.hazelcast.multimap.MultiMap;
-import com.hazelcast.partition.PartitionService;
-import com.hazelcast.replicatedmap.ReplicatedMap;
-import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
-import com.hazelcast.sql.SqlService;
-import com.hazelcast.topic.ITopic;
-import com.hazelcast.transaction.HazelcastXAResource;
-import com.hazelcast.transaction.TransactionContext;
-import com.hazelcast.transaction.TransactionException;
-import com.hazelcast.transaction.TransactionOptions;
-import com.hazelcast.transaction.TransactionalTask;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * A client-side proxy {@link com.hazelcast.core.HazelcastInstance} instance.
  */
-@SuppressWarnings("checkstyle:classfanoutcomplexity")
-public class HazelcastClientProxy implements HazelcastInstance, SerializationServiceSupport {
+public class HazelcastClientProxy extends AbstractHazelcastInstanceProxy<HazelcastClientInstanceImpl>
+        implements HazelcastInstance, SerializationServiceSupport {
 
-    public volatile HazelcastClientInstanceImpl client;
-
-    public HazelcastClientProxy(HazelcastClientInstanceImpl client) {
-        this.client = client;
-    }
-
-    @Nonnull
-    @Override
-    public Config getConfig() {
-        return getClient().getConfig();
-    }
-
-    @Nonnull
-    @Override
-    public String getName() {
-        return getClient().getName();
-    }
-
-    @Nonnull
-    @Override
-    public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
-        return getClient().getRingbuffer(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> IQueue<E> getQueue(@Nonnull String name) {
-        return getClient().getQueue(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ITopic<E> getTopic(@Nonnull String name) {
-        return getClient().getTopic(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
-        return getClient().getReliableTopic(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ISet<E> getSet(@Nonnull String name) {
-        return getClient().getSet(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> IList<E> getList(@Nonnull String name) {
-        return getClient().getList(name);
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> IMap<K, V> getMap(@Nonnull String name) {
-        return getClient().getMap(name);
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name) {
-        return getClient().getMultiMap(name);
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
-        return getClient().getReplicatedMap(name);
-    }
-
-    @Override
-    public ICacheManager getCacheManager() {
-        return getClient().getCacheManager();
-    }
-
-    @Nonnull
-    @Override
-    public Cluster getCluster() {
-        return getClient().getCluster();
-    }
-
-    @Nonnull
-    @Override
-    public Client getLocalEndpoint() {
-        return getClient().getLocalEndpoint();
-    }
-
-    @Nonnull
-    @Override
-    public IExecutorService getExecutorService(@Nonnull String name) {
-        return getClient().getExecutorService(name);
-    }
-
-    @Nonnull
-    @Override
-    public DurableExecutorService getDurableExecutorService(@Nonnull String name) {
-        return getClient().getDurableExecutorService(name);
-    }
-
-    @Override
-    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task)
-            throws TransactionException {
-        return getClient().executeTransaction(task);
-    }
-
-    @Override
-    public <T> T executeTransaction(@Nonnull TransactionOptions options, @Nonnull TransactionalTask<T> task)
-            throws TransactionException {
-        return getClient().executeTransaction(options, task);
-    }
-
-    @Override
-    public TransactionContext newTransactionContext() {
-        return getClient().newTransactionContext();
-    }
-
-    @Override
-    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
-        return getClient().newTransactionContext(options);
-    }
-
-    @Nonnull
-    @Override
-    public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
-        return getClient().getFlakeIdGenerator(name);
-    }
-
-    @Nonnull
-    @Override
-    public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
-        return getClient().getCardinalityEstimator(name);
-    }
-
-    @Nonnull
-    @Override
-    public PNCounter getPNCounter(@Nonnull String name) {
-        return getClient().getPNCounter(name);
-    }
-
-    @Nonnull
-    @Override
-    public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
-        return getClient().getScheduledExecutorService(name);
-    }
-
-    @Override
-    public Collection<DistributedObject> getDistributedObjects() {
-        return getClient().getDistributedObjects();
-    }
-
-    @Override
-    public UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener) {
-        return getClient().addDistributedObjectListener(distributedObjectListener);
-    }
-
-    @Override
-    public boolean removeDistributedObjectListener(@Nonnull UUID registrationId) {
-        return getClient().removeDistributedObjectListener(registrationId);
-    }
-
-    @Nonnull
-    @Override
-    public PartitionService getPartitionService() {
-        return getClient().getPartitionService();
+    public HazelcastClientProxy(HazelcastClientInstanceImpl target) {
+        super(target);
     }
 
     @Nonnull
@@ -243,49 +46,13 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
 
     @Nonnull
     @Override
-    public ClientService getClientService() {
-        return getClient().getClientService();
-    }
-
-    @Nonnull
-    @Override
-    public LoggingService getLoggingService() {
-        return getClient().getLoggingService();
-    }
-
-    @Nonnull
-    @Override
     public LifecycleService getLifecycleService() {
-        final HazelcastClientInstanceImpl hz = client;
+        final HazelcastClientInstanceImpl hz = target;
         return hz != null ? hz.getLifecycleService() : new TerminatedLifecycleService();
     }
 
-    @Nonnull
-    @Override
-    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName, @Nonnull String name) {
-        return getClient().getDistributedObject(serviceName, name);
-    }
-
-    @Nonnull
-    @Override
-    public CPSubsystem getCPSubsystem() {
-        return getClient().getCPSubsystem();
-    }
-
-    @Nonnull
-    @Override
-    public ConcurrentMap<String, Object> getUserContext() {
-        return getClient().getUserContext();
-    }
-
     public ClientConfig getClientConfig() {
-        return getClient().getClientConfig();
-    }
-
-    @Nonnull
-    @Override
-    public HazelcastXAResource getXAResource() {
-        return getClient().getXAResource();
+        return getTarget().getClientConfig();
     }
 
     @Override
@@ -295,11 +62,12 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
 
     @Override
     public InternalSerializationService getSerializationService() {
-        return getClient().getSerializationService();
+        return getTarget().getSerializationService();
     }
 
-    protected HazelcastClientInstanceImpl getClient() {
-        final HazelcastClientInstanceImpl c = client;
+    @Override
+    public HazelcastClientInstanceImpl getTarget() {
+        final HazelcastClientInstanceImpl c = target;
         if (c == null || !c.getLifecycleService().isRunning()) {
             throw new HazelcastClientNotActiveException();
         }
@@ -307,22 +75,10 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
     }
 
     public String toString() {
-        final HazelcastClientInstanceImpl hazelcastInstance = client;
+        final HazelcastClientInstanceImpl hazelcastInstance = target;
         if (hazelcastInstance != null) {
             return hazelcastInstance.toString();
         }
         return "HazelcastClientInstance {NOT ACTIVE}";
-    }
-
-    @Nonnull
-    @Override
-    public SqlService getSql() {
-        return getClient().getSql();
-    }
-
-    @Nonnull
-    @Override
-    public JetService getJet() {
-        return client.getJet();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/HazelcastDataConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/HazelcastDataConnection.java
@@ -85,7 +85,7 @@ public class HazelcastDataConnection extends DataConnectionBase {
             this.proxy = new ConcurrentMemoizingSupplier<>(() -> {
                 HazelcastClientProxy hazelcastClientProxy = (HazelcastClientProxy) HazelcastClient
                         .newHazelcastClient(clientConfig);
-                return new HazelcastClientProxy(hazelcastClientProxy.client) {
+                return new HazelcastClientProxy(hazelcastClientProxy.getTarget()) {
                     @Override
                     public void shutdown() {
                         release();
@@ -161,7 +161,7 @@ public class HazelcastDataConnection extends DataConnectionBase {
             HazelcastClientProxy rememberedProxy = proxy.remembered();
             if (rememberedProxy != null) {
                 // the proxy has overridden shutdown method, need to close real client
-                rememberedProxy.client.shutdown();
+                rememberedProxy.getTarget().shutdown();
             }
             proxy = null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/AbstractHazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/AbstractHazelcastInstanceProxy.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+import com.hazelcast.cardinality.CardinalityEstimator;
+import com.hazelcast.client.ClientService;
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.cluster.Endpoint;
+import com.hazelcast.collection.IList;
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.collection.ISet;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.DistributedObjectListener;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.ICacheManager;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.LifecycleService;
+import com.hazelcast.cp.CPSubsystem;
+import com.hazelcast.crdt.pncounter.PNCounter;
+import com.hazelcast.durableexecutor.DurableExecutorService;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.jet.JetService;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.map.IMap;
+import com.hazelcast.multimap.MultiMap;
+import com.hazelcast.partition.PartitionService;
+import com.hazelcast.replicatedmap.ReplicatedMap;
+import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
+import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
+import com.hazelcast.sql.SqlService;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.transaction.HazelcastXAResource;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalTask;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * An abstract proxy to a target HazelcastInstance.
+ * <p/>
+ * The primary reason this class exists is that there are a collection of HazelcastInstance
+ * implementations that are proxies which leads to a lot of code duplication and this class
+ * will get rid of all the forwarding duplication.
+ *
+ * @param <H>
+ */
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
+public abstract class AbstractHazelcastInstanceProxy<H extends HazelcastInstance>
+        implements HazelcastInstance {
+
+    protected volatile H target;
+
+    public AbstractHazelcastInstanceProxy(H target) {
+        this.target = target;
+    }
+
+    /**
+     * Sets the target instance which could be <code>null</code>.
+     *
+     * @param target the target instance.
+     */
+    public void target(H target) {
+        this.target = target;
+    }
+
+    /**
+     * Gets the target instance which could be <code>null</code>.
+     *
+     * @return the target instance.
+     */
+    public H target() {
+        return target;
+    }
+
+    /**
+     * Gets the target instance. The default implementation will check
+     * if the target is actually set and throw an HazelcastInstanceNotActiveException
+     * if that isn't the case. Override this method for custom behavior.
+     *
+     * @return the target instance.
+     */
+    public H getTarget() {
+        H instance = target;
+        if (instance == null) {
+            throw new HazelcastInstanceNotActiveException();
+        }
+        return instance;
+    }
+
+    @Override
+    @Nonnull
+    public String getName() {
+        return getTarget().getName();
+    }
+
+    @Override
+    @Nonnull
+    public <E> IQueue<E> getQueue(@Nonnull String name) {
+        return getTarget().getQueue(name);
+    }
+
+    @Override
+    @Nonnull
+    public <E> ITopic<E> getTopic(@Nonnull String name) {
+        return getTarget().getTopic(name);
+    }
+
+    @Override
+    @Nonnull
+    public <E> ISet<E> getSet(@Nonnull String name) {
+        return getTarget().getSet(name);
+    }
+
+    @Override
+    @Nonnull
+    public <E> IList<E> getList(@Nonnull String name) {
+        return getTarget().getList(name);
+    }
+
+    @Override
+    @Nonnull
+    public <K, V> IMap<K, V> getMap(@Nonnull String name) {
+        return getTarget().getMap(name);
+    }
+
+    @Override
+    @Nonnull
+    public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
+        return getTarget().getReplicatedMap(name);
+    }
+
+    @Override
+    @Nonnull
+    public <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name) {
+        return getTarget().getMultiMap(name);
+    }
+
+    @Override
+    @Nonnull
+    public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
+        return getTarget().getRingbuffer(name);
+    }
+
+    @Override
+    @Nonnull
+    public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
+        return getTarget().getReliableTopic(name);
+    }
+
+    @Override
+    @Nonnull
+    public Cluster getCluster() {
+        return getTarget().getCluster();
+    }
+
+    @Override
+    @Nonnull
+    public Endpoint getLocalEndpoint() {
+        return getTarget().getLocalEndpoint();
+    }
+
+    @Override
+    @Nonnull
+    public IExecutorService getExecutorService(@Nonnull String name) {
+        return getTarget().getExecutorService(name);
+    }
+
+    @Override
+    @Nonnull
+    public DurableExecutorService getDurableExecutorService(@Nonnull String name) {
+        return getTarget().getDurableExecutorService(name);
+    }
+
+    @Override
+    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task) throws TransactionException {
+        return getTarget().executeTransaction(task);
+    }
+
+    @Override
+    public <T> T executeTransaction(@Nonnull TransactionOptions options,
+                                    @Nonnull TransactionalTask<T> task) throws TransactionException {
+        return getTarget().executeTransaction(options, task);
+    }
+
+    @Override
+    public TransactionContext newTransactionContext() {
+        return getTarget().newTransactionContext();
+    }
+
+    @Override
+    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
+        return getTarget().newTransactionContext(options);
+    }
+
+    @Override
+    @Nonnull
+    public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
+        return getTarget().getFlakeIdGenerator(name);
+    }
+
+    @Override
+    public Collection<DistributedObject> getDistributedObjects() {
+        return getTarget().getDistributedObjects();
+    }
+
+    @Override
+    public UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener) {
+        return getTarget().addDistributedObjectListener(distributedObjectListener);
+    }
+
+    @Override
+    public boolean removeDistributedObjectListener(@Nonnull UUID registrationId) {
+        return getTarget().removeDistributedObjectListener(registrationId);
+    }
+
+    @Override
+    @Nonnull
+    public Config getConfig() {
+        return getTarget().getConfig();
+    }
+
+    @Override
+    @Nonnull
+    public PartitionService getPartitionService() {
+        return getTarget().getPartitionService();
+    }
+
+    @Override
+    @Nonnull
+    public SplitBrainProtectionService getSplitBrainProtectionService() {
+        return getTarget().getSplitBrainProtectionService();
+    }
+
+    @Override
+    @Nonnull
+    public ClientService getClientService() {
+        return getTarget().getClientService();
+    }
+
+    @Override
+    @Nonnull
+    public LoggingService getLoggingService() {
+        return getTarget().getLoggingService();
+    }
+
+    @Override
+    @Nonnull
+    public LifecycleService getLifecycleService() {
+        return getTarget().getLifecycleService();
+    }
+
+    @Override
+    @Nonnull
+    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName, @Nonnull String name) {
+        return getTarget().getDistributedObject(serviceName, name);
+    }
+
+    @Override
+    @Nonnull
+    public ConcurrentMap<String, Object> getUserContext() {
+        return getTarget().getUserContext();
+    }
+
+    @Override
+    @Nonnull
+    public HazelcastXAResource getXAResource() {
+        return getTarget().getXAResource();
+    }
+
+    @Override
+    public ICacheManager getCacheManager() {
+        return getTarget().getCacheManager();
+    }
+
+    @Override
+    @Nonnull
+    public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
+        return getTarget().getCardinalityEstimator(name);
+    }
+
+    @Override
+    @Nonnull
+    public PNCounter getPNCounter(@Nonnull String name) {
+        return getTarget().getPNCounter(name);
+    }
+
+    @Override
+    @Nonnull
+    public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
+        return getTarget().getScheduledExecutorService(name);
+    }
+
+    @Override
+    @Nonnull
+    public CPSubsystem getCPSubsystem() {
+        return getTarget().getCPSubsystem();
+    }
+
+    @Override
+    @Nonnull
+    public SqlService getSql() {
+        return getTarget().getSql();
+    }
+
+    @Override
+    @Nonnull
+    public JetService getJet() {
+        return getTarget().getJet();
+    }
+
+    @Override
+    public void shutdown() {
+        getTarget().shutdown();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/AbstractHazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/AbstractHazelcastInstanceProxy.java
@@ -81,7 +81,7 @@ public abstract class AbstractHazelcastInstanceProxy<H extends HazelcastInstance
      *
      * @param target the target instance.
      */
-    public void target(H target) {
+    public void setTarget(H target) {
         this.target = target;
     }
 
@@ -90,7 +90,7 @@ public abstract class AbstractHazelcastInstanceProxy<H extends HazelcastInstance
      *
      * @return the target instance.
      */
-    public H target() {
+    public H getTargetOrNull() {
         return target;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/BootstrappedInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/BootstrappedInstanceProxy.java
@@ -16,64 +16,27 @@
 
 package com.hazelcast.instance.impl;
 
-import com.hazelcast.cardinality.CardinalityEstimator;
-import com.hazelcast.client.ClientService;
-import com.hazelcast.cluster.Cluster;
-import com.hazelcast.cluster.Endpoint;
-import com.hazelcast.collection.IList;
-import com.hazelcast.collection.IQueue;
-import com.hazelcast.collection.ISet;
-import com.hazelcast.config.Config;
-import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ICacheManager;
-import com.hazelcast.core.IExecutorService;
-import com.hazelcast.core.LifecycleService;
-import com.hazelcast.cp.CPSubsystem;
-import com.hazelcast.crdt.pncounter.PNCounter;
-import com.hazelcast.durableexecutor.DurableExecutorService;
-import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.instance.impl.executejar.ExecuteJobParameters;
 import com.hazelcast.jet.Job;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.logging.LoggingService;
-import com.hazelcast.map.IMap;
-import com.hazelcast.multimap.MultiMap;
-import com.hazelcast.partition.PartitionService;
-import com.hazelcast.replicatedmap.ReplicatedMap;
-import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
-import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
-import com.hazelcast.sql.SqlService;
-import com.hazelcast.topic.ITopic;
-import com.hazelcast.transaction.HazelcastXAResource;
-import com.hazelcast.transaction.TransactionContext;
-import com.hazelcast.transaction.TransactionException;
-import com.hazelcast.transaction.TransactionOptions;
-import com.hazelcast.transaction.TransactionalTask;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentMap;
 
 // A special HazelcastInstance that has a BootstrappedJetProxy
 @SuppressWarnings({"checkstyle:methodcount"})
-public final class BootstrappedInstanceProxy implements HazelcastInstance {
+public final class BootstrappedInstanceProxy extends AbstractHazelcastInstanceProxy {
 
     private static final ILogger LOGGER = Logger.getLogger(BootstrappedInstanceProxy.class);
-
-    private final HazelcastInstance instance;
 
     private final BootstrappedJetProxy jetProxy;
 
     private boolean shutDownAllowed = true;
 
     BootstrappedInstanceProxy(HazelcastInstance instance, BootstrappedJetProxy jetProxy) {
-        this.instance = instance;
+        super(instance);
         this.jetProxy = jetProxy;
     }
 
@@ -93,221 +56,6 @@ public final class BootstrappedInstanceProxy implements HazelcastInstance {
 
     public void removeExecuteJobParameters() {
         jetProxy.removeExecuteJobParameters();
-    }
-
-    @Nonnull
-    @Override
-    public String getName() {
-        return instance.getName();
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> IMap<K, V> getMap(@Nonnull String name) {
-        return instance.getMap(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> IQueue<E> getQueue(@Nonnull String name) {
-        return instance.getQueue(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ITopic<E> getTopic(@Nonnull String name) {
-        return instance.getTopic(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
-        return instance.getReliableTopic(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ISet<E> getSet(@Nonnull String name) {
-        return instance.getSet(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> IList<E> getList(@Nonnull String name) {
-        return instance.getList(name);
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name) {
-        return instance.getMultiMap(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
-        return instance.getRingbuffer(name);
-    }
-
-    @Nonnull
-    @Override
-    public IExecutorService getExecutorService(@Nonnull String name) {
-        return instance.getExecutorService(name);
-    }
-
-    @Nonnull
-    @Override
-    public DurableExecutorService getDurableExecutorService(@Nonnull String name) {
-        return instance.getDurableExecutorService(name);
-    }
-
-    @Override
-    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task) throws TransactionException {
-        return instance.executeTransaction(task);
-    }
-
-    @Override
-    public <T> T executeTransaction(@Nonnull TransactionOptions options,
-                                    @Nonnull TransactionalTask<T> task) throws TransactionException {
-        return instance.executeTransaction(options, task);
-    }
-
-    @Override
-    public TransactionContext newTransactionContext() {
-        return instance.newTransactionContext();
-    }
-
-    @Override
-    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
-        return instance.newTransactionContext(options);
-    }
-
-    @Nonnull
-    @Override
-    public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
-        return instance.getFlakeIdGenerator(name);
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
-        return instance.getReplicatedMap(name);
-    }
-
-    @Override
-    public ICacheManager getCacheManager() {
-        return instance.getCacheManager();
-    }
-
-    @Nonnull
-    @Override
-    public Cluster getCluster() {
-        return instance.getCluster();
-    }
-
-    @Nonnull
-    @Override
-    public Endpoint getLocalEndpoint() {
-        return instance.getLocalEndpoint();
-    }
-
-    @Override
-    public Collection<DistributedObject> getDistributedObjects() {
-        return instance.getDistributedObjects();
-    }
-
-    @Nonnull
-    @Override
-    public Config getConfig() {
-        return instance.getConfig();
-    }
-
-    @Nonnull
-    @Override
-    public PartitionService getPartitionService() {
-        return instance.getPartitionService();
-    }
-
-    @Nonnull
-    @Override
-    public SplitBrainProtectionService getSplitBrainProtectionService() {
-        return instance.getSplitBrainProtectionService();
-    }
-
-    @Nonnull
-    @Override
-    public ClientService getClientService() {
-        return instance.getClientService();
-    }
-
-    @Nonnull
-    @Override
-    public LoggingService getLoggingService() {
-        return instance.getLoggingService();
-    }
-
-    @Nonnull
-    @Override
-    public LifecycleService getLifecycleService() {
-        return instance.getLifecycleService();
-    }
-
-    @Nonnull
-    @Override
-    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName, @Nonnull String name) {
-        return instance.getDistributedObject(serviceName, name);
-    }
-
-    @Override
-    public UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener) {
-        return instance.addDistributedObjectListener(distributedObjectListener);
-    }
-
-    @Override
-    public boolean removeDistributedObjectListener(@Nonnull UUID registrationId) {
-        return instance.removeDistributedObjectListener(registrationId);
-    }
-
-    @Nonnull
-    @Override
-    public ConcurrentMap<String, Object> getUserContext() {
-        return instance.getUserContext();
-    }
-
-    @Nonnull
-    @Override
-    public HazelcastXAResource getXAResource() {
-        return instance.getXAResource();
-    }
-
-    @Nonnull
-    @Override
-    public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
-        return instance.getCardinalityEstimator(name);
-    }
-
-    @Nonnull
-    @Override
-    public PNCounter getPNCounter(@Nonnull String name) {
-        return instance.getPNCounter(name);
-    }
-
-    @Nonnull
-    @Override
-    public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
-        return instance.getScheduledExecutorService(name);
-    }
-
-    @Nonnull
-    @Override
-    public CPSubsystem getCPSubsystem() {
-        return instance.getCPSubsystem();
-    }
-
-    @Nonnull
-    @Override
-    public SqlService getSql() {
-        return instance.getSql();
     }
 
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/BootstrappedInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/BootstrappedInstanceProxy.java
@@ -27,7 +27,8 @@ import java.util.List;
 
 // A special HazelcastInstance that has a BootstrappedJetProxy
 @SuppressWarnings({"checkstyle:methodcount"})
-public final class BootstrappedInstanceProxy extends AbstractHazelcastInstanceProxy {
+public final class BootstrappedInstanceProxy
+        extends AbstractHazelcastInstanceProxy<HazelcastInstance> {
 
     private static final ILogger LOGGER = Logger.getLogger(BootstrappedInstanceProxy.class);
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceFactory.java
@@ -305,7 +305,7 @@ public final class HazelcastInstanceFactory {
             } else {
                 proxy.getLifecycleService().shutdown();
             }
-            proxy.target(null);
+            proxy.setTarget(null);
         }
     }
 
@@ -313,7 +313,7 @@ public final class HazelcastInstanceFactory {
         OutOfMemoryErrorDispatcher.deregisterServer(instance);
         InstanceFuture<HazelcastInstanceProxy> future = INSTANCE_MAP.remove(instance.getName());
         if (future != null && future.isSet()) {
-            future.get().target(null);
+            future.get().setTarget(null);
         }
         if (INSTANCE_MAP.size() == 0) {
             ManagementService.shutdown(instance.getName());

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceFactory.java
@@ -305,7 +305,7 @@ public final class HazelcastInstanceFactory {
             } else {
                 proxy.getLifecycleService().shutdown();
             }
-            proxy.original = null;
+            proxy.target(null);
         }
     }
 
@@ -313,7 +313,7 @@ public final class HazelcastInstanceFactory {
         OutOfMemoryErrorDispatcher.deregisterServer(instance);
         InstanceFuture<HazelcastInstanceProxy> future = INSTANCE_MAP.remove(instance.getName());
         if (future != null && future.isSet()) {
-            future.get().original = null;
+            future.get().target(null);
         }
         if (INSTANCE_MAP.size() == 0) {
             ManagementService.shutdown(instance.getName());

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceProxy.java
@@ -16,48 +16,12 @@
 
 package com.hazelcast.instance.impl;
 
-import com.hazelcast.cardinality.CardinalityEstimator;
-import com.hazelcast.client.ClientService;
-import com.hazelcast.cluster.Cluster;
-import com.hazelcast.cluster.Member;
-import com.hazelcast.collection.IList;
-import com.hazelcast.collection.IQueue;
-import com.hazelcast.collection.ISet;
-import com.hazelcast.config.Config;
-import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.HazelcastInstanceNotActiveException;
-import com.hazelcast.core.ICacheManager;
-import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.LifecycleService;
-import com.hazelcast.cp.CPSubsystem;
-import com.hazelcast.crdt.pncounter.PNCounter;
-import com.hazelcast.durableexecutor.DurableExecutorService;
-import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.jet.JetService;
-import com.hazelcast.logging.LoggingService;
-import com.hazelcast.map.IMap;
-import com.hazelcast.multimap.MultiMap;
-import com.hazelcast.partition.PartitionService;
-import com.hazelcast.replicatedmap.ReplicatedMap;
-import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
-import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
-import com.hazelcast.sql.SqlService;
-import com.hazelcast.topic.ITopic;
-import com.hazelcast.transaction.HazelcastXAResource;
-import com.hazelcast.transaction.TransactionContext;
-import com.hazelcast.transaction.TransactionException;
-import com.hazelcast.transaction.TransactionOptions;
-import com.hazelcast.transaction.TransactionalTask;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * A proxy around the actual HazelcastInstanceImpl. This class serves 2 purposes:
@@ -72,16 +36,15 @@ import java.util.concurrent.ConcurrentMap;
  * </li>
  * </ol>
  */
-@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
-public final class HazelcastInstanceProxy implements HazelcastInstance, SerializationServiceSupport {
-
-    protected volatile HazelcastInstanceImpl original;
+public final class HazelcastInstanceProxy
+        extends AbstractHazelcastInstanceProxy<HazelcastInstanceImpl>
+        implements HazelcastInstance, SerializationServiceSupport {
 
     private final String name;
 
-    protected HazelcastInstanceProxy(HazelcastInstanceImpl original) {
-        this.original = original;
-        name = original.getName();
+    protected HazelcastInstanceProxy(HazelcastInstanceImpl target) {
+        super(target);
+        name = target.getName();
     }
 
     @Nonnull
@@ -92,218 +55,9 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
 
     @Nonnull
     @Override
-    public <K, V> IMap<K, V> getMap(@Nonnull String name) {
-        return getOriginal().getMap(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> IQueue<E> getQueue(@Nonnull String name) {
-        return getOriginal().getQueue(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ITopic<E> getTopic(@Nonnull String name) {
-        return getOriginal().getTopic(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
-        return getOriginal().getReliableTopic(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ISet<E> getSet(@Nonnull String name) {
-        return getOriginal().getSet(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> IList<E> getList(@Nonnull String name) {
-        return getOriginal().getList(name);
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name) {
-        return getOriginal().getMultiMap(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
-        return getOriginal().getRingbuffer(name);
-    }
-
-    @Nonnull
-    @Override
-    public IExecutorService getExecutorService(@Nonnull String name) {
-        return getOriginal().getExecutorService(name);
-    }
-
-    @Nonnull
-    @Override
-    public DurableExecutorService getDurableExecutorService(@Nonnull String name) {
-        return getOriginal().getDurableExecutorService(name);
-    }
-
-    @Override
-    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task) throws TransactionException {
-        return getOriginal().executeTransaction(task);
-    }
-
-    @Override
-    public <T> T executeTransaction(@Nonnull TransactionOptions options,
-                                    @Nonnull TransactionalTask<T> task) throws TransactionException {
-        return getOriginal().executeTransaction(options, task);
-    }
-
-    @Override
-    public TransactionContext newTransactionContext() {
-        return getOriginal().newTransactionContext();
-    }
-
-    @Override
-    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
-        return getOriginal().newTransactionContext(options);
-    }
-
-    @Nonnull
-    @Override
-    public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
-        return getOriginal().getFlakeIdGenerator(name);
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
-        return getOriginal().getReplicatedMap(name);
-    }
-
-    @Override
-    public ICacheManager getCacheManager() {
-        return getOriginal().getCacheManager();
-    }
-
-    @Nonnull
-    @Override
-    public Cluster getCluster() {
-        return getOriginal().getCluster();
-    }
-
-    @Nonnull
-    @Override
-    public Member getLocalEndpoint() {
-        return getOriginal().getLocalEndpoint();
-    }
-
-    @Override
-    public Collection<DistributedObject> getDistributedObjects() {
-        return getOriginal().getDistributedObjects();
-    }
-
-    @Nonnull
-    @Override
-    public Config getConfig() {
-        return getOriginal().getConfig();
-    }
-
-    @Nonnull
-    @Override
-    public PartitionService getPartitionService() {
-        return getOriginal().getPartitionService();
-    }
-
-    @Nonnull
-    @Override
-    public SplitBrainProtectionService getSplitBrainProtectionService() {
-        return getOriginal().getSplitBrainProtectionService();
-    }
-
-    @Nonnull
-    @Override
-    public ClientService getClientService() {
-        return getOriginal().getClientService();
-    }
-
-    @Nonnull
-    @Override
-    public LoggingService getLoggingService() {
-        return getOriginal().getLoggingService();
-    }
-
-    @Nonnull
-    @Override
     public LifecycleService getLifecycleService() {
-        final HazelcastInstanceImpl hz = original;
+        final HazelcastInstanceImpl hz = target;
         return hz != null ? hz.getLifecycleService() : new TerminatedLifecycleService();
-    }
-
-    @Nonnull
-    @Override
-    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName, @Nonnull String name) {
-        return getOriginal().getDistributedObject(serviceName, name);
-    }
-
-    @Override
-    public UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener) {
-        return getOriginal().addDistributedObjectListener(distributedObjectListener);
-    }
-
-    @Override
-    public boolean removeDistributedObjectListener(@Nonnull UUID registrationId) {
-        return getOriginal().removeDistributedObjectListener(registrationId);
-    }
-
-    @Nonnull
-    @Override
-    public ConcurrentMap<String, Object> getUserContext() {
-        return getOriginal().getUserContext();
-    }
-
-    @Nonnull
-    @Override
-    public HazelcastXAResource getXAResource() {
-        return getOriginal().getXAResource();
-    }
-
-    @Nonnull
-    @Override
-    public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
-        return getOriginal().getCardinalityEstimator(name);
-    }
-
-    @Nonnull
-    @Override
-    public PNCounter getPNCounter(@Nonnull String name) {
-        return getOriginal().getPNCounter(name);
-    }
-
-    @Nonnull
-    @Override
-    public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
-        return getOriginal().getScheduledExecutorService(name);
-    }
-
-    @Nonnull
-    @Override
-    public CPSubsystem getCPSubsystem() {
-        return getOriginal().getCPSubsystem();
-    }
-
-    @Nonnull
-    @Override
-    public SqlService getSql() {
-        return getOriginal().getSql();
-    }
-
-    @Nonnull
-    @Override
-    public JetService getJet() {
-        return getOriginal().getJet();
     }
 
     @Override
@@ -313,20 +67,12 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
 
     @Override
     public InternalSerializationService getSerializationService() {
-        return getOriginal().getSerializationService();
-    }
-
-    public HazelcastInstanceImpl getOriginal() {
-        final HazelcastInstanceImpl hazelcastInstance = original;
-        if (hazelcastInstance == null) {
-            throw new HazelcastInstanceNotActiveException();
-        }
-        return hazelcastInstance;
+        return getTarget().getSerializationService();
     }
 
     @Override
     public String toString() {
-        final HazelcastInstanceImpl hazelcastInstance = original;
+        final HazelcastInstanceImpl hazelcastInstance = target;
         if (hazelcastInstance != null) {
             return hazelcastInstance.toString();
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AbstractUpdateMapP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AbstractUpdateMapP.java
@@ -174,7 +174,7 @@ public abstract class AbstractUpdateMapP<T, K, V> extends AsyncHazelcastWriterP 
                 partitioningStrategy = ((MapProxyImpl<K, ?>) map).getPartitionStrategy();
             } else {
                 HazelcastClientProxy clientProxy = (HazelcastClientProxy) instance;
-                ClientPartitionService clientPartitionService = clientProxy.target().getClientPartitionService();
+                ClientPartitionService clientPartitionService = clientProxy.getTargetOrNull().getClientPartitionService();
                 partitionCount = clientPartitionService.getPartitionCount();
                 partitionIdFn = clientPartitionService::getPartitionId;
                 serializationService = clientProxy.getSerializationService();

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AbstractUpdateMapP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AbstractUpdateMapP.java
@@ -174,7 +174,7 @@ public abstract class AbstractUpdateMapP<T, K, V> extends AsyncHazelcastWriterP 
                 partitioningStrategy = ((MapProxyImpl<K, ?>) map).getPartitionStrategy();
             } else {
                 HazelcastClientProxy clientProxy = (HazelcastClientProxy) instance;
-                ClientPartitionService clientPartitionService = clientProxy.client.getClientPartitionService();
+                ClientPartitionService clientPartitionService = clientProxy.target().getClientPartitionService();
                 partitionCount = clientPartitionService.getPartitionCount();
                 partitionIdFn = clientPartitionService::getPartitionId;
                 serializationService = clientProxy.getSerializationService();

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
@@ -424,7 +424,7 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
         @Override
         @Nonnull
         public List<Processor> get(int count) {
-            int remotePartitionCount = client.target().getClientPartitionService().getPartitionCount();
+            int remotePartitionCount = client.getTargetOrNull().getClientPartitionService().getPartitionCount();
 
             return IntStream.range(0, count)
                     .mapToObj(i -> {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
@@ -424,7 +424,7 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
         @Override
         @Nonnull
         public List<Processor> get(int count) {
-            int remotePartitionCount = client.client.getClientPartitionService().getPartitionCount();
+            int remotePartitionCount = client.target().getClientPartitionService().getPartitionCount();
 
             return IntStream.range(0, count)
                     .mapToObj(i -> {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
@@ -408,7 +408,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
             HazelcastInstance client = createRemoteClient(context, dataConnectionName, clientXml);
             try {
                 HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
-                remotePartitionCount = clientProxy.client.getClientPartitionService().getPartitionCount();
+                remotePartitionCount = clientProxy.target().getClientPartitionService().getPartitionCount();
             } finally {
                 client.shutdown();
             }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
@@ -408,7 +408,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
             HazelcastInstance client = createRemoteClient(context, dataConnectionName, clientXml);
             try {
                 HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
-                remotePartitionCount = clientProxy.target().getClientPartitionService().getPartitionCount();
+                remotePartitionCount = clientProxy.getTargetOrNull().getClientPartitionService().getPartitionCount();
             } finally {
                 client.shutdown();
             }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -744,7 +744,7 @@ public final class Util {
         if (instance instanceof HazelcastInstanceImpl) {
             return ((HazelcastInstanceImpl) instance);
         } else if (instance instanceof HazelcastInstanceProxy) {
-            return ((HazelcastInstanceProxy) instance).getOriginal();
+            return ((HazelcastInstanceProxy) instance).getTarget();
         } else {
             throw new IllegalArgumentException("This method can be called only with member" +
                     " instances such as HazelcastInstanceImpl and HazelcastInstanceProxy, but not " + instance.getClass());

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -28,7 +28,8 @@ import com.hazelcast.osgi.HazelcastOSGiService;
  * as proxy of delegated {@link com.hazelcast.core.HazelcastInstance} for getting from OSGi service.
  */
 @SuppressWarnings({"checkstyle:classfanoutcomplexity"})
-class HazelcastOSGiInstanceImpl extends AbstractHazelcastInstanceProxy
+class HazelcastOSGiInstanceImpl
+        extends AbstractHazelcastInstanceProxy<HazelcastInstance>
         implements HazelcastOSGiInstance {
 
     private final HazelcastOSGiService ownerService;

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -16,295 +16,32 @@
 
 package com.hazelcast.osgi.impl;
 
-import com.hazelcast.cardinality.CardinalityEstimator;
-import com.hazelcast.client.ClientService;
-import com.hazelcast.cluster.Cluster;
-import com.hazelcast.cluster.Endpoint;
-import com.hazelcast.collection.IList;
-import com.hazelcast.collection.IQueue;
-import com.hazelcast.collection.ISet;
 import com.hazelcast.config.Config;
-import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ICacheManager;
-import com.hazelcast.core.IExecutorService;
-import com.hazelcast.core.LifecycleService;
-import com.hazelcast.cp.CPSubsystem;
-import com.hazelcast.crdt.pncounter.PNCounter;
-import com.hazelcast.durableexecutor.DurableExecutorService;
-import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.instance.impl.AbstractHazelcastInstanceProxy;
 import com.hazelcast.internal.util.StringUtil;
-import com.hazelcast.jet.JetService;
-import com.hazelcast.logging.LoggingService;
-import com.hazelcast.map.IMap;
-import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.osgi.HazelcastOSGiInstance;
 import com.hazelcast.osgi.HazelcastOSGiService;
-import com.hazelcast.partition.PartitionService;
-import com.hazelcast.replicatedmap.ReplicatedMap;
-import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
-import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
-import com.hazelcast.sql.SqlService;
-import com.hazelcast.topic.ITopic;
-import com.hazelcast.transaction.HazelcastXAResource;
-import com.hazelcast.transaction.TransactionContext;
-import com.hazelcast.transaction.TransactionException;
-import com.hazelcast.transaction.TransactionOptions;
-import com.hazelcast.transaction.TransactionalTask;
-
-import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * {@link com.hazelcast.osgi.HazelcastOSGiInstance} implementation
  * as proxy of delegated {@link com.hazelcast.core.HazelcastInstance} for getting from OSGi service.
  */
 @SuppressWarnings({"checkstyle:classfanoutcomplexity"})
-class HazelcastOSGiInstanceImpl
+class HazelcastOSGiInstanceImpl extends AbstractHazelcastInstanceProxy
         implements HazelcastOSGiInstance {
 
-    private final HazelcastInstance delegatedInstance;
     private final HazelcastOSGiService ownerService;
 
-    HazelcastOSGiInstanceImpl(HazelcastInstance delegatedInstance,
+    HazelcastOSGiInstanceImpl(HazelcastInstance target,
                               HazelcastOSGiService ownerService) {
-        this.delegatedInstance = delegatedInstance;
+        super(target);
         this.ownerService = ownerService;
-    }
-
-    @Nonnull
-    @Override
-    public String getName() {
-        return delegatedInstance.getName();
-    }
-
-    @Nonnull
-    @Override
-    public <E> IQueue<E> getQueue(@Nonnull String name) {
-        return delegatedInstance.getQueue(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ITopic<E> getTopic(@Nonnull String name) {
-        return delegatedInstance.getTopic(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ISet<E> getSet(@Nonnull String name) {
-        return delegatedInstance.getSet(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> IList<E> getList(@Nonnull String name) {
-        return delegatedInstance.getList(name);
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> IMap<K, V> getMap(@Nonnull String name) {
-        return delegatedInstance.getMap(name);
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> ReplicatedMap<K, V> getReplicatedMap(@Nonnull String name) {
-        return delegatedInstance.getReplicatedMap(name);
-    }
-
-    @Nonnull
-    @Override
-    public <K, V> MultiMap<K, V> getMultiMap(@Nonnull String name) {
-        return delegatedInstance.getMultiMap(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> Ringbuffer<E> getRingbuffer(@Nonnull String name) {
-        return delegatedInstance.getRingbuffer(name);
-    }
-
-    @Nonnull
-    @Override
-    public <E> ITopic<E> getReliableTopic(@Nonnull String name) {
-        return delegatedInstance.getReliableTopic(name);
-    }
-
-    @Override
-    public ICacheManager getCacheManager() {
-        return delegatedInstance.getCacheManager();
-    }
-
-    @Nonnull
-    @Override
-    public Cluster getCluster() {
-        return delegatedInstance.getCluster();
-    }
-
-    @Nonnull
-    @Override
-    public Endpoint getLocalEndpoint() {
-        return delegatedInstance.getLocalEndpoint();
-    }
-
-    @Nonnull
-    @Override
-    public IExecutorService getExecutorService(@Nonnull String name) {
-        return delegatedInstance.getExecutorService(name);
-    }
-
-    @Nonnull
-    @Override
-    public DurableExecutorService getDurableExecutorService(@Nonnull String name) {
-        return delegatedInstance.getDurableExecutorService(name);
-    }
-
-    @Override
-    public <T> T executeTransaction(@Nonnull TransactionalTask<T> task) throws TransactionException {
-        return delegatedInstance.executeTransaction(task);
-    }
-
-    @Override
-    public <T> T executeTransaction(@Nonnull TransactionOptions options,
-                                    @Nonnull TransactionalTask<T> task) throws TransactionException {
-        return delegatedInstance.executeTransaction(options, task);
-    }
-
-    @Override
-    public TransactionContext newTransactionContext() {
-        return delegatedInstance.newTransactionContext();
-    }
-
-    @Override
-    public TransactionContext newTransactionContext(@Nonnull TransactionOptions options) {
-        return delegatedInstance.newTransactionContext(options);
-    }
-
-    @Nonnull
-    @Override
-    public FlakeIdGenerator getFlakeIdGenerator(@Nonnull String name) {
-        return delegatedInstance.getFlakeIdGenerator(name);
-    }
-
-    @Override
-    public Collection<DistributedObject> getDistributedObjects() {
-        return delegatedInstance.getDistributedObjects();
-    }
-
-    @Override
-    public UUID addDistributedObjectListener(@Nonnull DistributedObjectListener distributedObjectListener) {
-        return delegatedInstance.addDistributedObjectListener(distributedObjectListener);
-    }
-
-    @Override
-    public boolean removeDistributedObjectListener(@Nonnull UUID registrationId) {
-        return delegatedInstance.removeDistributedObjectListener(registrationId);
-    }
-
-    @Nonnull
-    @Override
-    public Config getConfig() {
-        return delegatedInstance.getConfig();
-    }
-
-    @Nonnull
-    @Override
-    public PartitionService getPartitionService() {
-        return delegatedInstance.getPartitionService();
-    }
-
-    @Nonnull
-    @Override
-    public SplitBrainProtectionService getSplitBrainProtectionService() {
-        return delegatedInstance.getSplitBrainProtectionService();
-    }
-
-    @Nonnull
-    @Override
-    public ClientService getClientService() {
-        return delegatedInstance.getClientService();
-    }
-
-    @Nonnull
-    @Override
-    public LoggingService getLoggingService() {
-        return delegatedInstance.getLoggingService();
-    }
-
-    @Nonnull
-    @Override
-    public LifecycleService getLifecycleService() {
-        return delegatedInstance.getLifecycleService();
-    }
-
-    @Nonnull
-    @Override
-    public <T extends DistributedObject> T getDistributedObject(@Nonnull String serviceName, @Nonnull String name) {
-        return delegatedInstance.getDistributedObject(serviceName, name);
-    }
-
-    @Nonnull
-    @Override
-    public ConcurrentMap<String, Object> getUserContext() {
-        return delegatedInstance.getUserContext();
-    }
-
-    @Nonnull
-    @Override
-    public HazelcastXAResource getXAResource() {
-        return delegatedInstance.getXAResource();
-    }
-
-    @Nonnull
-    @Override
-    public CardinalityEstimator getCardinalityEstimator(@Nonnull String name) {
-        return delegatedInstance.getCardinalityEstimator(name);
-    }
-
-    @Nonnull
-    @Override
-    public PNCounter getPNCounter(@Nonnull String name) {
-        return delegatedInstance.getPNCounter(name);
-    }
-
-    @Nonnull
-    @Override
-    public IScheduledExecutorService getScheduledExecutorService(@Nonnull String name) {
-        return delegatedInstance.getScheduledExecutorService(name);
-    }
-
-    @Nonnull
-    @Override
-    public CPSubsystem getCPSubsystem() {
-        return delegatedInstance.getCPSubsystem();
-    }
-
-    @Nonnull
-    @Override
-    public SqlService getSql() {
-        return delegatedInstance.getSql();
-    }
-
-    @Nonnull
-    @Override
-    public JetService getJet() {
-        return delegatedInstance.getJet();
-    }
-
-    @Override
-    public void shutdown() {
-        delegatedInstance.shutdown();
     }
 
     @Override
     public HazelcastInstance getDelegatedInstance() {
-        return delegatedInstance;
+        return target;
     }
 
     @Override
@@ -323,7 +60,7 @@ class HazelcastOSGiInstanceImpl
 
         HazelcastOSGiInstanceImpl that = (HazelcastOSGiInstanceImpl) o;
 
-        if (!delegatedInstance.equals(that.delegatedInstance)) {
+        if (!target.equals(that.target)) {
             return false;
         }
         if (!ownerService.equals(that.ownerService)) {
@@ -336,7 +73,7 @@ class HazelcastOSGiInstanceImpl
     @Override
     public int hashCode() {
         int result = ownerService.hashCode();
-        result = 31 * result + delegatedInstance.hashCode();
+        result = 31 * result + target.hashCode();
         return result;
     }
 
@@ -344,7 +81,7 @@ class HazelcastOSGiInstanceImpl
     public String toString() {
         final StringBuilder sb = new StringBuilder();
         sb.append("HazelcastOSGiInstanceImpl");
-        sb.append("{delegatedInstance='").append(delegatedInstance).append('\'');
+        sb.append("{delegatedInstance='").append(target).append('\'');
         Config config = getConfig();
         if (!StringUtil.isNullOrEmpty(config.getClusterName())) {
             sb.append(", clusterName=").append(config.getClusterName());
@@ -353,5 +90,4 @@ class HazelcastOSGiInstanceImpl
         sb.append('}');
         return sb.toString();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheClearTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheClearTest.java
@@ -211,7 +211,7 @@ public class CacheClearTest extends CacheTestSupport {
 
     private void registerInvalidationListener(CacheEventListener cacheEventListener, String name) {
         HazelcastInstanceProxy hzInstance = (HazelcastInstanceProxy) this.hazelcastInstance;
-        hzInstance.getOriginal().node.getNodeEngine().getEventService()
+        hzInstance.getTarget().node.getNodeEngine().getEventService()
                 .registerListener(ICacheService.SERVICE_NAME, name, cacheEventListener);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheDestroyTest.java
@@ -234,7 +234,7 @@ public class CacheDestroyTest extends CacheTestSupport {
 
     private void registerInvalidationListener(CacheEventListener cacheEventListener, String name) {
         HazelcastInstanceProxy hzInstance = (HazelcastInstanceProxy) this.hazelcastInstance;
-        hzInstance.getOriginal().node.getNodeEngine().getEventService()
+        hzInstance.getTarget().node.getNodeEngine().getEventService()
                 .registerListener(ICacheService.SERVICE_NAME, name, cacheEventListener);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientOutOfMemoryHandlerTest.java
@@ -48,7 +48,7 @@ public class ClientOutOfMemoryHandlerTest extends HazelcastTestSupport {
         client = hazelcastFactory.newHazelcastClient();
 
         instances = new HazelcastInstance[2];
-        instances[0] = ((HazelcastClientProxy) client).target();
+        instances[0] = ((HazelcastClientProxy) client).getTargetOrNull();
         instances[1] = null;
 
         outOfMemoryHandler = new ClientOutOfMemoryHandler();

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientOutOfMemoryHandlerTest.java
@@ -48,7 +48,7 @@ public class ClientOutOfMemoryHandlerTest extends HazelcastTestSupport {
         client = hazelcastFactory.newHazelcastClient();
 
         instances = new HazelcastInstance[2];
-        instances[0] = ((HazelcastClientProxy) client).client;
+        instances[0] = ((HazelcastClientProxy) client).target();
         instances[1] = null;
 
         outOfMemoryHandler = new ClientOutOfMemoryHandler();

--- a/hazelcast/src/test/java/com/hazelcast/client/TestHazelcastFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/TestHazelcastFactoryTest.java
@@ -54,7 +54,7 @@ public class TestHazelcastFactoryTest extends HazelcastTestSupport {
     @Test
     public void no_leaking_client_after_shutdown() {
         HazelcastInstance client = factory.newHazelcastClient();
-        HazelcastClientInstanceImpl clientInstanceImpl = ((HazelcastClientProxy) client).client;
+        HazelcastClientInstanceImpl clientInstanceImpl = ((HazelcastClientProxy) client).target();
 
         client.getLifecycleService().shutdown();
 
@@ -64,7 +64,7 @@ public class TestHazelcastFactoryTest extends HazelcastTestSupport {
     @Test
     public void no_leaking_client_after_terminate() {
         HazelcastInstance client = factory.newHazelcastClient();
-        HazelcastClientInstanceImpl clientInstanceImpl = ((HazelcastClientProxy) client).client;
+        HazelcastClientInstanceImpl clientInstanceImpl = ((HazelcastClientProxy) client).target();
 
         client.getLifecycleService().terminate();
 
@@ -75,8 +75,8 @@ public class TestHazelcastFactoryTest extends HazelcastTestSupport {
     public void no_leaking_client_after_shutdownAll() {
         HazelcastInstance client1 = factory.newHazelcastClient();
         HazelcastInstance client2 = factory.newHazelcastClient();
-        HazelcastClientInstanceImpl clientInstanceImpl1 = ((HazelcastClientProxy) client1).client;
-        HazelcastClientInstanceImpl clientInstanceImpl2 = ((HazelcastClientProxy) client2).client;
+        HazelcastClientInstanceImpl clientInstanceImpl1 = ((HazelcastClientProxy) client1).target();
+        HazelcastClientInstanceImpl clientInstanceImpl2 = ((HazelcastClientProxy) client2).target();
 
         factory.shutdownAll();
 
@@ -88,8 +88,8 @@ public class TestHazelcastFactoryTest extends HazelcastTestSupport {
     public void no_leaking_client_after_terminateAll() {
         HazelcastInstance client1 = factory.newHazelcastClient();
         HazelcastInstance client2 = factory.newHazelcastClient();
-        HazelcastClientInstanceImpl clientInstanceImpl1 = ((HazelcastClientProxy) client1).client;
-        HazelcastClientInstanceImpl clientInstanceImpl2 = ((HazelcastClientProxy) client2).client;
+        HazelcastClientInstanceImpl clientInstanceImpl1 = ((HazelcastClientProxy) client1).target();
+        HazelcastClientInstanceImpl clientInstanceImpl2 = ((HazelcastClientProxy) client2).target();
 
         factory.terminateAll();
 

--- a/hazelcast/src/test/java/com/hazelcast/client/TestHazelcastFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/TestHazelcastFactoryTest.java
@@ -54,7 +54,7 @@ public class TestHazelcastFactoryTest extends HazelcastTestSupport {
     @Test
     public void no_leaking_client_after_shutdown() {
         HazelcastInstance client = factory.newHazelcastClient();
-        HazelcastClientInstanceImpl clientInstanceImpl = ((HazelcastClientProxy) client).target();
+        HazelcastClientInstanceImpl clientInstanceImpl = ((HazelcastClientProxy) client).getTargetOrNull();
 
         client.getLifecycleService().shutdown();
 
@@ -64,7 +64,7 @@ public class TestHazelcastFactoryTest extends HazelcastTestSupport {
     @Test
     public void no_leaking_client_after_terminate() {
         HazelcastInstance client = factory.newHazelcastClient();
-        HazelcastClientInstanceImpl clientInstanceImpl = ((HazelcastClientProxy) client).target();
+        HazelcastClientInstanceImpl clientInstanceImpl = ((HazelcastClientProxy) client).getTargetOrNull();
 
         client.getLifecycleService().terminate();
 
@@ -75,8 +75,8 @@ public class TestHazelcastFactoryTest extends HazelcastTestSupport {
     public void no_leaking_client_after_shutdownAll() {
         HazelcastInstance client1 = factory.newHazelcastClient();
         HazelcastInstance client2 = factory.newHazelcastClient();
-        HazelcastClientInstanceImpl clientInstanceImpl1 = ((HazelcastClientProxy) client1).target();
-        HazelcastClientInstanceImpl clientInstanceImpl2 = ((HazelcastClientProxy) client2).target();
+        HazelcastClientInstanceImpl clientInstanceImpl1 = ((HazelcastClientProxy) client1).getTargetOrNull();
+        HazelcastClientInstanceImpl clientInstanceImpl2 = ((HazelcastClientProxy) client2).getTargetOrNull();
 
         factory.shutdownAll();
 
@@ -88,8 +88,8 @@ public class TestHazelcastFactoryTest extends HazelcastTestSupport {
     public void no_leaking_client_after_terminateAll() {
         HazelcastInstance client1 = factory.newHazelcastClient();
         HazelcastInstance client2 = factory.newHazelcastClient();
-        HazelcastClientInstanceImpl clientInstanceImpl1 = ((HazelcastClientProxy) client1).target();
-        HazelcastClientInstanceImpl clientInstanceImpl2 = ((HazelcastClientProxy) client2).target();
+        HazelcastClientInstanceImpl clientInstanceImpl1 = ((HazelcastClientProxy) client1).getTargetOrNull();
+        HazelcastClientInstanceImpl clientInstanceImpl2 = ((HazelcastClientProxy) client2).getTargetOrNull();
 
         factory.terminateAll();
 

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
@@ -198,7 +198,7 @@ public class ClientCacheClearTest extends CacheClearTest {
     private void registerInvalidationListener(EventHandler handler, String nameWithPrefix) {
         ListenerMessageCodec listenerCodec = createInvalidationListenerCodec(nameWithPrefix);
         HazelcastClientProxy hzClient = (HazelcastClientProxy) client;
-        final HazelcastClientInstanceImpl clientInstance = hzClient.client;
+        final HazelcastClientInstanceImpl clientInstance = hzClient.target();
         clientInstance.getListenerService().registerListener(listenerCodec, handler);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
@@ -198,7 +198,7 @@ public class ClientCacheClearTest extends CacheClearTest {
     private void registerInvalidationListener(EventHandler handler, String nameWithPrefix) {
         ListenerMessageCodec listenerCodec = createInvalidationListenerCodec(nameWithPrefix);
         HazelcastClientProxy hzClient = (HazelcastClientProxy) client;
-        final HazelcastClientInstanceImpl clientInstance = hzClient.target();
+        final HazelcastClientInstanceImpl clientInstance = hzClient.getTargetOrNull();
         clientInstance.getListenerService().registerListener(listenerCodec, handler);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/FencedLockClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/FencedLockClientBasicTest.java
@@ -77,14 +77,14 @@ public class FencedLockClientBasicTest extends FencedLockBasicTest {
 
         assertTrueEventually(() -> {
             HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
-            ClientProxySessionManager proxySessionManager = clientProxy.client.getProxySessionManager();
+            ClientProxySessionManager proxySessionManager = clientProxy.target().getProxySessionManager();
             assertEquals(NO_SESSION_ID, proxySessionManager.getSession((RaftGroupId) lock.getGroupId()));
         });
     }
 
     @Override
     protected AbstractProxySessionManager getSessionManager(HazelcastInstance instance) {
-        return (((HazelcastClientProxy) client).client).getProxySessionManager();
+        return (((HazelcastClientProxy) client).target()).getProxySessionManager();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/FencedLockClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/FencedLockClientBasicTest.java
@@ -77,14 +77,14 @@ public class FencedLockClientBasicTest extends FencedLockBasicTest {
 
         assertTrueEventually(() -> {
             HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
-            ClientProxySessionManager proxySessionManager = clientProxy.target().getProxySessionManager();
+            ClientProxySessionManager proxySessionManager = clientProxy.getTargetOrNull().getProxySessionManager();
             assertEquals(NO_SESSION_ID, proxySessionManager.getSession((RaftGroupId) lock.getGroupId()));
         });
     }
 
     @Override
     protected AbstractProxySessionManager getSessionManager(HazelcastInstance instance) {
-        return (((HazelcastClientProxy) client).target()).getProxySessionManager();
+        return (((HazelcastClientProxy) client).getTargetOrNull()).getProxySessionManager();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/UnsafeFencedLockClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/UnsafeFencedLockClientBasicTest.java
@@ -67,7 +67,7 @@ public class UnsafeFencedLockClientBasicTest extends UnsafeFencedLockBasicTest {
 
     @Override
     protected AbstractProxySessionManager getSessionManager(HazelcastInstance instance) {
-        return (((HazelcastClientProxy) client).client).getProxySessionManager();
+        return (((HazelcastClientProxy) client).target()).getProxySessionManager();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/UnsafeFencedLockClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/lock/UnsafeFencedLockClientBasicTest.java
@@ -67,7 +67,7 @@ public class UnsafeFencedLockClientBasicTest extends UnsafeFencedLockBasicTest {
 
     @Override
     protected AbstractProxySessionManager getSessionManager(HazelcastInstance instance) {
-        return (((HazelcastClientProxy) client).target()).getProxySessionManager();
+        return (((HazelcastClientProxy) client).getTargetOrNull()).getProxySessionManager();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreClientBasicTest.java
@@ -61,7 +61,7 @@ public class SessionAwareSemaphoreClientBasicTest extends SessionAwareSemaphoreB
 
     @Override
     protected AbstractProxySessionManager getSessionManager(HazelcastInstance instance) {
-        return (((HazelcastClientProxy) instance).client).getProxySessionManager();
+        return (((HazelcastClientProxy) instance).target()).getProxySessionManager();
     }
 
     @Override
@@ -78,7 +78,7 @@ public class SessionAwareSemaphoreClientBasicTest extends SessionAwareSemaphoreB
         final int drainPermits = semaphore.drainPermits();
 
         HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
-        ClientProxySessionManager proxySessionManager = clientProxy.client.getProxySessionManager();
+        ClientProxySessionManager proxySessionManager = clientProxy.target().getProxySessionManager();
         SessionAwareSemaphoreProxy proxy = (SessionAwareSemaphoreProxy) semaphore;
         RaftGroupId groupId = (RaftGroupId) proxy.getGroupId();
         final long session = proxySessionManager.getSession(groupId);

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreClientBasicTest.java
@@ -61,7 +61,7 @@ public class SessionAwareSemaphoreClientBasicTest extends SessionAwareSemaphoreB
 
     @Override
     protected AbstractProxySessionManager getSessionManager(HazelcastInstance instance) {
-        return (((HazelcastClientProxy) instance).target()).getProxySessionManager();
+        return (((HazelcastClientProxy) instance).getTargetOrNull()).getProxySessionManager();
     }
 
     @Override
@@ -78,7 +78,7 @@ public class SessionAwareSemaphoreClientBasicTest extends SessionAwareSemaphoreB
         final int drainPermits = semaphore.drainPermits();
 
         HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
-        ClientProxySessionManager proxySessionManager = clientProxy.target().getProxySessionManager();
+        ClientProxySessionManager proxySessionManager = clientProxy.getTargetOrNull().getProxySessionManager();
         SessionAwareSemaphoreProxy proxy = (SessionAwareSemaphoreProxy) semaphore;
         RaftGroupId groupId = (RaftGroupId) proxy.getGroupId();
         final long session = proxySessionManager.getSession(groupId);

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -60,7 +60,7 @@ public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends H
         newInstances(3);
         String proxyName = "semaphore@group";
         HazelcastInstance client = ((TestHazelcastFactory) factory).newHazelcastClient();
-        sessionManager = (((HazelcastClientProxy) client).target()).getProxySessionManager();
+        sessionManager = (((HazelcastClientProxy) client).getTargetOrNull()).getProxySessionManager();
         semaphore = (SessionAwareSemaphoreProxy) client.getCPSubsystem().getSemaphore(proxyName);
         groupId = (RaftGroupId) semaphore.getGroupId();
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest.java
@@ -60,7 +60,7 @@ public class SessionAwareSemaphoreReleaseAcquiredSessionsOnFailureTest extends H
         newInstances(3);
         String proxyName = "semaphore@group";
         HazelcastInstance client = ((TestHazelcastFactory) factory).newHazelcastClient();
-        sessionManager = (((HazelcastClientProxy) client).client).getProxySessionManager();
+        sessionManager = (((HazelcastClientProxy) client).target()).getProxySessionManager();
         semaphore = (SessionAwareSemaphoreProxy) client.getCPSubsystem().getSemaphore(proxyName);
         groupId = (RaftGroupId) semaphore.getGroupId();
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/UnsafeSessionAwareSemaphoreClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/UnsafeSessionAwareSemaphoreClientBasicTest.java
@@ -56,7 +56,7 @@ public class UnsafeSessionAwareSemaphoreClientBasicTest extends UnsafeSessionAwa
 
     @Override
     protected AbstractProxySessionManager getSessionManager(HazelcastInstance instance) {
-        return (((HazelcastClientProxy) client).target()).getProxySessionManager();
+        return (((HazelcastClientProxy) client).getTargetOrNull()).getProxySessionManager();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/UnsafeSessionAwareSemaphoreClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/UnsafeSessionAwareSemaphoreClientBasicTest.java
@@ -56,7 +56,7 @@ public class UnsafeSessionAwareSemaphoreClientBasicTest extends UnsafeSessionAwa
 
     @Override
     protected AbstractProxySessionManager getSessionManager(HazelcastInstance instance) {
-        return (((HazelcastClientProxy) client).client).getProxySessionManager();
+        return (((HazelcastClientProxy) client).target()).getProxySessionManager();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/session/ClientSessionManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/session/ClientSessionManagerTest.java
@@ -126,7 +126,7 @@ public class ClientSessionManagerTest extends AbstractProxySessionManagerTest {
     }
 
     protected AbstractProxySessionManager getSessionManager() {
-        return spy((((HazelcastClientProxy) client).target()).getProxySessionManager());
+        return spy((((HazelcastClientProxy) client).getTargetOrNull()).getProxySessionManager());
     }
 
     private static class SessionProxyImpl extends SessionAwareProxy {

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/session/ClientSessionManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/session/ClientSessionManagerTest.java
@@ -126,7 +126,7 @@ public class ClientSessionManagerTest extends AbstractProxySessionManagerTest {
     }
 
     protected AbstractProxySessionManager getSessionManager() {
-        return spy((((HazelcastClientProxy) client).client).getProxySessionManager());
+        return spy((((HazelcastClientProxy) client).target()).getProxySessionManager());
     }
 
     private static class SessionProxyImpl extends SessionAwareProxy {

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/clientside/ClientTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/clientside/ClientTestUtil.java
@@ -36,7 +36,7 @@ public final class ClientTestUtil {
     public static HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance hz) {
         HazelcastClientInstanceImpl impl = null;
         if (hz instanceof HazelcastClientProxy) {
-            impl = ((HazelcastClientProxy) hz).client;
+            impl = ((HazelcastClientProxy) hz).target();
         } else if (hz instanceof HazelcastClientInstanceImpl) {
             impl = (HazelcastClientInstanceImpl) hz;
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/clientside/ClientTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/clientside/ClientTestUtil.java
@@ -36,7 +36,7 @@ public final class ClientTestUtil {
     public static HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance hz) {
         HazelcastClientInstanceImpl impl = null;
         if (hz instanceof HazelcastClientProxy) {
-            impl = ((HazelcastClientProxy) hz).target();
+            impl = ((HazelcastClientProxy) hz).getTargetOrNull();
         } else if (hz instanceof HazelcastClientInstanceImpl) {
             impl = (HazelcastClientInstanceImpl) hz;
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/management/MCMessageTasksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/management/MCMessageTasksTest.java
@@ -501,6 +501,6 @@ public class MCMessageTasksTest extends HazelcastTestSupport {
     }
 
     private HazelcastClientInstanceImpl getClientImpl() {
-        return ((HazelcastClientProxy) client).target();
+        return ((HazelcastClientProxy) client).getTargetOrNull();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/management/MCMessageTasksTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/management/MCMessageTasksTest.java
@@ -140,7 +140,7 @@ public class MCMessageTasksTest extends HazelcastTestSupport {
     public void testChangeClusterVersionMessageTask() throws Exception {
         ClientMessage clientMessage = MCChangeClusterVersionCodec.encodeRequest((byte) 8, (byte) 10);
         String expectedExceptionMsg = "Node's codebase version "
-                + ((HazelcastInstanceProxy) member).getOriginal().node.getVersion()
+                + ((HazelcastInstanceProxy) member).getTarget().node.getVersion()
                 + " is incompatible with the requested cluster version 8.10";
         assertFailure(clientMessage, VersionMismatchException.class, expectedExceptionMsg);
     }
@@ -501,6 +501,6 @@ public class MCMessageTasksTest extends HazelcastTestSupport {
     }
 
     private HazelcastClientInstanceImpl getClientImpl() {
-        return ((HazelcastClientProxy) client).client;
+        return ((HazelcastClientProxy) client).target();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/management/MCTrustedInterfacesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/management/MCTrustedInterfacesTest.java
@@ -108,7 +108,7 @@ public class MCTrustedInterfacesTest extends HazelcastTestSupport {
     @Test
     public void testGetSystemPropertiesMessageTask_passing() throws Exception {
         HazelcastInstance client = factory.newHazelcastClient(new ClientConfig(), "222.222.222.222");
-        HazelcastClientInstanceImpl clientImpl = ((HazelcastClientProxy) client).target();
+        HazelcastClientInstanceImpl clientImpl = ((HazelcastClientProxy) client).getTargetOrNull();
         ClientInvocation invocation = new ClientInvocation(
                 clientImpl,
                 MCGetSystemPropertiesCodec.encodeRequest(),
@@ -301,7 +301,7 @@ public class MCTrustedInterfacesTest extends HazelcastTestSupport {
     }
 
     private void assertFailureOnUntrustedInterface(ClientMessage clientMessage) throws Exception {
-        ClientInvocation invocation = new ClientInvocation(((HazelcastClientProxy) client).target(), clientMessage, null);
+        ClientInvocation invocation = new ClientInvocation(((HazelcastClientProxy) client).getTargetOrNull(), clientMessage, null);
         ClientInvocationFuture future = invocation.invoke();
         try {
             future.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, SECONDS);

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/management/MCTrustedInterfacesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/management/MCTrustedInterfacesTest.java
@@ -108,7 +108,7 @@ public class MCTrustedInterfacesTest extends HazelcastTestSupport {
     @Test
     public void testGetSystemPropertiesMessageTask_passing() throws Exception {
         HazelcastInstance client = factory.newHazelcastClient(new ClientConfig(), "222.222.222.222");
-        HazelcastClientInstanceImpl clientImpl = ((HazelcastClientProxy) client).client;
+        HazelcastClientInstanceImpl clientImpl = ((HazelcastClientProxy) client).target();
         ClientInvocation invocation = new ClientInvocation(
                 clientImpl,
                 MCGetSystemPropertiesCodec.encodeRequest(),
@@ -301,7 +301,7 @@ public class MCTrustedInterfacesTest extends HazelcastTestSupport {
     }
 
     private void assertFailureOnUntrustedInterface(ClientMessage clientMessage) throws Exception {
-        ClientInvocation invocation = new ClientInvocation(((HazelcastClientProxy) client).client, clientMessage, null);
+        ClientInvocation invocation = new ClientInvocation(((HazelcastClientProxy) client).target(), clientMessage, null);
         ClientInvocationFuture future = invocation.invoke();
         try {
             future.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, SECONDS);

--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
@@ -74,7 +74,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(24, metricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.client.getClientStatisticsService().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.target().getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
@@ -98,7 +98,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(defaultConfig.getCollectionFrequencySeconds(), metricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.client.getClientStatisticsService().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.target().getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
@@ -115,7 +115,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(24, originalMetricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.client.getClientStatisticsService().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.target().getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
@@ -137,13 +137,13 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(defaultConfig.getCollectionFrequencySeconds(), originalMetricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.client.getClientStatisticsService().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.target().getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
     @Test
     public void testDebugMetricsSysPropNotSet() {
-        MetricsRegistry metricsRegistry = createClient().client.getMetricsRegistry();
+        MetricsRegistry metricsRegistry = createClient().target().getMetricsRegistry();
 
         assertEquals(INFO, metricsRegistry.minimumLevel());
     }
@@ -151,7 +151,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
     @Test
     public void testDebugMetricsSysPropDisabled() {
         System.setProperty(ClientProperty.METRICS_DEBUG.getName(), "false");
-        MetricsRegistry metricsRegistry = createClient().client.getMetricsRegistry();
+        MetricsRegistry metricsRegistry = createClient().target().getMetricsRegistry();
 
         assertEquals(INFO, metricsRegistry.minimumLevel());
     }
@@ -159,7 +159,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
     @Test
     public void testDebugMetricsSysPropEnabled() {
         System.setProperty(ClientProperty.METRICS_DEBUG.getName(), "true");
-        MetricsRegistry metricsRegistry = createClient().client.getMetricsRegistry();
+        MetricsRegistry metricsRegistry = createClient().target().getMetricsRegistry();
 
         assertEquals(DEBUG, metricsRegistry.minimumLevel());
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/internal/metrics/ClientMetricsPropertiesTest.java
@@ -74,7 +74,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(24, metricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.target().getClientStatisticsService().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.getTargetOrNull().getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
@@ -98,7 +98,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(defaultConfig.getCollectionFrequencySeconds(), metricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.target().getClientStatisticsService().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.getTargetOrNull().getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
@@ -115,7 +115,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(24, originalMetricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.target().getClientStatisticsService().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.getTargetOrNull().getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
@@ -137,13 +137,13 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
         assertEquals(defaultConfig.getCollectionFrequencySeconds(), originalMetricsConfig.getCollectionFrequencySeconds());
 
         // verify that the overridden config is used
-        ClientMetricsConfig metricsConfigUsed = client.target().getClientStatisticsService().getMetricsConfig();
+        ClientMetricsConfig metricsConfigUsed = client.getTargetOrNull().getClientStatisticsService().getMetricsConfig();
         assertSame(originalMetricsConfig, metricsConfigUsed);
     }
 
     @Test
     public void testDebugMetricsSysPropNotSet() {
-        MetricsRegistry metricsRegistry = createClient().target().getMetricsRegistry();
+        MetricsRegistry metricsRegistry = createClient().getTargetOrNull().getMetricsRegistry();
 
         assertEquals(INFO, metricsRegistry.minimumLevel());
     }
@@ -151,7 +151,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
     @Test
     public void testDebugMetricsSysPropDisabled() {
         System.setProperty(ClientProperty.METRICS_DEBUG.getName(), "false");
-        MetricsRegistry metricsRegistry = createClient().target().getMetricsRegistry();
+        MetricsRegistry metricsRegistry = createClient().getTargetOrNull().getMetricsRegistry();
 
         assertEquals(INFO, metricsRegistry.minimumLevel());
     }
@@ -159,7 +159,7 @@ public class ClientMetricsPropertiesTest extends HazelcastTestSupport {
     @Test
     public void testDebugMetricsSysPropEnabled() {
         System.setProperty(ClientProperty.METRICS_DEBUG.getName(), "true");
-        MetricsRegistry metricsRegistry = createClient().target().getMetricsRegistry();
+        MetricsRegistry metricsRegistry = createClient().getTargetOrNull().getMetricsRegistry();
 
         assertEquals(DEBUG, metricsRegistry.minimumLevel());
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheMemoryLeakTest.java
@@ -379,7 +379,7 @@ public class ClientQueryCacheMemoryLeakTest extends HazelcastTestSupport {
     }
 
     private static void assertNoUserListenerLeft(String mapName, HazelcastInstance client) {
-        ProxyManager proxyManager = ((HazelcastClientProxy) client).target().getProxyManager();
+        ProxyManager proxyManager = ((HazelcastClientProxy) client).getTargetOrNull().getProxyManager();
         ClientContext context = proxyManager.getContext();
         ClientQueryCacheContext queryCacheContext = context.getQueryCacheContext();
         SubscriberContext subscriberContext = queryCacheContext.getSubscriberContext();

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheMemoryLeakTest.java
@@ -379,7 +379,7 @@ public class ClientQueryCacheMemoryLeakTest extends HazelcastTestSupport {
     }
 
     private static void assertNoUserListenerLeft(String mapName, HazelcastInstance client) {
-        ProxyManager proxyManager = ((HazelcastClientProxy) client).client.getProxyManager();
+        ProxyManager proxyManager = ((HazelcastClientProxy) client).target().getProxyManager();
         ClientContext context = proxyManager.getContext();
         ClientQueryCacheContext queryCacheContext = context.getQueryCacheContext();
         SubscriberContext subscriberContext = queryCacheContext.getSubscriberContext();

--- a/hazelcast/src/test/java/com/hazelcast/client/queue/QueueResetAgeStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/queue/QueueResetAgeStatisticsTest.java
@@ -52,7 +52,7 @@ public class QueueResetAgeStatisticsTest
     @Before
     public void setup() {
         member = hazelcastFactory.newHazelcastInstance();
-        client = ((HazelcastClientProxy) hazelcastFactory.newHazelcastClient()).client;
+        client = ((HazelcastClientProxy) hazelcastFactory.newHazelcastClient()).target();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/queue/QueueResetAgeStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/queue/QueueResetAgeStatisticsTest.java
@@ -52,7 +52,7 @@ public class QueueResetAgeStatisticsTest
     @Before
     public void setup() {
         member = hazelcastFactory.newHazelcastInstance();
-        client = ((HazelcastClientProxy) hazelcastFactory.newHazelcastClient()).target();
+        client = ((HazelcastClientProxy) hazelcastFactory.newHazelcastClient()).getTargetOrNull();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
@@ -84,7 +84,7 @@ public class ClientTestSupport extends HazelcastTestSupport {
             return (HazelcastClientInstanceImpl) client;
         }
         HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
-        return clientProxy.target();
+        return clientProxy.getTargetOrNull();
     }
 
     public static void makeSureDisconnectedFromServer(final HazelcastInstance client, UUID memberUUID) {

--- a/hazelcast/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
@@ -84,7 +84,7 @@ public class ClientTestSupport extends HazelcastTestSupport {
             return (HazelcastClientInstanceImpl) client;
         }
         HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
-        return clientProxy.client;
+        return clientProxy.target();
     }
 
     public static void makeSureDisconnectedFromServer(final HazelcastInstance client, UUID memberUUID) {

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -75,7 +75,7 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
     public HazelcastInstance newHazelcastClient(ClientConfig config, String sourceIp) {
         if (!mockNetwork) {
             HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
-            registerJvmNameAndPidMetric(((HazelcastClientProxy) client).target());
+            registerJvmNameAndPidMetric(((HazelcastClientProxy) client).getTargetOrNull());
             return client;
         }
 
@@ -86,7 +86,7 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
         ClientConnectionManagerFactory connectionManagerFactory = clientRegistry.createClientServiceFactory(sourceIp);
         AddressProvider addressProvider = createAddressProvider(config);
         HazelcastInstance proxy = HazelcastClientUtil.newHazelcastClient(config, connectionManagerFactory, addressProvider);
-        HazelcastClientInstanceImpl client = ((HazelcastClientProxy) proxy).target();
+        HazelcastClientInstanceImpl client = ((HazelcastClientProxy) proxy).getTargetOrNull();
         registerJvmNameAndPidMetric(client);
         clients.put(client.getName(), client);
         return proxy;

--- a/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -75,7 +75,7 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
     public HazelcastInstance newHazelcastClient(ClientConfig config, String sourceIp) {
         if (!mockNetwork) {
             HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
-            registerJvmNameAndPidMetric(((HazelcastClientProxy) client).client);
+            registerJvmNameAndPidMetric(((HazelcastClientProxy) client).target());
             return client;
         }
 
@@ -86,7 +86,7 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
         ClientConnectionManagerFactory connectionManagerFactory = clientRegistry.createClientServiceFactory(sourceIp);
         AddressProvider addressProvider = createAddressProvider(config);
         HazelcastInstance proxy = HazelcastClientUtil.newHazelcastClient(config, connectionManagerFactory, addressProvider);
-        HazelcastClientInstanceImpl client = ((HazelcastClientProxy) proxy).client;
+        HazelcastClientInstanceImpl client = ((HazelcastClientProxy) proxy).target();
         registerJvmNameAndPidMetric(client);
         clients.put(client.getName(), client);
         return proxy;

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/TestUtil.java
@@ -98,8 +98,8 @@ public final class TestUtil {
             return (HazelcastInstanceImpl) hz;
         } else if (hz instanceof HazelcastInstanceProxy) {
             HazelcastInstanceProxy proxy = (HazelcastInstanceProxy) hz;
-            if (proxy.target() != null) {
-                return proxy.target();
+            if (proxy.getTargetOrNull() != null) {
+                return proxy.getTargetOrNull();
             }
         }
         Class<? extends HazelcastInstance> clazz = hz.getClass();

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/TestUtil.java
@@ -98,8 +98,8 @@ public final class TestUtil {
             return (HazelcastInstanceImpl) hz;
         } else if (hz instanceof HazelcastInstanceProxy) {
             HazelcastInstanceProxy proxy = (HazelcastInstanceProxy) hz;
-            if (proxy.original != null) {
-                return proxy.original;
+            if (proxy.target() != null) {
+                return proxy.target();
             }
         }
         Class<? extends HazelcastInstance> clazz = hz.getClass();

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MCReloadConfigOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MCReloadConfigOperationTest.java
@@ -33,7 +33,7 @@ public class MCReloadConfigOperationTest
     public void test()
             throws ExecutionException, InterruptedException {
         ClientInvocation inv = new ClientInvocation(
-                ((HazelcastClientProxy) client).target(),
+                ((HazelcastClientProxy) client).getTargetOrNull(),
                 MCReloadConfigCodec.encodeRequest(),
                 null
         );

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MCReloadConfigOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MCReloadConfigOperationTest.java
@@ -33,7 +33,7 @@ public class MCReloadConfigOperationTest
     public void test()
             throws ExecutionException, InterruptedException {
         ClientInvocation inv = new ClientInvocation(
-                ((HazelcastClientProxy) client).client,
+                ((HazelcastClientProxy) client).target(),
                 MCReloadConfigCodec.encodeRequest(),
                 null
         );

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MCUpdateConfigOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MCUpdateConfigOperationTest.java
@@ -33,7 +33,7 @@ public class MCUpdateConfigOperationTest
     public void test()
             throws ExecutionException, InterruptedException {
         ClientInvocation inv = new ClientInvocation(
-                ((HazelcastClientProxy) client).client,
+                ((HazelcastClientProxy) client).target(),
                 MCUpdateConfigCodec.encodeRequest(
                         "hazelcast:\n"
                                 + "  map:\n"

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MCUpdateConfigOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MCUpdateConfigOperationTest.java
@@ -33,7 +33,7 @@ public class MCUpdateConfigOperationTest
     public void test()
             throws ExecutionException, InterruptedException {
         ClientInvocation inv = new ClientInvocation(
-                ((HazelcastClientProxy) client).target(),
+                ((HazelcastClientProxy) client).getTargetOrNull(),
                 MCUpdateConfigCodec.encodeRequest(
                         "hazelcast:\n"
                                 + "  map:\n"

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/operation/DisabledOperationsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/operation/DisabledOperationsTest.java
@@ -54,7 +54,7 @@ public class DisabledOperationsTest {
 
         // scripting and console are disabled by default
         factory.newHazelcastInstance(smallInstanceConfig());
-        client = ((HazelcastClientProxy) factory.newHazelcastClient()).client;
+        client = ((HazelcastClientProxy) factory.newHazelcastClient()).target();
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/operation/DisabledOperationsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/operation/DisabledOperationsTest.java
@@ -54,7 +54,7 @@ public class DisabledOperationsTest {
 
         // scripting and console are disabled by default
         factory.newHazelcastInstance(smallInstanceConfig());
-        client = ((HazelcastClientProxy) factory.newHazelcastClient()).target();
+        client = ((HazelcastClientProxy) factory.newHazelcastClient()).getTargetOrNull();
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/operation/GetMapConfigOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/operation/GetMapConfigOperationTest.java
@@ -58,7 +58,7 @@ public class GetMapConfigOperationTest extends HazelcastTestSupport {
         config.addMapConfig(withIndex);
 
         hz = factory.newHazelcastInstance(config);
-        client = ((HazelcastClientProxy) factory.newHazelcastClient()).target();
+        client = ((HazelcastClientProxy) factory.newHazelcastClient()).getTargetOrNull();
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/operation/GetMapConfigOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/operation/GetMapConfigOperationTest.java
@@ -58,7 +58,7 @@ public class GetMapConfigOperationTest extends HazelcastTestSupport {
         config.addMapConfig(withIndex);
 
         hz = factory.newHazelcastInstance(config);
-        client = ((HazelcastClientProxy) factory.newHazelcastClient()).client;
+        client = ((HazelcastClientProxy) factory.newHazelcastClient()).target();
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/operation/RunConsoleCommandOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/operation/RunConsoleCommandOperationTest.java
@@ -52,7 +52,7 @@ public class RunConsoleCommandOperationTest extends HazelcastTestSupport {
         Config config = smallInstanceConfig();
         config.getManagementCenterConfig().setConsoleEnabled(true);
         hz = factory.newHazelcastInstance(config);
-        client = ((HazelcastClientProxy) factory.newHazelcastClient()).client;
+        client = ((HazelcastClientProxy) factory.newHazelcastClient()).target();
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/operation/RunConsoleCommandOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/operation/RunConsoleCommandOperationTest.java
@@ -52,7 +52,7 @@ public class RunConsoleCommandOperationTest extends HazelcastTestSupport {
         Config config = smallInstanceConfig();
         config.getManagementCenterConfig().setConsoleEnabled(true);
         hz = factory.newHazelcastInstance(config);
-        client = ((HazelcastClientProxy) factory.newHazelcastClient()).target();
+        client = ((HazelcastClientProxy) factory.newHazelcastClient()).getTargetOrNull();
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/operation/RunScriptOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/operation/RunScriptOperationTest.java
@@ -58,7 +58,7 @@ public class RunScriptOperationTest extends HazelcastTestSupport {
         config.getManagementCenterConfig().setScriptingEnabled(true);
         config.setInstanceName(randomString());
         hz = factory.newHazelcastInstance(config);
-        client = ((HazelcastClientProxy) factory.newHazelcastClient()).target();
+        client = ((HazelcastClientProxy) factory.newHazelcastClient()).getTargetOrNull();
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/operation/RunScriptOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/operation/RunScriptOperationTest.java
@@ -58,7 +58,7 @@ public class RunScriptOperationTest extends HazelcastTestSupport {
         config.getManagementCenterConfig().setScriptingEnabled(true);
         config.setInstanceName(randomString());
         hz = factory.newHazelcastInstance(config);
-        client = ((HazelcastClientProxy) factory.newHazelcastClient()).client;
+        client = ((HazelcastClientProxy) factory.newHazelcastClient()).target();
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/SingleProtocolHandlerRegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/SingleProtocolHandlerRegressionTest.java
@@ -61,7 +61,7 @@ public class SingleProtocolHandlerRegressionTest extends HazelcastTestSupport {
     @Repeat(50)
     public void testWrongProtocolRegressionTest() {
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(createMemberEndpointConfig());
-        ServerConnectionManager connectionManager = ((HazelcastInstanceProxy) instance).getOriginal().node
+        ServerConnectionManager connectionManager = ((HazelcastInstanceProxy) instance).getTarget().node
                 .getServer().getConnectionManager(CLIENT);
         // Get address of the client endpoint
         InetAddress address = instance.getCluster().getLocalMember().getSocketAddress(CLIENT).getAddress();

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
@@ -247,7 +247,7 @@ public abstract class JetSplitBrainTestSupport extends JetTestSupport {
     private static boolean isInstanceActive(HazelcastInstance instance) {
         if (instance instanceof HazelcastInstanceProxy) {
             try {
-                ((HazelcastInstanceProxy) instance).getOriginal();
+                ((HazelcastInstanceProxy) instance).getTarget();
                 return true;
             } catch (HazelcastInstanceNotActiveException exception) {
                 return false;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ProcessorClassLoaderCleanupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ProcessorClassLoaderCleanupTest.java
@@ -95,7 +95,7 @@ public class ProcessorClassLoaderCleanupTest extends JetTestSupport {
         assertJobStatusEventually(job, JobStatus.RUNNING);
 
         JetServiceBackend jetServiceBackend =
-                ((HazelcastInstanceProxy) member).getOriginal().node.getNodeEngine().getService(JetServiceBackend.SERVICE_NAME);
+                ((HazelcastInstanceProxy) member).getTarget().node.getNodeEngine().getService(JetServiceBackend.SERVICE_NAME);
         JobClassLoaderService jobClassLoaderService = jetServiceBackend.getJobClassLoaderService();
 
         ChildFirstClassLoader classLoader = (ChildFirstClassLoader) jobClassLoaderService.getProcessorClassLoader(job.getId(), source.name());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/IndexCreateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/IndexCreateTest.java
@@ -183,7 +183,7 @@ public class IndexCreateTest extends HazelcastTestSupport {
         List<HazelcastInstanceProxy> members = handler.initialize(hazelcastFactory, indexConfigs);
 
         for (HazelcastInstanceProxy member : members) {
-            MapService service = member.getOriginal().node.nodeEngine.getService(MapService.SERVICE_NAME);
+            MapService service = member.getTarget().node.nodeEngine.getService(MapService.SERVICE_NAME);
             MapServiceContext mapServiceContext = service.getMapServiceContext();
             MapContainer mapContainer = mapServiceContext.getMapContainer(MAP_NAME);
 

--- a/hazelcast/src/test/java/com/hazelcast/partition/strategy/AttributePartitioningStrategyIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/strategy/AttributePartitioningStrategyIntegrationTest.java
@@ -178,7 +178,7 @@ public class AttributePartitioningStrategyIntegrationTest extends SimpleTestInCl
         }
 
         return Arrays.stream(instances())
-                .filter(instance -> ((HazelcastInstanceProxy) instance).getOriginal().node.address
+                .filter(instance -> ((HazelcastInstanceProxy) instance).getTarget().node.address
                         .equals(partition.getOwner().getAddress()))
                 .findFirst()
                 .orElseThrow(() -> new HazelcastException("Can not find partition owner"));

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -301,7 +301,7 @@ public class TestHazelcastInstanceFactory {
         if (inst instanceof HazelcastInstanceImpl) {
             return ((HazelcastInstanceImpl) inst).node.isMaster();
         } else if (inst instanceof HazelcastInstanceProxy) {
-            return ((HazelcastInstanceProxy) inst).getOriginal().node.isMaster();
+            return ((HazelcastInstanceProxy) inst).getTarget().node.isMaster();
         } else {
             throw new IllegalArgumentException("This method can be called only member"
                     + " instances such as HazelcastInstanceImpl and HazelcastInstanceProxy.");


### PR DESCRIPTION
There are a set of HazelcastInstance implementations that are proxies and do not do much more than forwarding to request to some target object. This leads to a lot of code duplication.

The AbstractHazelcastInstanceProxy takes care of the forwarding logic so that the proxies can concentrate on adding additional behavior.
