### PR TITLE
Fix test failure for SqlDataLinkStatementTest.when_createDataLinkWithoutType_then_throws [HZ-2197]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlDataLinkStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlDataLinkStatementTest.java
@@ -58,7 +58,7 @@ public class SqlDataLinkStatementTest extends SqlTestSupport {
             DataLink dataLink = dataLinkService.getAndRetainDataLink(dlName, DummyDataLink.class);
             assertThat(dataLink).isNotNull();
             assertThat(dataLink.getConfig().getClassName()).isEqualTo(DummyDataLink.class.getName());
-            assertThat(dataLink.getConfig().getProperties().get("b")).isEqualTo("c");
+            assertThat(dataLink.getConfig().getProperties()).containsEntry("b", "c");
         }
     }
 
@@ -117,7 +117,7 @@ public class SqlDataLinkStatementTest extends SqlTestSupport {
         assertThatThrownBy(() ->
                 instance().getSql().execute("CREATE DATA LINK " + dlName))
                 .isInstanceOf(HazelcastException.class)
-                .hasMessageContaining("Was expecting one of:\n    \"TYPE\" ...");
+                .hasMessageContaining("Was expecting one of:" + System.lineSeparator() + "    \"TYPE\" ...");
     }
 
     @Test


### PR DESCRIPTION
Changed when_createDataLinkWithoutType_then_throws test to use System.lineSeparator because \n was failing on Windows JDK

Changed when_createDataLink_then_success() test to use AssertJ's containsEntry() method, which is easier to read

Fixes : https://hazelcast.atlassian.net/browse/HZ-2197

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible