### PR TITLE
Fix HazelcastTransactionManager timeout [5.0.z]

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
@@ -26,6 +26,7 @@ public class ServiceBeanWithTransactionalContext {
 
     TransactionalTaskContext transactionalContext;
     OtherServiceBeanWithTransactionalContext otherService;
+    static final int TIMEOUT = 1;
 
     public ServiceBeanWithTransactionalContext(TransactionalTaskContext transactionalContext,
                                                OtherServiceBeanWithTransactionalContext otherService) {
@@ -62,5 +63,25 @@ public class ServiceBeanWithTransactionalContext {
     public void putUsingOtherBean_thenSameBeanThrowingException_sameTransaction(DummyObject object, DummyObject otherObject) {
         otherService.put(otherObject);
         putWithException(object);
+    }
+
+    @Transactional
+    public void putWithDelay(DummyObject object, int delay) {
+        try {
+            Thread.sleep(delay * 1000);
+            put(object);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Transactional(timeout = TIMEOUT)
+    public void putWithDelay_transactionTimeoutValue(DummyObject object, int delay) {
+        try {
+            Thread.sleep(delay * 1000);
+            put(object);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -32,13 +32,17 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.NoTransactionException;
 import org.springframework.transaction.TransactionSuspensionNotSupportedException;
+import org.springframework.transaction.TransactionSystemException;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.hazelcast.spring.transaction.ServiceBeanWithTransactionalContext.TIMEOUT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.annotation.DirtiesContext.MethodMode.AFTER_METHOD;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"transaction-applicationContext-hazelcast.xml"})
@@ -70,6 +74,9 @@ public class TestSpringManagedHazelcastTransaction {
     @Autowired
     HazelcastInstance instance;
 
+    @Autowired
+    HazelcastTransactionManager transactionManager;
+
     /**
      * Tests that transactionalContext cannot be accessed when there is no transaction.
      */
@@ -93,6 +100,63 @@ public class TestSpringManagedHazelcastTransaction {
 
         // then
         assertNotNull(magic);
+    }
+
+    /**
+     * Tests that slow transaction will commit when no timeout value is set
+     * neither for the transaction nor in the transaction manager
+     */
+    @Test
+    public void noExceptionWithoutTimeoutValue() {
+        // when
+        service.putWithDelay(new DummyObject(1L, "magic"), TIMEOUT + 1);
+
+        // then
+        assertEquals(1L, instance.getMap("dummyObjectMap").size());
+    }
+
+    /**
+     * Tests that transaction times out when its duration exceeds the value configured for the transaction
+     */
+    @Test
+    public void transactionTimedOutExceptionWhenTimeoutValueIsSetForTransaction() {
+        // given
+        expectedException.expect(TransactionSystemException.class);
+        expectedException.expectMessage("Transaction is timed-out!");
+
+        // when
+        service.putWithDelay_transactionTimeoutValue(new DummyObject(1L, "magic"), TIMEOUT + 1);
+    }
+
+    /**
+     * Tests that transaction times out when its duration exceeds the default value
+     * configured in the transaction manager AND no value is configured for the transaction
+     */
+    @Test
+    @DirtiesContext(methodMode = AFTER_METHOD)
+    public void transactionTimedOutExceptionWhenTimeoutValueIsSetInTransactionManager() {
+        // given
+        transactionManager.setDefaultTimeout(TIMEOUT);
+        expectedException.expect(TransactionSystemException.class);
+        expectedException.expectMessage("Transaction is timed-out!");
+
+        // when
+        service.putWithDelay(new DummyObject(1L, "magic"), TIMEOUT + 1);
+    }
+
+    /**
+     * Tests that timeout value of the transaction takes precedence over the default value in the transaction manager
+     */
+    @Test
+    @DirtiesContext(methodMode = AFTER_METHOD)
+    public void transactionTimeoutTakesPrecedenceOverTransactionManagerDefaultTimeout() {
+        // given
+        transactionManager.setDefaultTimeout(TIMEOUT + 2);
+        expectedException.expect(TransactionSystemException.class);
+        expectedException.expectMessage("Transaction is timed-out!");
+
+        // when
+        service.putWithDelay_transactionTimeoutValue(new DummyObject(1L, "magic"), TIMEOUT + 1);
     }
 
     /**

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
@@ -18,6 +18,7 @@ package com.hazelcast.spring.transaction;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionOptions;
 import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.transaction.NoTransactionException;
 import org.springframework.transaction.TransactionDefinition;
@@ -28,6 +29,8 @@ import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.transaction.support.ResourceTransactionManager;
 import org.springframework.transaction.support.SmartTransactionObject;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * {@link org.springframework.transaction.PlatformTransactionManager} implementation
@@ -103,10 +106,7 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
 
         try {
             if (txObject.getTransactionContextHolder() == null) {
-                TransactionContext transactionContext = hazelcastInstance.newTransactionContext();
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Opened new TransactionContext [" + transactionContext + "]");
-                }
+                TransactionContext transactionContext = getTransactionContext(definition);
                 txObject.setTransactionContextHolder(new TransactionContextHolder(transactionContext), true);
             }
 
@@ -119,6 +119,20 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
             closeTransactionContextAfterFailedBegin(txObject);
             throw new CannotCreateTransactionException("Could not begin Hazelcast transaction", ex);
         }
+    }
+
+    private TransactionContext getTransactionContext(TransactionDefinition definition) {
+        TransactionOptions options = TransactionOptions.getDefault();
+        if (definition.getTimeout() != TransactionDefinition.TIMEOUT_DEFAULT) {
+            options.setTimeout(definition.getTimeout(), TimeUnit.SECONDS);
+        } else if (getDefaultTimeout() != TransactionDefinition.TIMEOUT_DEFAULT) {
+            options.setTimeout(getDefaultTimeout(), TimeUnit.SECONDS);
+        }
+        TransactionContext transactionContext = hazelcastInstance.newTransactionContext(options);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Opened new TransactionContext [" + transactionContext + "]");
+        }
+        return transactionContext;
     }
 
     private void closeTransactionContextAfterFailedBegin(HazelcastTransactionObject txObject) {


### PR DESCRIPTION
HazelcastTransactionManager doesn't use timeout values set either for the transaction or as the default value in the transaction manager

Fixes https://github.com/hazelcast/hazelcast/issues/23460

Backport:
[v5.0.z](https://github.com/hazelcast/hazelcast/tree/5.0.z)

Breaking changes (list specific methods/types/messages):

    None

Checklist:

    [ x ] Labels (Team: Core, Type: Defect, Source: Community, Module: Transactions) and Milestone set
    [ x ] Send backports/forwardports if fix needs to be applied to past/future releases

