### PR TITLE
Fix test use System.lineSeparator because \n was failing on Windows JDK [HZ-2197]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlDataLinkStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlDataLinkStatementTest.java
@@ -140,7 +140,7 @@ public class SqlDataLinkStatementTest extends SqlTestSupport {
                 instance().getSql().execute("CREATE DATA LINK " + dlName
                         + " TYPE \"" + DummyDataLink.class.getName() + "\" "))
                 .isInstanceOf(HazelcastException.class)
-                .hasMessageContaining("Was expecting:\n    \"OPTIONS\" ...");
+                .hasMessageContaining("Was expecting:" + System.lineSeparator() + "    \"OPTIONS\" ...");
     }
 
     @Test


### PR DESCRIPTION
This is another fix for another test to use System.lineSeparator instead of \n on Windows JDK

Fixes : https://hazelcast.atlassian.net/browse/HZ-2197

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

