### PR TITLE
[TPC] Various improvements NioAsyncSocket scheduling

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/AsyncSocket.java
@@ -125,7 +125,8 @@ public abstract class AsyncSocket extends AbstractAsyncSocket {
     public abstract boolean isReadable();
 
     /**
-     * Start the AsyncSocket. The Socket should be started only once.
+     * Start the AsyncSocket by scheduling it on the reactor. The Socket should be
+     * started only once.
      * <p/>
      * Typically you do not want to share this AsyncSocket with other threads till this
      * method is called.
@@ -193,6 +194,8 @@ public abstract class AsyncSocket extends AbstractAsyncSocket {
      * Connects asynchronously to some address.
      * <p/>
      * This method is not thread-safe.
+     * <p/>
+     * This method should be called after {@link #start()}.
      *
      * @param address the address to connect to.
      * @return a {@link CompletableFuture}

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocketTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertCompletesEventually;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminateAll;
@@ -56,10 +57,10 @@ public abstract class AsyncSocketTest {
     @Test
     public void test_construction() {
         Reactor reactor = newReactor();
-        AsyncSocketBuilder socketBuilder = reactor
+        AsyncSocket socket = reactor
                 .newAsyncSocketBuilder()
-                .setReadHandler(new DevNullReadHandler());
-        AsyncSocket socket = socketBuilder.build();
+                .setReadHandler(new DevNullReadHandler())
+                .build();
 
         assertNotNull(socket.metrics());
         assertNotNull(socket.context());
@@ -92,13 +93,15 @@ public abstract class AsyncSocketTest {
     }
 
     @Test
-    public void test_connect() {
+    public void test_connect() throws ExecutionException, InterruptedException {
         Reactor reactor = newReactor();
+        CompletableFuture<AsyncSocket> remoteSocketFuture = new CompletableFuture<>();
         AsyncServerSocket serverSocket = reactor.newAsyncServerSocketBuilder()
                 .setAcceptConsumer(acceptRequest -> {
                     AsyncSocket socket = reactor.newAsyncSocketBuilder(acceptRequest)
                             .setReadHandler(new DevNullReadHandler())
                             .build();
+                    remoteSocketFuture.complete(socket);
                     socket.start();
                 })
                 .build();
@@ -106,18 +109,31 @@ public abstract class AsyncSocketTest {
         serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
         serverSocket.start();
 
-        AsyncSocket clientSocket = reactor.newAsyncSocketBuilder()
+        AsyncSocket localSocket = reactor.newAsyncSocketBuilder()
                 .setReadHandler(new DevNullReadHandler())
                 .build();
-        clientSocket.start();
+        localSocket.start();
 
-        CompletableFuture<Void> connect = clientSocket.connect(serverSocket.getLocalAddress());
+        CompletableFuture<Void> connect = localSocket.connect(serverSocket.getLocalAddress());
 
         assertCompletesEventually(connect);
-        assertNull(connect.join());
-        assertEquals(serverSocket.getLocalAddress(), clientSocket.getRemoteAddress());
-    }
+        assertCompletesEventually(remoteSocketFuture);
 
+        assertNull(connect.join());
+
+        AsyncSocket remoteSocket = remoteSocketFuture.get();
+
+        assertEquals(serverSocket.getLocalAddress(), localSocket.getRemoteAddress());
+
+        assertNotNull(localSocket.getLocalAddress());
+        assertNotNull(localSocket.getRemoteAddress());
+
+        assertNotNull(remoteSocket.getLocalAddress());
+        assertNotNull(remoteSocket.getRemoteAddress());
+
+        assertEquals(localSocket.getLocalAddress(), remoteSocket.getRemoteAddress());
+        assertEquals(localSocket.getRemoteAddress(), remoteSocket.getLocalAddress());
+    }
 
     @Test
     public void test_connect_whenNoServerRunning() {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
@@ -47,7 +47,7 @@ public abstract class AsyncSocket_LargePayloadTest {
     public long testTimeoutMs = ASSERT_TRUE_EVENTUALLY_TIMEOUT;
 
     private final AtomicLong iteration = new AtomicLong();
-    private final PrintAtomicLongThread debugThread = new PrintAtomicLongThread(iteration);
+    private final PrintAtomicLongThread debugThread = new PrintAtomicLongThread("at:", iteration);
     private Reactor clientReactor;
     private Reactor serverReactor;
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
@@ -27,6 +27,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.tpcengine.AsyncSocketOptions.SO_RCVBUF;
 import static com.hazelcast.internal.tpcengine.AsyncSocketOptions.SO_SNDBUF;
@@ -45,6 +46,8 @@ public abstract class AsyncSocket_LargePayloadTest {
     public int iterations = 20;
     public long testTimeoutMs = ASSERT_TRUE_EVENTUALLY_TIMEOUT;
 
+    private final AtomicLong iteration = new AtomicLong();
+    private final PrintAtomicLongThread debugThread = new PrintAtomicLongThread(iteration);
     private Reactor clientReactor;
     private Reactor serverReactor;
 
@@ -54,12 +57,14 @@ public abstract class AsyncSocket_LargePayloadTest {
     public void before() {
         clientReactor = newReactorBuilder().build().start();
         serverReactor = newReactorBuilder().build().start();
+        debugThread.start();
     }
 
     @After
     public void after() throws InterruptedException {
         terminate(clientReactor);
         terminate(serverReactor);
+        debugThread.shutdown();
     }
 
     @Test
@@ -234,13 +239,13 @@ public abstract class AsyncSocket_LargePayloadTest {
         AsyncServerSocket serverSocket = serverReactor.newAsyncServerSocketBuilder()
                 .set(SO_RCVBUF, SOCKET_BUFFER_SIZE)
                 .setAcceptConsumer(acceptRequest -> {
-                    AsyncSocketBuilder channelBuilder = serverReactor.newAsyncSocketBuilder(acceptRequest);
-                    channelBuilder.set(TCP_NODELAY, true);
-                    channelBuilder.set(SO_SNDBUF, SOCKET_BUFFER_SIZE);
-                    channelBuilder.set(SO_RCVBUF, SOCKET_BUFFER_SIZE);
-                    channelBuilder.setReadHandler(new ServerReadHandler());
-                    AsyncSocket socket = channelBuilder.build();
-                    socket.start();
+                    serverReactor.newAsyncSocketBuilder(acceptRequest)
+                            .set(TCP_NODELAY, true)
+                            .set(SO_SNDBUF, SOCKET_BUFFER_SIZE)
+                            .set(SO_RCVBUF, SOCKET_BUFFER_SIZE)
+                            .setReadHandler(new ServerReadHandler())
+                            .build()
+                            .start();
                 })
                 .build();
         serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
@@ -275,10 +280,6 @@ public abstract class AsyncSocket_LargePayloadTest {
                     break;
                 }
 
-                if (round % 100 == 0) {
-                    System.out.println("server round:" + round);
-                }
-
                 upcast(payloadBuffer).flip();
                 IOBuffer responseBuf = responseAllocator.allocate(SIZEOF_INT + SIZEOF_LONG + payloadSize);
                 responseBuf.writeInt(payloadSize);
@@ -293,7 +294,7 @@ public abstract class AsyncSocket_LargePayloadTest {
         }
     }
 
-    private static class ClientReadHandler extends ReadHandler {
+    private class ClientReadHandler extends ReadHandler {
         private final CountDownLatch latch;
         private ByteBuffer payloadBuffer;
         private long round;
@@ -329,10 +330,7 @@ public abstract class AsyncSocket_LargePayloadTest {
                     break;
                 }
                 upcast(payloadBuffer).flip();
-
-                if (round % 100 == 0) {
-                    System.out.println("client round:" + round);
-                }
+                iteration.incrementAndGet();
 
                 if (round == 0) {
                     latch.countDown();
@@ -350,4 +348,5 @@ public abstract class AsyncSocket_LargePayloadTest {
             }
         }
     }
+
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_LargePayloadTest.java
@@ -47,7 +47,7 @@ public abstract class AsyncSocket_LargePayloadTest {
     public long testTimeoutMs = ASSERT_TRUE_EVENTUALLY_TIMEOUT;
 
     private final AtomicLong iteration = new AtomicLong();
-    private final PrintAtomicLongThread debugThread = new PrintAtomicLongThread("at:", iteration);
+    private final PrintAtomicLongThread printThread = new PrintAtomicLongThread("at:", iteration);
     private Reactor clientReactor;
     private Reactor serverReactor;
 
@@ -57,14 +57,14 @@ public abstract class AsyncSocket_LargePayloadTest {
     public void before() {
         clientReactor = newReactorBuilder().build().start();
         serverReactor = newReactorBuilder().build().start();
-        debugThread.start();
+        printThread.start();
     }
 
     @After
     public void after() throws InterruptedException {
         terminate(clientReactor);
         terminate(serverReactor);
-        debugThread.shutdown();
+        printThread.shutdown();
     }
 
     @Test

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_RpcTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_RpcTest.java
@@ -55,7 +55,7 @@ public abstract class AsyncSocket_RpcTest {
     public int iterations = 200;
     public long testTimeoutMs = ASSERT_TRUE_EVENTUALLY_TIMEOUT;
     private final AtomicLong iteration = new AtomicLong();
-    private final PrintAtomicLongThread debugThread = new PrintAtomicLongThread(iteration);
+    private final PrintAtomicLongThread debugThread = new PrintAtomicLongThread("at:", iteration);
 
     private final ConcurrentMap<Long, CompletableFuture> futures = new ConcurrentHashMap<>();
     private Reactor clientReactor;

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_RpcTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/AsyncSocket_RpcTest.java
@@ -55,7 +55,7 @@ public abstract class AsyncSocket_RpcTest {
     public int iterations = 200;
     public long testTimeoutMs = ASSERT_TRUE_EVENTUALLY_TIMEOUT;
     private final AtomicLong iteration = new AtomicLong();
-    private final PrintAtomicLongThread debugThread = new PrintAtomicLongThread("at:", iteration);
+    private final PrintAtomicLongThread printThread = new PrintAtomicLongThread("at:", iteration);
 
     private final ConcurrentMap<Long, CompletableFuture> futures = new ConcurrentHashMap<>();
     private Reactor clientReactor;
@@ -67,14 +67,14 @@ public abstract class AsyncSocket_RpcTest {
     public void before() {
         clientReactor = newReactorBuilder().build().start();
         serverReactor = newReactorBuilder().build().start();
-        debugThread.start();
+        printThread.start();
     }
 
     @After
     public void after() throws InterruptedException {
         terminate(clientReactor);
         terminate(serverReactor);
-        debugThread.shutdown();
+        printThread.shutdown();
     }
 
     @Test

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/PrintAtomicLongThread.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/PrintAtomicLongThread.java
@@ -20,12 +20,14 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class PrintAtomicLongThread extends Thread {
 
+    private final String prefix;
     private volatile boolean stopped = false;
     private final AtomicLong atomicLong;
 
-    public PrintAtomicLongThread(AtomicLong atomicLong) {
+    public PrintAtomicLongThread(String prefix, AtomicLong atomicLong) {
         super("PrintAtomicLongThread");
         this.atomicLong = atomicLong;
+        this.prefix = prefix;
     }
 
     @Override
@@ -37,7 +39,7 @@ public class PrintAtomicLongThread extends Thread {
                 return;
             }
 
-            System.out.println("At round:" + atomicLong);
+            System.out.println(prefix + atomicLong);
         }
     }
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/PrintAtomicLongThread.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/PrintAtomicLongThread.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpcengine;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class PrintAtomicLongThread extends Thread {
+
+    private volatile boolean stopped = false;
+    private final AtomicLong atomicLong;
+
+    public PrintAtomicLongThread(AtomicLong atomicLong) {
+        super("PrintAtomicLongThread");
+        this.atomicLong = atomicLong;
+    }
+
+    @Override
+    public void run() {
+        while (!stopped) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                return;
+            }
+
+            System.out.println("At round:" + atomicLong);
+        }
+    }
+
+    public void shutdown() {
+        stopped = true;
+        interrupt();
+    }
+}


### PR DESCRIPTION
1) The NioAsyncSocket is automatically scheduled till the connect has been completed. This will prevent any write to the socket leading to the scheduling of the NioAsyncSocket on the reactor. Only when the connect has been completed, writes to the socket are going to be scheduled.

2) The assert in the NioAsyncSocket.Handler.onWrite isn't valid. If the SelectionKey is canceled, it will also lead to a call to this method without the flushThread being set and causes the assert to fail.

3) Various minor cleanups and testing improvements.
