### PR TITLE
Update the developers section in the root POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,14 +200,11 @@
     </scm>
     <developers>
         <developer>
-            <id>oztalip</id>
-            <name>talip ozturk</name>
-            <email>talip@hazelcast.com</email>
-        </developer>
-        <developer>
-            <id>fuad</id>
-            <name>fuad malikov</name>
-            <email>fuad@hazelcast.com</email>
+            <id>hazelcast-team</id>
+            <name>Hazelcast team</name>
+            <email>info@hazelcast.com</email>
+            <organization>Hazelcast, Inc.</organization>
+            <organizationUrl>https://hazelcast.com</organizationUrl>
         </developer>
     </developers>
 


### PR DESCRIPTION
The `developers` section in the root Maven POM file is stale.
This PR fixes it by using a generic `Hazelcast team` entry. 

The EE side doesn't need the change as we don't publish to Maven central and we don't have the `<developers>` section in the POM.