### PR TITLE
[TPC] TpcIntegrationTest_Nightly too many iterations.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/tpc/TpcIntegrationTest_Nightly.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/tpc/TpcIntegrationTest_Nightly.java
@@ -25,6 +25,6 @@ import org.junit.runner.RunWith;
 @Category(NightlyTest.class)
 public class TpcIntegrationTest_Nightly extends TpcIntegrationTest {
     public TpcIntegrationTest_Nightly() {
-        iterations = 10_000;
+        iterations = 5_000;
     }
 }


### PR DESCRIPTION
The test timed out before the 10K iterations were completed (only 8K were done). So I cut the number of iterations in half.
