### PR TITLE
Allow operation in the PASSIVE state [HZ-1708]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
@@ -403,17 +403,16 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void pendingInvocations_shouldBeNotified_whenMemberLeft_whenClusterState_PASSIVE() throws Exception {
+    public void pendingInvocations_shouldBeNotified_whenMemberLeft_whenClusterState_PASSIVE() {
         pendingInvocations_shouldBeNotified_whenMemberLeft_whenClusterState_doesNotAllowJoin(ClusterState.PASSIVE);
     }
 
     @Test
-    public void pendingInvocations_shouldBeNotified_whenMemberLeft_whenClusterState_FROZEN() throws Exception {
+    public void pendingInvocations_shouldBeNotified_whenMemberLeft_whenClusterState_FROZEN() {
         pendingInvocations_shouldBeNotified_whenMemberLeft_whenClusterState_doesNotAllowJoin(ClusterState.FROZEN);
     }
 
-    private void pendingInvocations_shouldBeNotified_whenMemberLeft_whenClusterState_doesNotAllowJoin(ClusterState state)
-            throws Exception {
+    private void pendingInvocations_shouldBeNotified_whenMemberLeft_whenClusterState_doesNotAllowJoin(ClusterState state) {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         HazelcastInstance hz1 = factory.newHazelcastInstance();
         HazelcastInstance hz2 = factory.newHazelcastInstance();
@@ -425,7 +424,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
         changeClusterStateEventually(hz2, state);
         hz1.shutdown();
 
-        assertTrueEventually(() -> Assert.assertThrows(MemberLeftException.class, future::get));
+        Assert.assertThrows(MemberLeftException.class, future::get);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/partition/IndeterminateOperationStateExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/IndeterminateOperationStateExceptionTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.IndeterminateOperationStateException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.map.IMap;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
@@ -266,7 +267,7 @@ public class IndeterminateOperationStateExceptionTest extends HazelcastTestSuppo
         }
     }
 
-    public static class SilentOperation extends Operation {
+    public static class SilentOperation extends Operation implements AllowedDuringPassiveState {
 
         static final String EXECUTION_STARTED = "execution-started";
 


### PR DESCRIPTION
A cluster can move to the PASSIVE before operation execution. 
For `SilentOperation` we can implement `AllowedDuringPassiveState` to fix the issue.

Fix https://github.com/hazelcast/hazelcast/issues/20297

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
