### PR TITLE
Add waiting for the cluster size [HZ-2219]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -805,10 +805,11 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         config.getMapConfig("test").addEntryListenerConfig(listenerConfig);
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
-        factory.newHazelcastInstance(config);
+        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(2, hz1, hz2);
 
         IMap<Object, Object> map = hz1.getMap("test");
-
         map.put(1, 1);
 
         //Let post join continue only after put happened


### PR DESCRIPTION
Fix https://github.com/hazelcast/hazelcast/issues/23214

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
