### PR TITLE
Include stack trace in SQL client exceptions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlExecuteMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlExecuteMessageTask.java
@@ -33,8 +33,6 @@ import com.hazelcast.sql.impl.security.SqlSecurityContext;
 import java.security.AccessControlException;
 import java.security.Permission;
 
-import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
-
 /**
  * SQL query execute task.
  */
@@ -117,7 +115,9 @@ public class SqlExecuteMessageTask extends SqlAbstractMessageTask<SqlExecuteCode
         if (!(throwable instanceof Exception)) {
             return super.encodeException(throwable);
         }
-        logFine(logger, "Client SQL error: %s", throwable);
+        if (logger.isFineEnabled()) {
+            logger.fine("Client SQL error: " + throwable, throwable);
+        }
         SqlError error = SqlClientUtils.exceptionToClientError((Exception) throwable, nodeEngine.getLocalMember().getUuid());
 
         return SqlExecuteCodec.encodeResponse(

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlFetchMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlFetchMessageTask.java
@@ -25,8 +25,6 @@ import com.hazelcast.sql.impl.SqlInternalService;
 import java.security.AccessControlException;
 import java.security.Permission;
 
-import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
-
 /**
  * SQL query fetch task.
  */

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlFetchMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/client/SqlFetchMessageTask.java
@@ -75,7 +75,9 @@ public class SqlFetchMessageTask extends SqlAbstractMessageTask<SqlFetchCodec.Re
         if (!(throwable instanceof Exception)) {
             return super.encodeException(throwable);
         }
-        logFine(logger, "Client SQL error: %s", throwable);
+        if (logger.isFineEnabled()) {
+            logger.fine("Client SQL error: " + throwable, throwable);
+        }
         SqlError error = SqlClientUtils.exceptionToClientError((Exception) throwable, nodeEngine.getLocalMember().getUuid());
 
         return SqlFetchCodec.encodeResponse(

--- a/hazelcast/src/test/resources/log4j2.xml
+++ b/hazelcast/src/test/resources/log4j2.xml
@@ -42,5 +42,8 @@
 <!--        <Logger name="com.hazelcast.internal.partition.operation.MigrationRequestOperation" level="trace"/>-->
         <!--<Logger name="com.hazelcast.client.impl.spi.ClientInvocationService" level="trace"/>-->
         <!--<Logger name="com.hazelcast.client.impl.connection.ClientConnectionManager" level="trace"/>-->
+        <Logger name="com.hazelcast.sql.impl.client.SqlExecuteMessageTask" level="DEBUG"/>
+        <Logger name="com.hazelcast.sql.impl.client.SqlFetchMessageTask" level="DEBUG"/>
+
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Exceptions in responses to SQL client requests are logged on FINE level. Fix the logging so that it includes the stack trace.

Enable these logs for tests.