### PR TITLE
Remove unused onSpinWait util

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadUtil.java
@@ -18,35 +18,14 @@ package com.hazelcast.internal.util;
 
 import com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-
-import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
-import static java.lang.invoke.MethodType.methodType;
 
 /**
  * Utility class to manipulate and query thread ID.
  */
 public final class ThreadUtil {
 
-    private static final MethodHandle ON_SPIN_WAIT_REFERENCE;
-
-    static {
-        // Here we are trying to access java.lang.Thread.onSpinWait() method.
-        // The method is available after java version 9.
-        MethodHandle methodHandle = null;
-        try {
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            methodHandle = lookup.findStatic(Thread.class, "onSpinWait", methodType(void.class));
-        } catch (Exception ignored) {
-            ignore(ignored);
-        }
-
-        ON_SPIN_WAIT_REFERENCE = methodHandle;
-    }
-
-    private static final ThreadLocal<Long> THREAD_LOCAL = new ThreadLocal<Long>();
+    private static final ThreadLocal<Long> THREAD_LOCAL = new ThreadLocal<>();
 
     private ThreadUtil() {
     }
@@ -113,24 +92,4 @@ public final class ThreadUtil {
     public static boolean isRunningOnPartitionThread() {
         return Thread.currentThread() instanceof PartitionOperationThread;
     }
-
-    /**
-     * Only valid with java 9 or later.
-     * <p>
-     * Caller thread of this method hints the runtime that it is
-     * busy-waiting. The runtime may take action to improve the
-     * performance of invoking spin-wait loop constructions.
-     */
-    public static void hintOnSpinWait() {
-        if (ON_SPIN_WAIT_REFERENCE == null) {
-            return;
-        }
-
-        try {
-            ON_SPIN_WAIT_REFERENCE.invokeExact();
-        } catch (Throwable ignored) {
-            ignore(ignored);
-        }
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/BackoffIdleStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/BackoffIdleStrategy.java
@@ -73,6 +73,7 @@ public class BackoffIdleStrategy implements IdleStrategy {
     @Override
     public boolean idle(long n) {
         if (n < yieldThreshold) {
+            // TODO: Think to call Thread.onSpinWait which is introduced in java 9.
             return false;
         }
         if (n < parkThreshold) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/BackoffIdleStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/BackoffIdleStrategy.java
@@ -20,7 +20,6 @@ package com.hazelcast.internal.util.concurrent;
 import java.util.concurrent.locks.LockSupport;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
-import static com.hazelcast.internal.util.ThreadUtil.hintOnSpinWait;
 import static java.lang.Long.numberOfLeadingZeros;
 import static java.lang.Long.parseLong;
 import static java.lang.Math.min;
@@ -74,7 +73,6 @@ public class BackoffIdleStrategy implements IdleStrategy {
     @Override
     public boolean idle(long n) {
         if (n < yieldThreshold) {
-            hintOnSpinWait();
             return false;
         }
         if (n < parkThreshold) {


### PR DESCRIPTION
Follow up of https://github.com/hazelcast/hazelcast-enterprise/pull/5837

**Reasoning:**
The utility method was mainly introduced for Epoch bump but now there is no apparent need after merge of refactoring in https://github.com/hazelcast/hazelcast-enterprise/pull/5837