### PR TITLE
Change scope of s3mock-testcontainers dependency

### DIFF
--- a/extensions/s3/pom.xml
+++ b/extensions/s3/pom.xml
@@ -87,6 +87,7 @@
             <artifactId>s3mock-testcontainers</artifactId>
             <!-- Remember to update tag in S3MockContainer constructor as well -->
             <version>2.11.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
seems it was in compile scope accidentally.
