### PR TITLE
Fix GenericMapStoreIntegrationTest.testExceptionIsConstructable [HZ-2225]

### DIFF
--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
@@ -304,7 +304,13 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
         IMap<Integer, Person> map = client.getMap(tableName);
         map.loadAll(false);
 
-        execute("DROP MAPPING \"__map-store." + tableName + "\"");
+        String mappingName = "__map-store." + tableName;
+        execute("DROP MAPPING \"" + mappingName + "\"");
+
+        // DROP MAPPING is executed asynchronously. Ensure that it has finished
+        Row row = new Row(mappingName);
+        List<Row> rows = Collections.singletonList(row);
+        assertTrueEventually(() -> assertDoesNotContainRow(client, "SHOW MAPPINGS", rows), 30);
 
         String message = "did you forget to CREATE MAPPING?";
         Person person = new Person(42, "name-42");


### PR DESCRIPTION
Drop mapping is executed asynchronously. Wait for it to be finished 

Fixes : https://hazelcast.atlassian.net/browse/HZ-2225
GH : https://github.com/hazelcast/hazelcast/issues/23846

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible