### PR TITLE
Backport sync fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/services/WanSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/services/WanSupportingService.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.wan.impl.InternalWanEvent;
 
 import java.util.Collection;
+import java.util.concurrent.CompletionStage;
 
 /**
  * An interface that can be implemented by internal services to give them the
@@ -38,12 +39,13 @@ public interface WanSupportingService {
     void onReplicationEvent(InternalWanEvent event, WanAcknowledgeType acknowledgeType);
 
     /**
-     * Processes a WAN sync batch.
+     * Processes a WAN sync batch asynchronously.
      *
      * @param batch           collection of events, which represents a batch
      * @param acknowledgeType determines should this method wait for the event to be processed fully
      *                        or should it return after the event has been dispatched to the
      *                        appropriate member
+     * @return the CompletionStage to indicate processing of all entries in the batch
      */
-    void onSyncBatch(Collection<InternalWanEvent> batch, WanAcknowledgeType acknowledgeType);
+    CompletionStage<Void> onSyncBatch(Collection<InternalWanEvent> batch, WanAcknowledgeType acknowledgeType);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -69,6 +69,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CompletionStage;
 
 import static com.hazelcast.core.EntryEventType.INVALIDATION;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_DISCRIMINATOR_NAME;
@@ -210,8 +211,8 @@ public class MapService implements ManagedService, ChunkedMigrationAwareService,
     }
 
     @Override
-    public void onSyncBatch(Collection<InternalWanEvent> batch, WanAcknowledgeType acknowledgeType) {
-        wanSupportingService.onSyncBatch(batch, acknowledgeType);
+    public CompletionStage<Void> onSyncBatch(Collection<InternalWanEvent> batch, WanAcknowledgeType acknowledgeType) {
+        return wanSupportingService.onSyncBatch(batch, acknowledgeType);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/WanMapSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/WanMapSupportingService.java
@@ -30,6 +30,7 @@ import com.hazelcast.wan.WanEventCounters;
 import com.hazelcast.wan.impl.InternalWanEvent;
 
 import java.util.Collection;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
@@ -58,7 +59,7 @@ class WanMapSupportingService implements WanSupportingService {
     }
 
     @Override
-    public void onSyncBatch(Collection<InternalWanEvent> batch, WanAcknowledgeType acknowledgeType) {
+    public CompletionStage<Void> onSyncBatch(Collection<InternalWanEvent> batch, WanAcknowledgeType acknowledgeType) {
         // code should never reach here
         throw new UnsupportedOperationException("WAN Synchronization requires Hazelcast Enterprise Edition");
     }


### PR DESCRIPTION
Backport: https://github.com/hazelcast/hazelcast/pull/23919

Backports had minor conflicts.

Note that this PR does not backports member crash fix related scenarios
as they were not a regression, and they aren't very simple to backport.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/5872
