### PR TITLE
Use shared state for tasks from a single connector [#24018] [HZ-2232]

### DIFF
--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ConnectorWrapper.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ConnectorWrapper.java
@@ -42,7 +42,7 @@ public class ConnectorWrapper {
     private final List<TaskRunner> taskRunners = new CopyOnWriteArrayList<>();
     private final AtomicInteger taskIdGenerator = new AtomicInteger();
     private final ReentrantLock reconfigurationLock = new ReentrantLock();
-
+    private final State state = new State();
     private final String name;
 
     public ConnectorWrapper(Properties properties) {
@@ -77,7 +77,7 @@ public class ConnectorWrapper {
 
     public TaskRunner createTaskRunner() {
         String taskName = name + "-task-" + taskIdGenerator.getAndIncrement();
-        TaskRunner taskRunner = new TaskRunner(taskName, this::createSourceTask);
+        TaskRunner taskRunner = new TaskRunner(taskName, state, this::createSourceTask);
         taskRunners.add(taskRunner);
         requestTaskReconfiguration();
         return taskRunner;

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
@@ -129,6 +129,7 @@ public class ReadKafkaConnectP extends AbstractProcessor implements DynamicMetri
         return broadcastKey("snapshot-" + processorIndex);
     }
 
+    @Override
     protected void restoreFromSnapshot(@Nonnull Object key, @Nonnull Object value) {
         boolean forThisProcessor = snapshotKey().equals(key);
         if (forThisProcessor) {

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
@@ -49,7 +49,7 @@ public class ReadKafkaConnectP extends AbstractProcessor implements DynamicMetri
     private final EventTimeMapper<SourceRecord> eventTimeMapper;
     private TaskRunner taskRunner;
     private boolean snapshotInProgress;
-    private Traverser<Entry<BroadcastKey<String>, TaskRunner.State>> snapshotTraverser;
+    private Traverser<Entry<BroadcastKey<String>, State>> snapshotTraverser;
     private boolean snapshotsEnabled;
     private int processorIndex;
     private Traverser<?> traverser;
@@ -132,7 +132,7 @@ public class ReadKafkaConnectP extends AbstractProcessor implements DynamicMetri
     protected void restoreFromSnapshot(@Nonnull Object key, @Nonnull Object value) {
         boolean forThisProcessor = snapshotKey().equals(key);
         if (forThisProcessor) {
-            taskRunner.restoreSnapshot((TaskRunner.State) value);
+            taskRunner.restoreSnapshot((State) value);
         }
     }
 

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/SourceOffsetStorageReader.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/SourceOffsetStorageReader.java
@@ -40,7 +40,8 @@ class SourceOffsetStorageReader implements OffsetStorageReader {
     public <V> Map<Map<String, V>, Map<String, Object>> offsets(Collection<Map<String, V>> partitions) {
         Map<Map<String, V>, Map<String, Object>> map = new HashMap<>();
         for (Map<String, V> partition : partitions) {
-            Map<String, Object> offset = (Map<String, Object>) state.getPartitionsToOffset().get(partition);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> offset = (Map<String, Object>) state.getOffset(partition);
             map.put(partition, offset);
         }
         return map;

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/SourceOffsetStorageReader.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/SourceOffsetStorageReader.java
@@ -25,10 +25,10 @@ import java.util.Map;
 
 class SourceOffsetStorageReader implements OffsetStorageReader {
 
-    private final Map<Map<String, ?>, Map<String, ?>> partitionsToOffset;
+    private final State state;
 
-    SourceOffsetStorageReader(Map<Map<String, ?>, Map<String, ?>> partitionsToOffset) {
-        this.partitionsToOffset = partitionsToOffset;
+    SourceOffsetStorageReader(State state) {
+        this.state = state;
     }
 
     @Override
@@ -40,7 +40,7 @@ class SourceOffsetStorageReader implements OffsetStorageReader {
     public <V> Map<Map<String, V>, Map<String, Object>> offsets(Collection<Map<String, V>> partitions) {
         Map<Map<String, V>, Map<String, Object>> map = new HashMap<>();
         for (Map<String, V> partition : partitions) {
-            Map<String, Object> offset = (Map<String, Object>) partitionsToOffset.get(partition);
+            Map<String, Object> offset = (Map<String, Object>) state.getPartitionsToOffset().get(partition);
             map.put(partition, offset);
         }
         return map;

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/State.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/State.java
@@ -53,8 +53,8 @@ class State implements Serializable {
         partitionsToOffset.putAll(state.partitionsToOffset);
     }
 
-    Map<Map<String, ?>, Map<String, ?>> getPartitionsToOffset() {
-        return partitionsToOffset;
+    Map<String, ?> getOffset(Map<String, ?> partition) {
+        return partitionsToOffset.get(partition);
     }
 
     @Override

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/State.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/State.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.connect.impl;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+class State implements Serializable {
+
+    /**
+     * Key represents the partition which the record originated from. Value
+     * represents the offset within that partition. Kafka Connect represents
+     * the partition and offset as arbitrary values so that is why it is
+     * stored as map.
+     * See {@link SourceRecord} for more information regarding the format.
+     */
+    private final Map<Map<String, ?>, Map<String, ?>> partitionsToOffset;
+
+    State() {
+        this.partitionsToOffset = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * just for testing
+     */
+    State(Map<Map<String, ?>, Map<String, ?>> partitionsToOffset) {
+        this.partitionsToOffset = new ConcurrentHashMap<>(partitionsToOffset);
+    }
+
+    void commitRecord(SourceRecord rec) {
+        partitionsToOffset.put(rec.sourcePartition(), rec.sourceOffset());
+    }
+
+    void load(State state) {
+        partitionsToOffset.putAll(state.partitionsToOffset);
+    }
+
+    Map<Map<String, ?>, Map<String, ?>> getPartitionsToOffset() {
+        return partitionsToOffset;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        State state = (State) o;
+        return partitionsToOffset.equals(state.partitionsToOffset);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitionsToOffset);
+    }
+
+    @Override
+    public String toString() {
+        return "State{" +
+                "partitionsToOffset=" + partitionsToOffset +
+                '}';
+    }
+}

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
@@ -34,9 +34,9 @@ import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.apache.kafka.connect.data.Values;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.jetbrains.annotations.NotNull;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,6 +50,8 @@ import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -59,10 +61,13 @@ import java.util.stream.Collectors;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.config.ProcessingGuarantee.AT_LEAST_ONCE;
+import static com.hazelcast.jet.core.JobStatus.FAILED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
+import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
 import static com.hazelcast.jet.kafka.connect.KafkaConnectSources.connect;
 import static com.hazelcast.test.OverridePropertyRule.set;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -151,16 +156,14 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         randomProperties.setProperty("quickstart", "orders");
 
         Pipeline pipeline = Pipeline.create();
-        StreamStage<Map.Entry<String, String>> streamStage = pipeline.readFrom(connect(randomProperties))
+        StreamStage<Map.Entry<String, Integer>> streamStage = pipeline.readFrom(connect(randomProperties))
                 .withoutTimestamps()
                 .setLocalParallelism(localParallelism)
-                .map(record -> entry(record.headers().lastWithName("task.id").value().toString(),
-                        Values.convertToString(record.valueSchema(), record.value()))
-                );
+                .map(record -> entry(getTaskId(record), getOrderId(record)));
         streamStage
                 .writeTo(AssertionSinks.assertCollectedEventually(120,
                         list -> {
-                            Map<String, List<String>> recordsByTaskId = entriesToMap(list);
+                            Map<String, List<Integer>> recordsByTaskId = groupByKey(list);
                             LOGGER.info("recordsByTaskId = " + countEntriesByTaskId(recordsByTaskId));
                             assertThat(recordsByTaskId).allSatisfy((taskId, records) ->
                                     assertThat(records.size()).isGreaterThan(ITEM_COUNT)
@@ -192,17 +195,19 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
                 assertThat(times).hasSize(localParallelism);
                 assertThat(times).allSatisfy(a -> assertThat(a).isNotNegative());
             });
-
         }
     }
-
     @NotNull
-    private static List<Map.Entry<String, Integer>> countEntriesByTaskId(Map<String, List<String>> recordsByTaskId) {
+    private static List<Map.Entry<String, Integer>> countEntriesByTaskId(Map<String, List<Integer>> recordsByTaskId) {
         return recordsByTaskId.entrySet().stream().map(e -> entry(e.getKey(), e.getValue().size())).collect(toList());
     }
 
+    private static String getTaskId(SourceRecord record) {
+        return record.headers().lastWithName("task.id").value().toString();
+    }
+
     @Nonnull
-    private static Map<String, List<String>> entriesToMap(List<Map.Entry<String, String>> list) {
+    private static <T> Map<String, List<T>> groupByKey(List<Map.Entry<String, T>> list) {
         return list.stream()
                 .collect(Collectors.groupingBy(Map.Entry::getKey,
                         Collectors.mapping(Map.Entry::getValue, toList())));
@@ -213,66 +218,111 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         return getMBeanValues(objectName, "sourceRecordPollTotal");
     }
 
-
     private static List<Long> getSourceRecordPollTotalTimes() throws Exception {
         ObjectName objectName = new ObjectName("com.hazelcast:type=Metrics,prefix=kafka.connect,*");
         return getMBeanValues(objectName, "sourceRecordPollTotalAvgTime");
     }
 
-    @Ignore // https://github.com/hazelcast/hazelcast/issues/24018
     @Test
     public void testSnapshotting() throws Exception {
+        Config config = smallInstanceConfig();
+        enableEventJournal(config);
+        config.getJetConfig().setResourceUploadEnabled(true);
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+
         int localParallelism = 3;
         Properties randomProperties = new Properties();
         randomProperties.setProperty("name", "datagen-connector");
         randomProperties.setProperty("connector.class", "io.confluent.kafka.connect.datagen.DatagenConnector");
         randomProperties.setProperty("max.interval", "1");
-        randomProperties.setProperty("kafka.topic", "users");
-        randomProperties.setProperty("quickstart", "users");
+        randomProperties.setProperty("kafka.topic", "not-used");
+        randomProperties.setProperty("quickstart", "orders");
 
         Pipeline pipeline = Pipeline.create();
-        StreamStage<String> streamStage = pipeline.readFrom(connect(randomProperties))
+        StreamStage<Map.Entry<String, Integer>> streamStage = pipeline.readFrom(connect(randomProperties))
                 .withoutTimestamps()
                 .setLocalParallelism(localParallelism)
-                .map(record -> Values.convertToString(record.valueSchema(), record.value()) + ", task.id: "
-                        + record.headers().lastWithName("task.id").value());
-        streamStage.writeTo(Sinks.logger());
-        streamStage
-                .writeTo(AssertionSinks.assertCollectedEventually(60,
-                        list -> assertEquals(localParallelism * ITEM_COUNT, list.size())));
+                .map(record -> entry(getTaskId(record), getOrderId(record)));
+        streamStage.writeTo(Sinks.list("testResults"));
 
         JobConfig jobConfig = new JobConfig();
         jobConfig.addJarsInZip(new URL(CONNECTOR_URL));
+        enableSnapshotting(jobConfig);
+
+        Job job = hazelcastInstance.getJet().newJob(pipeline, jobConfig);
+
+        List<Map.Entry<String, Integer>> testResults = hazelcastInstance.getList("testResults");
+
+        Map<String, Integer> minOrderIdByTaskIdBeforeSuspend = new HashMap<>();
+        assertTrueEventually(() -> {
+            Map<String, List<Integer>> recordsByTaskId = groupByKey(testResults);
+            assertThat(recordsByTaskId.keySet()).hasSize(localParallelism);
+            assertThat(recordsByTaskId).allSatisfy((taskId, records) ->
+                    assertThat(records.size()).isGreaterThan(ITEM_COUNT)
+            );
+            minOrderIdByTaskIdBeforeSuspend.putAll(getMinOrderIdByTaskId(recordsByTaskId));
+            LOGGER.debug("Min order ids before snapshot = {}", minOrderIdByTaskIdBeforeSuspend);
+            LOGGER.debug("Max order ids before snapshot = {}", getMaxOrderIdByTaskId(recordsByTaskId));
+        });
+
+        waitForNextSnapshot(hazelcastInstance, job);
+        assertJobStatusEventually(job, RUNNING);
+        job.suspend();
+        assertJobStatusEventually(job, SUSPENDED);
+
+        testResults.clear();
+        job.resume();
+
+        Map<String, Integer> minOrderIdByTaskIdAfterSuspend = new HashMap<>();
+        assertTrueEventually(() -> {
+            Map<String, List<Integer>> recordsByTaskId = groupByKey(testResults);
+
+            assertThat(recordsByTaskId.keySet()).hasSize(localParallelism);
+            assertThat(recordsByTaskId).allSatisfy((taskId, records) ->
+                    assertThat(records.size()).isGreaterThan(ITEM_COUNT)
+            );
+            minOrderIdByTaskIdAfterSuspend.putAll(getMinOrderIdByTaskId(recordsByTaskId));
+            LOGGER.debug("Min order ids after snapshot = {}", minOrderIdByTaskIdAfterSuspend);
+            LOGGER.debug("Max order ids after snapshot = {}", getMaxOrderIdByTaskId(recordsByTaskId));
+            job.cancel();
+        });
+        assertJobStatusEventually(job, FAILED);
+        for (Map.Entry<String, Integer> minOrderId : minOrderIdByTaskIdAfterSuspend.entrySet()) {
+            String taskId = minOrderId.getKey();
+            assertThat(minOrderId.getValue()).isGreaterThan(minOrderIdByTaskIdBeforeSuspend.get(taskId));
+        }
+    }
+
+    private void waitForNextSnapshot(HazelcastInstance hazelcastInstance, Job job) {
+        JobRepository jobRepository = new JobRepository(hazelcastInstance);
+        waitForNextSnapshot(jobRepository, job.getId(), 30, false);
+    }
+
+    private static void enableSnapshotting(JobConfig jobConfig) {
         jobConfig.setProcessingGuarantee(AT_LEAST_ONCE);
         jobConfig.setSnapshotIntervalMillis(10);
+    }
 
-        Config config = smallInstanceConfig();
+    private static void enableEventJournal(Config config) {
         config.addMapConfig(new MapConfig("*")
                 .setEventJournalConfig(new EventJournalConfig().setEnabled(true))
                 .setBackupCount(3)
         );
-        config.getJetConfig().setResourceUploadEnabled(true);
-        HazelcastInstance[] hazelcastInstances = createHazelcastInstances(config, 3);
-        JobRepository jobRepository = new JobRepository(hazelcastInstances[0]);
-        Job job = hazelcastInstances[0].getJet().newJob(pipeline, jobConfig);
-        assertJobStatusEventually(job, RUNNING);
-
-        waitForFirstSnapshot(jobRepository, job.getId(), 30, false);
-
-        hazelcastInstances[1].shutdown();
-
-        assertTrueEventually(() -> assertEquals(2, hazelcastInstances[0].getCluster().getMembers().size()));
-
-        assertJobStatusEventually(job, RUNNING);
-
-        try {
-            job.join();
-            fail("Job should have completed with an AssertionCompletedException, but completed normally");
-        } catch (CompletionException e) {
-            String errorMsg = e.getCause().getMessage();
-            assertTrue("Job was expected to complete with AssertionCompletedException, but completed with: "
-                    + e.getCause(), errorMsg.contains(AssertionCompletedException.class.getName()));
-        }
     }
 
+    private static Map<String, Integer> getMinOrderIdByTaskId(Map<String, List<Integer>> recordsByTaskId) {
+        return recordsByTaskId.entrySet().stream()
+                .map(e -> entry(e.getKey(), e.getValue().stream().min(Comparator.comparingInt(i -> i)).get()))
+                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static Map<String, Integer> getMaxOrderIdByTaskId(Map<String, List<Integer>> recordsByTaskId) {
+        return recordsByTaskId.entrySet().stream()
+                .map(e -> entry(e.getKey(), e.getValue().stream().max(Comparator.comparingInt(i -> i)).get()))
+                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static Integer getOrderId(SourceRecord record) {
+        return Values.convertToStruct(record.valueSchema(), record.value()).getInt32("orderid");
+    }
 }

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectPTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectPTest.java
@@ -151,16 +151,16 @@ public class ReadKafkaConnectPTest extends HazelcastTestSupport {
         readKafkaConnectP.saveToSnapshot();
         lastSnapshot = outbox.snapshotQueue().peek();
         assertThat(lastSnapshot).isNotNull();
-        assertThat((TaskRunner.State) lastSnapshot.getValue()).isEqualTo(stateWithOffset(42));
+        assertThat((State) lastSnapshot.getValue()).isEqualTo(stateWithOffset(42));
 
     }
 
     @Nonnull
-    private static TaskRunner.State stateWithOffset(int value) {
+    private static State stateWithOffset(int value) {
         Map<Map<String, ?>, Map<String, ?>> partitionsToOffset = new HashMap<>();
         SourceRecord lastRecord = dummyRecord(value);
         partitionsToOffset.put(lastRecord.sourcePartition(), lastRecord.sourceOffset());
-        TaskRunner.State state = new TaskRunner.State(partitionsToOffset);
+        State state = new State(partitionsToOffset);
         return state;
     }
 

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/SourceOffsetStorageReaderTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/SourceOffsetStorageReaderTest.java
@@ -35,8 +35,8 @@ public class SourceOffsetStorageReaderTest {
     @Test
     public void should_return_null_offset_for_non_existing_partition() {
         Map<String, String> partition = mapOf("part1", "something");
-        Map<Map<String, ?>, Map<String, ?>> emptyPartitionToOffset = new HashMap<>();
-        SourceOffsetStorageReader sut = new SourceOffsetStorageReader(emptyPartitionToOffset);
+        State state = new State();
+        SourceOffsetStorageReader sut = new SourceOffsetStorageReader(state);
         Map<String, Object> offset = sut.offset(partition);
         assertThat(offset).isNull();
     }
@@ -44,8 +44,9 @@ public class SourceOffsetStorageReaderTest {
     @Test
     public void should_return_offset_for_existing_partition() {
         Map<String, String> partition = mapOf("part1", "something");
-        Map<Map<String, ?>, Map<String, ?>> emptyPartitionToOffset = mapOf(partition, mapOf("part1", 123));
-        SourceOffsetStorageReader sut = new SourceOffsetStorageReader(emptyPartitionToOffset);
+        Map<Map<String, ?>, Map<String, ?>> partitionToOffset = mapOf(partition, mapOf("part1", 123));
+        State state = new State(partitionToOffset);
+        SourceOffsetStorageReader sut = new SourceOffsetStorageReader(state);
         Map<String, Object> offset = sut.offset(partition);
         assertThat(offset).isEqualTo(mapOf("part1", 123));
     }

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/TaskRunnerTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/TaskRunnerTest.java
@@ -46,7 +46,7 @@ public class TaskRunnerTest {
     public static final OverridePropertyRule enableLogging = set("hazelcast.logging.type", "log4j2");
     private static final int CONFIGURED_ITEMS_SIZE = 3;
     private final DummySourceConnector connector = new DummySourceConnector();
-    private final TaskRunner taskRunner = new TaskRunner("some-task-name", DummyTask::new);
+    private final TaskRunner taskRunner = new TaskRunner("some-task-name", new State(), DummyTask::new);
 
 
     @Before
@@ -128,28 +128,28 @@ public class TaskRunnerTest {
         for (SourceRecord sourceRecord : taskRunner.poll()) {
             taskRunner.commitRecord(sourceRecord);
         }
-        TaskRunner.State snapshot = taskRunner.createSnapshot();
+        State snapshot = taskRunner.createSnapshot();
 
         Map<Map<String, ?>, Map<String, ?>> partitionsToOffset = new HashMap<>();
         SourceRecord lastRecord = dummyRecord(2);
         partitionsToOffset.put(lastRecord.sourcePartition(), lastRecord.sourceOffset());
-        assertThat(snapshot).isEqualTo(new TaskRunner.State(partitionsToOffset));
+        assertThat(snapshot).isEqualTo(new State(partitionsToOffset));
     }
 
     @Test
     public void should_restore_snapshot() {
-        TaskRunner.State initialSnapshot = taskRunner.createSnapshot();
-        assertThat(initialSnapshot).isEqualTo(new TaskRunner.State(new HashMap<>()));
+        State initialSnapshot = taskRunner.createSnapshot();
+        assertThat(initialSnapshot).isEqualTo(new State(new HashMap<>()));
 
         Map<Map<String, ?>, Map<String, ?>> partitionsToOffset = new HashMap<>();
         SourceRecord sourceRecord = dummyRecord(42);
         partitionsToOffset.put(sourceRecord.sourcePartition(), sourceRecord.sourceOffset());
-        TaskRunner.State stateToRestore = new TaskRunner.State(partitionsToOffset);
+        State stateToRestore = new State(partitionsToOffset);
 
         taskRunner.restoreSnapshot(stateToRestore);
 
-        TaskRunner.State snapshot = taskRunner.createSnapshot();
-        assertThat(snapshot).isEqualTo(new TaskRunner.State(partitionsToOffset));
+        State snapshot = taskRunner.createSnapshot();
+        assertThat(snapshot).isEqualTo(new State(partitionsToOffset));
     }
 
     private void assertPolledRecordsSize(int expected) {


### PR DESCRIPTION
- Use shared state for tasks from a single connector because after resuming the job there's no guarantee that the task with given id will be run with the same `processorIndex`. This results with failure of finding a snapshot to restore
- Reworked `testSnapshotting` test to be more robust and checking snapshotting in detail

Fixes https://github.com/hazelcast/hazelcast/issues/24018

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
