### PR TITLE
Fix DefaultAddressPickerTest.testPublicAddress_withDefaultPortAndLocalhost [HZ-2236]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DelegatingAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DelegatingAddressPickerTest.java
@@ -198,11 +198,11 @@ public class DelegatingAddressPickerTest {
         return config;
     }
 
-    private void assertAddressBetweenPorts(Address expected, Address actual, NetworkConfig networkConfig) {
-       assertAddressBetweenPorts(expected, actual, networkConfig.isPortAutoIncrement(), networkConfig.getPortCount());
+    static void assertAddressBetweenPorts(Address expected, Address actual, NetworkConfig networkConfig) {
+        assertAddressBetweenPorts(expected, actual, networkConfig.isPortAutoIncrement(), networkConfig.getPortCount());
     }
 
-    private void assertAddressBetweenPorts(Address expected, Address actual, boolean isPortAutoIncrement, int portCount) {
+    static void assertAddressBetweenPorts(Address expected, Address actual, boolean isPortAutoIncrement, int portCount) {
         int beginPort = expected.getPort();
         int endPort = beginPort;
 


### PR DESCRIPTION
The test is failing because of Address already in use exception.
The expected address is localhost:5701 but actual address is localhost:5702. So change the test to expect a range of addresses 

Fixes https://hazelcast.atlassian.net/browse/HZ-2236

GH : https://github.com/hazelcast/hazelcast/issues/23856

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
