### PR TITLE
Fix DefaultAddressPickerTest.testPublicAddress_withDefaultPortAndLocalhost [HZ-2236]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.instance.impl;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.instance.impl.DefaultAddressPicker.AddressDefinition;
 import com.hazelcast.instance.impl.DefaultAddressPicker.InterfaceDefinition;
@@ -47,6 +48,7 @@ import java.util.Enumeration;
 
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV4_STACK;
 import static com.hazelcast.instance.impl.DefaultAddressPicker.PREFER_IPV6_ADDRESSES;
+import static com.hazelcast.instance.impl.DelegatingAddressPickerTest.assertAddressBetweenPorts;
 import static com.hazelcast.test.OverridePropertyRule.clear;
 import static com.hazelcast.test.OverridePropertyRule.set;
 import static com.hazelcast.internal.util.AddressUtil.getAddressHolder;
@@ -74,8 +76,8 @@ public class DefaultAddressPickerTest {
     @Rule
     public final OverridePropertyRule ruleSysPropPreferIpv6Addresses = clear(PREFER_IPV6_ADDRESSES);
 
-    private ILogger logger = Logger.getLogger(AddressPicker.class);
-    private Config config = new Config();
+    private final ILogger logger = Logger.getLogger(AddressPicker.class);
+    private final Config config = new Config();
     private AddressPicker addressPicker;
     private InetAddress loopback;
 
@@ -241,15 +243,18 @@ public class DefaultAddressPickerTest {
     }
 
     private void testPublicAddress(String host, int port) throws Exception {
-        config.getNetworkConfig().setPublicAddress(port < 0 ? host : (host + ":" + port));
+        NetworkConfig networkConfig = config.getNetworkConfig();
+        networkConfig.setPublicAddress(port < 0 ? host : (host + ":" + port));
         addressPicker = new DefaultAddressPicker(config, logger);
         addressPicker.pickAddress();
 
         if (port < 0) {
-            port = config.getNetworkConfig().getPort();
+            port = networkConfig.getPort();
         }
 
-        assertEquals(new Address(host, port), addressPicker.getPublicAddress(null));
+        Address expected = new Address(host, port);
+        Address actual = addressPicker.getPublicAddress(null);
+        assertAddressBetweenPorts(expected, actual, networkConfig);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DelegatingAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DelegatingAddressPickerTest.java
@@ -198,11 +198,11 @@ public class DelegatingAddressPickerTest {
         return config;
     }
 
-    private void assertAddressBetweenPorts(Address expected, Address actual, NetworkConfig networkConfig) {
+    static void assertAddressBetweenPorts(Address expected, Address actual, NetworkConfig networkConfig) {
        assertAddressBetweenPorts(expected, actual, networkConfig.isPortAutoIncrement(), networkConfig.getPortCount());
     }
 
-    private void assertAddressBetweenPorts(Address expected, Address actual, boolean isPortAutoIncrement, int portCount) {
+    static void assertAddressBetweenPorts(Address expected, Address actual, boolean isPortAutoIncrement, int portCount) {
         int beginPort = expected.getPort();
         int endPort = beginPort;
 


### PR DESCRIPTION
The test is failing because of Address already in use exception.
The expected address is localhost:5701 but actual address is localhost:5702. So change the test to expect a range of addresses

Fixes https://hazelcast.atlassian.net/browse/HZ-2236

GH : https://github.com/hazelcast/hazelcast/issues/23856

Backport of: https://github.com/hazelcast/hazelcast/pull/24161

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
