### PR TITLE
Fix anyOf test [HZ-2244]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ArbitraryArityConstructionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ArbitraryArityConstructionTest.java
@@ -94,10 +94,13 @@ public class Invocation_ArbitraryArityConstructionTest extends HazelcastTestSupp
         assertEquals(RESPONSE, f1.join());
         assertThrows(CompletionException.class, f2::join);
 
-        // This isn't ideal, but I don't see a good way for us to get results
-        // of anyOf future. So this test is here to document the behavior.
-        assertThrows(AssertionError.class, () -> assertEquals(RESPONSE, anyOf.join()));
-        assertEquals(RESPONSE, getSerializationService(local).<NormalResponse>toObject(anyOf.join()).getValue());
+        try {
+            // response being in the serialized form is a limitation not a requirement
+            assertEquals(RESPONSE, getSerializationService(local).<NormalResponse>toObject(anyOf.join()).getValue());
+            // reaching here is normal, anyOf completed via f1
+        } catch (CompletionException ignore) {
+            // reaching here is also normal, anyOf completed via f2
+        }
     }
 
     @Test


### PR DESCRIPTION
CompletableFuture.anyOf() can be completed also via f2 as well. In that
case, `anyOf.join()` would throw. This PR adjust the test scenario
according to that.

Fixes https://github.com/hazelcast/hazelcast/issues/24049