### PR TITLE
Downgrade mockito version to fix mock issues [HZ-2245]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/StsMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/StsMonitorTest.java
@@ -41,7 +41,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.quality.Strictness;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -119,7 +118,7 @@ public class StsMonitorTest {
 
     @Test
     public void testWatchResumesAfter410Gone() {
-        ClusterTopologyIntentTracker tracker = Mockito.mock(ClusterTopologyIntentTracker.class, Mockito.withSettings().strictness(Strictness.LENIENT));
+        ClusterTopologyIntentTracker tracker = Mockito.mock(ClusterTopologyIntentTracker.class);
         KubernetesClient.StsMonitor stsMonitor = buildStsMonitor(namespace, apiServerBaseUrl, token, tracker);
 
         // initial STS list

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <http.client.version>4.5.14</http.client.version>
         <jsr107.tck.version>1.1.1</jsr107.tck.version>
         <junit.version>4.13.2</junit.version>
-        <mockito.version>4.11.0</mockito.version>
+        <mockito.version>3.6.0</mockito.version>
         <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
         <testcontainers.version>1.17.6</testcontainers.version>


### PR DESCRIPTION
After the mockito-core upgrade from 3.6.0 to 4.11.0 version (PR https://github.com/hazelcast/hazelcast/pull/23277), we encountered a number of issues - calling real methods of mocked objects. 
Problematic JDK platforms: Zing (Azul), IBM (OpenJ-9, IBM-8).

Therefore, we decided to roll back the changes until the Hazelcast platform migrates to the new JDK version.

Fix https://github.com/hazelcast/hazelcast/issues/23477

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
