### PR TITLE
Fix ClientMessageProtectionTest [API-1995]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageReader.java
@@ -84,7 +84,7 @@ public final class ClientMessageReader {
                 if (Integer.MAX_VALUE - frameLength < sumUntrustedMessageLength
                         || sumUntrustedMessageLength + frameLength > maxMessageLength) {
                     throw new MaxMessageSizeExceeded(
-                            format("The client message size (%d + %d) exceededs the maximum allowed length (%d)",
+                            format("The client message size (%d + %d) exceeded the maximum allowed length (%d)",
                                     sumUntrustedMessageLength, frameLength, maxMessageLength));
                 }
                 sumUntrustedMessageLength += frameLength;

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageProtectionTest.java
@@ -150,8 +150,11 @@ public class ClientMessageProtectionTest {
             socket.setSoTimeout(5000);
             try (OutputStream os = socket.getOutputStream(); InputStream is = socket.getInputStream()) {
                 os.write(CLIENT_BINARY.getBytes(StandardCharsets.UTF_8));
-                ClientTestUtil.writeClientMessage(os, clientMessage);
+                // The socket might be closed after we write the large string
+                // frame and before the frames next to that. So, even the
+                // write message call below could throw.
                 expected.expect(connectionClosedException());
+                ClientTestUtil.writeClientMessage(os, clientMessage);
                 ClientTestUtil.readResponse(is);
             }
         }


### PR DESCRIPTION
In the failing `testExceededMessageSize`, we are writing a large authentication message and expecting the connection to close when we try to read over the socket, which happens all the time.

However, under some orderings, we might even get some IO exceptions while writing the message. If the server processes the large frame before the client sends the frames that come after that large frame, the server might close the connection due to the exceeded message size limits. And, you can easily get an exception while writing the next smaller frames.

To solve it, I have moved the expected exception call to before writing the message line.

closes https://github.com/hazelcast/hazelcast/issues/23467