### PR TITLE
Log progress in EntryProcessorBouncingNodesTest [HZ-2226]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
@@ -109,6 +109,7 @@ public class EntryProcessorBouncingNodesTest extends HazelcastTestSupport {
         HazelcastInstance steadyMember = bounceMemberRule.getSteadyMember();
         final IMap<Integer, ListHolder> map = steadyMember.getMap(MAP_NAME);
         while (iteration < ITERATIONS) {
+            System.out.println(String.format("Iteration %d of %d", iteration + 1, ITERATIONS));
             IncrementProcessor processor = new IncrementProcessor(iteration);
             expected.add(iteration);
             for (int i = 0; i < ENTRIES; ++i) {

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
@@ -21,6 +21,8 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
@@ -88,6 +90,8 @@ public class EntryProcessorBouncingNodesTest extends HazelcastTestSupport {
             .driverType(BounceTestConfiguration.DriverType.ALWAYS_UP_MEMBER)
             .build();
 
+    private final ILogger logger = Logger.getLogger(getClass());
+
     @Before
     public void setUp() {
         HazelcastInstance instance = bounceMemberRule.getSteadyMember();
@@ -109,7 +113,7 @@ public class EntryProcessorBouncingNodesTest extends HazelcastTestSupport {
         HazelcastInstance steadyMember = bounceMemberRule.getSteadyMember();
         final IMap<Integer, ListHolder> map = steadyMember.getMap(MAP_NAME);
         while (iteration < ITERATIONS) {
-            System.out.println(String.format("Iteration %d of %d", iteration + 1, ITERATIONS));
+            logger.info(String.format("Iteration %d of %d", iteration + 1, ITERATIONS));
             IncrementProcessor processor = new IncrementProcessor(iteration);
             expected.add(iteration);
             for (int i = 0; i < ENTRIES; ++i) {


### PR DESCRIPTION
Purpose is to determine whether test is stuck or is making very slow progress and times out in sonar build.