### PR TITLE
Add an option to force reading from Mongo with only one processor

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
@@ -23,6 +23,7 @@ import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.core.AbstractProcessor;
 import com.hazelcast.jet.core.BroadcastKey;
 import com.hazelcast.jet.core.EventTimeMapper;
+import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.jet.mongodb.impl.CursorTraverser.EmptyItem;
 import com.hazelcast.logging.ILogger;
@@ -92,9 +93,22 @@ public class ReadMongoP<I> extends AbstractProcessor {
     private boolean snapshotInProgress;
     private final MongoChunkedReader reader;
     private final MongoConnection connection;
+    /**
+     * Means that user requested the query to be executed in non-distributed way.
+     * This property set to true should mean that
+     * {@link com.hazelcast.jet.core.ProcessorMetaSupplier#forceTotalParallelismOne} was used.
+     */
+    private final boolean nonDistributed;
 
     private Traverser<?> traverser;
     private Traverser<Entry<BroadcastKey<Integer>, Object>> snapshotTraverser;
+
+    /**
+     * Parallelization of reading is possible only when
+     * user didn't mark the processor as nonDistributed
+     * and when totalParallelism is higher than 1.
+     */
+    private boolean canParallelize;
 
     public ReadMongoP(ReadMongoParams<I> params) {
         if (params.isStream()) {
@@ -108,12 +122,14 @@ public class ReadMongoP<I> extends AbstractProcessor {
         }
         this.connection = new MongoConnection(params.clientSupplier, params.dataLinkRef, client -> reader.connect(client,
                 snapshotsEnabled));
+        this.nonDistributed = params.isNonDistributed();
     }
 
     @Override
     protected void init(@Nonnull Context context) {
         logger = context.logger();
         totalParallelism = context.totalParallelism();
+        canParallelize = !nonDistributed && totalParallelism > 1;
         processorIndex = context.globalProcessorIndex();
         this.snapshotsEnabled = context.snapshottingEnabled();
 
@@ -296,7 +312,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
             if (supportsSnapshots && lastKey != null) {
                 aggregateList.add(match(gt("_id", lastKey)).toBsonDocument());
             }
-            if (totalParallelism > 1) {
+            if (canParallelize) {
                 aggregateList.addAll(0, partitionAggregate(totalParallelism, processorIndex, false));
             }
             if (collection != null) {
@@ -399,7 +415,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
         @Override
         public void onConnect(MongoClient mongoClient, boolean snapshotsEnabled) {
             List<Bson> aggregateList = new ArrayList<>(aggregates);
-            if (totalParallelism > 1) {
+            if (canParallelize) {
                 aggregateList.addAll(0, partitionAggregate(totalParallelism, processorIndex, true));
             }
             ChangeStreamIterable<Document> changeStream;

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoParams.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoParams.java
@@ -49,6 +49,7 @@ public class ReadMongoParams<I> implements Serializable {
     Long startAtTimestamp;
     EventTimePolicy<? super I> eventTimePolicy;
     BiFunctionEx<ChangeStreamDocument<Document>, Long, I> mapStreamFn;
+    boolean nonDistributed;
 
     public ReadMongoParams(boolean stream) {
         this.stream = stream;
@@ -164,5 +165,14 @@ public class ReadMongoParams<I> implements Serializable {
     public ReadMongoParams<I> addAggregate(@Nonnull Bson doc) {
         this.aggregates.add(doc);
         return this;
+    }
+
+    public ReadMongoParams<I> setNonDistributed(boolean nonDistributed) {
+        this.nonDistributed = nonDistributed;
+        return this;
+    }
+
+    public boolean isNonDistributed() {
+        return nonDistributed;
     }
 }

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/AbstractMongoTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/AbstractMongoTest.java
@@ -96,19 +96,21 @@ public abstract class AbstractMongoTest extends SimpleTestInClusterSupport {
 
     @After
     public void clear() {
-        try (MongoClient mongoClient = MongoClients.create(mongoContainer.getConnectionString())) {
-            for (String databaseName : mongoClient.listDatabaseNames()) {
-                if (databaseName.startsWith("test")) {
-                    MongoDatabase database = mongoClient.getDatabase(databaseName);
-                    database.drop();
+        if (mongoContainer != null) {
+            try (MongoClient mongoClient = MongoClients.create(mongoContainer.getConnectionString())) {
+                for (String databaseName : mongoClient.listDatabaseNames()) {
+                    if (databaseName.startsWith("test")) {
+                        MongoDatabase database = mongoClient.getDatabase(databaseName);
+                        database.drop();
+                    }
                 }
+                List<String> allowedDatabasesLeft = asList("admin", "local", "config", "tech");
+                assertTrueEventually(() -> {
+                    ArrayList<String> databasesLeft = mongoClient.listDatabaseNames().into(new ArrayList<>());
+                    assertEquals(allowedDatabasesLeft.size(), databasesLeft.size());
+                    assertContainsAll(databasesLeft, allowedDatabasesLeft);
+                });
             }
-            List<String> allowedDatabasesLeft = asList("admin", "local", "config", "tech");
-            assertTrueEventually(() -> {
-                ArrayList<String> databasesLeft = mongoClient.listDatabaseNames().into(new ArrayList<>());
-                assertEquals(allowedDatabasesLeft.size(), databasesLeft.size());
-                assertContainsAll(databasesLeft, allowedDatabasesLeft);
-            });
         }
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoTable.java
@@ -33,6 +33,8 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.hazelcast.jet.sql.impl.connector.mongodb.Options.FORCE_PARALLELISM_ONE;
+import static java.lang.Boolean.parseBoolean;
 import static java.util.stream.Collectors.toList;
 
 class MongoTable extends JetTable {
@@ -49,6 +51,7 @@ class MongoTable extends JetTable {
     private final String[] externalNames;
     private final QueryDataType[] fieldTypes;
     private final BsonType[] fieldExternalTypes;
+    private final boolean forceMongoParallelismOne;
 
     MongoTable(
             @Nonnull String schemaName,
@@ -77,6 +80,8 @@ class MongoTable extends JetTable {
         this.fieldExternalTypes = getFields().stream()
                                              .map(field -> ((MongoTableField) field).externalType)
                                              .toArray(BsonType[]::new);
+
+       this.forceMongoParallelismOne = parseBoolean(options.getOrDefault(FORCE_PARALLELISM_ONE, "false"));
     }
 
     public MongoTableField getField(String name) {
@@ -172,6 +177,10 @@ class MongoTable extends JetTable {
         return types;
     }
 
+    public boolean isForceMongoParallelismOne() {
+        return forceMongoParallelismOne;
+    }
+
     @Override
     public String toString() {
         return "MongoTable{" +
@@ -180,6 +189,7 @@ class MongoTable extends JetTable {
                 ", connectionString='" + connectionString + '\'' +
                 ", options=" + options +
                 ", streaming=" + streaming +
+                ", forceMongoParallelismOne=" + forceMongoParallelismOne +
                 '}';
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
@@ -36,6 +36,8 @@ final class Options {
     static final String DATABASE_NAME_OPTION = "database";
     static final String START_AT_OPTION = "startAt";
     static final String PK_COLUMN = "idColumn";
+    static final String FORCE_PARALLELISM_ONE = "forceMongoReadParallelismOne";
+
     private static final String POSSIBLE_VALUES = "This property should " +
             " have value of: a) 'now' b) time in epoch milliseconds or c) " +
             " ISO-formatted instant in UTC timezone, like '2023-03-24T15:31:00Z'.";


### PR DESCRIPTION
Reasoning: serverless Mongo does not support `$function`, so it's better to read in one processor than not read at all.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible