### PR TITLE
Support schema in Jdbc connector [HZ-2035]

### DIFF
--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapLoaderTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapLoaderTest.java
@@ -341,7 +341,7 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
 
     @Test
     public void givenRowAndIdColumn_whenLoadAll_thenReturnGenericRecord() throws Exception {
-        createTable(mapName, quote("person-id") +" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") + " INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 1);
 
         Properties properties = new Properties();
@@ -376,7 +376,7 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
 
     @Test
     public void givenRowAndIdColumn_whenLoadAllKeys_thenReturnKeys() throws Exception {
-        createTable(mapName, quote("person-id") +" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") + " INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 1);
 
         Properties properties = new Properties();

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapLoaderTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapLoaderTest.java
@@ -160,7 +160,7 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
     @Test
     public void givenTableMultipleColumns_whenLoad_thenReturnGenericRecord() throws Exception {
         createTable(mapName, "id INT PRIMARY KEY", "name VARCHAR(100)", "age INT", "address VARCHAR(100)");
-        executeJdbc("INSERT INTO \"" + mapName + "\" VALUES(0, 'name-0', 42, 'Palo Alto, CA 94306')");
+        executeJdbc("INSERT INTO " + mapName + " VALUES(0, 'name-0', 42, 'Palo Alto, CA 94306')");
 
         mapLoader = createMapLoader();
         GenericRecord record = mapLoader.load(0);
@@ -174,7 +174,7 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
     @Test
     public void givenTableVarcharPKColumn_whenLoad_thenReturnGenericRecordWithCorrectType() throws Exception {
         createTable(mapName, "id VARCHAR(100)", "name VARCHAR(100)");
-        executeJdbc("INSERT INTO \"" + mapName + "\" VALUES('0', 'name-0')");
+        executeJdbc("INSERT INTO " + mapName + " VALUES('0', 'name-0')");
 
         GenericMapLoader<String> mapLoader = createMapLoader();
         GenericRecord record = mapLoader.load("0");
@@ -187,7 +187,7 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
     @Test
     public void givenTable_whenSetColumns_thenGenericRecordHasSetColumns() throws Exception {
         createTable(mapName, "id INT PRIMARY KEY", "name VARCHAR(100)", "age INT", "address VARCHAR(100)");
-        executeJdbc("INSERT INTO \"" + mapName + "\" VALUES(0, 'name-0', 42, 'Palo Alto, CA 94306')");
+        executeJdbc("INSERT INTO " + mapName + " VALUES(0, 'name-0', 42, 'Palo Alto, CA 94306')");
 
         Properties properties = new Properties();
         properties.setProperty(DATA_LINK_REF_PROPERTY, TEST_DATABASE_REF);
@@ -283,7 +283,7 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
 
     @Test
     public void givenRowAndIdColumn_whenLoad_thenReturnGenericRecord() throws Exception {
-        createTable(mapName, "\"person-id\" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") + " INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 1);
 
         Properties properties = new Properties();
@@ -341,7 +341,7 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
 
     @Test
     public void givenRowAndIdColumn_whenLoadAll_thenReturnGenericRecord() throws Exception {
-        createTable(mapName, "\"person-id\" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") +" INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 1);
 
         Properties properties = new Properties();
@@ -376,7 +376,7 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
 
     @Test
     public void givenRowAndIdColumn_whenLoadAllKeys_thenReturnKeys() throws Exception {
-        createTable(mapName, "\"person-id\" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") +" INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 1);
 
         Properties properties = new Properties();

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
@@ -150,7 +150,7 @@ public class GenericMapStoreTest extends GenericMapLoaderTest {
 
     @Test
     public void whenStore_thenTableContainsRow() throws Exception {
-        createTable(mapName, "\"person-id\" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") + " INT PRIMARY KEY", "name VARCHAR(100)");
 
         Properties properties = new Properties();
         properties.setProperty(DATA_LINK_REF_PROPERTY, TEST_DATABASE_REF);
@@ -204,7 +204,7 @@ public class GenericMapStoreTest extends GenericMapLoaderTest {
 
     @Test
     public void givenRowAndIdColumn_whenStore_thenRowIsUpdated() throws Exception {
-        createTable(mapName, "\"person-id\" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") +" INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 1);
 
         Properties properties = new Properties();
@@ -273,7 +273,7 @@ public class GenericMapStoreTest extends GenericMapLoaderTest {
 
     @Test
     public void givenIdColumn_whenDelete_thenRowRemovedFromTable() throws Exception {
-        createTable(mapName, "\"person-id\" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") +" INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 2);
 
         Properties properties = new Properties();
@@ -303,7 +303,7 @@ public class GenericMapStoreTest extends GenericMapLoaderTest {
 
     @Test
     public void givenIdColumn_whenDeleteAll_thenRowRemovedFromTable() throws Exception {
-        createTable(mapName, "\"person-id\" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") +" INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 2);
 
         Properties properties = new Properties();

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
@@ -204,7 +204,7 @@ public class GenericMapStoreTest extends GenericMapLoaderTest {
 
     @Test
     public void givenRowAndIdColumn_whenStore_thenRowIsUpdated() throws Exception {
-        createTable(mapName, quote("person-id") +" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") + " INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 1);
 
         Properties properties = new Properties();
@@ -273,7 +273,7 @@ public class GenericMapStoreTest extends GenericMapLoaderTest {
 
     @Test
     public void givenIdColumn_whenDelete_thenRowRemovedFromTable() throws Exception {
-        createTable(mapName, quote("person-id") +" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") + " INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 2);
 
         Properties properties = new Properties();
@@ -303,7 +303,7 @@ public class GenericMapStoreTest extends GenericMapLoaderTest {
 
     @Test
     public void givenIdColumn_whenDeleteAll_thenRowRemovedFromTable() throws Exception {
-        createTable(mapName, quote("person-id") +" INT PRIMARY KEY", "name VARCHAR(100)");
+        createTable(mapName, quote("person-id") + " INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(mapName, 2);
 
         Properties properties = new Properties();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresUpsertQueryBuilder.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresUpsertQueryBuilder.java
@@ -16,78 +16,56 @@
 
 package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
+import com.hazelcast.jet.sql.impl.connector.jdbc.AbstractQueryBuilder;
 import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcTable;
-import org.apache.calcite.sql.SqlDialect;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Iterator;
 
 /**
  * Builder for upsert statement
  */
-public class PostgresUpsertQueryBuilder {
-
-    private final String query;
-
-    private final String quotedTableName;
-    private final List<String> quotedColumnNames;
-
-    private final List<String> quotedPrimaryKeys;
+public class PostgresUpsertQueryBuilder extends AbstractQueryBuilder {
 
     public PostgresUpsertQueryBuilder(JdbcTable jdbcTable) {
-        SqlDialect sqlDialect = jdbcTable.sqlDialect();
-        // Quote identifiers
-        quotedTableName = sqlDialect.quoteIdentifier(new StringBuilder(), jdbcTable.getExternalNameList()).toString();
-        quotedColumnNames = jdbcTable.dbFieldNames()
-                .stream()
-                .map(sqlDialect::quoteIdentifier)
-                .collect(Collectors.toList());
+        super(jdbcTable);
 
-        quotedPrimaryKeys = jdbcTable.getPrimaryKeyList()
-                .stream()
-                .map(sqlDialect::quoteIdentifier)
-                .collect(Collectors.toList());
+        StringBuilder sb = new StringBuilder();
 
+        appendInsertClause(sb);
+        sb.append(' ');
+        appendValuesClause(sb);
+        sb.append(' ');
+        appendOnConflictClause(sb);
 
-        StringBuilder stringBuilder = new StringBuilder();
-
-        getInsertClause(stringBuilder);
-        getValuesClause(stringBuilder);
-        getOnConflictClause(stringBuilder);
-
-        query = stringBuilder.toString();
+        query = sb.toString();
     }
 
-    void getInsertClause(StringBuilder stringBuilder) {
-        stringBuilder.append("INSERT INTO ")
-                .append(quotedTableName)
-                .append(" (")
-                .append(String.join(",", quotedColumnNames))
-                .append(") ");
+    void appendInsertClause(StringBuilder sb) {
+        sb.append("INSERT INTO ");
+        dialect.quoteIdentifier(sb, jdbcTable.getExternalNameList());
+        sb.append(' ');
+        appendFieldNames(sb, jdbcTable.dbFieldNames());
     }
 
-    void getValuesClause(StringBuilder stringBuilder) {
-        String values = quotedColumnNames.stream()
-                .map(dbFieldName -> "?")
-                .collect(Collectors.joining(","));
-
-        stringBuilder.append("VALUES (").append(values).append(") ");
+    void appendValuesClause(StringBuilder sb) {
+        sb.append("VALUES ");
+        appendValues(sb, jdbcTable.dbFieldNames().size());
     }
 
-    void getOnConflictClause(StringBuilder stringBuilder) {
-        String primaryKeys = String.join(",", quotedPrimaryKeys);
+    void appendOnConflictClause(StringBuilder sb) {
+        sb.append("ON CONFLICT ");
+        appendFieldNames(sb, jdbcTable.getPrimaryKeyList());
+        sb.append(" DO UPDATE SET ");
 
-        String values = quotedColumnNames.stream()
-                .map(dbFieldName -> dbFieldName + " = EXCLUDED." + dbFieldName)
-                .collect(Collectors.joining(","));
-
-        stringBuilder.append("ON CONFLICT (").append(primaryKeys).append(") DO UPDATE SET ").append(values);
-    }
-
-    /**
-     * Returns the built upsert statement
-     */
-    public String query() {
-        return query;
+        Iterator<String> it = jdbcTable.dbFieldNames().iterator();
+        while (it.hasNext()) {
+            String dbFieldName = it.next();
+            dialect.quoteIdentifier(sb, dbFieldName);
+            sb.append(" = EXCLUDED.");
+            dialect.quoteIdentifier(sb, dbFieldName);
+            if (it.hasNext()) {
+                sb.append(',');
+            }
+        }
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DeleteJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DeleteJdbcSqlConnectorTest.java
@@ -19,10 +19,7 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import java.sql.SQLException;
 
 import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 
@@ -189,22 +186,6 @@ public class DeleteJdbcSqlConnectorTest extends JdbcSqlTestSupport {
 
         execute("DELETE FROM " + tableName + " WHERE \"person-id\" = 0");
         assertJdbcRowsAnyOrder(tableName);
-    }
-
-    @Test
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/23476")
-    public void deleteFromTableNonDefaultSchema() throws SQLException {
-        String schemaName = randomName();
-        executeJdbc("CREATE SCHEMA " + schemaName);
-        String fullyQualifiedTable = schemaName + "." + tableName;
-
-        createTable(fullyQualifiedTable);
-        insertItems(fullyQualifiedTable, 2);
-        createMapping(fullyQualifiedTable);
-
-        execute("DELETE FROM \"" + fullyQualifiedTable + "\"");
-
-        assertJdbcRowsAnyOrder(fullyQualifiedTable);
     }
 
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/InsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/InsertJdbcSqlConnectorTest.java
@@ -23,8 +23,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.sql.SQLException;
-
 import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -172,26 +170,4 @@ public class InsertJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         );
     }
 
-    @Test
-    @Ignore("Requires https://github.com/hazelcast/hazelcast/pull/23634")
-    public void insertIntoTableNonDefaultSchema() throws SQLException {
-        createTable(alternativeSchemaTable);
-        createMapping(alternativeSchemaTable);
-
-        execute("INSERT INTO \"" + alternativeSchemaTable + "\" VALUES (0, 'name-0')");
-        assertJdbcRowsAnyOrder(alternativeSchemaTable, new Row(0, "name-0"));
-    }
-
-
-    @Test
-    @Ignore("Requires https://github.com/hazelcast/hazelcast/pull/23634")
-    public void insertIntoTableWithExternalNameNonDefaultSchema() throws Exception {
-        createTable(alternativeSchemaTable);
-        String mappingName = "mapping_" + randomName();
-        createMapping(alternativeSchemaTable, mappingName);
-
-        execute("INSERT INTO " + mappingName + " VALUES (0, 'name-0')");
-
-        assertJdbcRowsAnyOrder(alternativeSchemaTable, new Row(0, "name-0"));
-    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -218,19 +217,19 @@ public class JdbcJoinTest extends JdbcSqlTestSupport {
     }
 
     @Test
-    @Ignore("Requires https://github.com/hazelcast/hazelcast/pull/23634")
     public void joinWithOtherJdbcNonDefaultSchema() throws SQLException {
-        String schemaName = randomTableName();
+        String schemaName = randomName();
         executeJdbc("CREATE SCHEMA " + schemaName);
         String fullyQualifiedTable = schemaName + "." + tableName;
         createTable(fullyQualifiedTable);
         insertItems(fullyQualifiedTable, ITEM_COUNT);
-        createMapping(fullyQualifiedTable);
+        String mappingName = randomTableName();
+        createMapping(fullyQualifiedTable, mappingName);
 
         assertRowsAnyOrder(
                 "SELECT t1.id, t2.name " +
                         "FROM " + tableName + " t1 " +
-                        "JOIN \"" + fullyQualifiedTable + "\" t2 " +
+                        "JOIN \"" + mappingName + "\" t2 " +
                         "   ON t1.id = t2.id",
                 newArrayList(
                         new Row(0, "name-0"),

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlTestSupport.java
@@ -37,6 +37,7 @@ import java.util.Properties;
 
 import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -81,6 +82,12 @@ public abstract class JdbcSqlTestSupport extends SqlTestSupport {
     @Nonnull
     protected static String randomTableName() {
         return "table_" + randomName();
+    }
+
+    protected String quote(String... parts) {
+        return Arrays.stream(parts)
+                     .map(part -> '\"' + part.replaceAll("\"", "\"\"") + '\"')
+                     .collect(joining("."));
     }
 
     /**
@@ -149,7 +156,7 @@ public abstract class JdbcSqlTestSupport extends SqlTestSupport {
     protected static void createMapping(String tableName, String mappingName) {
         execute(
                 "CREATE MAPPING \"" + mappingName + "\""
-                        + " EXTERNAL NAME \"" + tableName + "\""
+                        + " EXTERNAL NAME " + tableName + " "
                         + " ("
                         + " id INT, "
                         + " name VARCHAR "

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/MappingJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/MappingJdbcSqlConnectorTest.java
@@ -77,7 +77,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         createTable("schema1." + tableName);
 
         String mappingName = "mapping_" + randomName();
-        createMapping("schema1\".\"" + tableName, mappingName);
+        createMapping("\"schema1\".\"" + tableName + '\"', mappingName);
 
         assertRowsAnyOrder("SHOW MAPPINGS",
                 newArrayList(new Row(mappingName))

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SchemaJdbcConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SchemaJdbcConnectorTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.jdbc;
+
+
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.jdbc.H2DatabaseProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
+import static org.assertj.core.util.Lists.newArrayList;
+
+@RunWith(HazelcastParametrizedRunner.class)
+@Category(QuickTest.class)
+public class SchemaJdbcConnectorTest extends JdbcSqlTestSupport {
+
+    @Parameter
+    public String schema;
+
+    @Parameter(value = 1)
+    public String table;
+
+    @Parameter(value = 2)
+    public String externalName;
+
+    private String tableFull;
+
+    @Parameters(name = "{index}: schemaName={0}, tableName={1}, externalTableName={2}")
+    public static List<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {
+                        "schema1",
+                        "table1",
+                        "schema1.table1",
+                },
+                {
+                        "schema-with-hyphen",
+                        "table-with-hyphen",
+                        "\"schema-with-hyphen\".\"table-with-hyphen\"",
+                },
+                {
+                        "schema with space",
+                        "table with space",
+                        "\"schema with space\".\"table with space\"",
+                },
+                {
+                        "schema.with.dot",
+                        "table.with.dot",
+                        "\"schema.with.dot\".\"table.with.dot\"",
+                },
+                {
+                        "schema.with.quote\"",
+                        "table.with.quote\"",
+                        "\"schema.with.quote\"\"\".\"table.with.quote\"\"\"",
+                },
+                {
+                        "schema.with.backtick`",
+                        "table.with.backtick`",
+                        "\"schema.with.backtick`\".\"table.with.backtick`\"",
+                }
+        });
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(new H2DatabaseProvider());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        tableFull = quote(schema, table);
+        try {
+            executeJdbc("CREATE SCHEMA " + quote(schema));
+        } catch (Exception e) {
+            logger.info("Could not create schema", e);
+        }
+        createTable(tableFull);
+    }
+
+    @After
+    public void after() throws SQLException {
+        try {
+            executeJdbc("DROP TABLE " + tableFull);
+        } catch (Exception e) {
+            logger.info("Could not drop schema", e);
+        }
+    }
+
+    protected void myCreateMapping(String mappingName) {
+        execute(
+                "CREATE MAPPING \"" + mappingName + "\""
+                        + " EXTERNAL NAME " + externalName + ""
+                        + " ("
+                        + " id INT, "
+                        + " name VARCHAR "
+                        + ") "
+                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "OPTIONS ( "
+                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
+                        + ")"
+        );
+    }
+
+    @Test
+    public void selectFromTableWithSchema() throws Exception {
+        insertItems(tableFull, 1);
+
+        String mappingName = "mapping_" + randomName();
+        myCreateMapping(mappingName);
+
+        assertRowsAnyOrder(
+                "SELECT * FROM " + mappingName,
+                newArrayList(
+                        new Row(0, "name-0")
+                )
+        );
+    }
+
+    @Test
+    public void insertIntoTableWithSchema() {
+        String mappingName = "mapping_" + randomName();
+        myCreateMapping(mappingName);
+
+        execute("INSERT INTO " + mappingName + " VALUES (0, 'name-0')");
+
+        assertJdbcRowsAnyOrder(tableFull, new Row(0, "name-0"));
+    }
+
+    @Test
+    public void updateTableWithSchema() throws Exception {
+        insertItems(tableFull, 1);
+        String mappingName = "mapping_" + randomName();
+        myCreateMapping(mappingName);
+
+        execute("UPDATE " + mappingName + " SET name = 'updated'");
+
+        assertJdbcRowsAnyOrder(tableFull, new Row(0, "updated"));
+    }
+
+    @Test
+    public void deleteFromTableWithSchema() throws Exception {
+        insertItems(tableFull, 1);
+        String mappingName = "mapping_" + randomName();
+        myCreateMapping(mappingName);
+
+        execute("DELETE FROM " + mappingName);
+        assertJdbcRowsAnyOrder(tableFull);
+    }
+
+    @Test
+    public void sinkIntoTableWithSchema() throws Exception {
+        String mappingName = "mapping_" + randomName();
+        myCreateMapping(mappingName);
+
+        execute("SINK INTO " + mappingName + " VALUES (0, 'name-0')");
+
+        assertJdbcRowsAnyOrder(tableFull, new Row(0, "name-0"));
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectJdbcSqlConnectorTest.java
@@ -19,10 +19,7 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import java.sql.SQLException;
 
 import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static org.assertj.core.util.Lists.emptyList;
@@ -219,50 +216,4 @@ public class SelectJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         );
     }
 
-    @Test
-    @Ignore("Requires https://github.com/hazelcast/hazelcast/pull/23634")
-    public void selectAllFromTableNonDefaultSchema() throws SQLException {
-        String schemaName = randomName();
-        executeJdbc("CREATE SCHEMA " + schemaName);
-        String fullyQualifiedTable = schemaName + "." + tableName;
-
-        createTable(fullyQualifiedTable);
-        insertItems(fullyQualifiedTable, ITEM_COUNT);
-        createMapping(fullyQualifiedTable);
-
-        assertRowsAnyOrder(
-                "SELECT * FROM \"" + fullyQualifiedTable + "\"",
-                newArrayList(
-                        new Row(0, "name-0"),
-                        new Row(1, "name-1"),
-                        new Row(2, "name-2"),
-                        new Row(3, "name-3"),
-                        new Row(4, "name-4")
-                )
-        );
-    }
-
-    @Test
-    @Ignore("Requires https://github.com/hazelcast/hazelcast/pull/23634")
-    public void selectAllFromTableSpaceInSchema() throws SQLException {
-        String schemaName = "\"prefix " + randomName() + "\"";
-        executeJdbc("CREATE SCHEMA " + schemaName);
-        String fullyQualifiedTable = schemaName + "." + tableName;
-        String mappingName = randomName();
-
-        createTable(fullyQualifiedTable);
-        insertItems(fullyQualifiedTable, ITEM_COUNT);
-        createMapping("\"" + schemaName + "\"." + tableName, mappingName);
-
-        assertRowsAnyOrder(
-                "SELECT * FROM " + mappingName,
-                newArrayList(
-                        new Row(0, "name-0"),
-                        new Row(1, "name-1"),
-                        new Row(2, "name-2"),
-                        new Row(3, "name-3"),
-                        new Row(4, "name-4")
-                )
-        );
-    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/UpdateJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/UpdateJdbcSqlConnectorTest.java
@@ -19,10 +19,7 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import java.sql.SQLException;
 
 import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 
@@ -445,22 +442,4 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         );
     }
 
-    @Test
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/23476")
-    public void updateTableNonDefaultSchema() throws SQLException {
-        String schemaName = randomName();
-        executeJdbc("CREATE SCHEMA " + schemaName);
-        String fullyQualifiedTable = schemaName + "." + tableName;
-
-        createTable(fullyQualifiedTable);
-        insertItems(fullyQualifiedTable, 2);
-        createMapping(fullyQualifiedTable);
-
-        execute("UPDATE \"" + fullyQualifiedTable + "\" SET name = 'updated'");
-
-        assertJdbcRowsAnyOrder(fullyQualifiedTable,
-                new Row(0, "updated"),
-                new Row(1, "updated")
-        );
-    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/h2/H2UpsertQueryBuilderTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/h2/H2UpsertQueryBuilderTest.java
@@ -27,12 +27,13 @@ import org.mockito.MockitoAnnotations;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 public class H2UpsertQueryBuilderTest {
+
     @Mock
-    JdbcTable jdbcTable;
+    JdbcTable table;
 
     SqlDialect sqlDialect = H2SqlDialect.DEFAULT;
 
@@ -40,48 +41,48 @@ public class H2UpsertQueryBuilderTest {
     public void setUp() {
         MockitoAnnotations.openMocks(this);
 
-        when(jdbcTable.getExternalName()).thenReturn(new String[]{"table1"});
-        when(jdbcTable.getExternalNameList()).thenReturn(Collections.singletonList("table1"));
-        when(jdbcTable.getPrimaryKeyList()).thenReturn(Arrays.asList("pk1", "pk2"));
-        when(jdbcTable.dbFieldNames()).thenReturn(Arrays.asList("field1", "field2"));
-        when(jdbcTable.sqlDialect()).thenReturn(sqlDialect);
+        when(table.getExternalName()).thenReturn(new String[]{"table1"});
+        when(table.getExternalNameList()).thenReturn(Collections.singletonList("table1"));
+        when(table.getPrimaryKeyList()).thenReturn(Arrays.asList("pk1", "pk2"));
+        when(table.dbFieldNames()).thenReturn(Arrays.asList("field1", "field2"));
+        when(table.sqlDialect()).thenReturn(sqlDialect);
     }
 
     @Test
-    public void testGetMergeClause() {
-        H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(jdbcTable);
-        StringBuilder stringBuilder = new StringBuilder();
-        builder.getMergeClause(stringBuilder);
+    public void appendMergeClause() {
+        H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(table);
+        StringBuilder sb = new StringBuilder();
+        builder.appendMergeClause(sb);
 
-        String insertClause = stringBuilder.toString();
-        assertEquals("MERGE INTO \"table1\" (\"field1\",\"field2\") ", insertClause);
+        String mergeClause = sb.toString();
+        assertThat(mergeClause).isEqualTo("MERGE INTO \"table1\" (\"field1\",\"field2\")");
     }
 
     @Test
-    public void testGetKeyClause() {
-        H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(jdbcTable);
-        StringBuilder stringBuilder = new StringBuilder();
-        builder.getKeyClause(stringBuilder);
+    public void appendKeyClause() {
+        H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(table);
+        StringBuilder sb = new StringBuilder();
+        builder.appendKeyClause(sb);
 
-        String keyClause = stringBuilder.toString();
-        assertEquals("KEY (\"pk1\",\"pk2\") ", keyClause);
+        String keyClause = sb.toString();
+        assertThat(keyClause).isEqualTo("KEY (\"pk1\",\"pk2\")");
     }
 
     @Test
-    public void testGetValuesClause() {
-        H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(jdbcTable);
-        StringBuilder stringBuilder = new StringBuilder();
-        builder.getValuesClause(stringBuilder);
+    public void appendValuesClause() {
+        H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(table);
+        StringBuilder sb = new StringBuilder();
+        builder.appendValuesClause(sb);
 
-        String valueClause = stringBuilder.toString();
-        assertEquals("VALUES (?,?)", valueClause);
+        String valueClause = sb.toString();
+        assertThat(valueClause).isEqualTo("VALUES (?,?)");
     }
 
     @Test
     public void testQuery() {
-        H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(jdbcTable);
+        H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(table);
 
         String query = builder.query();
-        assertEquals("MERGE INTO \"table1\" (\"field1\",\"field2\") KEY (\"pk1\",\"pk2\") VALUES (?,?)", query);
+        assertThat(query).isEqualTo("MERGE INTO \"table1\" (\"field1\",\"field2\") KEY (\"pk1\",\"pk2\") VALUES (?,?)");
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSchemaJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSchemaJdbcSqlConnectorTest.java
@@ -14,31 +14,20 @@
  * limitations under the License.
  */
 
-package com.hazelcast.mapstore.mysql;
+package com.hazelcast.jet.sql.impl.connector.jdbc.mssql;
 
-import com.hazelcast.mapstore.GenericMapStoreTest;
+import com.hazelcast.jet.sql.impl.connector.jdbc.SchemaJdbcConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
+import com.hazelcast.test.jdbc.MSSQLDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import java.util.Arrays;
-
-import static java.util.stream.Collectors.joining;
-
-@Category({NightlyTest.class, ParallelJVMTest.class})
-public class MySQLGenericMapStoreTest extends GenericMapStoreTest {
+@Category(NightlyTest.class)
+public class MSSQLSchemaJdbcSqlConnectorTest extends SchemaJdbcConnectorTest {
 
     @BeforeClass
-    public static void beforeClass()  {
-        initialize(new MySQLDatabaseProvider());
+    public static void beforeClass() {
+        initialize(new MSSQLDatabaseProvider());
     }
 
-    @Override
-    protected String quote(String... parts) {
-        return Arrays.stream(parts)
-                     .map(part -> '`' + part.replaceAll("`", "``") + '`')
-                     .collect(joining("."));
-    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLSchemaJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLSchemaJdbcSqlConnectorTest.java
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.mapstore.mysql;
+package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
-import com.hazelcast.mapstore.GenericMapStoreTest;
+import com.hazelcast.jet.sql.impl.connector.jdbc.SchemaJdbcConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
@@ -27,11 +26,11 @@ import java.util.Arrays;
 
 import static java.util.stream.Collectors.joining;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
-public class MySQLGenericMapStoreTest extends GenericMapStoreTest {
+@Category(NightlyTest.class)
+public class MySQLSchemaJdbcSqlConnectorTest extends SchemaJdbcConnectorTest {
 
     @BeforeClass
-    public static void beforeClass()  {
+    public static void beforeClass() {
         initialize(new MySQLDatabaseProvider());
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLUpsertQueryBuilderTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLUpsertQueryBuilderTest.java
@@ -25,9 +25,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
-import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 public class MySQLUpsertQueryBuilderTest {
@@ -42,47 +42,51 @@ public class MySQLUpsertQueryBuilderTest {
         MockitoAnnotations.openMocks(this);
 
         when(jdbcTable.getExternalName()).thenReturn(new String[]{"table1"});
-        when(jdbcTable.getExternalNameList()).thenReturn(Collections.singletonList("table1"));
+        when(jdbcTable.getExternalNameList()).thenReturn(singletonList("table1"));
         when(jdbcTable.dbFieldNames()).thenReturn(Arrays.asList("field1", "field2"));
         when(jdbcTable.sqlDialect()).thenReturn(sqlDialect);
     }
 
     @Test
-    public void testGetInsertClause() {
+    public void appendInsertClause() {
         MySQLUpsertQueryBuilder builder = new MySQLUpsertQueryBuilder(jdbcTable);
-        StringBuilder stringBuilder = new StringBuilder();
-        builder.getInsertClause(stringBuilder);
+        StringBuilder sb = new StringBuilder();
+        builder.appendInsertClause(sb);
 
-        String insertClause = stringBuilder.toString();
-        assertEquals("INSERT INTO `table1` (`field1`,`field2`) ", insertClause);
+        String insertClause = sb.toString();
+        assertThat(insertClause).isEqualTo("INSERT INTO `table1` (`field1`,`field2`)");
     }
 
     @Test
-    public void testGetValuesClause() {
+    public void appendValuesClause() {
         MySQLUpsertQueryBuilder builder = new MySQLUpsertQueryBuilder(jdbcTable);
-        StringBuilder stringBuilder = new StringBuilder();
-        builder.getValuesClause(stringBuilder);
+        StringBuilder sb = new StringBuilder();
+        builder.appendValuesClause(sb);
 
-        String valuesClause = stringBuilder.toString();
-        assertEquals("VALUES (?,?) ", valuesClause);
+        String valuesClause = sb.toString();
+        assertThat(valuesClause).isEqualTo("VALUES (?,?)");
     }
 
     @Test
-    public void testGetOnDuplicateClause() {
+    public void appendOnDuplicateClause() {
         MySQLUpsertQueryBuilder builder = new MySQLUpsertQueryBuilder(jdbcTable);
-        StringBuilder stringBuilder = new StringBuilder();
-        builder.getOnDuplicateClause(stringBuilder);
+        StringBuilder sb = new StringBuilder();
+        builder.appendOnDuplicateClause(sb);
 
-        String valuesClause = stringBuilder.toString();
-        assertEquals("ON DUPLICATE KEY UPDATE `field1` = VALUES(`field1`),`field2` = VALUES(`field2`)",
-                valuesClause);
+        String valuesClause = sb.toString();
+        assertThat(valuesClause).isEqualTo(
+                "ON DUPLICATE KEY UPDATE " +
+                        "`field1` = VALUES(`field1`)," +
+                        "`field2` = VALUES(`field2`)");
     }
 
     @Test
-    public void testQuery() {
+    public void query() {
         MySQLUpsertQueryBuilder builder = new MySQLUpsertQueryBuilder(jdbcTable);
         String result = builder.query();
-        assertEquals("INSERT INTO `table1` (`field1`,`field2`) VALUES (?,?) " +
-                     "ON DUPLICATE KEY UPDATE `field1` = VALUES(`field1`),`field2` = VALUES(`field2`)", result);
+        assertThat(result).isEqualTo(
+                "INSERT INTO `table1` (`field1`,`field2`) VALUES (?,?)" +
+                        " ON DUPLICATE KEY UPDATE `field1` = VALUES(`field1`),`field2` = VALUES(`field2`)"
+        );
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresSchemaJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresSchemaJdbcSqlConnectorTest.java
@@ -14,31 +14,20 @@
  * limitations under the License.
  */
 
-package com.hazelcast.mapstore.mysql;
+package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
-import com.hazelcast.mapstore.GenericMapStoreTest;
+import com.hazelcast.jet.sql.impl.connector.jdbc.SchemaJdbcConnectorTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
+import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import java.util.Arrays;
-
-import static java.util.stream.Collectors.joining;
-
-@Category({NightlyTest.class, ParallelJVMTest.class})
-public class MySQLGenericMapStoreTest extends GenericMapStoreTest {
+@Category(NightlyTest.class)
+public class PostgresSchemaJdbcSqlConnectorTest extends SchemaJdbcConnectorTest {
 
     @BeforeClass
-    public static void beforeClass()  {
-        initialize(new MySQLDatabaseProvider());
+    public static void beforeClass() {
+        initialize(new PostgresDatabaseProvider());
     }
 
-    @Override
-    protected String quote(String... parts) {
-        return Arrays.stream(parts)
-                     .map(part -> '`' + part.replaceAll("`", "``") + '`')
-                     .collect(joining("."));
-    }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresUpsertQueryBuilderTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresUpsertQueryBuilderTest.java
@@ -32,7 +32,7 @@ import org.mockito.MockitoAnnotations;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -56,34 +56,38 @@ public class PostgresUpsertQueryBuilderTest {
     }
 
     @Test
-    public void testGetInsertClause() {
+    public void testAppendInsertClause() {
         PostgresUpsertQueryBuilder builder = new PostgresUpsertQueryBuilder(jdbcTable);
-        StringBuilder stringBuilder = new StringBuilder();
-        builder.getInsertClause(stringBuilder);
+        StringBuilder sb = new StringBuilder();
+        builder.appendInsertClause(sb);
 
-        String insertClause = stringBuilder.toString();
-        assertEquals("INSERT INTO \"table1\" (\"field1\",\"field2\") ", insertClause);
+        String insertClause = sb.toString();
+        assertThat(insertClause).isEqualTo("INSERT INTO \"table1\" (\"field1\",\"field2\")");
     }
 
     @Test
-    public void testGetValuesClause() {
+    public void testAppendValuesClause() {
         PostgresUpsertQueryBuilder builder = new PostgresUpsertQueryBuilder(jdbcTable);
-        StringBuilder stringBuilder = new StringBuilder();
-        builder.getValuesClause(stringBuilder);
+        StringBuilder sb = new StringBuilder();
+        builder.appendValuesClause(sb);
 
-        String valuesClause = stringBuilder.toString();
-        assertEquals("VALUES (?,?) ", valuesClause);
+        String valuesClause = sb.toString();
+        assertThat(valuesClause).isEqualTo("VALUES (?,?)");
     }
 
     @Test
-    public void testGetOnConflictClause() {
+    public void testAppendOnConflictClause() {
         PostgresUpsertQueryBuilder builder = new PostgresUpsertQueryBuilder(jdbcTable);
-        StringBuilder stringBuilder = new StringBuilder();
-        builder.getOnConflictClause(stringBuilder);
+        StringBuilder sb = new StringBuilder();
+        builder.appendOnConflictClause(sb);
 
-        String valuesClause = stringBuilder.toString();
-        assertEquals("ON CONFLICT (\"pk1\",\"pk2\") " +
-                "DO UPDATE SET \"field1\" = EXCLUDED.\"field1\",\"field2\" = EXCLUDED.\"field2\"", valuesClause);
+        String valuesClause = sb.toString();
+        assertThat(valuesClause).isEqualTo(
+                "ON CONFLICT (\"pk1\",\"pk2\") " +
+                        "DO UPDATE SET " +
+                        "\"field1\" = EXCLUDED.\"field1\"," +
+                        "\"field2\" = EXCLUDED.\"field2\""
+        );
     }
 
     @Test
@@ -92,6 +96,6 @@ public class PostgresUpsertQueryBuilderTest {
         String result = builder.query();
         String expected = "INSERT INTO \"table1\" (\"field1\",\"field2\") VALUES (?,?) ON CONFLICT (\"pk1\",\"pk2\") " +
                 "DO UPDATE SET \"field1\" = EXCLUDED.\"field1\",\"field2\" = EXCLUDED.\"field2\"";
-        assertEquals(expected, result);
+        assertThat(result).isEqualTo(expected);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
@@ -26,7 +26,7 @@ public class MySQLDatabaseProvider implements TestDatabaseProvider {
 
     @Override
     public String createDatabase(String dbName) {
-        jdbcUrl = "jdbc:tc:mysql:8.0.29:///" + dbName + "?TC_DAEMON=true&sessionVariables=sql_mode=ANSI&user=root&password=";
+        jdbcUrl = "jdbc:tc:mysql:8.0.29:///" + dbName + "?TC_DAEMON=true&user=root&password=";
         waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
     }


### PR DESCRIPTION
Use all parts of the external name to generate queries.

Move tests related to the schema to SchemaJdbcConnectorTest (previously
ignored failing tests).

Clean up query builders to use one style - StringBuilder.

Correctly quote the external name for schema + table name and also for
fields. Removed `sessionVariables=sql_mode=ANSI` as it is no longer
needed.

Fixes #23476 / HZ-1988

NOTE TO REVIEWERS: This PR is based on https://github.com/hazelcast/hazelcast/pull/23772
It's enough to review only commit fbaf687c272688b91f69f75163bea983930b3b64.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
