### PR TITLE
Use data link from mapping and remove data-link-name option

### DIFF
--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
@@ -80,16 +80,7 @@ public final class KafkaProcessors {
         return ProcessorMetaSupplier.of(
                 PREFERRED_LOCAL_PARALLELISM,
                 StreamKafkaP.processorSupplier(
-                        (context) -> {
-                            KafkaDataLink kafkaDataLink = context
-                                    .dataLinkService()
-                                    .getAndRetainDataLink(dataLinkRef.getName(), KafkaDataLink.class);
-                            try {
-                                return kafkaDataLink.newConsumer();
-                            } finally {
-                                kafkaDataLink.release();
-                            }
-                        },
+                        StreamKafkaP.kafkaConsumerFn(dataLinkRef),
                         Arrays.asList(topics),
                         projectionFn,
                         eventTimePolicy

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.mapstore;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
@@ -96,7 +95,6 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
 
     static final String DATA_LINK_REF_PROPERTY = "data-link-ref";
     static final String TABLE_NAME_PROPERTY = "table-name";
-    static final String MAPPING_TYPE_PROPERTY = "mapping-type";
 
     static final String ID_COLUMN_PROPERTY = "id-column";
 
@@ -175,11 +173,10 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
                 logger.fine("Discovered following mapping columns: " + mappingColumns);
             }
 
-            mappingHelper.createMappingWithColumns(
+            mappingHelper.createMapping(
                     mappingName,
                     genericMapStoreProperties.tableName,
                     mappingColumns,
-                    deriveMappingType(),
                     genericMapStoreProperties.dataLinkRef,
                     genericMapStoreProperties.idColumn
             );
@@ -202,22 +199,13 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
         }
     }
 
-    private String deriveMappingType() {
-        if (genericMapStoreProperties.mappingType != null) {
-            return genericMapStoreProperties.mappingType;
-        } else {
-            return nodeEngine().getDataLinkService().typeForDataLink(genericMapStoreProperties.dataLinkRef);
-        }
-    }
-
-
     private String resolveMappingColumns() {
         // Create a temporary mapping
         String tempMapping = "temp_mapping_" + UuidUtil.newUnsecureUuidString();
         mappingHelper.createMapping(
                 tempMapping,
                 genericMapStoreProperties.tableName,
-                deriveMappingType(),
+                null,
                 genericMapStoreProperties.dataLinkRef,
                 genericMapStoreProperties.idColumn
         );
@@ -354,7 +342,7 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
         }
     }
 
-    @VisibleForTesting
+    // Visible for testing
     boolean initHasFinished() {
         return initFinished.getCount() == 0;
     }

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStoreProperties.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStoreProperties.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import static com.hazelcast.mapstore.GenericMapLoader.COLUMNS_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.DATA_LINK_REF_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.ID_COLUMN_PROPERTY;
-import static com.hazelcast.mapstore.GenericMapLoader.MAPPING_TYPE_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.TABLE_NAME_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.TYPE_NAME_PROPERTY;
 
@@ -37,7 +36,6 @@ class GenericMapStoreProperties {
 
     final String dataLinkRef;
     final String tableName;
-    final String mappingType;
     final String idColumn;
     final List<String> columns;
 
@@ -48,7 +46,6 @@ class GenericMapStoreProperties {
     GenericMapStoreProperties(Properties properties, String mapName) {
         dataLinkRef = properties.getProperty(DATA_LINK_REF_PROPERTY);
         tableName = properties.getProperty(TABLE_NAME_PROPERTY, mapName);
-        mappingType = properties.getProperty(MAPPING_TYPE_PROPERTY);
         idColumn = properties.getProperty(ID_COLUMN_PROPERTY, "id");
 
         String columnsProperty = properties.getProperty(COLUMNS_PROPERTY);

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/MappingHelper.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/MappingHelper.java
@@ -23,8 +23,6 @@ import com.hazelcast.sql.SqlService;
 
 import java.util.List;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
-
 final class MappingHelper {
 
     private final SqlService sqlService;
@@ -38,9 +36,9 @@ final class MappingHelper {
         sqlService.execute(
                 "CREATE MAPPING \"" + mappingName + "\""
                 + " EXTERNAL NAME \"" + tableName + "\" "
+                + " DATA LINK " + dataLinkRef
                 + " TYPE " + mappingType
                 + " OPTIONS ("
-                + "    '" + OPTION_DATA_LINK_NAME + "' = '" + dataLinkRef + "', "
                 + "    'idColumn' = '" + idColumn + "' "
                 + ")"
         ).close();
@@ -52,9 +50,9 @@ final class MappingHelper {
                 "CREATE MAPPING \"" + mappingName + "\" "
                 + "EXTERNAL NAME \"" + tableName + "\" "
                 + (mappingColumns != null ? " ( " + mappingColumns + " ) " : "")
+                + " DATA LINK " + dataLinkRef
                 + "TYPE " + mappingType + " "
                 + "OPTIONS ("
-                + "    '" + OPTION_DATA_LINK_NAME + "' = '" + dataLinkRef + "', "
                 + "    'idColumn' = '" + idColumn + "' "
                 + ")"
         ).close();

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/MappingHelper.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/MappingHelper.java
@@ -51,8 +51,7 @@ final class MappingHelper {
                 + "EXTERNAL NAME \"" + tableName + "\" "
                 + (mappingColumns != null ? " ( " + mappingColumns + " ) " : "")
                 + " DATA LINK " + dataLinkRef
-                + "TYPE " + mappingType + " "
-                + "OPTIONS ("
+                + " OPTIONS ("
                 + "    'idColumn' = '" + idColumn + "' "
                 + ")"
         ).close();

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/MappingHelper.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/MappingHelper.java
@@ -31,26 +31,13 @@ final class MappingHelper {
         this.sqlService = sqlService;
     }
 
-    public void createMapping(String mappingName, String tableName, String mappingType, String dataLinkRef,
-                              String idColumn) {
-        sqlService.execute(
-                "CREATE MAPPING \"" + mappingName + "\""
-                + " EXTERNAL NAME \"" + tableName + "\" "
-                + " DATA LINK " + dataLinkRef
-                + " TYPE " + mappingType
-                + " OPTIONS ("
-                + "    'idColumn' = '" + idColumn + "' "
-                + ")"
-        ).close();
-    }
-
-    public void createMappingWithColumns(String mappingName, String tableName, String mappingColumns,
-                                         String mappingType, String dataLinkRef, String idColumn) {
+    public void createMapping(String mappingName, String tableName, String mappingColumns,
+                              String dataLinkRef, String idColumn) {
         sqlService.execute(
                 "CREATE MAPPING \"" + mappingName + "\" "
                 + "EXTERNAL NAME \"" + tableName + "\" "
                 + (mappingColumns != null ? " ( " + mappingColumns + " ) " : "")
-                + " DATA LINK " + dataLinkRef
+                + " DATA LINK \"" + dataLinkRef + "\" "
                 + " OPTIONS ("
                 + "    'idColumn' = '" + idColumn + "' "
                 + ")"

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -206,10 +206,12 @@ public interface SqlConnector {
      * the user can see it by listing the catalog. Jet will later pass it to
      * {@link #createTable}.
      *
-     * @param nodeEngine an instance of {@link NodeEngine}
-     * @param options    user-provided options
-     * @param userFields user-provided list of fields, possibly empty
+     * @param nodeEngine   an instance of {@link NodeEngine}
+     * @param options      user-provided options
+     * @param userFields   user-provided list of fields, possibly empty
      * @param externalName external name of the table
+     * @param dataLinkName name of the data link to use, may be null if the connector supports specifying
+     *                     connection details in options
      * @return final field list, must not be empty
      */
     @Nonnull
@@ -217,8 +219,8 @@ public interface SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    );
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName);
 
     /**
      * Creates a {@link Table} object with the given fields. Should return
@@ -228,6 +230,8 @@ public interface SqlConnector {
      * Jet calls this method for each statement execution and for each mapping.
      *
      * @param nodeEngine     an instance of {@link NodeEngine}
+     * @param dataLinkName   name of the data link to use, may be null if the connector supports specifying
+     *                       connection details in options
      * @param options        connector specific options
      * @param resolvedFields list of fields as returned from {@link
      *                       #resolveAndValidateFields}
@@ -238,9 +242,9 @@ public interface SqlConnector {
             @Nonnull String schemaName,
             @Nonnull String mappingName,
             @Nonnull String[] externalName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> resolvedFields
-    );
+            @Nonnull List<MappingField> resolvedFields);
 
     /**
      * Returns a supplier for a source vertex reading the input according to
@@ -329,7 +333,8 @@ public interface SqlConnector {
     default boolean isNestedLoopReaderSupported() {
         try {
             // nestedLoopReader() is supported, if the class overrides the default method in this class
-            Method m = getClass().getMethod("nestedLoopReader", DagBuildContext.class, HazelcastRexNode.class, List.class,
+            Method m = getClass().getMethod("nestedLoopReader", DagBuildContext.class, HazelcastRexNode.class,
+                    List.class,
                     JetJoinInfo.class);
             return m.getDeclaringClass() != SqlConnector.class;
         } catch (NoSuchMethodException e) {
@@ -401,9 +406,9 @@ public interface SqlConnector {
 
         /**
          * Returns the context table. It is:<ul>
-         *     <li>for scans, it's the scanned table
-         *     <li>for DML, it's the target table
-         *     <li>for nested loop reader, it's the table read in the inner loop (the right join input)
+         * <li>for scans, it's the scanned table
+         * <li>for DML, it's the target table
+         * <li>for nested loop reader, it's the table read in the inner loop (the right join input)
          * </ul>
          *
          * @throws IllegalStateException if the table doesn't apply in the current context
@@ -414,9 +419,9 @@ public interface SqlConnector {
         /**
          * Converts a boolean {@link HazelcastRexNode}. When evaluating a {@link RexInputRef},
          * this context is assumed:<ul>
-         *     <li>If a table is set (see {@link #getTable()}), then it's assumed that it's that table's fields
-         *     <li>If it's a single-input rel, then it's then input
-         *     <li>Otherwise the conversion of an input ref will fail.
+         * <li>If a table is set (see {@link #getTable()}), then it's assumed that it's that table's fields
+         * <li>If it's a single-input rel, then it's then input
+         * <li>Otherwise the conversion of an input ref will fail.
          * </ul>
          */
         @Nullable

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/file/FileSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/file/FileSqlConnector.java
@@ -71,8 +71,8 @@ public class FileSqlConnector implements SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    ) {
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName) {
         return resolveAndValidateFields(options, userFields);
     }
 
@@ -91,9 +91,9 @@ public class FileSqlConnector implements SqlConnector {
             @Nonnull String schemaName,
             @Nonnull String mappingName,
             @Nonnull String[] externalName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> resolvedFields
-    ) {
+            @Nonnull List<MappingField> resolvedFields) {
         Metadata metadata = METADATA_RESOLVERS.resolveMetadata(resolvedFields, options);
 
         return new FileTable.SpecificFileTable(

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
@@ -64,8 +64,8 @@ class SeriesSqlConnector implements SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    ) {
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName) {
         throw new UnsupportedOperationException("Resolving fields not supported for " + typeName());
     }
 
@@ -76,9 +76,9 @@ class SeriesSqlConnector implements SqlConnector {
             @Nonnull String schemaName,
             @Nonnull String name,
             @Nonnull String[] externalName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> resolvedFields
-    ) {
+            @Nonnull List<MappingField> resolvedFields) {
         throw new UnsupportedOperationException("Creating table not supported for " + typeName());
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
@@ -64,8 +64,8 @@ public class StreamSqlConnector implements SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    ) {
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName) {
         throw new UnsupportedOperationException("Resolving fields not supported for " + typeName());
     }
 
@@ -76,9 +76,9 @@ public class StreamSqlConnector implements SqlConnector {
             @Nonnull String schemaName,
             @Nonnull String name,
             @Nonnull String[] externalName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> resolvedFields
-    ) {
+            @Nonnull List<MappingField> resolvedFields) {
         throw new UnsupportedOperationException("Creating table not supported for " + typeName());
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
@@ -68,8 +68,8 @@ final class InfoSchemaConnector implements SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    ) {
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName) {
         throw new UnsupportedOperationException();
     }
 
@@ -79,9 +79,9 @@ final class InfoSchemaConnector implements SqlConnector {
             @Nonnull String schemaName,
             @Nonnull String mappingName,
             @Nonnull String[] externalName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> resolvedFields
-    ) {
+            @Nonnull List<MappingField> resolvedFields) {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -61,7 +61,6 @@ public class JdbcSqlConnector implements SqlConnector {
 
     public static final String TYPE_NAME = "JDBC";
 
-    public static final String OPTION_DATA_LINK_NAME = "data-link-name";
     public static final String OPTION_JDBC_BATCH_LIMIT = "jdbc.batch-limit";
 
     public static final String JDBC_BATCH_LIMIT_DEFAULT_VALUE = "100";

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
@@ -86,14 +86,13 @@ public class KafkaSqlConnector implements SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    ) {
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName) {
         if (externalName.length > 1) {
             throw QueryException.error("Invalid external name " + quoteCompoundIdentifier(externalName)
                     + ", external name for Kafka is allowed to have only a single component referencing the topic " +
                     "name");
         }
-
         return METADATA_RESOLVERS.resolveAndValidateFields(userFields, options, nodeEngine);
     }
 
@@ -104,9 +103,9 @@ public class KafkaSqlConnector implements SqlConnector {
             @Nonnull String schemaName,
             @Nonnull String mappingName,
             @Nonnull String[] externalName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> resolvedFields
-    ) {
+            @Nonnull List<MappingField> resolvedFields) {
         KvMetadata keyMetadata = METADATA_RESOLVERS.resolveMetadata(true, resolvedFields, options, null);
         KvMetadata valueMetadata = METADATA_RESOLVERS.resolveMetadata(false, resolvedFields, options, null);
         List<TableField> fields = concat(keyMetadata.getFields().stream(), valueMetadata.getFields().stream())

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaTable.java
@@ -41,6 +41,7 @@ class KafkaTable extends JetTable {
     private final UpsertTargetDescriptor valueUpsertDescriptor;
 
     private final String topicName;
+    private final String dataLinkName;
     private final Map<String, String> options;
 
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -51,6 +52,7 @@ class KafkaTable extends JetTable {
             List<TableField> fields,
             TableStatistics statistics,
             String topicName,
+            String dataLinkName,
             Map<String, String> options,
             QueryTargetDescriptor keyQueryDescriptor,
             UpsertTargetDescriptor keyUpsertDescriptor,
@@ -66,11 +68,16 @@ class KafkaTable extends JetTable {
         this.valueUpsertDescriptor = valueUpsertDescriptor;
 
         this.topicName = topicName;
+        this.dataLinkName = dataLinkName;
         this.options = options;
     }
 
     String topicName() {
         return topicName;
+    }
+
+    String dataLinkName() {
+        return dataLinkName;
     }
 
     Properties kafkaConsumerProperties() {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/RowProjectorProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/RowProjectorProcessorSupplier.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.jet.sql.impl.connector.kafka;
 
+import com.hazelcast.datalink.DataLinkService;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.kafka.impl.StreamKafkaP;
+import com.hazelcast.jet.pipeline.DataLinkRef;
 import com.hazelcast.jet.sql.impl.connector.keyvalue.KvRowProjector;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -50,6 +52,7 @@ import static java.util.Collections.singletonList;
 final class RowProjectorProcessorSupplier implements ProcessorSupplier, DataSerializable {
 
     private Properties properties;
+    private String dataLinkName;
     private String topic;
     private FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider;
     private KvRowProjector.Supplier projectorSupplier;
@@ -57,6 +60,7 @@ final class RowProjectorProcessorSupplier implements ProcessorSupplier, DataSeri
     private transient ExpressionEvalContext evalContext;
     private transient EventTimePolicy<JetSqlRow> eventTimePolicy;
     private transient Extractors extractors;
+    private transient DataLinkService dataLinkService;
 
     @SuppressWarnings("unused")
     private RowProjectorProcessorSupplier() {
@@ -64,6 +68,7 @@ final class RowProjectorProcessorSupplier implements ProcessorSupplier, DataSeri
 
     RowProjectorProcessorSupplier(
             Properties properties,
+            String dataLinkName,
             String topic,
             FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider,
             QueryPath[] paths,
@@ -74,6 +79,7 @@ final class RowProjectorProcessorSupplier implements ProcessorSupplier, DataSeri
             List<Expression<?>> projection
     ) {
         this.properties = properties;
+        this.dataLinkName = dataLinkName;
         this.topic = topic;
         this.eventTimePolicyProvider = eventTimePolicyProvider;
         this.projectorSupplier = KvRowProjector.supplier(
@@ -93,6 +99,7 @@ final class RowProjectorProcessorSupplier implements ProcessorSupplier, DataSeri
                 ? EventTimePolicy.noEventTime()
                 : eventTimePolicyProvider.apply(evalContext);
         extractors = Extractors.newBuilder(evalContext.getSerializationService()).build();
+        dataLinkService = context.dataLinkService();
     }
 
     @Nonnull
@@ -102,7 +109,8 @@ final class RowProjectorProcessorSupplier implements ProcessorSupplier, DataSeri
         for (int i = 0; i < count; i++) {
             KvRowProjector projector = projectorSupplier.get(evalContext, extractors);
             Processor processor = new StreamKafkaP<>(
-                    StreamKafkaP.kafkaConsumerFn(properties),
+                    dataLinkName == null ? StreamKafkaP.kafkaConsumerFn(properties)
+                            : StreamKafkaP.kafkaConsumerFn(new DataLinkRef(dataLinkName)),
                     singletonList(topic),
                     record -> projector.project(record.key(), record.value()),
                     eventTimePolicy
@@ -115,6 +123,7 @@ final class RowProjectorProcessorSupplier implements ProcessorSupplier, DataSeri
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(properties);
+        out.writeString(dataLinkName);
         out.writeString(topic);
         out.writeObject(eventTimePolicyProvider);
         out.writeObject(projectorSupplier);
@@ -123,6 +132,7 @@ final class RowProjectorProcessorSupplier implements ProcessorSupplier, DataSeri
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         properties = in.readObject();
+        dataLinkName = in.readString();
         topic = in.readString();
         eventTimePolicyProvider = in.readObject();
         projectorSupplier = in.readObject();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -106,8 +106,8 @@ public class IMapSqlConnector implements SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    ) {
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName) {
         if (externalName.length > 1) {
             throw QueryException.error("Invalid external name " + quoteCompoundIdentifier(externalName)
                     + ", external name for IMap is allowed to have only a single component referencing the map name");
@@ -122,9 +122,9 @@ public class IMapSqlConnector implements SqlConnector {
             @Nonnull String schemaName,
             @Nonnull String mappingName,
             @Nonnull String[] externalName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> resolvedFields
-    ) {
+            @Nonnull List<MappingField> resolvedFields) {
         InternalSerializationService ss = (InternalSerializationService) nodeEngine.getSerializationService();
 
         KvMetadata keyMetadata = METADATA_RESOLVERS_WITH_COMPACT.resolveMetadata(

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolver.java
@@ -160,7 +160,10 @@ class FieldResolver {
         }
     }
 
-    Map<String, DocumentField> readFields(String[] externalNames, String dataLinkName, Map<String, String> options, boolean stream) {
+    Map<String, DocumentField> readFields(String[] externalNames,
+                                          String dataLinkName,
+                                          Map<String, String> options,
+                                          boolean stream) {
         String collectionName = externalNames[0]; // TODO HZ-2260
         Map<String, DocumentField> fields = new HashMap<>();
         Tuple2<MongoClient, MongoDataLink> connect = connect(dataLinkName, options);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
@@ -71,8 +71,8 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    ) {
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName) {
         if (externalName.length > 2) {
             throw QueryException.error("Invalid external name " + quoteCompoundIdentifier(externalName)
                     + ", external name for Mongo is allowed to have only one component (collection)"
@@ -92,8 +92,8 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
     @Nonnull
     @Override
     public Table createTable(@Nonnull NodeEngine nodeEngine, @Nonnull String schemaName, @Nonnull String mappingName,
-                             @Nonnull String[] externalName, @Nonnull Map<String, String> options,
-                             @Nonnull List<MappingField> resolvedFields) {
+                             @Nonnull String[] externalName, @Nullable String dataLinkName,
+                             @Nonnull Map<String, String> options, @Nonnull List<MappingField> resolvedFields) {
         String collectionName = externalName[0];
         FieldResolver fieldResolver = new FieldResolver(nodeEngine);
         String databaseName = Options.getDatabaseName(nodeEngine, options);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
@@ -79,7 +79,7 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
                     + " or two components (database and collection)");
         }
         FieldResolver fieldResolver = new FieldResolver(nodeEngine);
-        return fieldResolver.resolveFields(externalName, options, userFields, isStream());
+        return fieldResolver.resolveFields(externalName, dataLinkName, options, userFields, isStream());
     }
 
     @Nonnull
@@ -94,9 +94,9 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
     public Table createTable(@Nonnull NodeEngine nodeEngine, @Nonnull String schemaName, @Nonnull String mappingName,
                              @Nonnull String[] externalName, @Nullable String dataLinkName,
                              @Nonnull Map<String, String> options, @Nonnull List<MappingField> resolvedFields) {
-        String collectionName = externalName[0];
+        String collectionName = externalName[0]; // TODO HZ-2260
         FieldResolver fieldResolver = new FieldResolver(nodeEngine);
-        String databaseName = Options.getDatabaseName(nodeEngine, options);
+        String databaseName = Options.getDatabaseName(nodeEngine, dataLinkName, options);
         ConstantTableStatistics stats = new ConstantTableStatistics(0);
 
         List<TableField> fields = new ArrayList<>(resolvedFields.size());
@@ -129,7 +129,7 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
                         "DOCUMENT", !hasPK));
             }
         }
-        return new MongoTable(schemaName, mappingName, databaseName, collectionName, options, this,
+        return new MongoTable(schemaName, mappingName, databaseName, collectionName, dataLinkName, options, this,
                 fields, stats, isStreaming);
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoTable.java
@@ -55,6 +55,7 @@ class MongoTable extends JetTable {
             @Nonnull String name,
             @Nonnull String databaseName,
             @Nullable String collectionName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
             @Nonnull SqlConnector sqlConnector,
             @Nonnull List<TableField> fields,
@@ -65,7 +66,7 @@ class MongoTable extends JetTable {
         this.collectionName = collectionName;
         this.options = options;
         this.connectionString = options.get(Options.CONNECTION_STRING_OPTION);
-        this.dataLinkName = options.get(Options.DATA_LINK_REF_OPTION);
+        this.dataLinkName = dataLinkName;
         this.streaming = streaming;
 
         this.externalNames = getFields().stream()

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
@@ -31,7 +31,6 @@ import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 
 final class Options {
 
-    static final String DATA_LINK_REF_OPTION = "data-link-name";
     static final String CONNECTION_STRING_OPTION = "connectionString";
     static final String DATABASE_NAME_OPTION = "database";
     static final String START_AT_OPTION = "startAt";
@@ -63,14 +62,14 @@ final class Options {
         }
     }
 
-    static String getDatabaseName(NodeEngine nodeEngine, Map<String, String> options) {
+    static String getDatabaseName(NodeEngine nodeEngine, String dataLinkName, Map<String, String> options) {
         String name = options.get(Options.DATABASE_NAME_OPTION);
         if (name != null) {
             return name;
         }
-        if (options.containsKey(DATA_LINK_REF_OPTION)) {
+        if (dataLinkName != null) {
             MongoDataLink link =
-                    nodeEngine.getDataLinkService().getAndRetainDataLink(options.get(DATA_LINK_REF_OPTION), MongoDataLink.class);
+                    nodeEngine.getDataLinkService().getAndRetainDataLink(dataLinkName, MongoDataLink.class);
             try {
                 name = link.getDatabaseName();
                 if (name != null) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
@@ -154,7 +154,8 @@ public class TableResolverImpl implements TableResolver {
                 nodeEngine,
                 options,
                 mapping.fields(),
-                mapping.externalName()
+                mapping.externalName(),
+                mapping.dataLink()
         );
 
         return new Mapping(
@@ -314,7 +315,7 @@ public class TableResolverImpl implements TableResolver {
                     SCHEMA_NAME_PUBLIC,
                     mapping.name(),
                     mapping.externalName(),
-                    mapping.options(),
+                    mapping.dataLink(), mapping.options(),
                     mapping.fields()
             );
         } catch (Throwable e) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
@@ -19,8 +19,8 @@ package com.hazelcast.jet.sql.impl.schema;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.datalink.DataLink;
-import com.hazelcast.datalink.impl.JdbcDataLink;
 import com.hazelcast.datalink.impl.InternalDataLinkService;
+import com.hazelcast.datalink.impl.JdbcDataLink;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.jet.sql.impl.connector.SqlConnectorCache;
@@ -173,9 +173,12 @@ public class TableResolverImpl implements TableResolver {
         InternalDataLinkService dataLinkService = nodeEngine.getDataLinkService();
         DataLink dl = dataLinkService.getAndRetainDataLink(dataLink, DataLink.class);
         try {
+            String simpleName = dl.getClass().getSimpleName();
             // TODO: support more
             if (dl instanceof JdbcDataLink) {
                 connector = connectorCache.forType("JDBC");
+            } else if (simpleName.equals("MongoDataLink")) {
+                connector = connectorCache.forType("MongoDB");
             } else {
                 throw QueryException.error("Unknown data link class: " + dl.getClass().getName());
             }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
@@ -18,9 +18,7 @@ package com.hazelcast.jet.sql.impl.schema;
 
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.datalink.DataLink;
 import com.hazelcast.datalink.impl.InternalDataLinkService;
-import com.hazelcast.datalink.impl.JdbcDataLink;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.jet.sql.impl.connector.SqlConnectorCache;
@@ -169,23 +167,11 @@ public class TableResolverImpl implements TableResolver {
     }
 
     private SqlConnector extractConnector(@Nonnull String dataLink) {
-        SqlConnector connector;
         InternalDataLinkService dataLinkService = nodeEngine.getDataLinkService();
-        DataLink dl = dataLinkService.getAndRetainDataLink(dataLink, DataLink.class);
-        try {
-            String simpleName = dl.getClass().getSimpleName();
-            // TODO: support more
-            if (dl instanceof JdbcDataLink) {
-                connector = connectorCache.forType("JDBC");
-            } else if (simpleName.equals("MongoDataLink")) {
-                connector = connectorCache.forType("MongoDB");
-            } else {
-                throw QueryException.error("Unknown data link class: " + dl.getClass().getName());
-            }
-        } finally {
-            dl.release();
-        }
-        return connector;
+        // TODO atm data link and connector types match, but that's
+        // not going to be universally true in the future
+        String type = dataLinkService.typeForDataLink(dataLink);
+        return connectorCache.forType(type);
     }
 
     public void removeMapping(String name, boolean ifExists) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/AllTypesInsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/AllTypesInsertJdbcSqlConnectorTest.java
@@ -39,7 +39,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static java.util.Arrays.asList;
 
 @RunWith(HazelcastParametrizedRunner.class)
@@ -101,10 +100,7 @@ public class AllTypesInsertJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                 + "id INT, "
                 + "table_column " + mappingType
                 + ") "
-                + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                + ")"
+                + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("INSERT INTO " + mappingName + " VALUES(0, " + sqlValue + ")");

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/AllTypesSelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/AllTypesSelectJdbcSqlConnectorTest.java
@@ -36,7 +36,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static java.util.Arrays.asList;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -96,10 +95,7 @@ public class AllTypesSelectJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                 + " ("
                 + "table_column " + mappingType
                 + ") "
-                + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                + ")"
+                + "DATA LINK " + TEST_DATABASE_REF
         );
 
         assertRowsAnyOrder("SELECT * FROM " + mappingName, new Row(expected));

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DeleteJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DeleteJdbcSqlConnectorTest.java
@@ -21,8 +21,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
-
 public class DeleteJdbcSqlConnectorTest extends JdbcSqlTestSupport {
 
     private String tableName;
@@ -68,10 +66,7 @@ public class DeleteJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " person_id INT EXTERNAL NAME id, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("DELETE FROM " + tableName + " WHERE person_id = 0");
@@ -89,6 +84,7 @@ public class DeleteJdbcSqlConnectorTest extends JdbcSqlTestSupport {
 
         assertJdbcRowsAnyOrder(tableName, new Row(1, "name-1"));
     }
+
     @Test
     public void deleteFromTableWhereOnNonPKColumnWithExternalNme() throws Exception {
         createTable(tableName);
@@ -98,10 +94,7 @@ public class DeleteJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " fullName VARCHAR EXTERNAL NAME name "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("DELETE FROM " + tableName + " WHERE fullName = 'name-0'");
@@ -134,10 +127,7 @@ public class DeleteJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id2 INT, "
                         + " name VARCHAR"
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("DELETE FROM " + tableName + " WHERE id = 0 AND id2 = 1");
@@ -158,10 +148,7 @@ public class DeleteJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " name VARCHAR, "
                         + " id INT "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("DELETE FROM " + tableName + " WHERE id = 0");
@@ -177,11 +164,7 @@ public class DeleteJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         insertItems(tableName, 1);
 
         execute(
-                "CREATE MAPPING " + tableName
-                        + " TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + " OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                "CREATE MAPPING " + tableName + " DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("DELETE FROM " + tableName + " WHERE \"person-id\" = 0");

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/InsertJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/InsertJdbcSqlConnectorTest.java
@@ -23,13 +23,11 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class InsertJdbcSqlConnectorTest extends JdbcSqlTestSupport {
 
     private String tableName;
-    private String alternativeSchemaTable;
 
     @BeforeClass
     public static void beforeClass() {
@@ -41,7 +39,6 @@ public class InsertJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         tableName = randomTableName();
         String schemaName = randomName();
         executeJdbc("CREATE SCHEMA " + schemaName);
-        alternativeSchemaTable = schemaName + "." + tableName;
     }
 
     @Test
@@ -73,10 +70,7 @@ public class InsertJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " fullName VARCHAR EXTERNAL NAME name"
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("INSERT INTO " + tableName + " VALUES (0, 'name-0')");
@@ -105,10 +99,7 @@ public class InsertJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " fullName VARCHAR EXTERNAL NAME name"
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("INSERT INTO " + tableName + " (fullName, id) VALUES ('name-0', 0), ('name-1', 1)");
@@ -156,11 +147,7 @@ public class InsertJdbcSqlConnectorTest extends JdbcSqlTestSupport {
     public void insertIntoTableReverseColumnOrder() throws Exception {
         createTable(tableName, "id INT PRIMARY KEY", "name VARCHAR(10)");
         execute(
-                "CREATE MAPPING " + tableName
-                        + " TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + " OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                "CREATE MAPPING " + tableName + " DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("INSERT INTO " + tableName + " (name, id) VALUES ('name-0', 0)");

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcIMapTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcIMapTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JdbcIMapTest extends JdbcSqlTestSupport {
@@ -34,7 +33,7 @@ public class JdbcIMapTest extends JdbcSqlTestSupport {
     }
 
     @Test
-    public void InsertIntoIMapSelectFromJdbc() throws Exception {
+    public void insertIntoIMapSelectFromJdbc() throws Exception {
         String tableName = randomTableName();
         createTable(tableName);
         insertItems(tableName, 5);
@@ -44,10 +43,7 @@ public class JdbcIMapTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute(

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcJoinTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import java.sql.SQLException;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -49,10 +48,7 @@ public class JdbcJoinTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
     }
 
@@ -67,10 +63,7 @@ public class JdbcJoinTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         assertThatThrownBy(() ->
@@ -92,10 +85,7 @@ public class JdbcJoinTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         assertRowsAnyOrder(
@@ -125,10 +115,7 @@ public class JdbcJoinTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         assertRowsAnyOrder(
@@ -158,10 +145,7 @@ public class JdbcJoinTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         assertRowsAnyOrder(

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnectorBounceTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnectorBounceTest.java
@@ -39,7 +39,6 @@ import java.util.Properties;
 
 import static com.hazelcast.jet.sql.SqlTestSupport.assertRowsAnyOrder;
 import static com.hazelcast.jet.sql.SqlTestSupport.randomName;
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -88,10 +87,8 @@ public class JdbcSqlConnectorBounceTest {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
+                        + "DATA LINK " + TEST_DATABASE_REF
                         + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
         );
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnectorStabilityTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnectorStabilityTest.java
@@ -24,7 +24,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.hazelcast.function.ConsumerEx.noop;
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -50,10 +49,7 @@ public class JdbcSqlConnectorStabilityTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlTestSupport.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public abstract class JdbcSqlTestSupport extends SqlTestSupport {
 
-    protected static final String TEST_DATABASE_REF = "test-database-ref";
+    protected static final String TEST_DATABASE_REF = "testDatabaseRef";
 
     protected static TestDatabaseProvider databaseProvider;
 
@@ -146,10 +145,7 @@ public abstract class JdbcSqlTestSupport extends SqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
     }
 
@@ -161,19 +157,13 @@ public abstract class JdbcSqlTestSupport extends SqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
     }
 
     protected static void createJdbcMappingUsingDataLink(String name, String dataLink) {
         try (SqlResult result = instance().getSql().execute("CREATE OR REPLACE MAPPING " + name +
                 " DATA LINK " + quoteName(dataLink) + "\n"
-                + "OPTIONS ( "
-                + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                + ")"
         )) {
             assertThat(result.updateCount()).isEqualTo(0);
         }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/MappingJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/MappingJdbcSqlConnectorTest.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -89,10 +88,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                 "  \"id\" INTEGER," + LE +
                 "  \"name\" VARCHAR" + LE +
                 ")" + LE +
-                "TYPE \"JDBC\"" + LE +
-                "OPTIONS (" + LE +
-                "  'data-link-name'='test-database-ref'" + LE +
-                ")";
+                "DATA LINK \"testDatabaseRef\"";
         assertRowsAnyOrder("SELECT GET_DDL('relation', '" + mappingName + "')",
                 ImmutableList.of(new Row(expectedMappingQuery)));
     }
@@ -108,7 +104,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "DATA LINK " + TEST_DATABASE_REF
                 )
         ).isInstanceOf(HazelcastSqlException.class)
          .hasMessageContaining("Invalid external name \"aaaa\".\"bbbb\".\"cccc\".\"dddd\"");
@@ -125,14 +121,14 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "DATA LINK " + TEST_DATABASE_REF
                 )
         ).isInstanceOf(HazelcastSqlException.class)
          .hasMessageContaining("Invalid external name \"aaaa\".\"bbbb\".\"cccc\".\"dddd\"");
     }
 
     @Test
-    public void createMappingWithoutDataLinkRef() {
+    public void createMappingWithoutDataLink() {
         tableName = randomTableName();
 
         assertThatThrownBy(() ->
@@ -142,10 +138,10 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
+                        + "TYPE " + JdbcSqlConnector.TYPE_NAME
                 )
         ).isInstanceOf(HazelcastSqlException.class)
-         .hasMessageContaining("Missing option: 'data-link-name' must be set");
+         .hasMessageContaining("You must provide data link when using the Jdbc connector");
     }
 
     @Test
@@ -156,10 +152,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         ))
                 .isInstanceOf(HazelcastSqlException.class);
 
@@ -188,10 +181,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                 + " id INT, "
                 + " fullName VARCHAR EXTERNAL NAME name "
                 + ") "
-                + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                + ")"
+                + "DATA LINK " + TEST_DATABASE_REF
         );
 
         assertRowsAnyOrder("SHOW MAPPINGS",
@@ -215,10 +205,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " fullName VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
                 )
         ).isInstanceOf(HazelcastSqlException.class)
          .hasMessageContaining("Could not resolve field with name fullName");
@@ -243,10 +230,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " fullName VARCHAR EXTERNAL NAME myName "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
                 )
         ).isInstanceOf(HazelcastSqlException.class)
          .hasMessageContaining("Could not resolve field with external name myName");
@@ -266,10 +250,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id BOOLEAN, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
                 )
         ).isInstanceOf(HazelcastSqlException.class)
          .hasMessageContaining("Type BOOLEAN of field id does not match db type INTEGER");
@@ -285,10 +266,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         insertItems(tableName, 2);
 
         execute("CREATE MAPPING " + tableName
-                + " TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                + " OPTIONS ( "
-                + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                + ")"
+                + " DATA LINK " + TEST_DATABASE_REF
         );
 
         // If you change LinkedHashMap -> HashMap at JdbcSqlConnector:159, it will fail.
@@ -325,10 +303,7 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         createTable(tableName);
 
         execute("CREATE MAPPING " + tableName
-                + " TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                + ")"
+                + " DATA LINK " + TEST_DATABASE_REF
         );
 
         try (SqlResult result = sqlService.execute("SELECT * FROM " + tableName)) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SchemaJdbcConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SchemaJdbcConnectorTest.java
@@ -33,7 +33,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static org.assertj.core.util.Lists.newArrayList;
 
 @RunWith(HazelcastParametrizedRunner.class)
@@ -120,10 +119,7 @@ public class SchemaJdbcConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SelectJdbcSqlConnectorTest.java
@@ -21,7 +21,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -47,10 +46,7 @@ public class SelectJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
     }
 
@@ -120,10 +116,7 @@ public class SelectJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " fullName VARCHAR EXTERNAL NAME name"
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         assertRowsAnyOrder(
@@ -159,10 +152,7 @@ public class SelectJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " fullName VARCHAR EXTERNAL NAME name"
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         assertRowsAnyOrder(
@@ -195,10 +185,7 @@ public class SelectJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         assertRowsAnyOrder(

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SinkJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/SinkJdbcSqlConnectorTest.java
@@ -21,8 +21,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
-
 public class SinkJdbcSqlConnectorTest extends JdbcSqlTestSupport {
 
     private String tableName;
@@ -66,10 +64,7 @@ public class SinkJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " fullName VARCHAR EXTERNAL NAME name"
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("SINK INTO " + tableName + " VALUES (0, 'name-0')");
@@ -98,10 +93,7 @@ public class SinkJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " fullName VARCHAR EXTERNAL NAME name"
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("SINK INTO " + tableName + " (fullName, id) VALUES ('name-0', 0), ('name-1', 1)");
@@ -132,13 +124,7 @@ public class SinkJdbcSqlConnectorTest extends JdbcSqlTestSupport {
     @Test
     public void sinkIntoTableReverseColumnOrder() throws Exception {
         createTable(tableName, "id INT PRIMARY KEY", "name VARCHAR(10)");
-        execute(
-                "CREATE MAPPING " + tableName
-                        + " TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + " OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
-        );
+        execute("CREATE MAPPING " + tableName + " DATA LINK " + TEST_DATABASE_REF);
 
         execute("SINK INTO " + tableName + " (name, id) VALUES ('name-0', 0)");
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/UpdateJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/UpdateJdbcSqlConnectorTest.java
@@ -21,8 +21,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static com.hazelcast.jet.sql.impl.connector.jdbc.JdbcSqlConnector.OPTION_DATA_LINK_NAME;
-
 public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
 
     private String tableName;
@@ -46,10 +44,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET name = 'updated'");
@@ -69,10 +64,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET name = 'updated' WHERE id=0");
@@ -92,10 +84,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET name = 'updated' WHERE id = ?", 0);
@@ -115,10 +104,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET name = 'updated' WHERE name='name-0'");
@@ -138,10 +124,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " person_id INT EXTERNAL NAME id, "
                         + " name VARCHAR"
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET name = 'updated' WHERE person_id = 0");
@@ -161,10 +144,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " fullName VARCHAR EXTERNAL NAME name"
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET fullName = 'updated' WHERE id = 0");
@@ -184,10 +164,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET name = 'updated-'||id");
@@ -207,10 +184,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id INT, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET name = ?", "updated");
@@ -229,10 +203,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " person_id INT EXTERNAL NAME id, "
                         + " name VARCHAR "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET name = 'updated-'||person_id");
@@ -254,10 +225,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " fullName VARCHAR EXTERNAL NAME name,"
                         + " age INT "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET age = 42 WHERE fullName='name-0'");
@@ -279,10 +247,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " name VARCHAR,"
                         + " age INT "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET age = ? WHERE name = ?", 42, "name-0");
@@ -304,10 +269,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " name VARCHAR,"
                         + " age INT "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET age = ?, name = ? WHERE id = ?", 42, "updated", 0);
@@ -346,10 +308,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " id2 INT, "
                         + " name VARCHAR"
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET name = 'updated' WHERE id = 0 AND id2 = 1");
@@ -371,10 +330,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
                         + " name VARCHAR, "
                         + " id INT "
                         + ") "
-                        + "TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
+                        + "DATA LINK " + TEST_DATABASE_REF
         );
 
         execute("UPDATE " + tableName + " SET name = 'updated' WHERE id = 0");
@@ -390,13 +346,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         createTable(tableName);
         insertItems(tableName, 1);
 
-        execute(
-                "CREATE MAPPING " + tableName
-                        + " TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + " OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
-        );
+        execute("CREATE MAPPING " + tableName + " DATA LINK " + TEST_DATABASE_REF);
 
         execute("UPDATE " + tableName + " SET name = 'updated' WHERE id = 0");
         assertJdbcRowsAnyOrder(tableName,
@@ -409,13 +359,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         createTable(tableName, "\"person-id\" INT PRIMARY KEY", "name VARCHAR(100)");
         insertItems(tableName, 1);
 
-        execute(
-                "CREATE MAPPING " + tableName
-                        + " TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + " OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
-        );
+        execute("CREATE MAPPING " + tableName + " DATA LINK " + TEST_DATABASE_REF);
 
         execute("UPDATE " + tableName + " SET name = 'updated' WHERE \"person-id\" = 0");
         assertJdbcRowsAnyOrder(tableName,
@@ -428,13 +372,7 @@ public class UpdateJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         createTable(tableName, "id INT PRIMARY KEY", "\"full-name\" VARCHAR(100)");
         insertItems(tableName, 1);
 
-        execute(
-                "CREATE MAPPING " + tableName
-                        + " TYPE " + JdbcSqlConnector.TYPE_NAME + ' '
-                        + " OPTIONS ( "
-                        + " '" + OPTION_DATA_LINK_NAME + "'='" + TEST_DATABASE_REF + "'"
-                        + ")"
-        );
+        execute("CREATE MAPPING " + tableName + " DATA LINK " + TEST_DATABASE_REF);
 
         execute("UPDATE " + tableName + " SET \"full-name\" = 'updated' WHERE id = 0");
         assertJdbcRowsAnyOrder(tableName,

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolverTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolverTest.java
@@ -103,7 +103,7 @@ public class FieldResolverTest {
             Map<String, String> readOpts = new HashMap<>();
             readOpts.put("connectionString", mongoContainer.getConnectionString());
             readOpts.put("database", databaseName);
-            Map<String, DocumentField> fields = resolver.readFields(new String[]{collectionName}, readOpts, false);
+            Map<String, DocumentField> fields = resolver.readFields(new String[]{collectionName}, null, readOpts, false);
             assertThat(fields).containsOnlyKeys("firstName", "lastName", "birthYear", "title", "unionType", "intOrString");
             assertThat(fields.get("lastName").columnType).isEqualTo(BsonType.STRING);
             assertThat(fields.get("birthYear").columnType).isEqualTo(BsonType.INT32);
@@ -134,7 +134,7 @@ public class FieldResolverTest {
             Map<String, String> readOpts = new HashMap<>();
             readOpts.put("connectionString", mongoContainer.getConnectionString());
             readOpts.put("database", databaseName);
-            Map<String, DocumentField> fields = resolver.readFields(new String[]{collectionName}, readOpts, false);
+            Map<String, DocumentField> fields = resolver.readFields(new String[]{collectionName}, null, readOpts, false);
             assertThat(fields).containsOnlyKeys("_id", "firstName", "lastName", "birthYear", "citizenship",
                     "citizenshipButList");
             assertThat(fields.get("lastName").columnType).isEqualTo(BsonType.STRING);
@@ -161,7 +161,7 @@ public class FieldResolverTest {
             Map<String, String> readOpts = new HashMap<>();
             readOpts.put("connectionString", mongoContainer.getConnectionString());
             readOpts.put("database", databaseName);
-            List<MappingField> fields = resolver.resolveFields(new String[]{collectionName}, readOpts, Collections.emptyList(), false);
+            List<MappingField> fields = resolver.resolveFields(new String[]{collectionName}, null, readOpts, Collections.emptyList(), false);
             assertThat(fields).contains(
                     fieldWithSameExternal("_id", OBJECT, BsonType.OBJECT_ID).setPrimaryKey(true),
                     fieldWithSameExternal("firstName", VARCHAR, BsonType.STRING),
@@ -188,7 +188,7 @@ public class FieldResolverTest {
             Map<String, String> readOpts = new HashMap<>();
             readOpts.put("connectionString", mongoContainer.getConnectionString());
             readOpts.put("database", databaseName);
-            List<MappingField> fields = resolver.resolveFields(new String[]{collectionName}, readOpts, Collections.emptyList(), true);
+            List<MappingField> fields = resolver.resolveFields(new String[]{collectionName}, null, readOpts, Collections.emptyList(), true);
             assertThat(fields).contains(
                     fieldWithSameExternal("resumeToken", VARCHAR, BsonType.STRING),
                     fieldWithSameExternal("operationType", VARCHAR, BsonType.STRING),
@@ -221,7 +221,7 @@ public class FieldResolverTest {
             Map<String, String> readOpts = new HashMap<>();
             readOpts.put("connectionString", mongoContainer.getConnectionString());
             readOpts.put("database", databaseName);
-            List<MappingField> fields = resolver.resolveFields(new String[]{collectionName}, readOpts, Arrays.asList(
+            List<MappingField> fields = resolver.resolveFields(new String[]{collectionName}, null, readOpts, Arrays.asList(
                     new MappingField("id", OBJECT).setExternalName("_id"),
                     new MappingField("birthYear", QueryDataType.BIGINT)
             ), false);
@@ -251,7 +251,7 @@ public class FieldResolverTest {
             readOpts.put("connectionString", mongoContainer.getConnectionString());
             readOpts.put("database", databaseName);
             try {
-                resolver.resolveFields(new String[]{collectionName}, readOpts, singletonList(
+                resolver.resolveFields(new String[]{collectionName}, null, readOpts, singletonList(
                         new MappingField("id", QueryDataType.MAP).setExternalName("_id")
                 ), false);
             } catch (IllegalStateException e) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoBatchSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoBatchSqlConnectorTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.jet.sql.impl.connector.mongodb;
 
-import com.hazelcast.config.DataLinkConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.logging.LogListener;
 import com.hazelcast.map.IMap;

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlTest.java
@@ -15,6 +15,8 @@
  */
 package com.hazelcast.jet.sql.impl.connector.mongodb;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.config.DataLinkConfig;
 import com.hazelcast.jet.sql.SqlTestSupport;
 import com.hazelcast.sql.SqlService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -46,6 +48,7 @@ public abstract class MongoSqlTest extends SqlTestSupport {
     protected static MongoDatabase database;
     protected static String databaseName;
     protected static String collectionName;
+    private static String connectionString;
 
     @Rule
     public final TestName testName = new TestName();
@@ -54,11 +57,23 @@ public abstract class MongoSqlTest extends SqlTestSupport {
     public static void beforeClass() throws InterruptedException {
         assumeDockerEnabled();
         mongoContainer.start();
-
-        initialize(2, null);
-        sqlService = instance().getSql();
-        mongoClient = MongoClients.create(mongoContainer.getConnectionString());
+        connectionString = mongoContainer.getConnectionString();
         databaseName = randomName();
+
+        Config conf = new Config();
+        conf.getJetConfig().setEnabled(true);
+        DataLinkConfig testMongo = new DataLinkConfig();
+        testMongo.setShared(true)
+                 .setType("MongoDB")
+                 .setName("testMongo")
+                 .setProperty("connectionString", connectionString)
+                 .setProperty("database", databaseName);
+        conf.addDataLinkConfig(testMongo);
+        initialize(2, conf);
+
+        sqlService = instance().getSql();
+
+        mongoClient = MongoClients.create(connectionString);
         database = mongoClient.getDatabase(databaseName);
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAbstractSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAbstractSqlConnector.java
@@ -114,8 +114,8 @@ public abstract class TestAbstractSqlConnector implements SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    ) {
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName) {
         if (userFields.size() > 0) {
             throw QueryException.error("Don't specify external fields, they are fixed");
         }
@@ -139,9 +139,9 @@ public abstract class TestAbstractSqlConnector implements SqlConnector {
             @Nonnull String schemaName,
             @Nonnull String mappingName,
             @Nonnull String[] externalName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> resolvedFields
-    ) {
+            @Nonnull List<MappingField> resolvedFields) {
         String[] names = options.get(OPTION_NAMES).split(DELIMITER);
         String[] types = options.get(OPTION_TYPES).split(DELIMITER);
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAllTypesSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAllTypesSqlConnector.java
@@ -124,8 +124,8 @@ public class TestAllTypesSqlConnector implements SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    ) {
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName) {
         if (userFields.size() > 0) {
             throw QueryException.error("Don't specify external fields, they are fixed");
         }
@@ -138,9 +138,9 @@ public class TestAllTypesSqlConnector implements SqlConnector {
             @Nonnull String schemaName,
             @Nonnull String mappingName,
             @Nonnull String[] externalName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> resolvedFields
-    ) {
+            @Nonnull List<MappingField> resolvedFields) {
         return new TestAllTypesTable(this, schemaName, mappingName);
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestFailingSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestFailingSqlConnector.java
@@ -67,8 +67,8 @@ public class TestFailingSqlConnector implements SqlConnector {
             @Nonnull NodeEngine nodeEngine,
             @Nonnull Map<String, String> options,
             @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName
-    ) {
+            @Nonnull String[] externalName,
+            @Nullable String dataLinkName) {
         if (userFields.size() > 0) {
             throw QueryException.error("Don't specify external fields, they are fixed");
         }
@@ -81,9 +81,9 @@ public class TestFailingSqlConnector implements SqlConnector {
             @Nonnull String schemaName,
             @Nonnull String mappingName,
             @Nonnull String[] externalName,
+            @Nullable String dataLinkName,
             @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> resolvedFields
-    ) {
+            @Nonnull List<MappingField> resolvedFields) {
         return new TestFailingTable(
                 this,
                 schemaName,

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/SqlMappingTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/SqlMappingTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 
 import static com.hazelcast.function.ConsumerEx.noop;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -59,12 +58,14 @@ public class SqlMappingTest extends SqlTestSupport {
                 .isInstanceOf(HazelcastSqlException.class)
                 .hasFieldOrPropertyWithValue("code", SqlErrorCode.OBJECT_NOT_FOUND)
                 .hasFieldOrPropertyWithValue("suggestion", null)
-                .hasMessageContaining("Object 'map' not found within 'hazelcast.public', did you forget to CREATE MAPPING?");
+                .hasMessageContaining("Object 'map' not found within 'hazelcast.public', did you forget to CREATE " +
+                        "MAPPING?");
         assertThatThrownBy(() -> client().getSql().execute("SELECT * FROM hazelcast.public.map").forEach(noop()))
                 .isInstanceOf(HazelcastSqlException.class)
                 .hasFieldOrPropertyWithValue("code", SqlErrorCode.OBJECT_NOT_FOUND)
                 .hasFieldOrPropertyWithValue("suggestion", null)
-                .hasMessageContaining("Object 'map' not found within 'hazelcast.public', did you forget to CREATE MAPPING?");
+                .hasMessageContaining("Object 'map' not found within 'hazelcast.public', did you forget to CREATE " +
+                        "MAPPING?");
     }
 
     @Test
@@ -163,18 +164,6 @@ public class SqlMappingTest extends SqlTestSupport {
                         " DATA LINK " + dlName + "\nOPTIONS ()"))
                 .isInstanceOf(HazelcastSqlException.class)
                 .hasMessageContaining("Data link '" + dlName + "' not found");
-    }
-
-    @Test
-    public void when_dataLinkUnknown_then_fail() {
-        String dlName = randomName();
-        String mappingName = randomName();
-        createDataLink(instance(), dlName, "DUMMY", false, emptyMap());
-        assertThatThrownBy(() ->
-                instance().getSql().execute("CREATE OR REPLACE MAPPING " + mappingName +
-                        " DATA LINK " + dlName + "\nOPTIONS ()"))
-                .isInstanceOf(HazelcastSqlException.class)
-                .hasMessageContaining("Unknown data link class: ");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TableResolverImplTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TableResolverImplTest.java
@@ -98,7 +98,8 @@ public class TableResolverImplTest {
         Mapping mapping = mapping();
 
         given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
-        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(), mapping.externalName()))
+        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
+                mapping.externalName(), mapping.dataLink()))
                 .willThrow(new RuntimeException("expected test exception"));
 
         // when
@@ -116,7 +117,8 @@ public class TableResolverImplTest {
         Mapping mapping = mapping();
 
         given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
-        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(), mapping.externalName()))
+        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
+                mapping.externalName(), mapping.dataLink()))
                 .willReturn(singletonList(new MappingField("field_name", INT)));
         given(relationsStorage.putIfAbsent(eq(mapping.name()), isA(Mapping.class))).willReturn(false);
 
@@ -134,7 +136,8 @@ public class TableResolverImplTest {
         Mapping mapping = mapping();
 
         given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
-        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(), mapping.externalName()))
+        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
+                mapping.externalName(), mapping.dataLink()))
                 .willReturn(singletonList(new MappingField("field_name", INT)));
         given(relationsStorage.putIfAbsent(eq(mapping.name()), isA(Mapping.class))).willReturn(false);
 
@@ -151,7 +154,8 @@ public class TableResolverImplTest {
         Mapping mapping = mapping();
 
         given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
-        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(), mapping.externalName()))
+        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
+                mapping.externalName(), mapping.dataLink()))
                 .willReturn(singletonList(new MappingField("field_name", INT)));
 
         // when

--- a/hazelcast/src/main/java/com/hazelcast/datalink/impl/DataLinkServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/datalink/impl/DataLinkServiceImpl.java
@@ -155,7 +155,7 @@ public class DataLinkServiceImpl implements InternalDataLinkService {
     public String typeForDataLink(String name) {
         DataLinkEntry dataLink = dataLinks.get(name);
         if (dataLink == null) {
-            throw new HazelcastException("DataLink with name '" + name + "' does not exist");
+            throw new HazelcastException("Data link '" + name + "' not found");
         }
         String type = dataLinkClassToType.get(dataLink.instance.getClass());
         if (type == null) {

--- a/hazelcast/src/test/java/com/hazelcast/datalink/impl/DataLinkServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/datalink/impl/DataLinkServiceImplTest.java
@@ -410,7 +410,7 @@ public class DataLinkServiceImplTest extends HazelcastTestSupport {
     public void type_for_data_link_should_throw_when_data_link_does_not_exist() {
         assertThatThrownBy(() -> dataLinkService.typeForDataLink("non-existing-data-link"))
                 .isInstanceOf(HazelcastException.class)
-                .hasMessage("DataLink with name 'non-existing-data-link' does not exist");
+                .hasMessage("Data link 'non-existing-data-link' not found");
     }
 
     private InternalDataLinkService getDataLinkService() {


### PR DESCRIPTION
Fixes #24100 / HZ-2210


Breaking changes (list specific methods/types/messages):
* added dataLinkName parameter to `resolveAndValidateFields` and `createTable` in SqlConnector interface

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
