### PR TITLE
Add projection function to Kafka Connect sources [HZ-2261]

### DIFF
--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/KafkaConnectSources.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/KafkaConnectSources.java
@@ -62,7 +62,7 @@ public final class KafkaConnectSources {
      * <p>
      * Hazelcast Jet will instantiate tasks on a random cluster member and use local parallelism for scaling.
      * Property <code>tasks.max</code> is not allowed. Use {@link StreamStage#setLocalParallelism(int)} in the pipeline
-     * instead.
+     * instead. This limitation can be changed in the future.
      *
      * @param properties   Kafka connect properties
      * @param projectionFn function to create output objects from the Kafka {@link SourceRecord}s.

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/KafkaConnectSources.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/KafkaConnectSources.java
@@ -69,6 +69,7 @@ public final class KafkaConnectSources {
      *                     If the projection returns a {@code null} for an item,
      *                     that item will be filtered out.
      * @return a source to use in {@link com.hazelcast.jet.pipeline.Pipeline#readFrom(StreamSource)}
+     * @since 5.3
      */
     @Nonnull
     @Beta
@@ -116,6 +117,7 @@ public final class KafkaConnectSources {
      *
      * @param properties Kafka connect properties
      * @return a source to use in {@link com.hazelcast.jet.pipeline.Pipeline#readFrom(StreamSource)}
+     * @since 5.3
      */
     @Nonnull
     @Beta

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/KafkaConnectSources.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/KafkaConnectSources.java
@@ -76,7 +76,7 @@ public final class KafkaConnectSources {
     @Beta
     public static StreamSource<SourceRecord> connect(@Nonnull Properties properties) {
         Preconditions.checkRequiredProperty(properties, "name");
-        String name = properties.getProperty("name");
+        String name = "kafkaConnectSource(" + properties.getProperty("name") + ")";
 
         //fail fast, required by lazy-initialized KafkaConnectSource
         checkRequiredProperty(properties, "connector.class");

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/KafkaConnectSources.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/KafkaConnectSources.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.kafka.connect;
 
 import com.hazelcast.function.FunctionEx;
-import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.jet.pipeline.StreamSource;
@@ -29,6 +28,7 @@ import javax.annotation.Nonnull;
 import java.net.URL;
 import java.util.Properties;
 
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkRequiredProperty;
 import static com.hazelcast.jet.kafka.connect.impl.ReadKafkaConnectP.processSupplier;
 
@@ -74,7 +74,9 @@ public final class KafkaConnectSources {
     @Beta
     public static <T> StreamSource<T> connect(@Nonnull Properties properties,
                                               @Nonnull FunctionEx<SourceRecord, T> projectionFn) {
-        Preconditions.checkRequiredProperty(properties, "name");
+        checkRequiredProperty(properties, "name");
+        checkNotNull(projectionFn, "projectionFn is required");
+
         String name = "kafkaConnectSource(" + properties.getProperty("name") + ")";
 
         //fail fast, required by lazy-initialized KafkaConnectSource

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
@@ -105,7 +105,9 @@ public class ReadKafkaConnectP<T> extends AbstractProcessor implements DynamicMe
             this.traverser = sourceRecords.isEmpty() ? eventTimeMapper.flatMapIdle() :
                     traverseIterable(sourceRecords)
                             .flatMap(rec -> {
-                                long eventTime = rec.timestamp() == null ? 0 : rec.timestamp();
+                                long eventTime = rec.timestamp() == null ?
+                                        EventTimeMapper.NO_NATIVE_TIME
+                                        : rec.timestamp();
                                 T projectedRecord = projectionFn.apply(rec);
                                 taskRunner.commitRecord(rec);
                                 return eventTimeMapper.flatMapEvent(projectedRecord, 0, eventTime);

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
@@ -108,9 +108,6 @@ public class ReadKafkaConnectP<T> extends AbstractProcessor implements DynamicMe
                                 long eventTime = rec.timestamp() == null ? 0 : rec.timestamp();
                                 T projectedRecord = projectionFn.apply(rec);
                                 taskRunner.commitRecord(rec);
-                                if (projectedRecord == null) {
-                                    return Traversers.empty();
-                                }
                                 return eventTimeMapper.flatMapEvent(projectedRecord, 0, eventTime);
                             })
                             .onFirstNull(() -> traverser = null);

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
@@ -46,6 +46,7 @@ import java.util.stream.IntStream;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.KAFKA_CONNECT_PREFIX;
 import static com.hazelcast.internal.metrics.impl.ProviderHelper.provide;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.jet.Traversers.traverseIterable;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.core.BroadcastKey.broadcastKey;
@@ -64,8 +65,12 @@ public class ReadKafkaConnectP<T> extends AbstractProcessor implements DynamicMe
     private Traverser<?> traverser;
     private final LocalKafkaConnectStatsImpl localKafkaConnectStats = new LocalKafkaConnectStatsImpl();
 
-    public ReadKafkaConnectP(ConnectorWrapper connectorWrapper, EventTimePolicy<? super SourceRecord> eventTimePolicy,
+    public ReadKafkaConnectP(@Nonnull ConnectorWrapper connectorWrapper,
+                             @Nonnull EventTimePolicy<? super SourceRecord> eventTimePolicy,
                              @Nonnull FunctionEx<SourceRecord, T> projectionFn) {
+        checkNotNull(connectorWrapper, "connectorWrapper is required");
+        checkNotNull(eventTimePolicy, "eventTimePolicy is required");
+        checkNotNull(projectionFn, "projectionFn is required");
         this.connectorWrapper = connectorWrapper;
         this.eventTimeMapper = new EventTimeMapper<>(eventTimePolicy);
         this.projectionFn = projectionFn;
@@ -188,7 +193,7 @@ public class ReadKafkaConnectP<T> extends AbstractProcessor implements DynamicMe
     }
 
     public static <T> ProcessorSupplier processSupplier(@Nonnull Properties properties,
-                                                        EventTimePolicy<? super T> eventTimePolicy,
+                                                        @Nonnull EventTimePolicy<? super T> eventTimePolicy,
                                                         @Nonnull FunctionEx<SourceRecord, T> projectionFn) {
         return new ProcessorSupplier() {
             private transient ConnectorWrapper connectorWrapper;

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectCouchbaseIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectCouchbaseIntegrationTest.java
@@ -36,7 +36,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
-import org.apache.kafka.connect.data.Values;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -114,11 +113,10 @@ public class KafkaConnectCouchbaseIntegrationTest extends JetTestSupport {
 
         insertDocuments("items-1");
 
-
         Pipeline pipeline = Pipeline.create();
-        StreamStage<Map<String, Object>> streamStage = pipeline.readFrom(KafkaConnectSources.connect(connectorProperties))
+        StreamStage<Map<String, Object>> streamStage = pipeline.readFrom(KafkaConnectSources.connect(connectorProperties,
+                        SourceRecordUtil::convertToString))
                 .withoutTimestamps()
-                .map(record -> Values.convertToString(record.valueSchema(), record.value()))
                 .map(base64 -> Base64.getDecoder().decode(base64))
                 .map(JsonUtil::mapFrom);
 

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
@@ -217,7 +217,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         }
     }
 
-    private static <T> List<T> getMBeanValues(ObjectName objectName, String attribute) throws Exception {
+    private static <T> List<T> getMBeanValues(ObjectName objectName, String attribute) {
         return (List<T>) getMBeans(objectName).stream().map(i -> getAttribute(i, attribute)).collect(toList());
     }
 
@@ -230,7 +230,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         }
     }
 
-    private static List<ObjectInstance> getMBeans(ObjectName objectName) throws Exception {
+    private static List<ObjectInstance> getMBeans(ObjectName objectName) {
         MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
         return new ArrayList<>(platformMBeanServer.queryMBeans(objectName, null));
     }

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
@@ -96,7 +96,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         randomProperties.setProperty("quickstart", "orders");
 
         Pipeline pipeline = Pipeline.create();
-        StreamStage<Order> streamStage = pipeline.readFrom(connect(randomProperties, Order::new))
+        StreamStage<SourceRecord> streamStage = pipeline.readFrom(connect(randomProperties))
                 .withoutTimestamps()
                 .setLocalParallelism(1);
         streamStage.writeTo(Sinks.logger());

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.jetbrains.annotations.NotNull;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -267,7 +268,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         return getMBeanValues(objectName, "sourceRecordPollTotalAvgTime");
     }
 
-    //    @Ignore // https://github.com/hazelcast/hazelcast/issues/24018
+    @Ignore // https://github.com/hazelcast/hazelcast/issues/24018
     @Test
     public void test_snapshotting() throws Exception {
         int localParallelism = 3;

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectJdbcIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectJdbcIntegrationTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
-import org.apache.kafka.connect.data.Values;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -109,9 +108,9 @@ public class KafkaConnectJdbcIntegrationTest extends JetTestSupport {
 
 
         Pipeline pipeline = Pipeline.create();
-        StreamStage<String> streamStage = pipeline.readFrom(KafkaConnectSources.connect(randomProperties))
-                .withoutTimestamps()
-                .map(record -> Values.convertToString(record.valueSchema(), record.value()));
+        StreamStage<String> streamStage = pipeline.readFrom(KafkaConnectSources.connect(randomProperties,
+                        SourceRecordUtil::convertToString))
+                .withoutTimestamps();
         streamStage.writeTo(Sinks.logger());
         streamStage
                 .writeTo(AssertionSinks.assertCollectedEventually(60,
@@ -154,10 +153,10 @@ public class KafkaConnectJdbcIntegrationTest extends JetTestSupport {
 
 
         Pipeline pipeline = Pipeline.create();
-        StreamStage<String> streamStage = pipeline.readFrom(KafkaConnectSources.connect(randomProperties))
+        StreamStage<String> streamStage = pipeline.readFrom(KafkaConnectSources.connect(randomProperties,
+                        SourceRecordUtil::convertToString))
                 .withoutTimestamps()
-                .setLocalParallelism(localParallelism)
-                .map(record -> Values.convertToString(record.valueSchema(), record.value()));
+                .setLocalParallelism(localParallelism);
         streamStage.writeTo(Sinks.logger());
         streamStage
                 .writeTo(AssertionSinks.assertCollectedEventually(60,
@@ -197,9 +196,9 @@ public class KafkaConnectJdbcIntegrationTest extends JetTestSupport {
         createTable(connectionUrl, "dynamic_test_items1");
 
         Pipeline pipeline = Pipeline.create();
-        StreamStage<String> streamStage = pipeline.readFrom(KafkaConnectSources.connect(randomProperties))
-                .withoutTimestamps()
-                .map(record -> Values.convertToString(record.valueSchema(), record.value()));
+        StreamStage<String> streamStage = pipeline.readFrom(KafkaConnectSources.connect(randomProperties,
+                        SourceRecordUtil::convertToString))
+                .withoutTimestamps();
         streamStage.writeTo(Sinks.logger());
         streamStage
                 .writeTo(AssertionSinks.assertCollectedEventually(60,

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectNeo4jIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectNeo4jIntegrationTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.SlowTest;
-import org.apache.kafka.connect.data.Values;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -105,10 +104,10 @@ public class KafkaConnectNeo4jIntegrationTest extends JetTestSupport {
         insertNodes("items-1");
 
         Pipeline pipeline = Pipeline.create();
-        StreamStage<String> streamStage = pipeline.readFrom(KafkaConnectSources.connect(connectorProperties))
+        StreamStage<String> streamStage = pipeline.readFrom(KafkaConnectSources.connect(connectorProperties,
+                        SourceRecordUtil::convertToString))
                 .withoutTimestamps()
-                .setLocalParallelism(2)
-                .map(record -> Values.convertToString(record.valueSchema(), record.value()));
+                .setLocalParallelism(2);
         streamStage.writeTo(Sinks.logger());
         streamStage
                 .writeTo(AssertionSinks.assertCollectedEventually(60,

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectSourcesTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectSourcesTest.java
@@ -44,6 +44,17 @@ public class KafkaConnectSourcesTest {
     }
 
     @Test
+    public void should_fail_when_no_projectionFn() {
+        Properties properties = new Properties();
+        properties.setProperty("name", "some-name");
+        properties.setProperty("connector.class", "some-name");
+        assertThatThrownBy(() -> connect(properties, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("projectionFn is required");
+    }
+
+
+    @Test
     public void should_fail_when_tasks_max_property_set() {
         Properties properties = new Properties();
         properties.setProperty("name", "some-name");

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectSourcesTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectSourcesTest.java
@@ -38,7 +38,7 @@ public class KafkaConnectSourcesTest {
     @Test
     public void should_fail_when_no_name_property() {
         Properties properties = new Properties();
-        assertThatThrownBy(() -> connect(properties))
+        assertThatThrownBy(() -> connect(properties, SourceRecordUtil::convertToString))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Property 'name' is required");
     }
@@ -49,7 +49,7 @@ public class KafkaConnectSourcesTest {
         properties.setProperty("name", "some-name");
         properties.setProperty("connector.class", "some-name");
         properties.setProperty("tasks.max", "1");
-        assertThatThrownBy(() -> connect(properties))
+        assertThatThrownBy(() -> connect(properties, SourceRecordUtil::convertToString))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Property 'tasks.max' not allowed. Use setLocalParallelism(1) in the pipeline instead");
     }
@@ -58,7 +58,7 @@ public class KafkaConnectSourcesTest {
     public void should_fail_when_no_connector_class_property() {
         Properties properties = new Properties();
         properties.setProperty("name", "some-name");
-        assertThatThrownBy(() -> connect(properties))
+        assertThatThrownBy(() -> connect(properties, SourceRecordUtil::convertToString))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Property 'connector.class' is required");
     }
@@ -68,7 +68,7 @@ public class KafkaConnectSourcesTest {
         Properties properties = new Properties();
         properties.setProperty("name", "some-name");
         properties.setProperty("connector.class", "some-name");
-        StreamSource<SourceRecord> source = connect(properties);
+        StreamSource<SourceRecord> source = connect(properties, rec -> rec);
         assertThat(source).isNotNull();
     }
 }

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/SourceRecordUtil.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/SourceRecordUtil.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.connect;
+
+import org.apache.kafka.connect.data.Values;
+import org.apache.kafka.connect.source.SourceRecord;
+
+public final class SourceRecordUtil {
+
+    private SourceRecordUtil() {
+    }
+
+    static String convertToString(SourceRecord rec) {
+        return Values.convertToString(rec.valueSchema(), rec.value());
+    }
+}

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectPTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectPTest.java
@@ -62,7 +62,7 @@ public class ReadKafkaConnectPTest extends HazelcastTestSupport {
     @Before
     public void setUp() {
         ConnectorWrapper connectorWrapper = new ConnectorWrapper(minimalProperties());
-        readKafkaConnectP = new ReadKafkaConnectP(connectorWrapper, noEventTime());
+        readKafkaConnectP = new ReadKafkaConnectP<>(connectorWrapper, noEventTime(), rec -> (Integer) rec.value());
         outbox = new TestOutbox(new int[]{10}, 10);
         context = new TestProcessorContext();
         hazelcastInstance = createHazelcastInstance(smallInstanceConfig());
@@ -76,7 +76,7 @@ public class ReadKafkaConnectPTest extends HazelcastTestSupport {
         boolean complete = readKafkaConnectP.complete();
 
         assertFalse(complete);
-        assertThat(new ArrayList<>(outbox.queue(0))).containsExactly(dummyRecord(0), dummyRecord(1), dummyRecord(2));
+        assertThat(new ArrayList<>(outbox.queue(0))).containsExactly(0, 1, 2);
     }
 
     @Test
@@ -105,7 +105,7 @@ public class ReadKafkaConnectPTest extends HazelcastTestSupport {
 
         readKafkaConnectP.complete();
 
-        assertThat(new ArrayList<>(outbox.queue(0))).containsExactly(dummyRecord(0), dummyRecord(1), dummyRecord(2));
+        assertThat(new ArrayList<>(outbox.queue(0))).containsExactly(0, 1, 2);
 
     }
 

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectPTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectPTest.java
@@ -89,7 +89,8 @@ public class ReadKafkaConnectPTest extends HazelcastTestSupport {
 
     @Test
     public void should_require_eventTimePolicy() {
-        assertThatThrownBy(() -> new ReadKafkaConnectP<>(new ConnectorWrapper(minimalProperties()), null, rec -> (Integer) rec.value()))
+        assertThatThrownBy(() -> new ReadKafkaConnectP<>(new ConnectorWrapper(minimalProperties()), null,
+                rec -> (Integer) rec.value()))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("eventTimePolicy is required");
     }


### PR DESCRIPTION
- Adds projection function to Kafka Connect sources since Kafka's `SourceRecord` is not serializable thus can't be stored in the HZ map
- Prefixed Kafka Connect source name with "kafkaConnectSource"
- Fixes support tor native timestamps 

Fixes https://hazelcast.atlassian.net/browse/HZ-2261
Fixes https://github.com/hazelcast/hazelcast/issues/24147
Fixes https://github.com/hazelcast/hazelcast/issues/24146

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
