### PR TITLE
Various fixes for updating job configuration [HZ-2253] [HZ-2264] [HZ-2271]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlAlterJob.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlAlterJob.java
@@ -36,9 +36,9 @@ import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import static com.hazelcast.jet.sql.impl.parse.ParserResource.RESOURCE;
+import static com.hazelcast.jet.sql.impl.parse.SqlCreateJob.parseLong;
 import static com.hazelcast.jet.sql.impl.parse.UnparseUtil.unparseOptions;
 import static java.util.Objects.requireNonNull;
 
@@ -122,18 +122,9 @@ public class SqlAlterJob extends SqlAlter {
                 throw validator.newValidationError(option, RESOURCE.duplicateOption(key));
             }
 
-            Supplier<Long> valueAsLong = () -> {
-                try {
-                    return Long.parseLong(value);
-                } catch (NumberFormatException e) {
-                    throw validator.newValidationError(option.value(),
-                            RESOURCE.jobOptionIncorrectNumber(key, value));
-                }
-            };
-
             switch (key) {
                 case "snapshotIntervalMillis":
-                    deltaConfig.setSnapshotIntervalMillis(valueAsLong.get());
+                    deltaConfig.setSnapshotIntervalMillis(parseLong(validator, option));
                     break;
                 case "autoScaling":
                     deltaConfig.setAutoScaling(Boolean.parseBoolean(value));
@@ -148,11 +139,14 @@ public class SqlAlterJob extends SqlAlter {
                     deltaConfig.setStoreMetricsAfterJobCompletion(Boolean.parseBoolean(value));
                     break;
                 case "maxProcessorAccumulatedRecords":
-                    deltaConfig.setMaxProcessorAccumulatedRecords(valueAsLong.get());
+                    deltaConfig.setMaxProcessorAccumulatedRecords(parseLong(validator, option));
                     break;
                 case "suspendOnFailure":
                     deltaConfig.setSuspendOnFailure(Boolean.parseBoolean(value));
                     break;
+                case "processingGuarantee":
+                case "initialSnapshotName":
+                    throw validator.newValidationError(option.key(), RESOURCE.notSupported(key, "ALTER JOB"));
                 default:
                     throw validator.newValidationError(option.key(), RESOURCE.unknownJobOption(key));
             }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlCreateJob.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlCreateJob.java
@@ -176,7 +176,7 @@ public class SqlCreateJob extends SqlCreate {
         validator.validate(sqlInsert);
     }
 
-    private static long parseLong(SqlValidator validator, SqlOption option) {
+    static long parseLong(SqlValidator validator, SqlOption option) {
         try {
             return Long.parseLong(option.valueString());
         } catch (NumberFormatException e) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlJobManagementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlJobManagementTest.java
@@ -26,6 +26,8 @@ import com.hazelcast.sql.SqlService;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.stream.Stream;
+
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
@@ -369,6 +371,14 @@ public class SqlJobManagementTest extends SqlTestSupport {
         assertThatThrownBy(() -> sqlService.execute("ALTER JOB j SUSPEND", "param"))
                 .isInstanceOf(HazelcastSqlException.class)
                 .hasMessage("ALTER JOB does not support dynamic parameters");
+    }
+
+    @Test
+    public void when_alterJobWithUnsupportedOptions_then_fail() {
+        Stream.of("processingGuarantee", "initialSnapshotName").forEach(option ->
+                assertThatThrownBy(() -> sqlService.execute("ALTER JOB j OPTIONS ('" + option + "'='value')"))
+                        .isInstanceOf(HazelcastSqlException.class)
+                        .hasMessageContaining(option + " is not supported for ALTER JOB"));
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -29,7 +29,6 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionServiceState;
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.util.Clock;
 import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.internal.util.executor.ManagedExecutorService;
@@ -309,7 +308,7 @@ public class JobCoordinationService {
             } finally {
                 res.complete(null);
             }
-            tryStartJob(masterContext);
+            masterContext.jobContext().tryStartJob();
         });
         return res;
     }
@@ -1125,7 +1124,7 @@ public class JobCoordinationService {
             logger.severe("Master context for job " + idToString(jobId) + " not found to restart");
             return;
         }
-        tryStartJob(masterContext);
+        masterContext.jobContext().tryStartJob();
     }
 
     private void checkOperationalState() {
@@ -1266,7 +1265,7 @@ public class JobCoordinationService {
             logFinest(logger, "MasterContext for suspended %s is created", masterContext.jobIdString());
         } else {
             logger.info("Starting job " + idToString(jobId) + ": " + reason);
-            tryStartJob(masterContext);
+            masterContext.jobContext().tryStartJob();
         }
 
         return masterContext.jobContext().jobCompletionFuture();
@@ -1294,15 +1293,6 @@ public class JobCoordinationService {
             return true;
         }
         return false;
-    }
-
-    private void tryStartJob(MasterContext masterContext) {
-        masterContext.jobContext().tryStartJob();
-
-        if (masterContext.hasTimeout()) {
-            long remainingTime = masterContext.remainingTime(Clock.currentTimeMillis());
-            scheduleJobTimeout(masterContext.jobId(), Math.max(1, remainingTime));
-        }
     }
 
     private int getQuorumSize() {
@@ -1488,7 +1478,7 @@ public class JobCoordinationService {
         }).toArray();
     }
 
-    private void scheduleJobTimeout(final long jobId, final long timeout) {
+    void scheduleJobTimeout(final long jobId, final long timeout) {
         if (timeout <= 0) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -1295,7 +1295,7 @@ public class JobCoordinationService {
         return false;
     }
 
-    private int getQuorumSize() {
+    int getQuorumSize() {
         return (getDataMemberCount() / 2) + 1;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -722,7 +722,7 @@ public class JobCoordinationService {
 
     public CompletableFuture<Void> resumeJob(long jobId) {
         return runWithJob(jobId,
-                masterContext -> masterContext.jobContext().resumeJob(jobRepository::newExecutionId),
+                masterContext -> masterContext.jobContext().resumeJob(),
                 jobResult -> {
                     throw new IllegalStateException("Job already completed");
                 },
@@ -1297,7 +1297,7 @@ public class JobCoordinationService {
     }
 
     private void tryStartJob(MasterContext masterContext) {
-        masterContext.jobContext().tryStartJob(jobRepository::newExecutionId);
+        masterContext.jobContext().tryStartJob();
 
         if (masterContext.hasTimeout()) {
             long remainingTime = masterContext.remainingTime(Clock.currentTimeMillis());

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobExecutionRecord.java
@@ -104,10 +104,18 @@ public class JobExecutionRecord implements IdentifiedDataSerializable {
     }
 
     /**
-     * Updates the quorum size if it's larger than the current value. Ignores, if it's not.
+     * Updates the quorum size if it's larger than the current value and
+     * returns the previous value.
      */
-    void setLargerQuorumSize(int newQuorumSize) {
-        quorumSize.getAndAccumulate(newQuorumSize, Math::max);
+    int setLargerQuorumSize(int newQuorumSize) {
+        return quorumSize.getAndAccumulate(newQuorumSize, Math::max);
+    }
+
+    /**
+     * Sets the quorum size to zero and returns the previous value.
+     */
+    int resetQuorumSize() {
+        return quorumSize.getAndSet(0);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -47,7 +47,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.Util.entry;
-import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.core.JobStatus.NOT_RUNNING;
 import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
 import static com.hazelcast.jet.core.JobStatus.SUSPENDED_EXPORTING_SNAPSHOT;
@@ -175,8 +174,13 @@ public class MasterContext {
             if (jobStatus != SUSPENDED && jobStatus != SUSPENDED_EXPORTING_SNAPSHOT) {
                 throw new IllegalStateException("Job not suspended, but " + jobStatus);
             }
+            boolean wasSplitBrainProtectionEnabled = jobConfig().isSplitBrainProtectionEnabled();
             deltaConfig.applyTo(jobConfig());
             jobRepository.updateJobRecord(jobRecord);
+            if (jobConfig().isSplitBrainProtectionEnabled() != wasSplitBrainProtectionEnabled) {
+                updateQuorumSize(jobConfig().isSplitBrainProtectionEnabled()
+                        ? coordinationService.getQuorumSize() : 0);
+            }
             return jobConfig();
         } finally {
             unlock();
@@ -255,12 +259,12 @@ public class MasterContext {
         coordinationService().assertOnCoordinatorThread();
         // This method can be called in parallel if multiple members are added. We don't synchronize here,
         // but the worst that can happen is that we write the JobRecord out unnecessarily.
-        if (jobExecutionRecord.getQuorumSize() < newQuorumSize) {
-            jobExecutionRecord.setLargerQuorumSize(newQuorumSize);
-            writeJobExecutionRecord(false);
-            logger.info("Current quorum size: " + jobExecutionRecord.getQuorumSize() + " of job "
-                    + idToString(jobRecord.getJobId()) + " is updated to: " + newQuorumSize);
-        }
+        int quorumSize = newQuorumSize > 0
+            ? jobExecutionRecord.setLargerQuorumSize(newQuorumSize)
+            : jobExecutionRecord.resetQuorumSize();
+        writeJobExecutionRecord(false);
+        logger.info("Quorum size of job " + jobIdString() + " is updated from " + quorumSize
+                + " to " + (newQuorumSize > 0 ? Math.max(quorumSize, newQuorumSize) : 0));
     }
 
     void writeJobExecutionRecord(boolean canCreate) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.IndeterminateOperationStateException;
 import com.hazelcast.core.LocalMemberResetException;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.MembersView;
+import com.hazelcast.internal.util.Clock;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.core.DAG;
@@ -298,6 +299,11 @@ public class MasterJobContext {
                   finalizeExecution(e);
               }
           });
+
+        if (mc.hasTimeout()) {
+            long remainingTime = mc.remainingTime(Clock.currentTimeMillis());
+            mc.coordinationService().scheduleJobTimeout(mc.jobId(), Math.max(1, remainingTime));
+        }
     }
 
     private CompletableFuture<Map<MemberInfo, ExecutionPlan>> createExecutionPlans(

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
@@ -129,7 +129,7 @@ public abstract class JetSplitBrainTestSupport extends JetTestSupport {
         }
     }
 
-    private HazelcastInstance[] startInitialCluster(Config config, int clusterSize) {
+    protected HazelcastInstance[] startInitialCluster(Config config, int clusterSize) {
         HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
         for (int i = 0; i < clusterSize; i++) {
             instances[i] = createHazelcastInstance(config);


### PR DESCRIPTION
Provide more precise error for unsupported options in ALTER JOB [[HZ-2253]]
Add support for updating job timeout [[HZ-2264]]
Add support for updating split brain protection [[HZ-2271]]

Fixes #24196
Fixes #24209
Fixes #24229

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible


[HZ-2253]: https://hazelcast.atlassian.net/browse/HZ-2253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HZ-2264]: https://hazelcast.atlassian.net/browse/HZ-2264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HZ-2271]: https://hazelcast.atlassian.net/browse/HZ-2271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ