### PR TITLE
Fix memory leak in native space when metrics enabled [HZ-2074]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java
@@ -329,13 +329,28 @@ public class MetricsCompressor {
         lastDescriptor = null;
     }
 
-    private byte[] getRenderedBlob() {
+
+    /**
+     * Frees resources associated with this compressor. Needed to avoid keeping
+     * memory allocated by {@link Deflater} for a long time, until finalization.
+     */
+    public void close() {
         try {
-            writeDictionary();
             dictionaryDos.close();
             dictionaryCompressor.end();
             metricDos.close();
             metricsCompressor.end();
+        } catch (IOException e) {
+            // should never be thrown
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private byte[] getRenderedBlob() {
+        try {
+            writeDictionary();
+            close();
         } catch (IOException e) {
             // should never be thrown
             throw new RuntimeException(e);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/metrics/JobMetricsPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/metrics/JobMetricsPublisher.java
@@ -77,6 +77,7 @@ public class JobMetricsPublisher implements MetricsPublisher {
             MetricsCompressor compressor = entry.getValue();
             // remove compressors that didn't receive any metrics
             if (compressor.count() == 0) {
+                compressor.close();
                 it.remove();
             }
 


### PR DESCRIPTION
Free native memory used by MetricCompressors when they are disposed of deterministically instead of relying on finalizer. Finalizer may be too slow in loaded system.

Fixes HZ-2074, #23492

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible