### PR TITLE
Support for providing Mongo auth details outside of connection string

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/dataconnection/MongoDataConnection.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/dataconnection/MongoDataConnection.java
@@ -19,6 +19,10 @@ import com.hazelcast.config.DataConnectionConfig;
 import com.hazelcast.dataconnection.DataConnectionBase;
 import com.hazelcast.dataconnection.DataConnectionResource;
 import com.hazelcast.spi.annotation.Beta;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoClientSettings.Builder;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
@@ -27,8 +31,9 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkState;
+import static com.hazelcast.jet.mongodb.impl.Mappers.defaultCodecRegistry;
+import static java.util.Collections.singletonList;
 
 /**
  * Creates a MongoDB DataConnection.
@@ -51,24 +56,76 @@ public class MongoDataConnection extends DataConnectionBase {
      * will point.
      */
     public static final String DATABASE_PROPERTY = "database";
+
+    /**
+     * Name of the property holding username.
+     */
+    public static final String USERNAME_PROPERTY = "username";
+    /**
+     * Name of the property holding user password.
+     */
+    public static final String PASSWORD_PROPERTY = "password";
+    /**
+     * Name of a property which holds host:port address of the mongodb instance.
+     */
+    public static final String HOST_PROPERTY = "host";
+    /**
+     * Name of the property holding the name of the database in which user is created.
+     * Default value is {@code admin}.
+     */
+    public static final String AUTH_DB_PROPERTY = "authDb";
+
     private volatile MongoClient mongoClient;
     private final String databaseName;
+    private final String username;
+    private final String password;
+    private final String host;
+    private final String authDb;
 
     /**
      * Creates a new data connection based on given config.
      */
     public MongoDataConnection(DataConnectionConfig config) {
         super(config);
+        this.databaseName = config.getProperty(DATABASE_PROPERTY);
+        this.username = config.getProperty(USERNAME_PROPERTY);
+        this.password = config.getProperty(PASSWORD_PROPERTY);
+        this.host = config.getProperty(HOST_PROPERTY);
+        this.authDb = config.getProperty(AUTH_DB_PROPERTY, "admin");
+
+        checkState(allSame((username == null), (password == null), (host == null), (authDb == null)),
+        "You have to provide connectionString property or combination of username, password and host");
+
         if (config.isShared()) {
             this.mongoClient = new CloseableMongoClient(createClient(config), this::release);
         }
-        this.databaseName = config.getProperty(DATABASE_PROPERTY);
+    }
+
+    private static boolean allSame(boolean... booleans) {
+        if (booleans.length == 0) {
+            return true;
+        }
+        boolean first = booleans[0];
+        for (boolean aBoolean : booleans) {
+            if (first != aBoolean) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private MongoClient createClient(DataConnectionConfig config) {
         String connectionString = config.getProperty(CONNECTION_STRING_PROPERTY);
-        checkNotNull(connectionString, "connectionString property cannot be null");
-        return MongoClients.create(connectionString);
+        if (connectionString != null) {
+            return MongoClients.create(connectionString);
+        }
+        ServerAddress serverAddress = new ServerAddress(host);
+        MongoCredential credential = MongoCredential.createCredential(username, authDb, password.toCharArray());
+        Builder builder = MongoClientSettings.builder()
+                                             .codecRegistry(defaultCodecRegistry())
+                                             .applyToClusterSettings(s -> s.hosts(singletonList(serverAddress)))
+                                             .credential(credential);
+        return MongoClients.create(builder.build());
     }
 
     /**

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/AbstractMongoTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/AbstractMongoTest.java
@@ -53,7 +53,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractMongoTest extends SimpleTestInClusterSupport {
-    static final String TEST_MONGO_VERSION = System.getProperty("test.mongo.version", "6.0.3");
+    /**
+     * Version of MongoDB Container that will be used in the tests.
+     */
+    public static final String TEST_MONGO_VERSION = System.getProperty("test.mongo.version", "6.0.3");
 
     static MongoClient mongo;
     static BsonTimestamp startAtOperationTime;

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/dataconnection/MongoDataConnectionAuthTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/dataconnection/MongoDataConnectionAuthTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.jet.mongodb.dataconnection;
+
+import com.hazelcast.config.DataConnectionConfig;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.util.ArrayList;
+
+import static com.hazelcast.jet.mongodb.AbstractMongoTest.TEST_MONGO_VERSION;
+import static com.hazelcast.jet.mongodb.impl.Mappers.defaultCodecRegistry;
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
+import static java.util.Collections.singletonList;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
+public class MongoDataConnectionAuthTest extends SimpleTestInClusterSupport {
+
+    private static final String USERNAME = "user123";
+    private static final String PASSWORD = "password123";
+    private static final String DATABASE = "MongoDataConnectionAuthTest";
+    private static final String TEST_COLLECTION = "testCollection";
+    private static final Logger LOGGER = LoggerFactory.getLogger(MongoDataConnectionAuthTest.class);
+    private static final GenericContainer<?> mongoContainer = new GenericContainer<>("mongo:" + TEST_MONGO_VERSION)
+            .withEnv("MONGO_INITDB_ROOT_USERNAME", USERNAME)
+            .withEnv("MONGO_INITDB_ROOT_PASSWORD", PASSWORD)
+            .withEnv("MONGO_INITDB_DATABASE", DATABASE)
+            .withExposedPorts(27017)
+            .withLogConsumer(new Slf4jLogConsumer(LOGGER))
+            .waitingFor(Wait.forLogMessage("(?i).*Waiting for connections*.*", 1));
+    private static String connectionString;
+
+    @BeforeClass
+    public static void setUp() {
+        assumeDockerEnabled();
+        mongoContainer.start();
+        connectionString = "mongodb://" + mongoContainer.getHost() + ":" + mongoContainer.getMappedPort(27017)
+        + "/";
+    }
+
+    private static DataConnectionConfig getDataConnectionConfig() {
+        return new DataConnectionConfig("mongoDB")
+                .setType("MongoDB")
+                .setName("mongoDB")
+                .setProperty("database", DATABASE)
+                .setProperty("host", mongoContainer.getHost() + ":" + mongoContainer.getMappedPort(27017))
+                .setProperty("username", USERNAME)
+                .setProperty("password", PASSWORD)
+                .setShared(true);
+    }
+
+    @AfterClass
+    public static void clear() {
+        if (mongoContainer != null) {
+            mongoContainer.stop();
+        }
+    }
+
+    @Test
+    public void should_connect_with_credentials() {
+        // given / when
+        try (MongoClient mongo = mongoClient()) {
+            mongo.getDatabase(DATABASE).createCollection(TEST_COLLECTION);
+        }
+        MongoDataConnection dataConnection = new MongoDataConnection(getDataConnectionConfig());
+        MongoClient client = dataConnection.getClient();
+
+        // then
+        client.getDatabase(DATABASE).getCollection(TEST_COLLECTION).find().into(new ArrayList<>());
+        // no exception should be thrown
+        dataConnection.destroy();
+    }
+
+    private MongoClient mongoClient() {
+        MongoCredential credential = MongoCredential.createCredential(USERNAME, "admin", PASSWORD.toCharArray());
+        ServerAddress address = new ServerAddress(mongoContainer.getHost() + ":" + mongoContainer.getMappedPort(27017));
+        return MongoClients.create(MongoClientSettings.builder()
+                                                      .codecRegistry(defaultCodecRegistry())
+                                                      .applyToClusterSettings(s -> s.hosts(singletonList(
+                                                              address)))
+                                                      .credential(credential)
+                                                      .build());
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/DataConnectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DataConnectionConfig.java
@@ -146,6 +146,17 @@ public class DataConnectionConfig implements IdentifiedDataSerializable, NamedCo
     }
 
     /**
+     * Returns a single property of a data connection
+     *
+     * @param key the property key of a data connection
+     * @return property value or default value if the given key doesn't exist
+     */
+    @Nullable
+    public String getProperty(String key, String defaultValue) {
+        return properties.getProperty(key, defaultValue);
+    }
+
+    /**
      * Sets a single property. See {@link DataConnectionConfig#setProperties(Properties)}
      *
      * @param key   the property key


### PR DESCRIPTION
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
