### PR TITLE
SqlDataSerializerHook fix for rolling upgrades [HZ-2242]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetSqlSerializerHook.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetSqlSerializerHook.java
@@ -344,12 +344,14 @@ public class JetSqlSerializerHook implements DataSerializerHook {
 
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors =
                 new ConstructorFunction[SqlDataSerializerHook.LEN];
+        constructors[SqlDataSerializerHook.QUERY_DATA_TYPE] = arg -> new QueryDataType();
+        // SqlDataSerializerHook.QUERY_ID
         constructors[SqlDataSerializerHook.MAPPING] = arg -> new Mapping();
         constructors[SqlDataSerializerHook.MAPPING_FIELD] = arg -> new MappingField();
         constructors[SqlDataSerializerHook.VIEW] = arg -> new View();
         constructors[SqlDataSerializerHook.TYPE] = arg -> new Type();
         constructors[SqlDataSerializerHook.TYPE_FIELD] = arg -> new Type.TypeField();
-        constructors[SqlDataSerializerHook.QUERY_DATA_TYPE] = arg -> new QueryDataType();
+        // SqlDataSerializerHook.ROW_VALUE
         constructors[SqlDataSerializerHook.QUERY_DATA_TYPE_FIELD] = arg -> new QueryDataType.QueryDataTypeField();
 
         mapDataFactory.mergeConstructors(constructors);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetSqlSerializerHook.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/JetSqlSerializerHook.java
@@ -203,8 +203,6 @@ public class JetSqlSerializerHook implements DataSerializerHook {
 
     public static final int UPDATE_DATA_CONNECTION_OPERATION = 80;
 
-    public static final int QUERY_DATA_TYPE = 81;
-
     public static final int ROW_HEAP = 82;
     public static final int ROW_EMPTY = 83;
 
@@ -216,8 +214,6 @@ public class JetSqlSerializerHook implements DataSerializerHook {
 
     public static final int INTERVAL_YEAR_MONTH = 87;
     public static final int INTERVAL_DAY_SECOND = 88;
-
-    public static final int QUERY_DATA_TYPE_FIELD = 89;
 
     public static final int EXPRESSION_GET_DDL = 90;
 
@@ -325,8 +321,6 @@ public class JetSqlSerializerHook implements DataSerializerHook {
 
         constructors[DATA_CONNECTION] = arg -> new DataConnectionCatalogEntry();
 
-        constructors[QUERY_DATA_TYPE] = arg -> new QueryDataType();
-
         constructors[ROW_HEAP] = arg -> new HeapRow();
         constructors[ROW_EMPTY] = arg -> EmptyRow.INSTANCE;
 
@@ -339,7 +333,6 @@ public class JetSqlSerializerHook implements DataSerializerHook {
         constructors[INTERVAL_YEAR_MONTH] = arg -> new SqlYearMonthInterval();
         constructors[INTERVAL_DAY_SECOND] = arg -> new SqlDaySecondInterval();
 
-        constructors[QUERY_DATA_TYPE_FIELD] = arg -> new QueryDataType.QueryDataTypeField();
         constructors[EXPRESSION_GET_DDL] = arg -> new GetDdlFunction();
 
         return new ArrayDataSerializableFactory(constructors);
@@ -350,12 +343,14 @@ public class JetSqlSerializerHook implements DataSerializerHook {
         ArrayDataSerializableFactory mapDataFactory = (ArrayDataSerializableFactory) factories.get(SqlDataSerializerHook.F_ID);
 
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors =
-                new ConstructorFunction[SqlDataSerializerHook.TYPE_FIELD + 1];
+                new ConstructorFunction[SqlDataSerializerHook.LEN];
         constructors[SqlDataSerializerHook.MAPPING] = arg -> new Mapping();
         constructors[SqlDataSerializerHook.MAPPING_FIELD] = arg -> new MappingField();
         constructors[SqlDataSerializerHook.VIEW] = arg -> new View();
         constructors[SqlDataSerializerHook.TYPE] = arg -> new Type();
         constructors[SqlDataSerializerHook.TYPE_FIELD] = arg -> new Type.TypeField();
+        constructors[SqlDataSerializerHook.QUERY_DATA_TYPE] = arg -> new QueryDataType();
+        constructors[SqlDataSerializerHook.QUERY_DATA_TYPE_FIELD] = arg -> new QueryDataType.QueryDataTypeField();
 
         mapDataFactory.mergeConstructors(constructors);
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/type/QueryDataType.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/type/QueryDataType.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.sql.impl.type;
 
-import com.hazelcast.jet.sql.impl.JetSqlSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.schema.type.TypeKind;
 import com.hazelcast.sql.impl.type.converter.BigDecimalConverter;
 import com.hazelcast.sql.impl.type.converter.BigIntegerConverter;
@@ -214,12 +214,12 @@ public class QueryDataType implements IdentifiedDataSerializable, Serializable {
 
     @Override
     public int getFactoryId() {
-        return JetSqlSerializerHook.F_ID;
+        return SqlDataSerializerHook.F_ID;
     }
 
     @Override
     public int getClassId() {
-        return JetSqlSerializerHook.QUERY_DATA_TYPE;
+        return SqlDataSerializerHook.QUERY_DATA_TYPE;
     }
 
     @Override
@@ -401,12 +401,12 @@ public class QueryDataType implements IdentifiedDataSerializable, Serializable {
 
         @Override
         public int getFactoryId() {
-            return JetSqlSerializerHook.F_ID;
+            return SqlDataSerializerHook.F_ID;
         }
 
         @Override
         public int getClassId() {
-            return JetSqlSerializerHook.QUERY_DATA_TYPE_FIELD;
+            return SqlDataSerializerHook.QUERY_DATA_TYPE_FIELD;
         }
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.sql.impl.type;
 
-import com.hazelcast.jet.sql.impl.JetSqlSerializerHook;
 import com.hazelcast.sql.impl.CoreSqlTestSupport;
 import com.hazelcast.sql.impl.SqlCustomClass;
+import com.hazelcast.sql.impl.SqlDataSerializerHook;
 import com.hazelcast.sql.impl.type.converter.BigDecimalConverter;
 import com.hazelcast.sql.impl.type.converter.BigIntegerConverter;
 import com.hazelcast.sql.impl.type.converter.BooleanConverter;
@@ -159,7 +159,7 @@ public class QueryDataTypeTest extends CoreSqlTestSupport {
     public void testSerialization() {
         for (Converter converter : Converters.getConverters()) {
             QueryDataType original = new QueryDataType(converter);
-            QueryDataType restored = serializeAndCheck(original, JetSqlSerializerHook.QUERY_DATA_TYPE);
+            QueryDataType restored = serializeAndCheck(original, SqlDataSerializerHook.QUERY_DATA_TYPE);
 
             checkEquals(original, restored, true);
         }

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/type/QueryDataTypeTest.java
@@ -159,7 +159,11 @@ public class QueryDataTypeTest extends CoreSqlTestSupport {
     public void testSerialization() {
         for (Converter converter : Converters.getConverters()) {
             QueryDataType original = new QueryDataType(converter);
-            QueryDataType restored = serializeAndCheck(original, SqlDataSerializerHook.QUERY_DATA_TYPE);
+            QueryDataType restored = serializeAndCheck(
+                    original,
+                    SqlDataSerializerHook.F_ID,
+                    SqlDataSerializerHook.QUERY_DATA_TYPE
+            );
 
             checkEquals(original, restored, true);
         }

--- a/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/impl/SqlDataSerializerHook.java
@@ -34,6 +34,7 @@ public class SqlDataSerializerHook implements DataSerializerHook {
 
     public static final int F_ID = FactoryIdHelper.getFactoryId(SQL_DS_FACTORY, SQL_DS_FACTORY_ID);
 
+    public static final int QUERY_DATA_TYPE = 0;
     public static final int QUERY_ID = 1;
     public static final int MAPPING = 57;
     public static final int MAPPING_FIELD = 58;
@@ -41,8 +42,9 @@ public class SqlDataSerializerHook implements DataSerializerHook {
     public static final int TYPE = 63;
     public static final int TYPE_FIELD = 64;
     public static final int ROW_VALUE = 66;
+    public static final int QUERY_DATA_TYPE_FIELD = 67;
 
-    public static final int LEN = ROW_VALUE + 1;
+    public static final int LEN = QUERY_DATA_TYPE_FIELD + 1;
 
     @Override
     public int getFactoryId() {


### PR DESCRIPTION
Tested on a manual 5.2-5.3 rolling upgrade setup, seems schema is correctly transferred on a rolling upgrade now.
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/5884.