### PR TITLE
Make actions return ACTION_SUBMIT and ACTION_ADD_RESOURCES [HZ-1686]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetUploadJobMetaDataTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetUploadJobMetaDataTask.java
@@ -26,8 +26,6 @@ import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
-import javax.annotation.Nullable;
-
 /**
  * The task that creates UploadJobMetaDataOperation with client protocol message
  */
@@ -41,9 +39,8 @@ public class JetUploadJobMetaDataTask extends
     }
 
     @Override
-    @Nullable
     public String[] actions() {
-        return new String[]{ActionConstants.ACTION_SUBMIT};
+        return new String[]{ActionConstants.ACTION_SUBMIT, ActionConstants.ACTION_ADD_RESOURCES};
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetUploadJobMultipartTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetUploadJobMultipartTask.java
@@ -26,8 +26,6 @@ import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
-import javax.annotation.Nullable;
-
 /**
  * The task that creates UploadJobMultiPartOperation with client protocol message
  */
@@ -41,9 +39,8 @@ public class JetUploadJobMultipartTask extends
     }
 
     @Override
-    @Nullable
     public String[] actions() {
-        return new String[]{ActionConstants.ACTION_ADD_RESOURCES};
+        return new String[]{ActionConstants.ACTION_SUBMIT, ActionConstants.ACTION_ADD_RESOURCES};
     }
 
     @Override


### PR DESCRIPTION
Add ACTION_SUBMIT and ACTION_ADD_RESOURCES to jet job upload tasks


Fixes : https://hazelcast.atlassian.net/browse/HZ-2288
GH : https://github.com/hazelcast/hazelcast-enterprise/issues/5916


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
