### PR TITLE
Fix metrics NPE if Raft session endpointName is null [HZ-2277] [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
@@ -525,7 +525,8 @@ public class RaftSessionService extends AbstractCPMigrationAwareService
                 context.collect(desc.copy().withTag("endpoint", session.endpoint().toString()).withMetric("endpoint"), 0);
                 context.collect(desc.copy().withTag("endpointType", session.endpointType().toString())
                         .withMetric("endpointType"), 0);
-                context.collect(desc.copy().withTag("endpointName", session.endpointName())
+                String endpointName = session.endpointName() != null ? session.endpointName() : session.endpoint().toString();
+                context.collect(desc.copy().withTag("endpointName", endpointName)
                         .withMetric("endpointName"), 0);
 
                 context.collect(desc.copy().withMetric("version"), session.version());


### PR DESCRIPTION
If running Hazelcast in embedded mode, `CPSession#endpointName()` is `null`. In that case, the `endpointName` metric will return endpoint address instead of endpoint name.

Backport of: https://github.com/hazelcast/hazelcast/pull/24263

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
