### PR TITLE
Rename data link to data connection in permissions [HZ-2231] (#5904)

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/SqlPlanImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/SqlPlanImpl.java
@@ -55,18 +55,18 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
-import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE_LINK;
+import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE_DATACONNECTION;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE_TYPE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE_VIEW;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_DESTROY;
-import static com.hazelcast.security.permission.ActionConstants.ACTION_DROP_LINK;
+import static com.hazelcast.security.permission.ActionConstants.ACTION_DROP_DATACONNECTION;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_DROP_TYPE;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_DROP_VIEW;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_INDEX;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_PUT;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_REMOVE;
-import static com.hazelcast.security.permission.ActionConstants.ACTION_VIEW_LINK;
+import static com.hazelcast.security.permission.ActionConstants.ACTION_VIEW_DATACONNECTION;
 
 abstract class SqlPlanImpl extends SqlPlan {
 
@@ -268,9 +268,9 @@ abstract class SqlPlanImpl extends SqlPlan {
         @Override
         public void checkPermissions(SqlSecurityContext context) {
             if (isReplace()) {
-                context.checkPermission(new SqlPermission(name, ACTION_CREATE_LINK, ACTION_DROP_LINK));
+                context.checkPermission(new SqlPermission(name, ACTION_CREATE_DATACONNECTION, ACTION_DROP_DATACONNECTION));
             } else {
-                context.checkPermission(new SqlPermission(name, ACTION_CREATE_LINK));
+                context.checkPermission(new SqlPermission(name, ACTION_CREATE_DATACONNECTION));
             }
         }
 
@@ -315,7 +315,7 @@ abstract class SqlPlanImpl extends SqlPlan {
 
         @Override
         public void checkPermissions(SqlSecurityContext context) {
-            context.checkPermission(new SqlPermission(name, ACTION_VIEW_LINK, ACTION_DROP_LINK));
+            context.checkPermission(new SqlPermission(name, ACTION_VIEW_DATACONNECTION, ACTION_DROP_DATACONNECTION));
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
@@ -83,9 +83,9 @@ public final class ActionConstants {
     public static final String ACTION_DROP_VIEW = "drop-view";
     public static final String ACTION_CREATE_TYPE = "create-type";
     public static final String ACTION_DROP_TYPE = "drop-type";
-    public static final String ACTION_VIEW_LINK = "view-link";
-    public static final String ACTION_CREATE_LINK = "create-link";
-    public static final String ACTION_DROP_LINK = "drop-link";
+    public static final String ACTION_VIEW_DATACONNECTION = "view-dataconnection";
+    public static final String ACTION_CREATE_DATACONNECTION = "create-dataconnection";
+    public static final String ACTION_DROP_DATACONNECTION = "drop-dataconnection";
 
     private static final Map<String, PermissionFactory> PERMISSION_FACTORY_MAP = new HashMap<>();
 

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/SqlPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/SqlPermission.java
@@ -25,11 +25,11 @@ public class SqlPermission extends InstancePermission {
     private static final int DROP_VIEW = CREATE_VIEW << 1;
     private static final int CREATE_TYPE = DROP_VIEW << 1;
     private static final int DROP_TYPE = CREATE_TYPE << 1;
-    private static final int VIEW_LINK = DROP_TYPE << 1;
-    private static final int CREATE_LINK = VIEW_LINK << 1;
-    private static final int DROP_LINK = CREATE_LINK << 1;
+    private static final int VIEW_DATACONNECTION = DROP_TYPE << 1;
+    private static final int CREATE_DATACONNECTION = VIEW_DATACONNECTION << 1;
+    private static final int DROP_DATACONNECTION = CREATE_DATACONNECTION << 1;
     private static final int ALL = CREATE_MAPPING | DROP_MAPPING | CREATE_INDEX | CREATE_VIEW | DROP_VIEW
-            | CREATE_TYPE | DROP_TYPE | VIEW_LINK | CREATE_LINK | DROP_LINK;
+            | CREATE_TYPE | DROP_TYPE | VIEW_DATACONNECTION | CREATE_DATACONNECTION | DROP_DATACONNECTION;
 
     public SqlPermission(String name, String... actions) {
         super(name, actions);
@@ -57,12 +57,12 @@ public class SqlPermission extends InstancePermission {
                     mask |= CREATE_TYPE;
                 } else if (ActionConstants.ACTION_DROP_TYPE.equals(action)) {
                     mask |= DROP_TYPE;
-                } else if (ActionConstants.ACTION_VIEW_LINK.equals(action)) {
-                    mask |= VIEW_LINK;
-                } else if (ActionConstants.ACTION_CREATE_LINK.equals(action)) {
-                    mask |= CREATE_LINK;
-                } else if (ActionConstants.ACTION_DROP_LINK.equals(action)) {
-                    mask |= DROP_LINK;
+                } else if (ActionConstants.ACTION_VIEW_DATACONNECTION.equals(action)) {
+                    mask |= VIEW_DATACONNECTION;
+                } else if (ActionConstants.ACTION_CREATE_DATACONNECTION.equals(action)) {
+                    mask |= CREATE_DATACONNECTION;
+                } else if (ActionConstants.ACTION_DROP_DATACONNECTION.equals(action)) {
+                    mask |= DROP_DATACONNECTION;
                 }
                 // Note: DROP INDEX is not implemented yet, no need to have separate permission.
             }


### PR DESCRIPTION
Followup for #24224

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* names of data connections permissions were changes from values in previous BETA version

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

