### PR TITLE
Increase timeout in GenericMapStoreIntegrationTest [HZ-2308]

### DIFF
--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
@@ -345,7 +345,7 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
 
         Row row = new Row("__map-store." + tableName);
         List<Row> rows = Collections.singletonList(row);
-        assertTrueEventually(() -> assertDoesNotContainRow(client, "SHOW MAPPINGS", rows), 5);
+        assertTrueEventually(() -> assertDoesNotContainRow(client, "SHOW MAPPINGS", rows), 30);
     }
 
     @Test


### PR DESCRIPTION
On a local machine, the test sometimes takes over 2 s, it's possible that the timeout 5 s is not enough.

Fixes #23760

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
