### PR TITLE
Simplify ClientRegressionWithMockNetworkTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -18,7 +18,6 @@ package com.hazelcast.test;
 
 import classloading.ThreadLocalLeakTestUtils;
 import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Cluster;
 import com.hazelcast.cluster.ClusterState;
@@ -315,16 +314,6 @@ public abstract class HazelcastTestSupport {
         } else {
             return nodeCount == null ? new TestHazelcastInstanceFactory() : new TestHazelcastInstanceFactory(nodeCount);
         }
-    }
-
-    protected void assertNoRunningInstancesEventually(String methodName, TestHazelcastFactory hazelcastFactory) {
-        // check for running Hazelcast instances
-        assertTrueEventually(() -> {
-            Collection<HazelcastInstance> instances = hazelcastFactory.getAllHazelcastInstances();
-            if (!instances.isEmpty()) {
-                fail("After " + methodName + " following instances haven't been shut down: " + instances);
-            }
-        });
     }
 
     // ###########################################


### PR DESCRIPTION
In an earlier PR, we have added a latch to wait for a thread we started in a test to finish. And, we have added a check to make sure that there are no leftover instances.

For the first one, I believe waiting for the thread termination is just enough.

For the second one, the added check does not verify anything as I wrote in the original issue description. It feels weird to have it right after terminateAll call. So, I would like to remove it as well.

I will backport this simplified version to other 5.x branches.