### PR TITLE
Removed without backup flag variant of getRecordOrNull method [HZ-2287][5.0.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.partition.FragmentedMigrationAwareService;
 import com.hazelcast.internal.partition.IPartitionLostEvent;
+import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.partition.OffloadedReplicationPreparation;
 import com.hazelcast.internal.partition.PartitionAwareService;
 import com.hazelcast.internal.partition.PartitionMigrationEvent;
@@ -93,11 +94,11 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.MAP_TAG_I
  */
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity", "checkstyle:MethodCount"})
 public class MapService implements ManagedService, FragmentedMigrationAwareService, TransactionalService, RemoteService,
-                                   EventPublishingService<Object, ListenerAdapter>, PostJoinAwareService,
-                                   SplitBrainHandlerService, WanSupportingService, StatisticsAwareService<LocalMapStats>,
-                                   PartitionAwareService, ClientAwareService, SplitBrainProtectionAwareService,
-                                   NotifiableEventListener, ClusterStateListener, LockInterceptorService<Data>,
-                                   DynamicMetricsProvider, TenantContextAwareService, OffloadedReplicationPreparation {
+        EventPublishingService<Object, ListenerAdapter>, PostJoinAwareService,
+        SplitBrainHandlerService, WanSupportingService, StatisticsAwareService<LocalMapStats>,
+        PartitionAwareService, ClientAwareService, SplitBrainProtectionAwareService,
+        NotifiableEventListener, ClusterStateListener, LockInterceptorService<Data>,
+        DynamicMetricsProvider, TenantContextAwareService, OffloadedReplicationPreparation {
 
     public static final String SERVICE_NAME = "hz:impl:mapService";
 
@@ -276,10 +277,13 @@ public class MapService implements ManagedService, FragmentedMigrationAwareServi
 
     @Override
     public void onBeforeLock(String distributedObjectName, Data key) {
-        int partitionId = mapServiceContext.getNodeEngine().getPartitionService().getPartitionId(key);
+        IPartitionService partitionService = mapServiceContext.getNodeEngine().getPartitionService();
+        int partitionId = partitionService.getPartitionId(key);
         RecordStore recordStore = mapServiceContext.getRecordStore(partitionId, distributedObjectName);
+
+        boolean owner = partitionService.isPartitionOwner(partitionId);
         // we have no use for the return value, invoked just for the side-effects
-        recordStore.getRecordOrNull(key);
+        recordStore.getRecordOrNull(key, !owner);
     }
 
     public static ObjectNamespace getObjectNamespace(String mapName) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
@@ -40,7 +40,7 @@ public class GetEntryViewOperation extends ReadonlyKeyBasedMapOperation implemen
 
     @Override
     protected void runInternal() {
-        Record record = recordStore.getRecordOrNull(dataKey);
+        Record record = recordStore.getRecordOrNull(dataKey, false);
         if (record != null) {
             Data value = mapServiceContext.toData(record.getValue());
             ExpiryMetadata expiredMetadata = recordStore.getExpirySystem().getExpiredMetadata(dataKey);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1169,9 +1169,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public Record getRecordOrNull(Data key) {
+    public Record getRecordOrNull(Data key, boolean backup) {
         long now = getNow();
-        return getRecordOrNull(key, now, false);
+        return getRecordOrNull(key, now, backup);
     }
 
     protected Record getRecordOrNull(Data key, long now, boolean backup) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -475,11 +475,12 @@ public interface RecordStore<R extends Record> {
     /**
      * Returns live record or null if record is already expired. Does not load missing keys from a map store.
      *
-     * @param key key to be accessed
+     * @param key      key to be accessed
+     * @param backup true if partition is a backup-partition otherwise set false
      * @return live record or null
      * @see #get
      */
-    R getRecordOrNull(Data key);
+    R getRecordOrNull(Data key, boolean backup);
 
     /**
      * Check if record is reachable according to TTL or idle times.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -60,7 +60,7 @@ public class TxnLockAndGetOperation
         if (!recordStore.txnLock(getKey(), ownerUuid, getThreadId(), getCallId(), ttl, blockReads)) {
             throw new TransactionException("Transaction couldn't obtain lock.");
         }
-        Record record = recordStore.getRecordOrNull(dataKey);
+        Record record = recordStore.getRecordOrNull(dataKey, false);
         if (record == null && shouldLoad) {
             record = recordStore.loadRecordOrNull(dataKey, false, getCallerAddress());
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -78,7 +78,7 @@ public class TxnSetOperation extends BasePutOperation
     @Override
     protected void runInternal() {
         recordStore.unlock(dataKey, ownerUuid, threadId, getCallId());
-        Record record = recordStore.getRecordOrNull(dataKey);
+        Record record = recordStore.getRecordOrNull(dataKey, false);
         if (record == null || version == record.getVersion()) {
             EventService eventService = getNodeEngine().getEventService();
             if (eventService.hasEventRegistration(MapService.SERVICE_NAME, getName())) {

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -1008,7 +1008,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         for (PartitionContainer partitionContainer : partitionContainers) {
             RecordStore rs = partitionContainer.getExistingRecordStore(MAP_NAME);
             if (rs != null) {
-                Record record = rs.getRecordOrNull(key);
+                Record record = rs.getRecordOrNull(key, false);
 
                 if (record != null) {
                     assertEquals(expectedTtl, rs.getExpirySystem().getExpiredMetadata(key).getTtl());

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationListenerTest.java
@@ -19,13 +19,15 @@ package com.hazelcast.map;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.CPSubsystem;
+import com.hazelcast.cp.lock.FencedLock;
+import com.hazelcast.internal.util.RandomPicker;
 import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.internal.util.RandomPicker;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,6 +35,9 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -46,14 +51,14 @@ public class ExpirationListenerTest extends HazelcastTestSupport {
     @Before
     public void init() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(instanceCount);
-        Config config = new Config();
+        Config config = smallInstanceConfig();
         instances = factory.newInstances(config);
         HazelcastInstance randomNode = instances[RandomPicker.getInt(instanceCount)];
         map = randomNode.getMap(randomMapName());
     }
 
     @Test
-    public void testExpirationListener_notified_afterExpirationOfEntries() throws Exception {
+    public void test_expiration_listener_is_notified_after_expiration_of_entries() {
         int numberOfPutOperations = 1000;
         CountDownLatch expirationEventArrivalCount = new CountDownLatch(numberOfPutOperations);
 
@@ -75,7 +80,7 @@ public class ExpirationListenerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_whenTTLisModified_ExpirationListenernotified_afterExpirationOfEntries() throws Exception {
+    public void test_when_ttl_is_modified_expiration_listener_is_notified_after_expiration_of_entries() {
         int numberOfPutOperations = 1000;
         CountDownLatch expirationEventArrivalCount = new CountDownLatch(numberOfPutOperations);
 
@@ -100,6 +105,38 @@ public class ExpirationListenerTest extends HazelcastTestSupport {
         assertOpenEventually(expirationEventArrivalCount);
     }
 
+    @Test
+    public void testExpirationListener_notified_one_time_with_imap_locking() {
+        AtomicInteger eventCounter = new AtomicInteger();
+        EntryExpiredListener listener = new LockingOverIMapExpirationListener(eventCounter, map);
+
+        testListenerIsNotifiedOneTime(eventCounter, listener);
+    }
+
+    @Test
+    public void testExpirationListener_notified_one_time_with_cp_subsystem_locking() {
+        AtomicInteger eventCounter = new AtomicInteger();
+        EntryExpiredListener listener
+                = new LockingOverCpSubsystemExpirationListener(eventCounter, instances[0].getCPSubsystem());
+
+        testListenerIsNotifiedOneTime(eventCounter, listener);
+    }
+
+    private void testListenerIsNotifiedOneTime(AtomicInteger eventCounter, EntryExpiredListener entryExpiredListener) {
+        int numberOfPutOperations = 100;
+
+        map.addEntryListener(entryExpiredListener, true);
+
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.put(i, i, 100, TimeUnit.MILLISECONDS);
+        }
+
+        assertTrueEventually(() -> assertEquals("Map size is not zero", 0, map.size()));
+        assertTrueEventually(() -> assertEquals("Received unexpected number of events",
+                numberOfPutOperations, eventCounter.get()));
+    }
+
+
     private static class ExpirationListener implements EntryExpiredListener {
 
         private final CountDownLatch expirationEventCount;
@@ -111,6 +148,57 @@ public class ExpirationListenerTest extends HazelcastTestSupport {
         @Override
         public void entryExpired(EntryEvent event) {
             expirationEventCount.countDown();
+        }
+    }
+
+    private static class LockingOverIMapExpirationListener implements EntryExpiredListener {
+
+        private final IMap map;
+        private final AtomicInteger eventCounter;
+
+        LockingOverIMapExpirationListener(AtomicInteger eventCounter, IMap map) {
+            this.map = map;
+            this.eventCounter = eventCounter;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            eventCounter.incrementAndGet();
+
+            Object key = event.getKey();
+            map.lock(key);
+            try {
+                // mimic a slow execution
+                sleepMillis(10);
+            } finally {
+                map.unlock(key);
+            }
+        }
+    }
+
+    private static class LockingOverCpSubsystemExpirationListener implements EntryExpiredListener {
+
+        private final CPSubsystem cpSubsystem;
+        private final AtomicInteger eventCounter;
+
+        LockingOverCpSubsystemExpirationListener(AtomicInteger eventCounter, CPSubsystem cpSubsystem) {
+            this.cpSubsystem = cpSubsystem;
+            this.eventCounter = eventCounter;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            eventCounter.incrementAndGet();
+
+            Object key = event.getKey();
+            FencedLock lock = cpSubsystem.getLock(key.toString());
+            lock.lock();
+            try {
+                // mimic a slow execution
+                sleepMillis(100);
+            } finally {
+                lock.unlock();
+            }
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EntryLoaderSimpleTest.java
@@ -374,7 +374,7 @@ public class EntryLoaderSimpleTest extends HazelcastTestSupport {
         NodeEngineImpl nodeEngine = getNodeEngineImpl(owner);
         MapService mapService = nodeEngine.getService(MapService.SERVICE_NAME);
         RecordStore recordStore = mapService.getMapServiceContext().getPartitionContainer(partitionId).getRecordStore(mapName);
-        Record record = recordStore.getRecordOrNull(keyData);
+        Record record = recordStore.getRecordOrNull(keyData, false);
         Object actualValue = record == null ? null : serializationService.toObject(record.getValue());
         assertEquals(expectedValue, actualValue);
     }


### PR DESCRIPTION
Modifications:
- Removed without backup flag variant of getRecordOrNull method. Having it in MapService#onBeforeLock is causing backup nodes' event publishing while expectation is single event publishing by owner node.
