### PR TITLE
Fix ClientSessionManagerTest [API-2018]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/session/ClientSessionManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/session/ClientSessionManagerTest.java
@@ -18,6 +18,8 @@ package com.hazelcast.client.cp.internal.session;
 
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.Address;
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.internal.RaftGroupId;
 import com.hazelcast.cp.internal.session.AbstractProxySessionManager;
@@ -39,9 +41,14 @@ import org.junit.runner.RunWith;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -61,6 +68,39 @@ public class ClientSessionManagerTest extends AbstractProxySessionManagerTest {
     public void setupClient() {
         TestHazelcastFactory f = (TestHazelcastFactory) factory;
         client = f.newHazelcastClient();
+    }
+
+    @Test
+    public void sessionHeartbeatsAreStopped_afterClusterRestart() {
+        ClientProxySessionManager sessionManager = (ClientProxySessionManager) getSessionManager();
+        long sessionId = sessionManager.acquireSession(groupId);
+
+        AtomicInteger heartbeatCounter = new AtomicInteger();
+        doAnswer(invocation -> {
+            heartbeatCounter.incrementAndGet();
+            return invocation.callRealMethod();
+        }).when(sessionManager).heartbeat(groupId, sessionId);
+
+        assertTrueEventually(() -> verify(sessionManager, atLeastOnce()).heartbeat(groupId, sessionId));
+
+        Address address1 = members[0].getCPSubsystem().getLocalCPMember().getAddress();
+        Address address2 = members[1].getCPSubsystem().getLocalCPMember().getAddress();
+        Address address3 = members[2].getCPSubsystem().getLocalCPMember().getAddress();
+
+        members[0].getLifecycleService().terminate();
+        members[1].getLifecycleService().terminate();
+        members[2].getLifecycleService().terminate();
+
+        Config config = createConfig(3, 3);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(address1, config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(address2, config);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(address3, config);
+
+        waitUntilCPDiscoveryCompleted(instance1, instance2, instance3);
+
+        assertTrueEventually(() -> verify(sessionManager, times(1)).invalidateSession(groupId, sessionId));
+        int heartbeatCount = heartbeatCounter.get();
+        assertTrueAllTheTime(() -> verify(sessionManager, times(heartbeatCount)).heartbeat(groupId, sessionId), 3);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/session/AbstractProxySessionManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/session/AbstractProxySessionManagerTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.cp.internal.session;
 
-import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -42,7 +41,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,7 +52,7 @@ public abstract class AbstractProxySessionManagerTest extends HazelcastRaftTestS
 
     private static final int sessionTTLSeconds = 10;
 
-    HazelcastInstance[] members;
+    protected HazelcastInstance[] members;
     protected RaftGroupId groupId;
 
     @Before
@@ -162,31 +160,6 @@ public abstract class AbstractProxySessionManagerTest extends HazelcastRaftTestS
 
         SessionAccessor sessionAccessor = getSessionAccessor();
         assertTrueEventually(() -> assertFalse(sessionAccessor.isActive(groupId, sessionId)));
-    }
-
-    @Test
-    public void sessionHeartbeatsStopSent_afterClusterRestart() {
-        AbstractProxySessionManager sessionManager = getSessionManager();
-        long sessionId = sessionManager.acquireSession(groupId);
-
-        assertTrueEventually(() -> verify(sessionManager, atLeastOnce()).heartbeat(groupId, sessionId));
-
-        Address address1 = members[0].getCPSubsystem().getLocalCPMember().getAddress();
-        Address address2 = members[1].getCPSubsystem().getLocalCPMember().getAddress();
-        Address address3 = members[2].getCPSubsystem().getLocalCPMember().getAddress();
-
-        members[0].getLifecycleService().terminate();
-        members[1].getLifecycleService().terminate();
-        members[2].getLifecycleService().terminate();
-
-        Config config = createConfig(3, 3);
-        HazelcastInstance instance1 = factory.newHazelcastInstance(address1, config);
-        HazelcastInstance instance2 = factory.newHazelcastInstance(address2, config);
-        HazelcastInstance instance3 = factory.newHazelcastInstance(address3, config);
-
-        waitUntilCPDiscoveryCompleted(instance1, instance2, instance3);
-
-        assertTrueAllTheTime(() -> verify(sessionManager, atMost(10)).heartbeat(groupId, sessionId), 15);
     }
 
     @Test


### PR DESCRIPTION
The `sessionHeartbeatsStopSent_afterClusterRestart` test failed with an exception saying that we have made more heartbeat requests than expected.

Looking at the test, I saw that it is easily reproducible by adding a sleep before starting to shutdown members. In the test, we are asserting that the number of heartbeat requests we made over the test's duration is capped at 10, which might fail from time to time.

Besides that, the test was in the `AbstractProxySessionManagerTest` file, which means it was executed for the member and client side proxy session manager implementations. However, I believe it doesn't make sense to have a member-side test, because we are trying to verify that there are no more heartbeats sent after the cluster restart. But, we are trying to verify that with the session manager of one of the terminated members. I feel like we are testing the obvious - the dead member cannot connect to the newly started cluster and send heartbeats - and that is unnecessary. Therefore, I have moved the test to `ClientSessionManagerTest`.

To fix the problem, I have asserted that we are doing the session invalidation, and after that the number of heartbeats we have sent stays the same.

closes https://github.com/hazelcast/hazelcast/issues/23310