### PR TITLE
Extend set of masked fields in ConfigXmlGenerator [HZ-2289] (5.0.z)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -187,6 +187,9 @@ public class ConfigXmlGenerator {
     }
 
     private String getOrMaskValue(String value) {
+        if (value == null) {
+            return null;
+        }
         return maskSensitiveFields ? MASK_FOR_SENSITIVE_DATA : value;
     }
 
@@ -340,7 +343,7 @@ public class ConfigXmlGenerator {
                 .close();
     }
 
-    private static void ldapAuthenticationGenerator(XmlGenerator gen, LdapAuthenticationConfig c) {
+    private void ldapAuthenticationGenerator(XmlGenerator gen, LdapAuthenticationConfig c) {
         if (c == null) {
             return;
         }
@@ -357,7 +360,7 @@ public class ConfigXmlGenerator {
                 .nodeIfContents("role-search-scope", c.getRoleSearchScope())
                 .nodeIfContents("user-name-attribute", c.getUserNameAttribute())
                 .nodeIfContents("system-user-dn", c.getSystemUserDn())
-                .nodeIfContents("system-user-password", c.getSystemUserPassword())
+                .nodeIfContents("system-user-password", getOrMaskValue(c.getSystemUserPassword()))
                 .nodeIfContents("system-authentication", c.getSystemAuthentication())
                 .nodeIfContents("security-realm", c.getSecurityRealm())
                 .nodeIfContents("password-attribute", c.getPasswordAttribute())
@@ -368,7 +371,7 @@ public class ConfigXmlGenerator {
                 .close();
     }
 
-    private static void kerberosAuthenticationGenerator(XmlGenerator gen, KerberosAuthenticationConfig c) {
+    private void kerberosAuthenticationGenerator(XmlGenerator gen, KerberosAuthenticationConfig c) {
         if (c == null) {
             return;
         }
@@ -383,14 +386,14 @@ public class ConfigXmlGenerator {
         kerberosGen.close();
     }
 
-    private static void simpleAuthenticationGenerator(XmlGenerator gen, SimpleAuthenticationConfig c) {
+    private void simpleAuthenticationGenerator(XmlGenerator gen, SimpleAuthenticationConfig c) {
         if (c == null) {
             return;
         }
         XmlGenerator simpleGen = gen.open("simple");
         addClusterLoginElements(simpleGen, c).nodeIfContents("role-separator", c.getRoleSeparator());
         for (String username : c.getUsernames()) {
-            simpleGen.open("user", "username", username, "password", c.getPassword(username));
+            simpleGen.open("user", "username", username, "password", getOrMaskValue(c.getPassword(username)));
             for (String role : c.getRoles(username)) {
                 simpleGen.node("role", role);
             }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -122,17 +122,29 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         cfg.getNetworkConfig().setSymmetricEncryptionConfig(symmetricEncryptionConfig);
         cfg.setLicenseKey("HazelcastLicenseKey");
 
+        cfg.getSecurityConfig().addRealmConfig("simple",
+                new RealmConfig().setSimpleAuthenticationConfig(new SimpleAuthenticationConfig().addUser("test", "pass"))
+                        .setUsernamePasswordIdentityConfig("myidentity", "mypasswd"))
+                .addRealmConfig("ldap", new RealmConfig().setLdapAuthenticationConfig(
+                        new LdapAuthenticationConfig().setSystemUserDn("cn=test").setSystemUserPassword("ldappass")));
+
         Config newConfigViaXMLGenerator = getNewConfigViaXMLGenerator(cfg);
         SSLConfig generatedSSLConfig = newConfigViaXMLGenerator.getNetworkConfig().getSSLConfig();
+        SecurityConfig secCfg = newConfigViaXMLGenerator.getSecurityConfig();
 
-        assertEquals(generatedSSLConfig.getProperty("keyStorePassword"), MASK_FOR_SENSITIVE_DATA);
-        assertEquals(generatedSSLConfig.getProperty("trustStorePassword"), MASK_FOR_SENSITIVE_DATA);
+        assertEquals(MASK_FOR_SENSITIVE_DATA, generatedSSLConfig.getProperty("keyStorePassword"));
+        assertEquals(MASK_FOR_SENSITIVE_DATA, generatedSSLConfig.getProperty("trustStorePassword"));
 
         String secPassword = newConfigViaXMLGenerator.getNetworkConfig().getSymmetricEncryptionConfig().getPassword();
         String theSalt = newConfigViaXMLGenerator.getNetworkConfig().getSymmetricEncryptionConfig().getSalt();
-        assertEquals(secPassword, MASK_FOR_SENSITIVE_DATA);
-        assertEquals(theSalt, MASK_FOR_SENSITIVE_DATA);
-        assertEquals(newConfigViaXMLGenerator.getLicenseKey(), MASK_FOR_SENSITIVE_DATA);
+        assertEquals(MASK_FOR_SENSITIVE_DATA, secPassword);
+        assertEquals(MASK_FOR_SENSITIVE_DATA, theSalt);
+        assertEquals(MASK_FOR_SENSITIVE_DATA, newConfigViaXMLGenerator.getLicenseKey());
+        RealmConfig simpleRealm = secCfg.getRealmConfig("simple");
+        assertEquals(MASK_FOR_SENSITIVE_DATA, simpleRealm.getSimpleAuthenticationConfig().getPassword("test"));
+        assertEquals(MASK_FOR_SENSITIVE_DATA, simpleRealm.getUsernamePasswordIdentityConfig().getPassword());
+        assertEquals(MASK_FOR_SENSITIVE_DATA,
+                secCfg.getRealmConfig("ldap").getLdapAuthenticationConfig().getSystemUserPassword());
     }
 
     @Test
@@ -159,17 +171,17 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         Config newConfigViaXMLGenerator = getNewConfigViaXMLGenerator(cfg, false);
         SSLConfig generatedSSLConfig = newConfigViaXMLGenerator.getNetworkConfig().getSSLConfig();
 
-        assertEquals(generatedSSLConfig.getProperty("keyStorePassword"), password);
-        assertEquals(generatedSSLConfig.getProperty("trustStorePassword"), password);
+        assertEquals(password, generatedSSLConfig.getProperty("keyStorePassword"));
+        assertEquals(password, generatedSSLConfig.getProperty("trustStorePassword"));
 
         String secPassword = newConfigViaXMLGenerator.getNetworkConfig().getSymmetricEncryptionConfig().getPassword();
         String theSalt = newConfigViaXMLGenerator.getNetworkConfig().getSymmetricEncryptionConfig().getSalt();
-        assertEquals(secPassword, password);
-        assertEquals(theSalt, salt);
-        assertEquals(newConfigViaXMLGenerator.getLicenseKey(), licenseKey);
+        assertEquals(password, secPassword);
+        assertEquals(salt, theSalt);
+        assertEquals(licenseKey, newConfigViaXMLGenerator.getLicenseKey());
         SecurityConfig securityConfig = newConfigViaXMLGenerator.getSecurityConfig();
         RealmConfig realmConfig = securityConfig.getRealmConfig(securityConfig.getMemberRealm());
-        assertEquals(realmConfig.getUsernamePasswordIdentityConfig().getPassword(), password);
+        assertEquals(password, realmConfig.getUsernamePasswordIdentityConfig().getPassword());
     }
 
     private MemberAddressProviderConfig getMemberAddressProviderConfig(Config cfg) {
@@ -618,7 +630,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         SecurityConfig expectedConfig = new SecurityConfig().setClientRealmConfig("ldapRealm", realmConfig);
         cfg.setSecurityConfig(expectedConfig);
 
-        SecurityConfig actualConfig = getNewConfigViaXMLGenerator(cfg).getSecurityConfig();
+        SecurityConfig actualConfig = getNewConfigViaXMLGenerator(cfg, false).getSecurityConfig();
         assertEquals(expectedConfig, actualConfig);
     }
 
@@ -676,7 +688,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
                 );
         SecurityConfig expectedConfig = new SecurityConfig().setMemberRealmConfig("simpleRealm", realmConfig);
         cfg.setSecurityConfig(expectedConfig);
-        SecurityConfig actualConfig = getNewConfigViaXMLGenerator(cfg).getSecurityConfig();
+        SecurityConfig actualConfig = getNewConfigViaXMLGenerator(cfg, false).getSecurityConfig();
         assertEquals(expectedConfig, actualConfig);
     }
 


### PR DESCRIPTION
Backports #24266 

This PR adds masking to additional config fields in `ConfigXmlGenerator`.