### PR TITLE
Create new property for member to set the temporary directory to be used for storing jar uploads [HZ-2315]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JetServiceBackend.java
@@ -49,7 +49,8 @@ import com.hazelcast.jet.impl.submitjob.memberside.JobMetaDataParameterObject;
 import com.hazelcast.jet.impl.submitjob.memberside.JobMultiPartParameterObject;
 import com.hazelcast.jet.impl.submitjob.memberside.JobUploadStatus;
 import com.hazelcast.jet.impl.submitjob.memberside.JobUploadStore;
-import com.hazelcast.jet.impl.submitjob.memberside.validator.JobMetaDataParameterObjectValidator;
+import com.hazelcast.jet.impl.submitjob.memberside.validator.JarOnClientValidator;
+import com.hazelcast.jet.impl.submitjob.memberside.validator.JarOnMemberValidator;
 import com.hazelcast.jet.impl.util.ExceptionUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
@@ -401,15 +402,20 @@ public class JetServiceBackend implements ManagedService, MembershipAwareService
      * Execute the given jar
      */
     public void jarOnMember(JobMetaDataParameterObject jobMetaDataParameterObject) {
-        JobMetaDataParameterObjectValidator.validateJarOnMember(jobMetaDataParameterObject);
+        // Performs validations before processing the request
+        JarOnMemberValidator.validate(jobMetaDataParameterObject);
+
         executeJar(jobMetaDataParameterObject);
     }
 
     /**
      * Store the metadata about the jar that is uploaded from client side
      */
-    public void storeJobMetaData(JobMetaDataParameterObject jobMetaDataParameterObject) {
+    public void jarOnClient(JobMetaDataParameterObject jobMetaDataParameterObject) {
+        // Performs validations before processing the request
         checkResourceUploadEnabled();
+        JarOnClientValidator.validate(jobMetaDataParameterObject);
+
         try {
             // Delegate processing to store
             jobUploadStore.processJobMetaData(jobMetaDataParameterObject);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/UploadJobMetaDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/UploadJobMetaDataOperation.java
@@ -23,7 +23,9 @@ import com.hazelcast.jet.impl.submitjob.memberside.JobMetaDataParameterObject;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -33,6 +35,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeL
 import static com.hazelcast.internal.util.UUIDSerializationUtil.readUUID;
 import static com.hazelcast.internal.util.UUIDSerializationUtil.writeUUID;
 import static com.hazelcast.jet.impl.util.Util.checkJetIsEnabled;
+import static com.hazelcast.spi.properties.ClusterProperty.JAR_UPLOAD_TEMP_DIR_PATH;
 
 /**
  * Uploads the metadata of a job to be executed by a jar
@@ -76,8 +79,14 @@ public class UploadJobMetaDataOperation extends Operation implements IdentifiedD
     }
 
     private void runJarOnClient() {
+        // Assign the temporary directory to be used
+        NodeEngine nodeEngine = getNodeEngine();
+        HazelcastProperties hazelcastProperties = nodeEngine.getProperties();
+        String tempDirectory = hazelcastProperties.getString(JAR_UPLOAD_TEMP_DIR_PATH);
+        jobMetaDataParameterObject.setTempDirectoryPath(tempDirectory);
+
         JetServiceBackend jetServiceBackend = getJetServiceBackend();
-        jetServiceBackend.storeJobMetaData(jobMetaDataParameterObject);
+        jetServiceBackend.jarOnClient(jobMetaDataParameterObject);
     }
 
     protected JetServiceBackend getJetServiceBackend() {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/UploadJobMetaDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/operation/UploadJobMetaDataOperation.java
@@ -35,7 +35,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeL
 import static com.hazelcast.internal.util.UUIDSerializationUtil.readUUID;
 import static com.hazelcast.internal.util.UUIDSerializationUtil.writeUUID;
 import static com.hazelcast.jet.impl.util.Util.checkJetIsEnabled;
-import static com.hazelcast.spi.properties.ClusterProperty.JAR_UPLOAD_TEMP_DIR_PATH;
+import static com.hazelcast.spi.properties.ClusterProperty.JAR_UPLOAD_DIR_PATH;
 
 /**
  * Uploads the metadata of a job to be executed by a jar
@@ -79,11 +79,11 @@ public class UploadJobMetaDataOperation extends Operation implements IdentifiedD
     }
 
     private void runJarOnClient() {
-        // Assign the temporary directory to be used
+        // Assign the upload directory path
         NodeEngine nodeEngine = getNodeEngine();
         HazelcastProperties hazelcastProperties = nodeEngine.getProperties();
-        String tempDirectory = hazelcastProperties.getString(JAR_UPLOAD_TEMP_DIR_PATH);
-        jobMetaDataParameterObject.setTempDirectoryPath(tempDirectory);
+        String uploadDirectoryPath = hazelcastProperties.getString(JAR_UPLOAD_DIR_PATH);
+        jobMetaDataParameterObject.setUploadDirectoryPath(uploadDirectoryPath);
 
         JetServiceBackend jetServiceBackend = getJetServiceBackend();
         jetServiceBackend.jarOnClient(jobMetaDataParameterObject);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobMetaDataParameterObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobMetaDataParameterObject.java
@@ -43,7 +43,7 @@ public class JobMetaDataParameterObject {
 
     private Path jarPath;
 
-    private String tempDirectoryPath;
+    private String uploadDirectoryPath;
 
     public UUID getSessionId() {
         return sessionId;
@@ -121,12 +121,12 @@ public class JobMetaDataParameterObject {
         this.jarPath = jarPath;
     }
 
-    public String getTempDirectoryPath() {
-        return tempDirectoryPath;
+    public String getUploadDirectoryPath() {
+        return uploadDirectoryPath;
     }
 
-    public void setTempDirectoryPath(String tempDirectoryPath) {
-        this.tempDirectoryPath = tempDirectoryPath;
+    public void setUploadDirectoryPath(String uploadDirectoryPath) {
+        this.uploadDirectoryPath = uploadDirectoryPath;
     }
 
     // Not all parameters need to be exposed

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobMetaDataParameterObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobMetaDataParameterObject.java
@@ -43,6 +43,8 @@ public class JobMetaDataParameterObject {
 
     private Path jarPath;
 
+    private String tempDirectoryPath;
+
     public UUID getSessionId() {
         return sessionId;
     }
@@ -119,8 +121,16 @@ public class JobMetaDataParameterObject {
         this.jarPath = jarPath;
     }
 
+    public String getTempDirectoryPath() {
+        return tempDirectoryPath;
+    }
+
+    public void setTempDirectoryPath(String tempDirectoryPath) {
+        this.tempDirectoryPath = tempDirectoryPath;
+    }
+
     // Not all parameters need to be exposed
-    // Convert only parameters that should be with an exception
+    // Show only relevant parameters that should be in the exception
     public String exceptionString() {
         return "JobMetaDataParameterObject{" +
                "jarOnMember='" + jarOnMember + '\'' +

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatus.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.Duration;
@@ -159,8 +160,7 @@ public class JobUploadStatus {
     }
 
     void createNewTemporaryFile() throws IOException {
-        // Create a new temporary file
-        Path jarPath = Files.createTempFile(jobMetaDataParameterObject.getFileName(), ".jar"); //NOSONAR
+        Path jarPath = getJarPath();
 
         // Make it accessible only by the owner
         File jarFile = jarPath.toFile();
@@ -179,6 +179,19 @@ public class JobUploadStatus {
 
         // Keep the temporary file's path in the metadata object
         jobMetaDataParameterObject.setJarPath(jarPath);
+    }
+
+    Path getJarPath() throws IOException {
+        Path jarPath;
+        if (jobMetaDataParameterObject.getTempDirectoryPath() != null) {
+            Path path = Paths.get(jobMetaDataParameterObject.getTempDirectoryPath());
+            // Create a new temporary file in the given directory
+            jarPath = Files.createTempFile(path, jobMetaDataParameterObject.getFileName(), ".jar");
+        } else {
+            // Create a new temporary file in the default temporary file directory
+            jarPath = Files.createTempFile(jobMetaDataParameterObject.getFileName(), ".jar");
+        }
+        return jarPath;
     }
 
     private static void validateReceivedParameters(JobMultiPartParameterObject parameterObject) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatus.java
@@ -160,7 +160,7 @@ public class JobUploadStatus {
     }
 
     void createNewTemporaryFile() throws IOException {
-        Path jarPath = getJarPath();
+        Path jarPath = createJarPath();
 
         // Make it accessible only by the owner
         File jarFile = jarPath.toFile();
@@ -182,7 +182,7 @@ public class JobUploadStatus {
     }
 
     @SuppressWarnings("java:S5443")
-    Path getJarPath() throws IOException {
+    Path createJarPath() throws IOException {
         Path jarPath;
         if (jobMetaDataParameterObject.getUploadDirectoryPath() != null) {
             Path path = Paths.get(jobMetaDataParameterObject.getUploadDirectoryPath());

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatus.java
@@ -184,8 +184,8 @@ public class JobUploadStatus {
     @SuppressWarnings("java:S5443")
     Path getJarPath() throws IOException {
         Path jarPath;
-        if (jobMetaDataParameterObject.getTempDirectoryPath() != null) {
-            Path path = Paths.get(jobMetaDataParameterObject.getTempDirectoryPath());
+        if (jobMetaDataParameterObject.getUploadDirectoryPath() != null) {
+            Path path = Paths.get(jobMetaDataParameterObject.getUploadDirectoryPath());
             // Create a new temporary file in the given directory
             jarPath = Files.createTempFile(path, jobMetaDataParameterObject.getFileName(), ".jar");
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatus.java
@@ -181,6 +181,7 @@ public class JobUploadStatus {
         jobMetaDataParameterObject.setJarPath(jarPath);
     }
 
+    @SuppressWarnings("java:S5443")
     Path getJarPath() throws IOException {
         Path jarPath;
         if (jobMetaDataParameterObject.getTempDirectoryPath() != null) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.submitjob.memberside.validator;
+
+import com.hazelcast.jet.JetException;
+import com.hazelcast.jet.impl.submitjob.memberside.JobMetaDataParameterObject;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Java client has validation but non-java clients may not perform validation.
+ * This class performs the validation on the member side
+ */
+public final class JarOnClientValidator {
+
+    private JarOnClientValidator() {
+    }
+
+    public static void validate(JobMetaDataParameterObject parameterObject) {
+        if (!parameterObject.isJarOnClient()) {
+            throw new JetException("Request is not configured for jar on client");
+        }
+
+        validateTempDirectoryPath(parameterObject.getTempDirectoryPath());
+        validateJobParameters(parameterObject.getJobParameters());
+    }
+
+    static void validateTempDirectoryPath(String  tempDirectoryPath) {
+        if (tempDirectoryPath != null) {
+            Path path = Paths.get(tempDirectoryPath);
+            if (!Files.exists(path)) {
+                String errorMessage = String.format("The temporary file path does not exist: %s ", path);
+                throw new JetException(errorMessage);
+            }
+        }
+    }
+    static void validateJobParameters(List<String> jobParameters) {
+        // Check that parameter is not null
+        if (Objects.isNull(jobParameters)) {
+            throw new JetException("jobParameters can not be null");
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidator.java
@@ -35,10 +35,6 @@ public final class JarOnClientValidator {
     }
 
     public static void validate(JobMetaDataParameterObject parameterObject) {
-        if (!parameterObject.isJarOnClient()) {
-            throw new JetException("Request is not configured for jar on client");
-        }
-
         validateUploadDirectoryPath(parameterObject.getUploadDirectoryPath());
         validateJobParameters(parameterObject.getJobParameters());
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidator.java
@@ -39,15 +39,15 @@ public final class JarOnClientValidator {
             throw new JetException("Request is not configured for jar on client");
         }
 
-        validateTempDirectoryPath(parameterObject.getTempDirectoryPath());
+        validateUploadDirectoryPath(parameterObject.getUploadDirectoryPath());
         validateJobParameters(parameterObject.getJobParameters());
     }
 
-    static void validateTempDirectoryPath(String  tempDirectoryPath) {
-        if (tempDirectoryPath != null) {
-            Path path = Paths.get(tempDirectoryPath);
+    static void validateUploadDirectoryPath(String  uploadDirectoryPath) {
+        if (uploadDirectoryPath != null) {
+            Path path = Paths.get(uploadDirectoryPath);
             if (!Files.exists(path)) {
-                String errorMessage = String.format("The temporary file path does not exist: %s ", path);
+                String errorMessage = String.format("The upload directory path does not exist: %s ", path);
                 throw new JetException(errorMessage);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidator.java
@@ -43,7 +43,7 @@ public final class JarOnClientValidator {
         if (uploadDirectoryPath != null) {
             Path path = Paths.get(uploadDirectoryPath);
             if (!Files.exists(path)) {
-                String errorMessage = String.format("The upload directory path does not exist: %s ", path);
+                String errorMessage = String.format("The upload directory path does not exist: %s", path);
                 throw new JetException(errorMessage);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnMemberValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnMemberValidator.java
@@ -35,10 +35,6 @@ public final class JarOnMemberValidator {
     }
 
     public static void validate(JobMetaDataParameterObject parameterObject) {
-        if (!parameterObject.isJarOnMember()) {
-            throw new JetException("Request is not configured for jar on member");
-        }
-
         Path jarPath = parameterObject.getJarPath();
         validateJarPathNotNull(jarPath);
         validateFileSizeIsNotZero(jarPath);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnMemberValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnMemberValidator.java
@@ -29,12 +29,12 @@ import java.util.Objects;
  * Java client has validation but non-java clients may not perform validation.
  * This class performs the validation on the member side
  */
-public final class JobMetaDataParameterObjectValidator {
+public final class JarOnMemberValidator {
 
-    private JobMetaDataParameterObjectValidator() {
+    private JarOnMemberValidator() {
     }
 
-    public static void validateJarOnMember(JobMetaDataParameterObject parameterObject) {
+    public static void validate(JobMetaDataParameterObject parameterObject) {
         if (!parameterObject.isJarOnMember()) {
             throw new JetException("Request is not configured for jar on member");
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1872,6 +1872,12 @@ public final class ClusterProperty {
     public static final HazelcastProperty PERSISTENCE_AUTO_CLUSTER_STATE_STRATEGY = new HazelcastProperty(
             "hazelcast.persistence.auto.cluster.state.strategy", ClusterState.NO_MIGRATION);
 
+    /**
+     * The temporary directory path to be used for uploaded jars
+     */
+    public static final HazelcastProperty JAR_UPLOAD_TEMP_DIR_PATH
+            = new HazelcastProperty("hazelcast.cluster.jarupload.tempdir");
+
     private ClusterProperty() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1873,7 +1873,16 @@ public final class ClusterProperty {
             "hazelcast.persistence.auto.cluster.state.strategy", ClusterState.NO_MIGRATION);
 
     /**
-     * The directory path to be used for jar uploading
+     * The absolute directory path to be used for jar uploading. The path must exist and must have
+     * read + write + execute permissions for the Hazelcast process
+     * <p>
+     * In case of a shared file system, the same absolute path can be specified for all cluster members,
+     * but this defeats the purpose of being able to distinguish jars uploaded to a specific member.
+     * Therefore, it is suggested to have a unique path per cluster member
+     * <p>
+     * In case of a separate file system per member, the same absolute path can be used for all members
+     *
+     * @since 5.3
      */
     public static final HazelcastProperty JAR_UPLOAD_DIR_PATH
             = new HazelcastProperty("hazelcast.cluster.jarupload.dirpath");

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1873,15 +1873,12 @@ public final class ClusterProperty {
             "hazelcast.persistence.auto.cluster.state.strategy", ClusterState.NO_MIGRATION);
 
     /**
-     * The absolute directory path to be used for jar uploading. The path must exist and must have
+     * The directory path to be used for jar uploading. The path must exist and must have
      * read + write + execute permissions for the Hazelcast process
      * <p>
-     * In case of a shared file system, the same absolute path can be specified for all cluster members,
-     * but this defeats the purpose of being able to distinguish jars uploaded to a specific member.
-     * Therefore, it is suggested to have a unique path per cluster member
+     * A different path can be specified for each member
      * <p>
-     * In case of a separate file system per member, the same absolute path can be used for all members
-     *
+     * The path can be absolute or relative to current working directory of Hazelcast process
      * @since 5.3
      */
     public static final HazelcastProperty JAR_UPLOAD_DIR_PATH

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1,4 +1,5 @@
 /*
+/*
  * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1873,10 +1874,10 @@ public final class ClusterProperty {
             "hazelcast.persistence.auto.cluster.state.strategy", ClusterState.NO_MIGRATION);
 
     /**
-     * The temporary directory path to be used for uploaded jars
+     * The directory path to be used for jar uploading
      */
-    public static final HazelcastProperty JAR_UPLOAD_TEMP_DIR_PATH
-            = new HazelcastProperty("hazelcast.cluster.jarupload.tempdir");
+    public static final HazelcastProperty JAR_UPLOAD_DIR_PATH
+            = new HazelcastProperty("hazelcast.cluster.jarupload.dirpath");
 
     private ClusterProperty() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1,5 +1,4 @@
 /*
-/*
  * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1872,12 +1871,6 @@ public final class ClusterProperty {
      */
     public static final HazelcastProperty PERSISTENCE_AUTO_CLUSTER_STATE_STRATEGY = new HazelcastProperty(
             "hazelcast.persistence.auto.cluster.state.strategy", ClusterState.NO_MIGRATION);
-
-    /**
-     * The directory path to be used for jar uploading
-     */
-    public static final HazelcastProperty JAR_UPLOAD_DIR_PATH
-            = new HazelcastProperty("hazelcast.cluster.jarupload.dirpath");
 
     private ClusterProperty() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1872,6 +1872,12 @@ public final class ClusterProperty {
     public static final HazelcastProperty PERSISTENCE_AUTO_CLUSTER_STATE_STRATEGY = new HazelcastProperty(
             "hazelcast.persistence.auto.cluster.state.strategy", ClusterState.NO_MIGRATION);
 
+    /**
+     * The directory path to be used for jar uploading
+     */
+    public static final HazelcastProperty JAR_UPLOAD_DIR_PATH
+            = new HazelcastProperty("hazelcast.cluster.jarupload.dirpath");
+
     private ClusterProperty() {
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
@@ -195,7 +195,7 @@ public class JobUploadClientSuccessTest extends JetTestSupport {
                 String jobName = "job-" + value;
                 SubmitJobParameters submitJobParameters = SubmitJobParameters.withJarOnClient()
                         .setJarPath(getJarPath())
-                                .setJobName(jobName);
+                        .setJobName(jobName);
 
                 jetService.submitJobFromJar(submitJobParameters);
                 submittedJobNames.add(jobName);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.jet.impl.SubmitJobParameters;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.annotation.SlowTest;
@@ -77,6 +78,19 @@ public class JobUploadClientSuccessTest extends JetTestSupport {
     @Test
     public void test_jarUpload_whenResourceUploadIsEnabled() throws IOException {
         createCluster();
+        JetClientInstanceImpl jetService = getClientJetService();
+
+        SubmitJobParameters submitJobParameters = SubmitJobParameters.withJarOnClient()
+                .setJarPath(getJarPath());
+
+        jetService.submitJobFromJar(submitJobParameters);
+
+        assertJobIsRunning(jetService);
+    }
+
+    @Test
+    public void test_jarUpload_tempdir_whenResourceUploadIsEnabled() throws IOException {
+        createClusterWithTempDirectory(".");
         JetClientInstanceImpl jetService = getClientJetService();
 
         SubmitJobParameters submitJobParameters = SubmitJobParameters.withJarOnClient()
@@ -236,6 +250,15 @@ public class JobUploadClientSuccessTest extends JetTestSupport {
 
     private void createCluster() {
         Config config = smallInstanceConfig();
+        JetConfig jetConfig = config.getJetConfig();
+        jetConfig.setResourceUploadEnabled(true);
+
+        createHazelcastInstance(config);
+    }
+
+    private void createClusterWithTempDirectory(String tempDirectory) {
+        Config config = smallInstanceConfig();
+        config.setProperty(ClusterProperty.JAR_UPLOAD_TEMP_DIR_PATH.getName(), tempDirectory);
         JetConfig jetConfig = config.getJetConfig();
         jetConfig.setResourceUploadEnabled(true);
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
@@ -90,7 +90,7 @@ public class JobUploadClientSuccessTest extends JetTestSupport {
 
     @Test
     public void test_jarUpload_tempdir_whenResourceUploadIsEnabled() throws IOException {
-        createClusterWithTempDirectory(".");
+        createClusterWithUploadDirectoryPath(".");
         JetClientInstanceImpl jetService = getClientJetService();
 
         SubmitJobParameters submitJobParameters = SubmitJobParameters.withJarOnClient()
@@ -256,9 +256,9 @@ public class JobUploadClientSuccessTest extends JetTestSupport {
         createHazelcastInstance(config);
     }
 
-    private void createClusterWithTempDirectory(String tempDirectory) {
+    private void createClusterWithUploadDirectoryPath(String uploadDirectoryPath) {
         Config config = smallInstanceConfig();
-        config.setProperty(ClusterProperty.JAR_UPLOAD_TEMP_DIR_PATH.getName(), tempDirectory);
+        config.setProperty(ClusterProperty.JAR_UPLOAD_DIR_PATH.getName(), uploadDirectoryPath);
         JetConfig jetConfig = config.getJetConfig();
         jetConfig.setResourceUploadEnabled(true);
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
@@ -40,8 +40,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.List;
@@ -78,19 +81,6 @@ public class JobUploadClientSuccessTest extends JetTestSupport {
     @Test
     public void test_jarUpload_whenResourceUploadIsEnabled() throws IOException {
         createCluster();
-        JetClientInstanceImpl jetService = getClientJetService();
-
-        SubmitJobParameters submitJobParameters = SubmitJobParameters.withJarOnClient()
-                .setJarPath(getJarPath());
-
-        jetService.submitJobFromJar(submitJobParameters);
-
-        assertJobIsRunning(jetService);
-    }
-
-    @Test
-    public void test_jarUpload_tempdir_whenResourceUploadIsEnabled() throws IOException {
-        createClusterWithUploadDirectoryPath(".");
         JetClientInstanceImpl jetService = getClientJetService();
 
         SubmitJobParameters submitJobParameters = SubmitJobParameters.withJarOnClient()
@@ -248,6 +238,36 @@ public class JobUploadClientSuccessTest extends JetTestSupport {
         });
     }
 
+    @Test
+    public void test_jarUpload_tempdir_whenResourceUploadIsEnabled() throws IOException {
+        Path path = Paths.get("target/jardirectory");
+        try {
+            // Make sure the temp directory exist
+            Files.createDirectories(path);
+            String directoryPath = path.toString();
+
+            // Start cluster with the temp directory path
+            createClusterWithUploadDirectoryPath(directoryPath);
+
+            JetClientInstanceImpl jetService = getClientJetService();
+
+            SubmitJobParameters submitJobParameters = SubmitJobParameters.withJarOnClient()
+                    .setJarPath(getJarPath());
+
+            jetService.submitJobFromJar(submitJobParameters);
+
+            assertJobIsRunning(jetService);
+
+            // After a job is executed the jar is deleted. Test that no file exists in the temp dir
+            File directory = new File(directoryPath);
+            File[] jarFiles = directory.listFiles((dir, name) -> name.endsWith(".jar"));
+            assertThat(jarFiles).isNotNull().isEmpty();
+        } finally {
+            // Cleanup
+            Files.deleteIfExists(path);
+        }
+    }
+
     private void createCluster() {
         Config config = smallInstanceConfig();
         JetConfig jetConfig = config.getJetConfig();
@@ -256,7 +276,7 @@ public class JobUploadClientSuccessTest extends JetTestSupport {
         createHazelcastInstance(config);
     }
 
-    private void createClusterWithUploadDirectoryPath(String uploadDirectoryPath) {
+    public void createClusterWithUploadDirectoryPath(String uploadDirectoryPath) {
         Config config = smallInstanceConfig();
         config.setProperty(ClusterProperty.JAR_UPLOAD_DIR_PATH.getName(), uploadDirectoryPath);
         JetConfig jetConfig = config.getJetConfig();

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
@@ -242,7 +242,7 @@ public class JobUploadClientSuccessTest extends JetTestSupport {
     public void test_jarUpload_tempdir_whenResourceUploadIsEnabled() throws IOException {
         Path path = Paths.get("target/jardirectory");
         try {
-            // Make sure the temp directory exist
+            // Make sure the temp directory exists
             Files.createDirectories(path);
             String directoryPath = path.toString();
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatusTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatusTest.java
@@ -29,6 +29,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
@@ -193,5 +194,19 @@ public class JobUploadStatusTest {
 
         jobUploadStatus.changeLastUpdatedTime();
         assertEquals(fixedInstant, jobUploadStatus.lastUpdatedTime);
+    }
+
+    @Test
+    public void testGetJarPath() throws IOException {
+        Path jarPath = null;
+        try {
+            when(jobMetaDataParameterObject.getTempDirectoryPath()).thenReturn(".");
+            jarPath = jobUploadStatus.getJarPath();
+            assertTrue(Files.exists(jarPath));
+        } finally {
+            if (jarPath != null) {
+                Files.delete(jarPath);
+            }
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatusTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatusTest.java
@@ -205,7 +205,7 @@ public class JobUploadStatusTest {
             Files.createDirectories(path);
             String uploadPath = path.toAbsolutePath().toString();
             when(jobMetaDataParameterObject.getUploadDirectoryPath()).thenReturn(uploadPath);
-            jarPath = jobUploadStatus.getJarPath();
+            jarPath = jobUploadStatus.createJarPath();
             assertTrue(Files.exists(jarPath));
         } finally {
             if (jarPath != null) {

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatusTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatusTest.java
@@ -32,6 +32,7 @@ import org.mockito.MockitoAnnotations;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -200,7 +201,10 @@ public class JobUploadStatusTest {
     public void testGetJarPath() throws IOException {
         Path jarPath = null;
         try {
-            when(jobMetaDataParameterObject.getUploadDirectoryPath()).thenReturn(".");
+            Path path = Paths.get("target");
+            Files.createDirectories(path);
+            String uploadPath = path.toAbsolutePath().toString();
+            when(jobMetaDataParameterObject.getUploadDirectoryPath()).thenReturn(uploadPath);
             jarPath = jobUploadStatus.getJarPath();
             assertTrue(Files.exists(jarPath));
         } finally {

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatusTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/JobUploadStatusTest.java
@@ -200,7 +200,7 @@ public class JobUploadStatusTest {
     public void testGetJarPath() throws IOException {
         Path jarPath = null;
         try {
-            when(jobMetaDataParameterObject.getTempDirectoryPath()).thenReturn(".");
+            when(jobMetaDataParameterObject.getUploadDirectoryPath()).thenReturn(".");
             jarPath = jobUploadStatus.getJarPath();
             assertTrue(Files.exists(jarPath));
         } finally {

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidatorTest.java
@@ -25,9 +25,9 @@ public class JarOnClientValidatorTest {
 
     @Test
     public void testValidateTempDirectoryPath() {
-        assertThatThrownBy(() -> JarOnClientValidator.validateTempDirectoryPath("foo"))
+        assertThatThrownBy(() -> JarOnClientValidator.validateUploadDirectoryPath("foo"))
                 .isInstanceOf(JetException.class)
-                .hasMessageContaining("The temporary file path does not exist: foo");
+                .hasMessageContaining("The upload directory path does not exist: foo");
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.jet.impl.submitjob.memberside.validator;
 
 import com.hazelcast.jet.JetException;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnClientValidatorTest.java
@@ -1,0 +1,23 @@
+package com.hazelcast.jet.impl.submitjob.memberside.validator;
+
+import com.hazelcast.jet.JetException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class JarOnClientValidatorTest {
+
+    @Test
+    public void testValidateTempDirectoryPath() {
+        assertThatThrownBy(() -> JarOnClientValidator.validateTempDirectoryPath("foo"))
+                .isInstanceOf(JetException.class)
+                .hasMessageContaining("The temporary file path does not exist: foo");
+    }
+
+    @Test
+    public void testValidateJobParameters() {
+        assertThatThrownBy(() -> JarOnClientValidator.validateJobParameters(null))
+                .isInstanceOf(JetException.class)
+                .hasMessageContaining("jobParameters can not be null");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnMemberValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/memberside/validator/JarOnMemberValidatorTest.java
@@ -25,18 +25,18 @@ import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class JobMetaDataParameterObjectValidatorTest {
+public class JarOnMemberValidatorTest {
 
     @Test
     public void testValidateJarOnMember() {
         JobMetaDataParameterObject parameterObject = new JobMetaDataParameterObject();
-        assertThatThrownBy(() -> JobMetaDataParameterObjectValidator.validateJarOnMember(parameterObject))
+        assertThatThrownBy(() -> JarOnMemberValidator.validate(parameterObject))
                 .isInstanceOf(JetException.class);
     }
 
     @Test
     public void testValidateJarPathNotNull() {
-        assertThatThrownBy(() -> JobMetaDataParameterObjectValidator.validateJarPathNotNull(null))
+        assertThatThrownBy(() -> JarOnMemberValidator.validateJarPathNotNull(null))
                 .isInstanceOf(JetException.class)
                 .hasMessageContaining("File path can not be null");
     }
@@ -44,7 +44,7 @@ public class JobMetaDataParameterObjectValidatorTest {
     @Test
     public void testValidateFileExtension() {
         Path jarPath = Paths.get("foo");
-        assertThatThrownBy(() -> JobMetaDataParameterObjectValidator.validateFileExtension(jarPath))
+        assertThatThrownBy(() -> JarOnMemberValidator.validateFileExtension(jarPath))
                 .isInstanceOf(JetException.class)
                 .hasMessageContaining("File name extension should be .jar");
     }
@@ -52,15 +52,15 @@ public class JobMetaDataParameterObjectValidatorTest {
     @Test
     public void testValidateFileSizeIsNotZero() {
         Path jarPath = Paths.get("foo");
-        assertThatThrownBy(() -> JobMetaDataParameterObjectValidator.validateFileSizeIsNotZero(jarPath))
+        assertThatThrownBy(() -> JarOnMemberValidator.validateFileSizeIsNotZero(jarPath))
                 .isInstanceOf(JetException.class)
                 .hasMessageContaining("File is not accessible");
     }
 
     @Test
     public void testValidateJobParameters() {
-        assertThatThrownBy(() -> JobMetaDataParameterObjectValidator.validateJobParameters(null))
-                .isInstanceOf(JetException.class);
-
+        assertThatThrownBy(() -> JarOnMemberValidator.validateJobParameters(null))
+                .isInstanceOf(JetException.class)
+                .hasMessageContaining("jobParameters can not be null");
     }
 }


### PR DESCRIPTION
On the cloud environment the temp directory may need to be set. This allows easier permission management

The new property is ClusterProperty.JAR_UPLOAD_TEMP_DIR_PATH

Jira : https://hazelcast.atlassian.net/browse/HZ-2315

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
