### PR TITLE
Validate mapStoreConfig has data-connection-ref property [HZ-2314]

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
@@ -17,6 +17,7 @@
 package com.hazelcast.mapstore;
 
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.dataconnection.impl.JdbcDataConnection;
@@ -165,8 +166,14 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
 
     private void validateMapStoreConfig(HazelcastInstance instance, String mapName) {
         MapConfig mapConfig = instance.getConfig().findMapConfig(mapName);
-        if (!mapConfig.getMapStoreConfig().isOffload()) {
-            throw new HazelcastException("Config for GenericMapStore must have `offload` property set to true");
+        MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();
+        if (!mapStoreConfig.isOffload()) {
+            throw new HazelcastException("MapStoreConfig for " + mapConfig.getName() +
+                                         " must have `offload` property set to true");
+        }
+        if (mapStoreConfig.getProperty(DATA_CONNECTION_REF_PROPERTY) == null) {
+            throw new HazelcastException("MapStoreConfig for " + mapConfig.getName() +
+                                         " must have `" + DATA_CONNECTION_REF_PROPERTY + "` property set");
         }
     }
 

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/AllTypesGenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/AllTypesGenericMapStoreTest.java
@@ -135,15 +135,19 @@ public class AllTypesGenericMapStoreTest extends JdbcSqlTestSupport {
         tableName = randomTableName();
         createTable(tableName, "id INT PRIMARY KEY", "table_column " + type);
 
+        Properties properties = new Properties();
+        properties.setProperty(DATA_CONNECTION_REF_PROPERTY, TEST_DATABASE_REF);
+
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setClassName(GenericMapStore.class.getName());
+        mapStoreConfig.setProperties(properties);
+
         MapConfig mapConfig = new MapConfig(tableName);
         mapConfig.setMapStoreConfig(mapStoreConfig);
 
         instance().getConfig().addMapConfig(mapConfig);
 
-        Properties properties = new Properties();
-        properties.setProperty(DATA_CONNECTION_REF_PROPERTY, TEST_DATABASE_REF);
+
 
         mapStore = new GenericMapStore<>();
         mapStore.init(instance(), properties, tableName);

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreTest.java
@@ -392,7 +392,7 @@ public class GenericMapStoreTest extends GenericMapLoaderTest {
 
     @Override
     protected <K> GenericMapStore<K> createUnitUnderTest(Properties properties, HazelcastInstance instance, boolean init) {
-        MapConfig mapConfig = createMapConfigWithMapStore(mapName);
+        MapConfig mapConfig = createMapConfigWithMapStore(mapName, properties);
         instance.getConfig().addMapConfig(mapConfig);
 
         GenericMapStore<K> mapStore = new GenericMapStore<>();
@@ -403,9 +403,10 @@ public class GenericMapStoreTest extends GenericMapLoaderTest {
         return mapStore;
     }
 
-    private MapConfig createMapConfigWithMapStore(String mapName) {
+    private MapConfig createMapConfigWithMapStore(String mapName, Properties properties) {
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setClassName(GenericMapStore.class.getName());
+        mapStoreConfig.setProperties(properties);
         MapConfig mapConfig = new MapConfig(mapName);
         mapConfig.setMapStoreConfig(mapStoreConfig);
         return mapConfig;


### PR DESCRIPTION
Throw a readable exception if data-connection-ref property is not set for MapStoreConfig 

Fixes : https://github.com/hazelcast/hazelcast/pull/24310
Jira : https://hazelcast.atlassian.net/browse/HZ-2314

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
