### PR TITLE
Less flaky MongoStreamSqlConnectorTest [HZ-2304]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
@@ -77,6 +77,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiPredicate;
 
+import static com.hazelcast.jet.function.RunnableEx.noop;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JAVA_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS;
@@ -251,7 +252,7 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
             Collection<Row> expectedRows,
             long timeoutForNextMs
     ) {
-        assertRowsEventuallyInAnyOrder(sql, arguments, expectedRows, timeoutForNextMs, () -> {});
+        assertRowsEventuallyInAnyOrder(sql, arguments, expectedRows, timeoutForNextMs, noop());
     }
 
     /**


### PR DESCRIPTION
New just-after-execution action will allow to start inserting data after query has started, so we don't risk flakiness in this regards.

Fixes #24116

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
