### PR TITLE
Add convenience SqlService.executeUpdate method

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
@@ -508,16 +508,15 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
      * java serialization for both key and value with the given classes.
      */
     public static void createMapping(HazelcastInstance instance, String name, Class<?> keyClass, Class<?> valueClass) {
-        try (SqlResult result = instance.getSql().execute("CREATE OR REPLACE MAPPING " + name + " TYPE " + IMapSqlConnector.TYPE_NAME + "\n"
+        long updateCount = instance.getSql().executeUpdate("CREATE OR REPLACE MAPPING " + name + " TYPE " + IMapSqlConnector.TYPE_NAME + "\n"
                 + "OPTIONS (\n"
                 + '\'' + OPTION_KEY_FORMAT + "'='" + JAVA_FORMAT + "'\n"
                 + ", '" + OPTION_KEY_CLASS + "'='" + keyClass.getName() + "'\n"
                 + ", '" + OPTION_VALUE_FORMAT + "'='" + JAVA_FORMAT + "'\n"
                 + ", '" + OPTION_VALUE_CLASS + "'='" + valueClass.getName() + "'\n"
                 + ")"
-        )) {
-            assertThat(result.updateCount()).isEqualTo(0);
-        }
+        );
+        assertThat(updateCount).isEqualTo(0);
     }
 
     /**

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlDataConnectionStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlDataConnectionStatementTest.java
@@ -74,7 +74,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_createSharedDataConnection_then_success() {
         String dlName = randomName();
-        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
+        instance().getSql().executeUpdate("CREATE DATA CONNECTION " + dlName
                 + " TYPE \"DUMMY\" "
                 + " SHARED "
                 + " OPTIONS ('b' = 'c')");
@@ -91,7 +91,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_createDefaultSharingDataConnection_then_success() {
         String dlName = randomName();
-        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
+        instance().getSql().executeUpdate("CREATE DATA CONNECTION " + dlName
                 + " TYPE \"DUMMY\" "
                 + " OPTIONS ('b' = 'c')");
 
@@ -107,7 +107,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_createDataConnection_fullyQualified_then_success() {
         String dlName = randomName();
-        instance().getSql().executeStatement("CREATE DATA CONNECTION hazelcast.public." + dlName
+        instance().getSql().executeUpdate("CREATE DATA CONNECTION hazelcast.public." + dlName
                 + " TYPE \"DUMMY\" "
                 + " OPTIONS ('b' = 'c')");
         for (InternalDataConnectionService dataConnectionService : dataConnectionServices) {
@@ -122,7 +122,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     public void when_createDataConnectionInWrongNameSpace_then_throws() {
         String dlName = randomName();
         assertThatThrownBy(() ->
-                instance().getSql().executeStatement("CREATE DATA CONNECTION hazelcast.yyy." + dlName
+                instance().getSql().executeUpdate("CREATE DATA CONNECTION hazelcast.yyy." + dlName
                         + " TYPE \"DUMMY\" "
                         + " NOT SHARED "
                         + " OPTIONS ('b' = 'c')"))
@@ -133,7 +133,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_createDataConnectionIfAlreadyExists_then_throws() {
         String dlName = randomName();
-        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
+        instance().getSql().executeUpdate("CREATE DATA CONNECTION " + dlName
                 + " TYPE \"DUMMY\" "
                 + " NOT SHARED "
                 + " OPTIONS ('b' = 'c')");
@@ -144,7 +144,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
         }
 
         assertThatThrownBy(() ->
-                instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
+                instance().getSql().executeUpdate("CREATE DATA CONNECTION " + dlName
                         + " TYPE \"DUMMY\" "
                         + " NOT SHARED "
                         + " OPTIONS ('b' = 'c')"))
@@ -163,7 +163,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
         }
 
         assertThatThrownBy(() ->
-                instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
+                instance().getSql().executeUpdate("CREATE DATA CONNECTION " + dlName
                         + " TYPE \"DUMMY\" "
                         + " NOT SHARED "
                         + " OPTIONS ('b' = 'c')"))
@@ -175,7 +175,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     public void when_createDataConnectionWithoutType_then_throws() {
         String dlName = randomName();
         assertThatThrownBy(() ->
-                instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName))
+                instance().getSql().executeUpdate("CREATE DATA CONNECTION " + dlName))
                 .isInstanceOf(HazelcastException.class)
                 .hasMessageContaining("Was expecting one of:" + System.lineSeparator() + "    \"TYPE\" ...");
     }
@@ -198,7 +198,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     public void when_createDataConnectionWithoutOptions_then_success() {
         String dlName = randomName();
 
-        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName  + " TYPE DUMMY SHARED");
+        instance().getSql().executeUpdate("CREATE DATA CONNECTION " + dlName  + " TYPE DUMMY SHARED");
 
         for (InternalDataConnectionService dataConnectionService : dataConnectionServices) {
             DataConnection dataConnection = dataConnectionService.getAndRetainDataConnection(dlName, DummyDataConnection.class);
@@ -211,11 +211,11 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
         String dlName1 = randomName();
         String dlName2 = randomName();
 
-        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName1
+        instance().getSql().executeUpdate("CREATE DATA CONNECTION " + dlName1
                 + " TYPE \"DUMMY\" "
                 + " NOT SHARED "
                 + " OPTIONS ('b' = 'c')");
-        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName2
+        instance().getSql().executeUpdate("CREATE DATA CONNECTION " + dlName2
                 + " TYPE \"DUMMY\" "
                 + " NOT SHARED "
                 + " OPTIONS ('b' = 'c')");
@@ -248,7 +248,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
         }
 
         assertThatThrownBy(() ->
-                instance().getSql().executeStatement("DROP DATA CONNECTION " + dlName))
+                instance().getSql().executeUpdate("DROP DATA CONNECTION " + dlName))
                 .isInstanceOf(HazelcastException.class)
                 .hasMessageContaining("is configured via Config and can't be removed");
     }
@@ -256,14 +256,14 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_dropNonExistentDataConnection_withIfExists_then_success() {
         // this should throw no error
-        instance().getSql().executeStatement("DROP DATA CONNECTION IF EXISTS " + randomName());
+        instance().getSql().executeUpdate("DROP DATA CONNECTION IF EXISTS " + randomName());
     }
 
     @Test
     public void when_dropNonExistentDataConnection_withoutIfExists_then_throws() {
         String dlName = randomName();
         assertThatThrownBy(() ->
-                instance().getSql().executeStatement("DROP DATA CONNECTION " + dlName))
+                instance().getSql().executeUpdate("DROP DATA CONNECTION " + dlName))
                 .isInstanceOf(HazelcastException.class)
                 .hasMessageContaining("Data connection does not exist");
     }
@@ -271,12 +271,12 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_createIfNotExists_then_notOverwritten() {
         String dlName = randomName();
-        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
+        instance().getSql().executeUpdate("CREATE DATA CONNECTION " + dlName
                 + " TYPE \"DUMMY\" "
                 + " NOT SHARED "
                 + " OPTIONS ('b' = 'c')");
 
-        instance().getSql().executeStatement("CREATE DATA CONNECTION IF NOT EXISTS " + dlName
+        instance().getSql().executeUpdate("CREATE DATA CONNECTION IF NOT EXISTS " + dlName
                 + " TYPE \"DUMMY\" "
                 + " NOT SHARED "
                 + " OPTIONS ('d' = 'e')");

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlDataConnectionStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlDataConnectionStatementTest.java
@@ -74,7 +74,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_createSharedDataConnection_then_success() {
         String dlName = randomName();
-        instance().getSql().execute("CREATE DATA CONNECTION " + dlName
+        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
                 + " TYPE \"DUMMY\" "
                 + " SHARED "
                 + " OPTIONS ('b' = 'c')");
@@ -91,7 +91,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_createDefaultSharingDataConnection_then_success() {
         String dlName = randomName();
-        instance().getSql().execute("CREATE DATA CONNECTION " + dlName
+        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
                 + " TYPE \"DUMMY\" "
                 + " OPTIONS ('b' = 'c')");
 
@@ -107,7 +107,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_createDataConnection_fullyQualified_then_success() {
         String dlName = randomName();
-        instance().getSql().execute("CREATE DATA CONNECTION hazelcast.public." + dlName
+        instance().getSql().executeStatement("CREATE DATA CONNECTION hazelcast.public." + dlName
                 + " TYPE \"DUMMY\" "
                 + " OPTIONS ('b' = 'c')");
         for (InternalDataConnectionService dataConnectionService : dataConnectionServices) {
@@ -122,7 +122,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     public void when_createDataConnectionInWrongNameSpace_then_throws() {
         String dlName = randomName();
         assertThatThrownBy(() ->
-                instance().getSql().execute("CREATE DATA CONNECTION hazelcast.yyy." + dlName
+                instance().getSql().executeStatement("CREATE DATA CONNECTION hazelcast.yyy." + dlName
                         + " TYPE \"DUMMY\" "
                         + " NOT SHARED "
                         + " OPTIONS ('b' = 'c')"))
@@ -133,7 +133,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_createDataConnectionIfAlreadyExists_then_throws() {
         String dlName = randomName();
-        instance().getSql().execute("CREATE DATA CONNECTION " + dlName
+        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
                 + " TYPE \"DUMMY\" "
                 + " NOT SHARED "
                 + " OPTIONS ('b' = 'c')");
@@ -144,7 +144,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
         }
 
         assertThatThrownBy(() ->
-                instance().getSql().execute("CREATE DATA CONNECTION " + dlName
+                instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
                         + " TYPE \"DUMMY\" "
                         + " NOT SHARED "
                         + " OPTIONS ('b' = 'c')"))
@@ -163,7 +163,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
         }
 
         assertThatThrownBy(() ->
-                instance().getSql().execute("CREATE DATA CONNECTION " + dlName
+                instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
                         + " TYPE \"DUMMY\" "
                         + " NOT SHARED "
                         + " OPTIONS ('b' = 'c')"))
@@ -175,7 +175,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     public void when_createDataConnectionWithoutType_then_throws() {
         String dlName = randomName();
         assertThatThrownBy(() ->
-                instance().getSql().execute("CREATE DATA CONNECTION " + dlName))
+                instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName))
                 .isInstanceOf(HazelcastException.class)
                 .hasMessageContaining("Was expecting one of:" + System.lineSeparator() + "    \"TYPE\" ...");
     }
@@ -198,7 +198,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     public void when_createDataConnectionWithoutOptions_then_success() {
         String dlName = randomName();
 
-        instance().getSql().execute("CREATE DATA CONNECTION " + dlName  + " TYPE DUMMY SHARED");
+        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName  + " TYPE DUMMY SHARED");
 
         for (InternalDataConnectionService dataConnectionService : dataConnectionServices) {
             DataConnection dataConnection = dataConnectionService.getAndRetainDataConnection(dlName, DummyDataConnection.class);
@@ -211,11 +211,11 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
         String dlName1 = randomName();
         String dlName2 = randomName();
 
-        instance().getSql().execute("CREATE DATA CONNECTION " + dlName1
+        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName1
                 + " TYPE \"DUMMY\" "
                 + " NOT SHARED "
                 + " OPTIONS ('b' = 'c')");
-        instance().getSql().execute("CREATE DATA CONNECTION " + dlName2
+        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName2
                 + " TYPE \"DUMMY\" "
                 + " NOT SHARED "
                 + " OPTIONS ('b' = 'c')");
@@ -248,7 +248,7 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
         }
 
         assertThatThrownBy(() ->
-                instance().getSql().execute("DROP DATA CONNECTION " + dlName))
+                instance().getSql().executeStatement("DROP DATA CONNECTION " + dlName))
                 .isInstanceOf(HazelcastException.class)
                 .hasMessageContaining("is configured via Config and can't be removed");
     }
@@ -256,14 +256,14 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_dropNonExistentDataConnection_withIfExists_then_success() {
         // this should throw no error
-        instance().getSql().execute("DROP DATA CONNECTION IF EXISTS " + randomName());
+        instance().getSql().executeStatement("DROP DATA CONNECTION IF EXISTS " + randomName());
     }
 
     @Test
     public void when_dropNonExistentDataConnection_withoutIfExists_then_throws() {
         String dlName = randomName();
         assertThatThrownBy(() ->
-                instance().getSql().execute("DROP DATA CONNECTION " + dlName))
+                instance().getSql().executeStatement("DROP DATA CONNECTION " + dlName))
                 .isInstanceOf(HazelcastException.class)
                 .hasMessageContaining("Data connection does not exist");
     }
@@ -271,12 +271,12 @@ public class SqlDataConnectionStatementTest extends SqlTestSupport {
     @Test
     public void when_createIfNotExists_then_notOverwritten() {
         String dlName = randomName();
-        instance().getSql().execute("CREATE DATA CONNECTION " + dlName
+        instance().getSql().executeStatement("CREATE DATA CONNECTION " + dlName
                 + " TYPE \"DUMMY\" "
                 + " NOT SHARED "
                 + " OPTIONS ('b' = 'c')");
 
-        instance().getSql().execute("CREATE DATA CONNECTION IF NOT EXISTS " + dlName
+        instance().getSql().executeStatement("CREATE DATA CONNECTION IF NOT EXISTS " + dlName
                 + " TYPE \"DUMMY\" "
                 + " NOT SHARED "
                 + " OPTIONS ('d' = 'e')");

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -97,8 +97,8 @@ public interface SqlService {
      * SqlStatement} object and invokes {@link #execute(SqlStatement)}.
      *
      * <p>
-     * This method is meant to be used for statements other than "SELECT" queries and only if user does not really need the
-     * count of updated entries.
+     * This method is meant to be used for statements other than "SELECT" queries. The returned value is the
+     * number of updated(/inserted/deleted) rows.
      *
      * @param sql       SQL string
      * @param arguments query parameter values that will be passed to {@link SqlStatement#setParameters(List)}
@@ -107,19 +107,18 @@ public interface SqlService {
      * @throws HazelcastSqlException    in case of execution error
      * @see SqlService
      * @see SqlStatement
+     *
      * @see #execute(SqlStatement)
+     * @see #execute(String, Object...)
+     *
+     * @return The number of updated(/inserted/deleted) rows.
+     *
+     * @since 5.3
      */
-    @SuppressWarnings({"EmptyTryBlock", "checkstyle:EmptyBlock"})
-    default void executeStatement(@Nonnull String sql, Object... arguments) {
-        SqlStatement statement = new SqlStatement(sql);
-
-        if (arguments != null) {
-            for (Object arg : arguments) {
-                statement.addParameter(arg);
-            }
-
-        }
-        try (SqlResult ignored = execute(statement)) {
+    default long executeUpdate(@Nonnull String sql, Object... arguments) {
+        try (SqlResult result = execute(sql, arguments)) {
+            assert !result.isRowSet() : "Result should not contain rowSet when called from executeUpdate";
+            return result.updateCount();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -90,14 +90,14 @@ public interface SqlService {
     }
 
     /**
-     * Convenience method to execute a distributed non-DQL statement with the given
-     * parameter values.
+     * Convenience method to execute a distributed non-DQL statement (that is
+     * a statement that does not return rows) with the given parameter values.
      * <p>
      * Converts passed SQL string and parameter values into an {@link
      * SqlStatement} object and invokes {@link #execute(SqlStatement)}.
      *
      * <p>
-     * This method is meant to be used for statements other than "SELECT" queries.
+     * This method can be used for statements other than "SELECT" queries.
      * The returned value is the {@link SqlResult#updateCount()} value.
      *
      * @param sql       SQL string

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -90,15 +90,15 @@ public interface SqlService {
     }
 
     /**
-     * Convenient method to execute a distributed query with the given
+     * Convenience method to execute a distributed non-DQL statement with the given
      * parameter values.
      * <p>
      * Converts passed SQL string and parameter values into an {@link
      * SqlStatement} object and invokes {@link #execute(SqlStatement)}.
      *
      * <p>
-     * This method is meant to be used for statements other than "SELECT" queries. The returned value is the
-     * number of updated(/inserted/deleted) rows.
+     * This method is meant to be used for statements other than "SELECT" queries.
+     * The returned value is the {@link SqlResult#updateCount()} value.
      *
      * @param sql       SQL string
      * @param arguments query parameter values that will be passed to {@link SqlStatement#setParameters(List)}

--- a/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/sql/SqlService.java
@@ -90,6 +90,40 @@ public interface SqlService {
     }
 
     /**
+     * Convenient method to execute a distributed query with the given
+     * parameter values.
+     * <p>
+     * Converts passed SQL string and parameter values into an {@link
+     * SqlStatement} object and invokes {@link #execute(SqlStatement)}.
+     *
+     * <p>
+     * This method is meant to be used for statements other than "SELECT" queries and only if user does not really need the
+     * count of updated entries.
+     *
+     * @param sql       SQL string
+     * @param arguments query parameter values that will be passed to {@link SqlStatement#setParameters(List)}
+     * @throws NullPointerException     if the SQL string is null
+     * @throws IllegalArgumentException if the SQL string is empty
+     * @throws HazelcastSqlException    in case of execution error
+     * @see SqlService
+     * @see SqlStatement
+     * @see #execute(SqlStatement)
+     */
+    @SuppressWarnings({"EmptyTryBlock", "checkstyle:EmptyBlock"})
+    default void executeStatement(@Nonnull String sql, Object... arguments) {
+        SqlStatement statement = new SqlStatement(sql);
+
+        if (arguments != null) {
+            for (Object arg : arguments) {
+                statement.addParameter(arg);
+            }
+
+        }
+        try (SqlResult ignored = execute(statement)) {
+        }
+    }
+
+    /**
      * Executes an SQL statement.
      *
      * @param statement statement to be executed


### PR DESCRIPTION
Simply add a convenience method that takes care of closing underlying SqlResult when no real result is expected (non-DQL statement). In such case closing is not strictly necessary but is good practice since SqlResult is AutoCloseable.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
