### PR TITLE
Ignore tpc net tests for Ibm JDK 8

### DIFF
--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/TpcTestSupport.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/TpcTestSupport.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.tpcengine;
 
+import com.hazelcast.internal.tpcengine.util.JVM;
+
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -29,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 public class TpcTestSupport {
 
@@ -212,5 +215,12 @@ public class TpcTestSupport {
 
     public static void assertTrueEventually(AssertTask task, long timeoutSeconds) {
         assertTrueEventually(null, task, timeoutSeconds);
+    }
+
+    public static void assumeNotIbmJDK8() {
+        String vendor = System.getProperty("java.vendor");
+        boolean isIbmJDK = vendor.toLowerCase().contains("ibm");
+        boolean isIbmJDK8 = isIbmJDK && (JVM.getMajorVersion() == 8);
+        assumeFalse(isIbmJDK8);
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketBuilderTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketBuilderTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.tpcengine.Option;
 import com.hazelcast.internal.tpcengine.Reactor;
 import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
@@ -27,6 +28,7 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminateAll;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -38,6 +40,11 @@ public abstract class AsyncServerSocketBuilderTest {
     private final List<Reactor> reactors = new ArrayList<>();
 
     public abstract ReactorBuilder newReactorBuilder();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
+    }
 
     @After
     public void after() throws InterruptedException {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketMetricsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketMetricsTest.java
@@ -16,11 +16,18 @@
 
 package com.hazelcast.internal.tpcengine.net;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static junit.framework.TestCase.assertEquals;
 
 public class AsyncServerSocketMetricsTest {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
+    }
 
     @Test
     public void test_writeEvents() {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketOptionsTest.java
@@ -19,11 +19,13 @@ package com.hazelcast.internal.tpcengine.net;
 import com.hazelcast.internal.tpcengine.Reactor;
 import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminateAll;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_RCVBUF;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_REUSEADDR;
@@ -39,6 +41,11 @@ public abstract class AsyncServerSocketOptionsTest {
     private final List<Reactor> reactors = new ArrayList<>();
 
     public abstract ReactorBuilder newReactorBuilder();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
+    }
 
     @After
     public void after() {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.tpcengine.Reactor;
 import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import com.hazelcast.internal.tpcengine.util.CloseUtil;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.UncheckedIOException;
@@ -31,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertCompletesEventually;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertTrueEventually;
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminate;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminateAll;
 import static junit.framework.TestCase.assertNotNull;
@@ -52,6 +54,11 @@ public abstract class AsyncServerSocketTest {
         Reactor reactor = reactorBuilder.build();
         reactors.add(reactor);
         return reactor.start();
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
     }
 
     @After

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketBuilderTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketBuilderTest.java
@@ -21,11 +21,13 @@ import com.hazelcast.internal.tpcengine.Reactor;
 import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import com.hazelcast.internal.tpcengine.TpcTestSupport;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -42,6 +44,11 @@ public abstract class AsyncSocketBuilderTest {
         Reactor reactor = builder.build();
         reactors.add(reactor);
         return reactor.start();
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
     }
 
     @After

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketMetricsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketMetricsTest.java
@@ -16,11 +16,18 @@
 
 package com.hazelcast.internal.tpcengine.net;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static junit.framework.TestCase.assertEquals;
 
 public class AsyncSocketMetricsTest {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
+    }
 
     @Test
     public void test_bytesRead() {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketOptionsTest.java
@@ -20,11 +20,13 @@ import com.hazelcast.internal.tpcengine.Option;
 import com.hazelcast.internal.tpcengine.Reactor;
 import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminateAll;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_KEEPALIVE;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_RCVBUF;
@@ -47,6 +49,11 @@ public abstract class AsyncSocketOptionsTest {
     private final List<Reactor> reactors = new ArrayList<>();
 
     public abstract ReactorBuilder newReactorBuilder();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
+    }
 
     @After
     public void after() {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.tpcengine.net;
 import com.hazelcast.internal.tpcengine.Reactor;
 import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
@@ -30,6 +31,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertCompletesEventually;
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminateAll;
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
@@ -49,6 +51,11 @@ public abstract class AsyncSocketTest {
         Reactor reactor = builder.build();
         reactors.add(reactor);
         return reactor.start();
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
     }
 
     @After

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocket_LargePayloadTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.tpcengine.iobuffer.IOBufferAllocator;
 import com.hazelcast.internal.tpcengine.iobuffer.NonConcurrentIOBufferAllocator;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
@@ -34,6 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.ASSERT_TRUE_EVENTUALLY_TIMEOUT;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertOpenEventually;
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminate;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_RCVBUF;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_SNDBUF;
@@ -55,6 +57,11 @@ public abstract class AsyncSocket_LargePayloadTest {
     private Reactor serverReactor;
 
     public abstract ReactorBuilder newReactorBuilder();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
+    }
 
     @Before
     public void before() {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocket_ReadableTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocket_ReadableTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import com.hazelcast.internal.tpcengine.iobuffer.IOBuffer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
@@ -28,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertTrueEventually;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertTrueTwoSeconds;
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminate;
 import static com.hazelcast.internal.tpcengine.util.BitUtil.SIZEOF_LONG;
 import static org.junit.Assert.assertEquals;
@@ -42,6 +44,11 @@ public abstract class AsyncSocket_ReadableTest {
     private Reactor serverReactor;
 
     public abstract ReactorBuilder newReactorBuilder();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
+    }
 
     @Before
     public void before() {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocket_RpcTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocket_RpcTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.tpcengine.iobuffer.IOBufferAllocator;
 import com.hazelcast.internal.tpcengine.iobuffer.NonConcurrentIOBufferAllocator;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.ASSERT_TRUE_EVENTUALLY_TIMEOUT;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertJoinable;
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assumeNotIbmJDK8;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminate;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_RCVBUF;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_SNDBUF;
@@ -65,6 +67,11 @@ public abstract class AsyncSocket_RpcTest {
     private Reactor serverReactor;
 
     public abstract ReactorBuilder newReactorBuilder();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assumeNotIbmJDK8();
+    }
 
     @Before
     public void before() {


### PR DESCRIPTION
This PR ignores tests in `com.hazelcast.internal.tpcengine.net` package
for Ibm JDK 8.

See https://hazelcast.slack.com/archives/C03CKDYJ334/p1681825466684249