### PR TITLE
Validate keep-alive related socket options [HZ-2166]

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.3.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.3.xsd
@@ -5242,9 +5242,9 @@
             <xs:element name="send-buffer-size-kb" type="parameterized-positive-integer" minOccurs="0"/>
             <xs:element name="receive-buffer-size-kb" type="parameterized-positive-integer" minOccurs="0"/>
             <xs:element name="linger-seconds" type="parameterized-non-negative-integer" minOccurs="0"/>
-            <xs:element name="keep-idle-seconds" type="parameterized-unsigned-int" minOccurs="0" default="7200"/>
-            <xs:element name="keep-interval-seconds" type="parameterized-unsigned-int" minOccurs="0" default="75"/>
-            <xs:element name="keep-count" type="parameterized-unsigned-int" minOccurs="0" default="8"/>
+            <xs:element name="keep-idle-seconds" type="parameterized-positive-integer" minOccurs="0" default="7200"/>
+            <xs:element name="keep-interval-seconds" type="parameterized-positive-integer" minOccurs="0" default="75"/>
+            <xs:element name="keep-count" type="parameterized-positive-integer" minOccurs="0" default="8"/>
         </xs:all>
     </xs:complexType>
 

--- a/hazelcast/src/main/java/com/hazelcast/config/EndpointConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EndpointConfig.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.tpc.TpcSocketConfig;
 import com.hazelcast.config.tpc.TpcConfig;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.ProtocolType;
+import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.annotation.PrivateApi;
 
@@ -76,6 +77,21 @@ public class EndpointConfig implements NamedConfig {
      * See {@code jdk.net.ExtendedSocketOptions#TCP_KEEPINTERVAL}
      */
     public static final int DEFAULT_SOCKET_KEEP_COUNT = 8;
+
+    /**
+     * Maximum configurable number of seconds for {@link #socketKeepIdleSeconds}
+     */
+    private static final int MAX_SOCKET_KEEP_IDLE_SECONDS = 32767;
+
+    /**
+     * Maximum configurable number of seconds for {@link #socketKeepIntervalSeconds}
+     */
+    private static final int MAX_SOCKET_KEEP_INTERVAL_SECONDS = 32767;
+
+    /**
+     * Maximum configurable number of keep alive probes for {@link #socketKeepCount}
+     */
+    private static final int MAX_SOCKET_KEEP_COUNT = 127;
 
     protected String name;
     protected ProtocolType protocolType;
@@ -349,6 +365,8 @@ public class EndpointConfig implements NamedConfig {
 
     /**
      * Set the number of seconds a connection needs to be idle before TCP begins sending out keep-alive probes.
+     * Valid values are 1 to 32767.
+     * <p/>
      * This option is only applicable when {@link #setSocketKeepAlive(boolean) keep alive is true}.
      * Requires a recent JDK 8, JDK 11 or greater version that includes the required
      * <a href="https://bugs.openjdk.org/browse/JDK-8194298">JDK support</a>.
@@ -358,6 +376,9 @@ public class EndpointConfig implements NamedConfig {
      *      jdk.net.ExtendedSocketOptions#TCP_KEEPIDLE</a>
      */
     public EndpointConfig setSocketKeepIdleSeconds(int socketKeepIdleSeconds) {
+        Preconditions.checkPositive("socketKeepIdleSeconds", socketKeepIdleSeconds);
+        Preconditions.checkTrue(socketKeepIdleSeconds < MAX_SOCKET_KEEP_IDLE_SECONDS,
+                "socketKeepIdleSeconds value " + socketKeepIdleSeconds + " is outside valid range 1 - 32767");
         this.socketKeepIdleSeconds = socketKeepIdleSeconds;
         return this;
     }
@@ -381,16 +402,21 @@ public class EndpointConfig implements NamedConfig {
     /**
      * Set the number of seconds between keep-alive probes. Notice that this is the number of seconds between probes
      * after the initial {@link #setSocketKeepIdleSeconds(int) keep-alive idle time} has passed.
+     * Valid values are 1 to 32767.
+     * <p/>
      * This option is only applicable when {@link #setSocketKeepAlive(boolean) keep alive is true}.
      * Requires a recent JDK 8, JDK 11 or greater version that includes the required
      * <a href="https://bugs.openjdk.org/browse/JDK-8194298">JDK support</a>.
      *
      * @since 5.3.0
      * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.net/jdk/net/
-     ExtendedSocketOptions.html#TCP_KEEPINTERVAL">
+ExtendedSocketOptions.html#TCP_KEEPINTERVAL">
      *     jdk.net.ExtendedSocketOptions#TCP_KEEPINTERVAL</a>
      */
     public EndpointConfig setSocketKeepIntervalSeconds(int socketKeepIntervalSeconds) {
+        Preconditions.checkPositive("socketKeepIntervalSeconds", socketKeepIntervalSeconds);
+        Preconditions.checkTrue(socketKeepIntervalSeconds < MAX_SOCKET_KEEP_INTERVAL_SECONDS,
+                "socketKeepIntervalSeconds value " + socketKeepIntervalSeconds + " is outside valid range 1 - 32767");
         this.socketKeepIntervalSeconds = socketKeepIntervalSeconds;
         return this;
     }
@@ -413,7 +439,8 @@ public class EndpointConfig implements NamedConfig {
 
     /**
      * Set the maximum number of TCP keep-alive probes to send before giving up and closing the connection if no
-     * response is obtained from the other side.
+     * response is obtained from the other side. Valid values are 1 to 127.
+     * <p/>
      * This option is only applicable when {@link #setSocketKeepAlive(boolean) keep alive is true}.
      * Requires a recent JDK 8, JDK 11 or greater version that includes the required
      * <a href="https://bugs.openjdk.org/browse/JDK-8194298">JDK support</a>.
@@ -423,6 +450,9 @@ public class EndpointConfig implements NamedConfig {
      *     jdk.net.ExtendedSocketOptions#TCP_KEEPCOUNT</a>
      */
     public EndpointConfig setSocketKeepCount(int socketKeepCount) {
+        Preconditions.checkPositive("socketKeepCount", socketKeepCount);
+        Preconditions.checkTrue(socketKeepCount < MAX_SOCKET_KEEP_COUNT,
+                "socketKeepCount value " + socketKeepCount + " is outside valid range 1 - 127");
         this.socketKeepCount = socketKeepCount;
         return this;
     }

--- a/hazelcast/src/main/resources/hazelcast-config-5.3.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.3.json
@@ -4048,17 +4048,17 @@
         "keep-idle-seconds": {
           "type": "integer",
           "default": 7200,
-          "description": "Specifies the TCP Keep-Alive idle time: the number of seconds of idle time before keep-alive initiates a probe."
+          "description": "Specifies the TCP Keep-Alive idle time: the number of seconds of idle time before keep-alive initiates a probe. Valid values are 1 to 32767."
         },
         "keep-interval-seconds": {
           "type": "integer",
           "default": 75,
-          "description": "Specifies the TCP keep-alive interval: the number of seconds between keep-alive probes."
+          "description": "Specifies the TCP keep-alive interval: the number of seconds between keep-alive probes. Valid values are 1 to 32767."
         },
         "keep-count": {
           "type": "integer",
           "default": 8,
-          "description": "Specifies the TCP Keep-Alive count: the maximum number of TCP keep-alive probes to send before giving up and closing the connection if no response is obtained from the other side."
+          "description": "Specifies the TCP Keep-Alive count: the maximum number of TCP keep-alive probes to send before giving up and closing the connection if no response is obtained from the other side. Valid values are 1 to 127."
         }
       }
     },

--- a/hazelcast/src/main/resources/hazelcast-config-5.3.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.3.xsd
@@ -4990,9 +4990,9 @@
             <xs:element name="send-buffer-size-kb" type="xs:positiveInteger" minOccurs="0"/>
             <xs:element name="receive-buffer-size-kb" type="xs:positiveInteger" minOccurs="0"/>
             <xs:element name="linger-seconds" type="xs:nonNegativeInteger" minOccurs="0"/>
-            <xs:element name="keep-idle-seconds" type="xs:nonNegativeInteger" minOccurs="0" default="7200"/>
-            <xs:element name="keep-interval-seconds" type="xs:nonNegativeInteger" minOccurs="0" default="75"/>
-            <xs:element name="keep-count" type="xs:nonNegativeInteger" minOccurs="0" default="8"/>
+            <xs:element name="keep-idle-seconds" type="xs:positiveInteger" minOccurs="0" default="7200"/>
+            <xs:element name="keep-interval-seconds" type="xs:positiveInteger" minOccurs="0" default="75"/>
+            <xs:element name="keep-count" type="xs:positiveInteger" minOccurs="0" default="8"/>
         </xs:all>
     </xs:complexType>
     <xs:complexType name="rest-server-socket-endpoint-config">

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -490,6 +490,15 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testDefaultAdvancedNetworkConfig();
 
     @Test
+    public abstract void testAdvancedNetworkConfig_whenInvalidSocketKeepIdleSeconds();
+
+    @Test
+    public abstract void testAdvancedNetworkConfig_whenInvalidSocketKeepIntervalSeconds();
+
+    @Test
+    public abstract void testAdvancedNetworkConfig_whenInvalidSocketKeepCount();
+
+    @Test
     public abstract void testAmbiguousNetworkConfig_throwsException();
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/EndpointConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EndpointConfigTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -36,5 +37,29 @@ public class EndpointConfigTest extends HazelcastTestSupport {
                 .usingGetClass()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
+    }
+
+    @Test
+    public void testKeepCountValidation() {
+        EndpointConfig endpointConfig = new EndpointConfig();
+        Assert.assertThrows(IllegalArgumentException.class, () -> endpointConfig.setSocketKeepCount(0));
+        Assert.assertThrows(IllegalArgumentException.class, () -> endpointConfig.setSocketKeepCount(128));
+        Assert.assertThrows(IllegalArgumentException.class, () -> endpointConfig.setSocketKeepCount(-3));
+    }
+
+    @Test
+    public void testKeepIdleSecondsValidation() {
+        EndpointConfig endpointConfig = new EndpointConfig();
+        Assert.assertThrows(IllegalArgumentException.class, () -> endpointConfig.setSocketKeepIdleSeconds(0));
+        Assert.assertThrows(IllegalArgumentException.class, () -> endpointConfig.setSocketKeepIdleSeconds(32768));
+        Assert.assertThrows(IllegalArgumentException.class, () -> endpointConfig.setSocketKeepIdleSeconds(-17));
+    }
+
+    @Test
+    public void testKeepIntervalSecondsValidation() {
+        EndpointConfig endpointConfig = new EndpointConfig();
+        Assert.assertThrows(IllegalArgumentException.class, () -> endpointConfig.setSocketKeepIntervalSeconds(0));
+        Assert.assertThrows(IllegalArgumentException.class, () -> endpointConfig.setSocketKeepIntervalSeconds(32768));
+        Assert.assertThrows(IllegalArgumentException.class, () -> endpointConfig.setSocketKeepIntervalSeconds(-17));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -43,6 +43,7 @@ import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
 import com.hazelcast.wan.WanPublisherState;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -3952,6 +3953,45 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testAdvancedNetworkConfig_whenInvalidSocketKeepIdleSeconds() {
+        String invalid1 = getAdvancedNetworkConfigWithSocketOption("keep-idle-seconds", -1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid1));
+
+        String invalid2 = getAdvancedNetworkConfigWithSocketOption("keep-idle-seconds",0);
+        Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid2));
+
+        String invalid3 = getAdvancedNetworkConfigWithSocketOption("keep-idle-seconds",32768);
+        Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid3));
+    }
+
+    @Override
+    @Test
+    public void testAdvancedNetworkConfig_whenInvalidSocketKeepIntervalSeconds() {
+        String invalid1 = getAdvancedNetworkConfigWithSocketOption("keep-interval-seconds",-1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid1));
+
+        String invalid2 = getAdvancedNetworkConfigWithSocketOption("keep-interval-seconds",0);
+        Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid2));
+
+        String invalid3 = getAdvancedNetworkConfigWithSocketOption("keep-interval-seconds",32768);
+        Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid3));
+    }
+
+    @Override
+    @Test
+    public void testAdvancedNetworkConfig_whenInvalidSocketKeepCount() {
+        String invalid1 = getAdvancedNetworkConfigWithSocketOption("keep-count",-1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid1));
+
+        String invalid2 = getAdvancedNetworkConfigWithSocketOption("keep-count",0);
+        Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid2));
+
+        String invalid3 = getAdvancedNetworkConfigWithSocketOption("keep-count",128);
+        Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid3));
+    }
+
+    @Override
+    @Test
     public void testAmbiguousNetworkConfig_throwsException() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -4693,5 +4733,16 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
             assertThat(tpcSocketConfig.getReceiveBufferSizeKB()).isEqualTo(256);
             assertThat(tpcSocketConfig.getSendBufferSizeKB()).isEqualTo(256);
         });
+    }
+
+    public String getAdvancedNetworkConfigWithSocketOption(String socketOption, int value) {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  advanced-network:\n"
+                + "    enabled: true\n"
+                + "    member-server-socket-endpoint-config: \n"
+                + "      socket-options: \n"
+                + "        " + socketOption + ": " + value + "\n";
+        return yaml;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3957,36 +3957,36 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         String invalid1 = getAdvancedNetworkConfigWithSocketOption("keep-idle-seconds", -1);
         Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid1));
 
-        String invalid2 = getAdvancedNetworkConfigWithSocketOption("keep-idle-seconds",0);
+        String invalid2 = getAdvancedNetworkConfigWithSocketOption("keep-idle-seconds", 0);
         Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid2));
 
-        String invalid3 = getAdvancedNetworkConfigWithSocketOption("keep-idle-seconds",32768);
+        String invalid3 = getAdvancedNetworkConfigWithSocketOption("keep-idle-seconds", 32768);
         Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid3));
     }
 
     @Override
     @Test
     public void testAdvancedNetworkConfig_whenInvalidSocketKeepIntervalSeconds() {
-        String invalid1 = getAdvancedNetworkConfigWithSocketOption("keep-interval-seconds",-1);
+        String invalid1 = getAdvancedNetworkConfigWithSocketOption("keep-interval-seconds", -1);
         Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid1));
 
-        String invalid2 = getAdvancedNetworkConfigWithSocketOption("keep-interval-seconds",0);
+        String invalid2 = getAdvancedNetworkConfigWithSocketOption("keep-interval-seconds", 0);
         Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid2));
 
-        String invalid3 = getAdvancedNetworkConfigWithSocketOption("keep-interval-seconds",32768);
+        String invalid3 = getAdvancedNetworkConfigWithSocketOption("keep-interval-seconds", 32768);
         Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid3));
     }
 
     @Override
     @Test
     public void testAdvancedNetworkConfig_whenInvalidSocketKeepCount() {
-        String invalid1 = getAdvancedNetworkConfigWithSocketOption("keep-count",-1);
+        String invalid1 = getAdvancedNetworkConfigWithSocketOption("keep-count", -1);
         Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid1));
 
-        String invalid2 = getAdvancedNetworkConfigWithSocketOption("keep-count",0);
+        String invalid2 = getAdvancedNetworkConfigWithSocketOption("keep-count", 0);
         Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid2));
 
-        String invalid3 = getAdvancedNetworkConfigWithSocketOption("keep-count",128);
+        String invalid3 = getAdvancedNetworkConfigWithSocketOption("keep-count", 128);
         Assert.assertThrows(IllegalArgumentException.class, () -> buildConfig(invalid3));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/UnifiedNetworkIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/UnifiedNetworkIntegrationTest.java
@@ -30,10 +30,8 @@ import com.hazelcast.test.Accessors;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.core.Hazelcast.newHazelcastInstance;
@@ -42,16 +40,50 @@ import static com.hazelcast.internal.networking.nio.NetworkTestUtil.assumeKeepAl
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class UnifiedNetworkIntegrationTest {
-    @Rule
-    public ExpectedException expect = ExpectedException.none();
-
     @After
     public void tearDown() {
         Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testInvalidKeepIdleCount_failsStartup() throws Throwable {
+        assumeKeepAlivePerSocketOptionsSupported();
+        Config config = smallInstanceConfig();
+        config.setProperty(ClusterProperty.SOCKET_KEEP_COUNT.getName(), "-1");
+        assertThrows(IllegalArgumentException.class, () -> newHazelcastInstance(config));
+        config.setProperty(ClusterProperty.SOCKET_KEEP_COUNT.getName(), "128");
+        assertThrows(IllegalArgumentException.class, () -> newHazelcastInstance(config));
+        config.setProperty(ClusterProperty.SOCKET_KEEP_COUNT.getName(), "0");
+        assertThrows(IllegalArgumentException.class, () -> newHazelcastInstance(config));
+    }
+
+    @Test
+    public void testInvalidKeepIntervalSeconds_failsStartup() throws Throwable {
+        assumeKeepAlivePerSocketOptionsSupported();
+        Config config = smallInstanceConfig();
+        config.setProperty(ClusterProperty.SOCKET_KEEP_INTERVAL.getName(), "-1");
+        assertThrows(IllegalArgumentException.class, () -> newHazelcastInstance(config));
+        config.setProperty(ClusterProperty.SOCKET_KEEP_INTERVAL.getName(), "32768");
+        assertThrows(IllegalArgumentException.class, () -> newHazelcastInstance(config));
+        config.setProperty(ClusterProperty.SOCKET_KEEP_INTERVAL.getName(), "0");
+        assertThrows(IllegalArgumentException.class, () -> newHazelcastInstance(config));
+    }
+
+    @Test
+    public void testInvalidKeepIdleSeconds_failsStartup() throws Throwable {
+        assumeKeepAlivePerSocketOptionsSupported();
+        Config config = smallInstanceConfig();
+        config.setProperty(ClusterProperty.SOCKET_KEEP_IDLE.getName(), "-1");
+        assertThrows(IllegalArgumentException.class, () -> newHazelcastInstance(config));
+        config.setProperty(ClusterProperty.SOCKET_KEEP_IDLE.getName(), "32768");
+        assertThrows(IllegalArgumentException.class, () -> newHazelcastInstance(config));
+        config.setProperty(ClusterProperty.SOCKET_KEEP_IDLE.getName(), "0");
+        assertThrows(IllegalArgumentException.class, () -> newHazelcastInstance(config));
     }
 
     @Test


### PR DESCRIPTION
Validation was added in the relative `EndpointConfig` setters.
So when using advanced network, exception will be thrown at config time.
When using unified network and the associated cluster properties, validation
occurs (again in `EndpointConfig` setters) early during node startup.
XML/yaml/spring configuration also use `EndpointConfig` setters and fail fast.

Fixes #24001
