### PR TITLE
Add GenericMapLoader.LOAD_ALL_KEYS_PROPERTY to  disable loading all keys [HZ-2285]

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
@@ -41,6 +41,7 @@ import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.sql.SqlService;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -346,7 +347,7 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
     public Iterable<K> loadAllKeys() {
         // If loadAllKeys property is disabled, don't load anything
         if (!genericMapStoreProperties.loadAllKeys) {
-            return null;
+            return Collections.emptyList();
         }
 
         awaitSuccessfulInit();

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
@@ -113,7 +113,7 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
     /**
      * Property key to control loading of all keys when IMap is first created
      */
-    public static final String LOAD_ALL_KEYS_PROPERTY = "load_all_keys";
+    public static final String LOAD_ALL_KEYS_PROPERTY = "load-all-keys";
 
     /**
      * Timeout for initialization of GenericMapLoader
@@ -180,6 +180,19 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
             throw new HazelcastException("MapStoreConfig for " + mapConfig.getName() +
                                          " must have `" + DATA_CONNECTION_REF_PROPERTY + "` property set");
         }
+
+        // Validate that property is not an invalid boolean string
+        String loadAllKeys = mapStoreConfig.getProperty(LOAD_ALL_KEYS_PROPERTY);
+        if (loadAllKeys != null) {
+            if (!isBoolean(loadAllKeys)) {
+                throw new HazelcastException("MapStoreConfig for " + mapConfig.getName() +
+                                             " must have `" + LOAD_ALL_KEYS_PROPERTY + "` property set as true or false");
+            }
+        }
+    }
+
+    private boolean isBoolean(String value) {
+        return value.equalsIgnoreCase("false") || value.equalsIgnoreCase("true");
     }
 
     private ManagedExecutorService getMapStoreExecutor() {

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStoreProperties.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStoreProperties.java
@@ -69,7 +69,6 @@ class GenericMapStoreProperties {
         compactTypeName = properties.getProperty(TYPE_NAME_PROPERTY, mapName);
 
         String value = properties.getProperty(LOAD_ALL_KEYS_PROPERTY, "true");
-        // parseBoolean() returns false if the input is case-insensitive "true"
         loadAllKeys = Boolean.parseBoolean(value);
     }
 

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStoreProperties.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapStoreProperties.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import static com.hazelcast.mapstore.GenericMapLoader.COLUMNS_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.DATA_CONNECTION_REF_PROPERTY;
+import static com.hazelcast.mapstore.GenericMapLoader.LOAD_ALL_KEYS_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.ID_COLUMN_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.TABLE_NAME_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.TYPE_NAME_PROPERTY;
@@ -42,6 +43,11 @@ class GenericMapStoreProperties {
     final Set<String> allColumns = new HashSet<>();
     final boolean idColumnInColumns;
     final String compactTypeName;
+
+    /**
+     * Flag that indicates if {@link GenericMapLoader#loadAllKeys()} should run or not
+     */
+    final boolean loadAllKeys;
 
     GenericMapStoreProperties(Properties properties, String mapName) {
         dataConnectionRef = properties.getProperty(DATA_CONNECTION_REF_PROPERTY);
@@ -61,6 +67,10 @@ class GenericMapStoreProperties {
 
         idColumnInColumns = columns.isEmpty() || columns.contains(idColumn);
         compactTypeName = properties.getProperty(TYPE_NAME_PROPERTY, mapName);
+
+        String value = properties.getProperty(LOAD_ALL_KEYS_PROPERTY, "true");
+        // parseBoolean() returns false if the input is case-insensitive "true"
+        loadAllKeys = Boolean.parseBoolean(value);
     }
 
     boolean hasColumns() {

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapLoaderTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapLoaderTest.java
@@ -403,7 +403,7 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
         mapLoader = createMapLoader(properties, hz);
 
         List<Integer> ids = newArrayList(mapLoader.loadAllKeys());
-        assertThat(ids).isNull();
+        assertThat(ids).isEmpty();
     }
 
     @Test

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapLoaderTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapLoaderTest.java
@@ -432,10 +432,11 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
 
         properties.setProperty(ID_COLUMN_PROPERTY, "person-id");
         properties.setProperty(LOAD_ALL_KEYS_PROPERTY, "invalidBooleanValue");
-        mapLoader = createMapLoader(properties, hz);
+        assertThatThrownBy(() -> createMapLoader(properties, hz))
+                .isInstanceOf(HazelcastException.class)
+                .hasMessage("MapStoreConfig for " + mapName + " must have `load-all-keys` property set as true or false");
 
-        List<Integer> ids = newArrayList(mapLoader.loadAllKeys());
-        assertThat(ids).isNull();
+
     }
 
     @Test

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapLoaderTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapLoaderTest.java
@@ -41,6 +41,7 @@ import java.util.Properties;
 import static com.hazelcast.mapstore.GenericMapLoader.COLUMNS_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.DATA_CONNECTION_REF_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.ID_COLUMN_PROPERTY;
+import static com.hazelcast.mapstore.GenericMapLoader.LOAD_ALL_KEYS_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.MAPPING_PREFIX;
 import static com.hazelcast.mapstore.GenericMapLoader.TABLE_NAME_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapLoader.TYPE_NAME_PROPERTY;
@@ -387,6 +388,54 @@ public class GenericMapLoaderTest extends JdbcSqlTestSupport {
 
         List<Integer> ids = newArrayList(mapLoader.loadAllKeys());
         assertThat(ids).contains(0);
+    }
+
+    @Test
+    public void givenFalse_whenLoadAllKeys_thenReturnNull() throws Exception {
+        createTable(mapName, quote("person-id") + " INT PRIMARY KEY", "name VARCHAR(100)");
+        insertItems(mapName, 1);
+
+        Properties properties = new Properties();
+        properties.setProperty(DATA_CONNECTION_REF_PROPERTY, TEST_DATABASE_REF);
+
+        properties.setProperty(ID_COLUMN_PROPERTY, "person-id");
+        properties.setProperty(LOAD_ALL_KEYS_PROPERTY, "false");
+        mapLoader = createMapLoader(properties, hz);
+
+        List<Integer> ids = newArrayList(mapLoader.loadAllKeys());
+        assertThat(ids).isNull();
+    }
+
+    @Test
+    public void givenTrue_whenLoadAllKeys_thenReturnKeys() throws Exception {
+        createTable(mapName, quote("person-id") + " INT PRIMARY KEY", "name VARCHAR(100)");
+        insertItems(mapName, 1);
+
+        Properties properties = new Properties();
+        properties.setProperty(DATA_CONNECTION_REF_PROPERTY, TEST_DATABASE_REF);
+
+        properties.setProperty(ID_COLUMN_PROPERTY, "person-id");
+        properties.setProperty(LOAD_ALL_KEYS_PROPERTY, "true");
+        mapLoader = createMapLoader(properties, hz);
+
+        List<Integer> ids = newArrayList(mapLoader.loadAllKeys());
+        assertThat(ids).contains(0);
+    }
+
+    @Test
+    public void givenInvalid_whenLoadAllKeys_thenReturnKeys() throws Exception {
+        createTable(mapName, quote("person-id") + " INT PRIMARY KEY", "name VARCHAR(100)");
+        insertItems(mapName, 1);
+
+        Properties properties = new Properties();
+        properties.setProperty(DATA_CONNECTION_REF_PROPERTY, TEST_DATABASE_REF);
+
+        properties.setProperty(ID_COLUMN_PROPERTY, "person-id");
+        properties.setProperty(LOAD_ALL_KEYS_PROPERTY, "invalidBooleanValue");
+        mapLoader = createMapLoader(properties, hz);
+
+        List<Integer> ids = newArrayList(mapLoader.loadAllKeys());
+        assertThat(ids).isNull();
     }
 
     @Test

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
@@ -53,6 +53,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 
+import static com.hazelcast.mapstore.GenericMapLoader.LOAD_ALL_KEYS_PROPERTY;
+import static com.hazelcast.mapstore.GenericMapLoader.TABLE_NAME_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapStore.DATA_CONNECTION_REF_PROPERTY;
 import static com.hazelcast.mapstore.GenericMapStore.TYPE_NAME_PROPERTY;
 import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
@@ -115,6 +117,30 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
         mapStoreConfig.setProperty(TYPE_NAME_PROPERTY, "org.example.Person");
         mapConfig.setMapStoreConfig(mapStoreConfig);
         instance().getConfig().addMapConfig(mapConfig);
+    }
+
+    @Test
+    public void testLoadAllKeys() {
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setClassName(GenericMapStore.class.getName());
+        mapStoreConfig.setProperty(DATA_CONNECTION_REF_PROPERTY, TEST_DATABASE_REF);
+        mapStoreConfig.setProperty(TABLE_NAME_PROPERTY, tableName);
+        mapStoreConfig.setProperty(TYPE_NAME_PROPERTY, "org.example.Person");
+        mapStoreConfig.setProperty(LOAD_ALL_KEYS_PROPERTY, "false");
+
+        String mapName = tableName + "_disabled";
+        MapConfig mapConfig = new MapConfig(mapName);
+
+        mapConfig.setMapStoreConfig(mapStoreConfig);
+        instance().getConfig().addMapConfig(mapConfig);
+
+        HazelcastInstance client = client();
+        IMap<Integer, Person> map = client.getMap(mapName);
+
+        // LOAD_ALL_KEYS_PROPERTY is disabled, but we still can load
+        Person p = map.get(0);
+        assertThat(p.getId()).isZero();
+        assertThat(p.getName()).isEqualTo("name-0");
     }
 
     @Test

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
@@ -136,6 +136,7 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
 
         HazelcastInstance client = client();
         IMap<Integer, Person> map = client.getMap(mapName);
+        assertThat(map.size()).isZero();
 
         // LOAD_ALL_KEYS_PROPERTY is disabled, but we still can load
         Person p = map.get(0);


### PR DESCRIPTION
This PR adds a new property to disable the loading of all keys 

Jira : https://hazelcast.atlassian.net/browse/HZ-2285

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
