### PR TITLE
Support catalog and schema in listResources [HZ-2325]

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/KafkaDataConnectionTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/KafkaDataConnectionTest.java
@@ -32,6 +32,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
@@ -100,7 +101,7 @@ public class KafkaDataConnectionTest {
 
         Collection<DataConnectionResource> resources = kafkaDataConnection.listResources();
         List<DataConnectionResource> withoutConfluent =
-                resources.stream().filter(r -> !r.name().contains("__confluent")).collect(toList());
+                resources.stream().filter(r -> !Arrays.toString(r.name()).contains("__confluent")).collect(toList());
         assertThat(withoutConfluent).isEmpty();
     }
 
@@ -115,7 +116,7 @@ public class KafkaDataConnectionTest {
 
             Collection<DataConnectionResource> resources = kafkaDataConnection.listResources();
             List<DataConnectionResource> withoutConfluent =
-                    resources.stream().filter(r -> !r.name().contains("__confluent")).collect(toList());
+                    resources.stream().filter(r -> !Arrays.toString(r.name()).contains("__confluent")).collect(toList());
             assertThat(withoutConfluent)
                     .containsExactly(new DataConnectionResource("topic", "my-topic"));
         } finally {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
@@ -130,6 +130,7 @@ import static com.hazelcast.jet.sql.impl.parse.SqlCreateIndex.UNIQUE_KEY_TRANSFO
 import static com.hazelcast.jet.sql.impl.validate.types.HazelcastTypeUtils.toHazelcastType;
 import static com.hazelcast.spi.properties.ClusterProperty.SQL_CUSTOM_TYPES_ENABLED;
 import static com.hazelcast.sql.SqlColumnType.VARCHAR;
+import static com.hazelcast.sql.impl.QueryUtils.quoteCompoundIdentifier;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyIterator;
 import static java.util.Collections.singletonList;
@@ -432,7 +433,10 @@ public class PlanExecutor {
             rows = dataConnection.listResources().stream()
                                  .map(resource -> new JetSqlRow(
                                          serializationService,
-                                         new Object[]{resource.name(), resource.type()}
+                                         new Object[]{
+                                                 quoteCompoundIdentifier(resource.name()),
+                                                 resource.type()
+                                         }
                                  ))
                                  .collect(Collectors.toList());
         } finally {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/ShowStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/ShowStatementTest.java
@@ -171,8 +171,8 @@ public class ShowStatementTest extends SqlTestSupport {
     @Test
     public void test_showResources() {
         assertRowsOrdered("SHOW RESOURCES FOR \"" + DATA_CONNECTION_NAME + "\"", rows(2,
-                "testName1", "testType1",
-                "testName2", "testType2"
+                "\"testName1\"", "testType1",
+                "\"testPrefix1\".\"testName2\"", "testType2"
         ));
     }
 

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -747,6 +747,12 @@
             <version>${postgresql.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql.connector.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/DataConnectionResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/DataConnectionResource.java
@@ -19,6 +19,7 @@ package com.hazelcast.dataconnection;
 import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 
 import static java.util.Objects.requireNonNull;
 
@@ -34,12 +35,20 @@ import static java.util.Objects.requireNonNull;
 public class DataConnectionResource {
 
     private final String type;
-    private final String name;
+    private final String[] name;
 
     /**
      * Create a Resource with given type and name
      */
     public DataConnectionResource(@Nonnull String type, @Nonnull String name) {
+        this.type = requireNonNull(type);
+        this.name = new String[] {requireNonNull(name)};
+    }
+
+    /**
+     * Create a Resource with given type and name
+     */
+    public DataConnectionResource(@Nonnull String type, @Nonnull String... name) {
         this.type = requireNonNull(type);
         this.name = requireNonNull(name);
     }
@@ -54,11 +63,9 @@ public class DataConnectionResource {
 
     /**
      * Name of the resource, e.g. name of the JDBC table, including any namespace prefix such as schema.
-     * <p>
-     * TODO Should we use String[]?
      */
     @Nonnull
-    public String name() {
+    public String[] name() {
         return name;
     }
 
@@ -66,7 +73,7 @@ public class DataConnectionResource {
     public String toString() {
         return "Resource{"
                 + "type='" + type + '\''
-                + ", name='" + name + '\''
+                + ", name='" + Arrays.toString(name) + '\''
                 + '}';
     }
 
@@ -84,13 +91,13 @@ public class DataConnectionResource {
         if (!type.equals(dataConnectionResource.type)) {
             return false;
         }
-        return name.equals(dataConnectionResource.name);
+        return Arrays.equals(name, dataConnectionResource.name);
     }
 
     @Override
     public int hashCode() {
         int result = type.hashCode();
-        result = 31 * result + name.hashCode();
+        result = 31 * result + Arrays.hashCode(name);
         return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/impl/JdbcDataConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/impl/JdbcDataConnection.java
@@ -33,9 +33,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * {@link DataConnection} implementation for JDBC.
@@ -99,11 +101,13 @@ public class JdbcDataConnection extends DataConnectionBase {
             ResultSet tables = metaData.getTables(null, null, "%", null);
             List<DataConnectionResource> result = new ArrayList<>();
             while (tables.next()) {
-                result.add(new DataConnectionResource(
-                        "TABLE",
-                        // TODO quoting? Using String[]?
-                        tables.getString("TABLE_SCHEM") + "." + tables.getString("TABLE_NAME")
-                ));
+                String[] name = Stream.of(tables.getString("TABLE_CAT"),
+                                              tables.getString("TABLE_SCHEM"),
+                                              tables.getString("TABLE_NAME"))
+                                      .filter(Objects::nonNull)
+                                      .toArray(String[]::new);
+
+                result.add(new DataConnectionResource("TABLE", name));
             }
             return result;
         } catch (Exception e) {

--- a/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/DataConnectionTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/DataConnectionTestUtil.java
@@ -75,7 +75,7 @@ public final class DataConnectionTestUtil {
         public Collection<DataConnectionResource> listResources() {
             return Arrays.asList(
                     new DataConnectionResource("testType1", "testName1"),
-                    new DataConnectionResource("testType2", "testName2")
+                    new DataConnectionResource("testType2", "testPrefix1", "testName2")
             );
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/JdbcDataConnectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/JdbcDataConnectionTest.java
@@ -34,6 +34,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.hazelcast.dataconnection.impl.HikariTestUtil.assertEventuallyNoHikariThreads;
@@ -45,17 +46,18 @@ import static org.assertj.core.api.Assertions.entry;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class JdbcDataConnectionTest {
 
-    private static final String TEST_CONFIG_NAME = JdbcDataConnectionTest.class.getSimpleName();
-    private static final String JDBC_URL_SHARED = "jdbc:h2:mem:" + JdbcDataConnectionTest.class.getSimpleName() + "_shared";
+    private static final String TEST_NAME = JdbcDataConnectionTest.class.getSimpleName();
+    public static final String DB_NAME_SHARED = (TEST_NAME + "_shared").toUpperCase(Locale.ROOT);
+    private static final String JDBC_URL_SHARED = "jdbc:h2:mem:" + DB_NAME_SHARED;
 
     private static final DataConnectionConfig SHARED_DATA_CONNECTION_CONFIG = new DataConnectionConfig()
-            .setName(TEST_CONFIG_NAME)
+            .setName(TEST_NAME)
             .setProperty("jdbcUrl", JDBC_URL_SHARED)
             .setShared(true);
 
     private static final DataConnectionConfig SINGLE_USE_DATA_CONNECTION_CONFIG = new DataConnectionConfig()
-            .setName(TEST_CONFIG_NAME)
-            .setProperty("jdbcUrl", "jdbc:h2:mem:" + JdbcDataConnectionTest.class.getSimpleName() + "_single_use")
+            .setName(TEST_NAME)
+            .setProperty("jdbcUrl", "jdbc:h2:mem:" + TEST_NAME + "_single_use")
             .setShared(false);
 
     Connection connection1;
@@ -68,7 +70,7 @@ public class JdbcDataConnectionTest {
         close(connection1);
         close(connection2);
         jdbcDataConnection.release();
-        assertEventuallyNoHikariThreads(TEST_CONFIG_NAME);
+        assertEventuallyNoHikariThreads(TEST_NAME);
     }
 
     private static void close(Connection connection) throws Exception {
@@ -80,7 +82,7 @@ public class JdbcDataConnectionTest {
     @Test
     public void should_return_name() {
         jdbcDataConnection = new JdbcDataConnection(SHARED_DATA_CONNECTION_CONFIG);
-        assertThat(jdbcDataConnection.getName()).isEqualTo(TEST_CONFIG_NAME);
+        assertThat(jdbcDataConnection.getName()).isEqualTo(TEST_NAME);
     }
 
     @Test
@@ -128,7 +130,7 @@ public class JdbcDataConnectionTest {
         jdbcDataConnection = new JdbcDataConnection(SHARED_DATA_CONNECTION_CONFIG);
         HikariDataSource pool = jdbcDataConnection.pooledDataSource();
 
-        assertPoolNameEndsWith(pool, TEST_CONFIG_NAME);
+        assertPoolNameEndsWith(pool, TEST_NAME);
     }
 
     @Test
@@ -194,7 +196,7 @@ public class JdbcDataConnectionTest {
 
         List<DataConnectionResource> dataConnectionResources = jdbcDataConnection.listResources();
         assertThat(dataConnectionResources).contains(
-                new DataConnectionResource("TABLE", "PUBLIC.MY_TABLE")
+                new DataConnectionResource("TABLE", DB_NAME_SHARED, "PUBLIC", "MY_TABLE")
         );
     }
 
@@ -207,7 +209,7 @@ public class JdbcDataConnectionTest {
 
         List<DataConnectionResource> dataConnectionResources = jdbcDataConnection.listResources();
         assertThat(dataConnectionResources).contains(
-                new DataConnectionResource("TABLE", "MY_SCHEMA.MY_TABLE")
+                new DataConnectionResource("TABLE", DB_NAME_SHARED, "MY_SCHEMA", "MY_TABLE")
         );
     }
 
@@ -220,7 +222,7 @@ public class JdbcDataConnectionTest {
 
         List<DataConnectionResource> dataConnectionResources = jdbcDataConnection.listResources();
         assertThat(dataConnectionResources).contains(
-                new DataConnectionResource("TABLE", "PUBLIC.MY_TABLE_VIEW")
+                new DataConnectionResource("TABLE", DB_NAME_SHARED, "PUBLIC", "MY_TABLE_VIEW")
         );
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/ListResourcesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/ListResourcesTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.dataconnection.impl;
+
+import com.hazelcast.config.DataConnectionConfig;
+import com.hazelcast.dataconnection.DataConnectionResource;
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.jdbc.H2DatabaseProvider;
+import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
+import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
+import com.hazelcast.test.jdbc.TestDatabaseProvider;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(HazelcastParametrizedRunner.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ListResourcesTest {
+
+    @Parameters(name = "provider == {0}")
+    public static Object[] params() {
+        return new Object[][]{
+                {
+                        new H2DatabaseProvider(),
+                        new DataConnectionResource[]{
+                                new DataConnectionResource("TABLE", "testdb", "PUBLIC", "my_table"),
+                                new DataConnectionResource("TABLE", "testdb", "my_schema", "my_table")
+                        }
+                },
+                {
+                        new PostgresDatabaseProvider(),
+                        new DataConnectionResource[]{
+                                new DataConnectionResource("TABLE", "public", "my_table"),
+                                new DataConnectionResource("TABLE", "my_schema", "my_table")
+                        }
+                },
+                {
+                        new MySQLDatabaseProvider(),
+                        new DataConnectionResource[]{
+                                new DataConnectionResource("TABLE", "testdb", "my_table"),
+                                new DataConnectionResource("TABLE", "my_schema", "my_table")
+                        }
+                },
+        };
+    }
+
+    @Parameter
+    public TestDatabaseProvider provider;
+
+    @Parameter(1)
+    public DataConnectionResource[] expectedResources;
+
+    @Test
+    public void shouldListResourcesDefaultAndNonDefaultSchema() throws Exception {
+        String jdbcUrl = provider.createDatabase("testdb");
+
+        JdbcDataConnection dataConnection = new JdbcDataConnection(new DataConnectionConfig()
+                .setType("jdbc")
+                .setProperty("jdbcUrl", jdbcUrl)
+        );
+
+        executeJdbc(jdbcUrl, "CREATE TABLE my_table (id INTEGER, name VARCHAR(255) )");
+        executeJdbc(jdbcUrl, "CREATE SCHEMA my_schema");
+        executeJdbc(jdbcUrl, "CREATE TABLE my_schema.my_table (id INTEGER, name VARCHAR(255) )");
+
+        List<DataConnectionResource> dataConnectionResources = dataConnection.listResources();
+        assertThat(dataConnectionResources).contains(expectedResources);
+    }
+
+    public static void executeJdbc(String url, String sql) throws SQLException {
+        try (Connection conn = DriverManager.getConnection(url);
+             Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute(sql);
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes a leftover todo and a bug reported by MC for MySQL - MC-2048.

The resource name consists of multiple parts. These are supposed to be used for the external name when creating the mapping.
What those parts are is specific to the 3rd party system. E.g. each relational database handles catalog/schema/table name differently.

The output of `SHOW RESOURCES FOR ...` reflects this change and returns quoted compound identifier, similar to `externalName` in `information_schema.mappings`.



Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
