### PR TITLE
Always pre-compute connector type during mapping resolving [HZ-2324]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
@@ -376,11 +376,20 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
             throw new HazelcastException("Cannot create a mapping with a data connection or an object type " +
                     "until the cluster is upgraded to 5.3");
         }
+        String connectorType = node.connectorType();
+        // We want to compute connector type immediately to keep lazy dependency management strategy for SQL mappings.
+        if (connectorType == null) {
+            // if type is null, then data connection was used
+            String type = nodeEngine.getDataConnectionService()
+                    .typeForDataConnection(node.dataConnectionNameWithoutSchema());
+            connectorType = connectorCache.forType(type).typeName();
+        }
+
         mapping = new Mapping(
                 node.nameWithoutSchema(),
                 node.externalName(),
                 node.dataConnectionNameWithoutSchema(),
-                node.connectorType(),
+                connectorType,
                 node.objectType(),
                 mappingFields,
                 node.options()

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
@@ -192,6 +192,8 @@ public class PlanExecutor {
                 plan.ifNotExists());
         if (added) {
             broadcastUpdateDataConnectionOperations(plan.name());
+            // Only when data connection operation finish execution, we must sync existing mappings
+            catalog.syncMappingsWithDataConnection(plan.name());
         }
         return UpdateSqlResultImpl.createUpdateCountResult(0);
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/MappingsTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/MappingsTable.java
@@ -76,7 +76,7 @@ public class MappingsTable extends InfoSchemaTable {
                     mappingsSchema,
                     mapping.name(),
                     quoteCompoundIdentifier(mapping.externalName()),
-                    mapping.connectorType(),
+                    mapping.getConnectorType(),
                     uncheckCall(() -> JsonUtil.toJson(mapping.options()))
             };
             rows.add(row);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlCreateMapping.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlCreateMapping.java
@@ -201,7 +201,7 @@ public class SqlCreateMapping extends SqlCreate {
                         identifier(f.externalName()),
                         SqlParserPos.ZERO)),
                 identifier(mapping.dataConnection()),
-                identifier(mapping.connectorType()),
+                identifier(mapping.getConnectorType()),
                 identifier(mapping.objectType()),
                 reconstructOptions(mapping.options()),
                 true, false, SqlParserPos.ZERO

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlCreateMapping.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlCreateMapping.java
@@ -84,8 +84,6 @@ public class SqlCreateMapping extends SqlCreate {
         this.connectorType = connectorType;
         this.objectType = objectType;
         this.options = requireNonNull(options, "Options should not be null");
-
-        assert dataConnection == null || connectorType == null; // the syntax doesn't allow this
     }
 
     public String nameWithoutSchema() {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/RelationsStorage.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/RelationsStorage.java
@@ -58,6 +58,14 @@ public class RelationsStorage extends AbstractSchemaStorage {
         return (Mapping) storage().remove(name);
     }
 
+    public Collection<Mapping> getAllMappingsBasedOnDataConnection(String dataConnectionName) {
+        return storage().values().stream()
+                .filter(o -> o instanceof Mapping)
+                .map(o -> (Mapping) o)
+                .filter(m -> m.dataConnection().equals(dataConnectionName))
+                .collect(Collectors.toList());
+    }
+
     public Collection<Type> getAllTypes() {
         return storage().values().stream()
                 .filter(o -> o instanceof Type)

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/RelationsStorage.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/RelationsStorage.java
@@ -62,7 +62,7 @@ public class RelationsStorage extends AbstractSchemaStorage {
         return storage().values().stream()
                 .filter(o -> o instanceof Mapping)
                 .map(o -> (Mapping) o)
-                .filter(m -> m.dataConnection().equals(dataConnectionName))
+                .filter(m -> m.dataConnection() != null && m.dataConnection().equals(dataConnectionName))
                 .collect(Collectors.toList());
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
@@ -291,7 +291,8 @@ public class TableResolverImpl implements TableResolver {
                     SCHEMA_NAME_PUBLIC,
                     mapping.name(),
                     mapping.externalName(),
-                    mapping.dataConnection(), mapping.options(),
+                    mapping.dataConnection(),
+                    mapping.options(),
                     mapping.fields()
             );
         } catch (Throwable e) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/Mapping.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/Mapping.java
@@ -71,7 +71,6 @@ public class Mapping implements SqlCatalogObject, Versioned {
             List<MappingField> fields,
             Map<String, String> options
     ) {
-        assert connectorType == null || dataConnection == null;
         this.name = name;
         this.externalName = externalName;
         this.dataConnection = dataConnection;

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/Mapping.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/Mapping.java
@@ -88,8 +88,12 @@ public class Mapping implements SqlCatalogObject, Versioned {
         return externalName;
     }
 
-    public String connectorType() {
+    public String getConnectorType() {
         return connectorType;
+    }
+
+    public void setConnectorType(String connectorType) {
+        this.connectorType = connectorType;
     }
 
     public String dataConnection() {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/MappingJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/MappingJdbcSqlConnectorTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -309,6 +310,22 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         Object object = resultIt.next().getObject(0);
         assertThat(resultIt.hasNext()).isFalse();
         assertThat(object).isEqualTo(name);
+    }
+
+    @Test
+    public void test_() throws Exception {
+        // given
+        String dlName = randomName();
+        String name = randomName();
+        createTable(name);
+        Map<String, String> options = new HashMap<>();
+        options.put("jdbcUrl", dbConnectionUrl);
+
+        createDataConnection(instance(), dlName, "JDBC", false, options);
+        createJdbcMappingUsingDataConnection(name, dlName);
+        sqlService.execute("DROP DATA CONNECTION " + dlName);
+
+        assertRowsAnyOrder("SHOW DATA CONNECTIONS ", Collections.singletonList(new Row(TEST_DATABASE_REF)));
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/MappingJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/MappingJdbcSqlConnectorTest.java
@@ -318,25 +318,27 @@ public class MappingJdbcSqlConnectorTest extends JdbcSqlTestSupport {
     @Test
     public void given_mappingIsDeclaredWithDataConn_when_DataConnWasRemoved_then_success() throws Exception {
         // given
-        String dlName = randomName();
-        String name = randomName();
-        createTable(name);
+        String dcName = randomName();
+        String mappingName = randomName();
+        createTable(mappingName);
         Map<String, String> options = new HashMap<>();
         options.put("jdbcUrl", dbConnectionUrl);
 
         // when
-        createDataConnection(instance(), dlName, "JDBC", false, options);
-        createJdbcMappingUsingDataConnection(name, dlName);
-        sqlService.execute("DROP DATA CONNECTION " + dlName);
+        createDataConnection(instance(), dcName, "JDBC", false, options);
+        createJdbcMappingUsingDataConnection(mappingName, dcName);
+        sqlService.execute("DROP DATA CONNECTION " + dcName);
 
         // then
-        assertThat(dlName).isNotEqualTo(TEST_DATABASE_REF);
         assertRowsAnyOrder("SHOW DATA CONNECTIONS ", singletonList(new Row(TEST_DATABASE_REF)));
 
-        // Mapping doesn't provide data, since data connection was removed.
-        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM " + name))
+        // Ensure that engine is not broken after Data Conn removal with some unrelated query.
+        assertRowsAnyOrder("SHOW MAPPINGS ", singletonList(new Row(mappingName)));
+
+        // Mapping shouldn't provide data, since data connection was removed.
+        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM " + mappingName))
                 .hasMessageContaining("com.hazelcast.core.HazelcastException: Data connection '"
-                        + dlName + "' not found");
+                        + dcName + "' not found");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlPojoTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlPojoTest.java
@@ -140,7 +140,7 @@ public class SqlPojoTest extends SqlTestSupport {
                 m.name(),
                 m.externalName(),
                 null,
-                m.connectorType(),
+                m.getConnectorType(),
                 null,
                 new ArrayList<>(m.fields()),
                 brokenOptions));

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/RelationsStorageTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/RelationsStorageTest.java
@@ -74,8 +74,8 @@ public class RelationsStorageTest extends SimpleTestInClusterSupport {
 
         assertThat(storage.putIfAbsent(name, mapping(name, "type-1"))).isTrue();
         assertThat(storage.putIfAbsent(name, mapping(name, "type-2"))).isFalse();
-        assertTrue(storage.allObjects().stream().anyMatch(m -> m instanceof Mapping && ((Mapping) m).connectorType().equals("type-1")));
-        assertTrue(storage.allObjects().stream().noneMatch(m -> m instanceof Mapping && ((Mapping) m).connectorType().equals("type-2")));
+        assertTrue(storage.allObjects().stream().anyMatch(m -> m instanceof Mapping && ((Mapping) m).getConnectorType().equals("type-1")));
+        assertTrue(storage.allObjects().stream().noneMatch(m -> m instanceof Mapping && ((Mapping) m).getConnectorType().equals("type-2")));
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TableResolverImplTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TableResolverImplTest.java
@@ -97,7 +97,7 @@ public class TableResolverImplTest {
         // given
         Mapping mapping = mapping();
 
-        given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
+        given(connectorCache.forType(mapping.getConnectorType())).willReturn(connector);
         given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
                 mapping.externalName(), mapping.dataConnection()))
                 .willThrow(new RuntimeException("expected test exception"));
@@ -116,7 +116,7 @@ public class TableResolverImplTest {
         // given
         Mapping mapping = mapping();
 
-        given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
+        given(connectorCache.forType(mapping.getConnectorType())).willReturn(connector);
         given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
                 mapping.externalName(), mapping.dataConnection()))
                 .willReturn(singletonList(new MappingField("field_name", INT)));
@@ -135,7 +135,7 @@ public class TableResolverImplTest {
         // given
         Mapping mapping = mapping();
 
-        given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
+        given(connectorCache.forType(mapping.getConnectorType())).willReturn(connector);
         given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
                 mapping.externalName(), mapping.dataConnection()))
                 .willReturn(singletonList(new MappingField("field_name", INT)));
@@ -153,7 +153,7 @@ public class TableResolverImplTest {
         // given
         Mapping mapping = mapping();
 
-        given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
+        given(connectorCache.forType(mapping.getConnectorType())).willReturn(connector);
         given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
                 mapping.externalName(), mapping.dataConnection()))
                 .willReturn(singletonList(new MappingField("field_name", INT)));


### PR DESCRIPTION
Closes https://github.com/hazelcast/hazelcast/issues/24337

This patch introduces pre-computing of connector type during mapping resolving. Previously, if data connection was created, mapping was created with given data conn, and then data connection was removed, for each next query schema computation was broken (mapping can't find removed data conn -> fail). Good example is in #24337 