### PR TITLE
Restore nested EP offload behavor for map-store enabled maps [HZ-2334]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -205,7 +205,7 @@ public abstract class MapOperation extends AbstractNamedOperation
         return returnsResponse() ? RESPONSE : VOID;
     }
 
-    private boolean isMapStoreOffloadEnabled() {
+    protected final boolean isMapStoreOffloadEnabled() {
         // This is for nested calls from partition thread. When we see
         // nested call we directly run the call without offloading.
         if (mapStoreOffloadEnabled
@@ -214,6 +214,17 @@ public abstract class MapOperation extends AbstractNamedOperation
             return false;
         }
         return mapStoreOffloadEnabled;
+    }
+
+    public final boolean isTieredStoreAndPartitionCompactorEnabled() {
+        // This is for nested calls from partition thread. When we see
+        // nested call we directly run the call without offloading.
+        if (tieredStoreAndPartitionCompactorEnabled
+                && ThreadUtil.isRunningOnPartitionThread()
+                && isStepRunnerCurrentlyExecutingOnPartitionThread()) {
+            return false;
+        }
+        return tieredStoreAndPartitionCompactorEnabled;
     }
 
     protected Offload offloadOperation() {
@@ -504,9 +515,5 @@ public abstract class MapOperation extends AbstractNamedOperation
 
     public MapContainer getMapContainer() {
         return mapContainer;
-    }
-
-    public boolean isTieredStoreAndPartitionCompactorEnabled() {
-        return tieredStoreAndPartitionCompactorEnabled;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -100,8 +100,8 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
     static JsonObject getOperationStats(HazelcastInstance instance) {
         TimedMemberStateFactory timedMemberStateFactory = new TimedMemberStateFactory(getHazelcastInstanceImpl(instance));
         LocalOperationStats operationStats = timedMemberStateFactory.createTimedMemberState()
-                                                                    .getMemberState()
-                                                                    .getOperationStats();
+                .getMemberState()
+                .getOperationStats();
         return ((JsonSerializable) operationStats).toJson();
     }
 


### PR DESCRIPTION
followup of https://github.com/hazelcast/hazelcast/pull/24280, appeared after merge of it.

closes https://github.com/hazelcast/hazelcast/issues/24345

**Modification:**
- Restored unintentionally removed else statement here: https://github.com/hazelcast/hazelcast/pull/24349/files#diff-cd1bf76a9f6d029dd1c375ffa27eab208668c24db42a34b8f9c52dba35ce2c17R190
- put offload flag checks in `steppedOperationOffloadEnabled` method to control them in a central place.