### PR TITLE
Create pool in JdbcDataConnection lazily [HZ-2317]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DbUnreachableJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DbUnreachableJdbcSqlConnectorTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.net.ConnectException;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 public class DbUnreachableJdbcSqlConnectorTest extends JdbcSqlTestSupport {
@@ -42,6 +44,6 @@ public class DbUnreachableJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         assertThatThrownBy(() ->
                 sqlService.execute("CREATE MAPPING people DATA CONNECTION mysql")
         ).hasStackTraceContaining("Could not create pool for data connection 'mysql'")
-         .hasStackTraceContaining("Connection refused (Connection refused)");
+         .hasRootCauseInstanceOf(ConnectException.class);
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DbUnreachableJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DbUnreachableJdbcSqlConnectorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.jdbc;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class DbUnreachableJdbcSqlConnectorTest extends JdbcSqlTestSupport {
+
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(2, smallInstanceConfig());
+        sqlService = instance().getSql();
+    }
+
+    @Test
+    public void createMappingShouldThrowCorrectExceptionWhenDatabaseNotAvailable() {
+        sqlService.execute("CREATE DATA CONNECTION mysql "
+                + "TYPE JDBC "
+                + "OPTIONS("
+                + "'jdbcUrl'='jdbc:mysql://localhost:33066/mydb', "
+                + "'username'='root', "
+                + "'password'='123'"
+                + ")");
+
+        assertThatThrownBy(() ->
+                sqlService.execute("CREATE MAPPING people DATA CONNECTION mysql")
+        ).hasStackTraceContaining("Could not create pool for data connection 'mysql'")
+         .hasStackTraceContaining("Connection refused (Connection refused)");
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DbUnreachableJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/DbUnreachableJdbcSqlConnectorTest.java
@@ -34,7 +34,7 @@ public class DbUnreachableJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         sqlService.execute("CREATE DATA CONNECTION mysql "
                 + "TYPE JDBC "
                 + "OPTIONS("
-                + "'jdbcUrl'='jdbc:mysql://localhost:33066/mydb', "
+                + "'jdbcUrl'='jdbc:mysql:/fake-host:12345/noSuchDb', "
                 + "'username'='root', "
                 + "'password'='123'"
                 + ")");

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -742,6 +742,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mssqlserver</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/DataConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/DataConnection.java
@@ -73,7 +73,9 @@ import java.util.Map;
  * handled as remove+create.
  * <p>
  * Implementations of DataConnection must provide a constructor with a single argument
- * of type {@link DataConnectionConfig}.
+ * of type {@link DataConnectionConfig}. The constructor must not throw an exception
+ * under any circumstances. Any resource allocation should be done either asynchronously
+ * or lazily when the underlying instance is requested.
  *
  * @since 5.3
  */

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/impl/JdbcDataConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/impl/JdbcDataConnection.java
@@ -162,15 +162,19 @@ public class JdbcDataConnection extends DataConnectionBase {
 
     @Override
     public void destroy() {
-        if (pooledDataSourceSup != null) {
-            HikariDataSource dataSource = pooledDataSourceSup.get();
+        ConcurrentMemoizingSupplier<HikariDataSource> localPooledDataSourceSup = pooledDataSourceSup;
+        if (localPooledDataSourceSup != null) {
+            HikariDataSource dataSource = localPooledDataSourceSup.remembered();
             pooledDataSourceSup = null;
-            try {
-                dataSource.close();
-            } catch (Exception e) {
-                throw new HazelcastException("Could not close connection pool", e);
+            if (dataSource != null) {
+                try {
+                    dataSource.close();
+                } catch (Exception e) {
+                    throw new HazelcastException("Could not close connection pool", e);
+                }
             }
-        } else {
+        }
+        if (singleUseConnectionSup != null) {
             singleUseConnectionSup = null;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/impl/JdbcDataConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/impl/JdbcDataConnection.java
@@ -53,7 +53,7 @@ public class JdbcDataConnection extends DataConnectionBase {
     private static final AtomicInteger DATA_SOURCE_COUNTER = new AtomicInteger();
 
     private volatile ConcurrentMemoizingSupplier<HikariDataSource> pooledDataSourceSup;
-    private Supplier<Connection> singleUseConnectionSup;
+    private volatile Supplier<Connection> singleUseConnectionSup;
 
     public JdbcDataConnection(DataConnectionConfig config) {
         super(config);
@@ -174,9 +174,7 @@ public class JdbcDataConnection extends DataConnectionBase {
                 }
             }
         }
-        if (singleUseConnectionSup != null) {
-            singleUseConnectionSup = null;
-        }
+        singleUseConnectionSup = null;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/impl/ReferenceCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/impl/ReferenceCounter.java
@@ -50,7 +50,7 @@ public class ReferenceCounter {
      */
     public void retain() {
         referenceCount.updateAndGet(cnt -> {
-            if (cnt == 0) {
+            if (cnt <= 0) {
                 throw new IllegalStateException("Resurrected a dead object");
             }
             return cnt + 1;

--- a/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/JdbcDataConnectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/JdbcDataConnectionTest.java
@@ -40,6 +40,7 @@ import static com.hazelcast.dataconnection.impl.HikariTestUtil.assertEventuallyN
 import static com.hazelcast.dataconnection.impl.HikariTestUtil.assertPoolNameEndsWith;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -187,6 +188,18 @@ public class JdbcDataConnectionTest {
         assertThat(pool.isClosed())
                 .describedAs("Connection pool should have been closed")
                 .isTrue();
+    }
+
+    @Test
+    public void shared_connection_should_be_initialized_lazy() {
+        jdbcDataConnection = new JdbcDataConnection(new DataConnectionConfig()
+                .setName(TEST_CONFIG_NAME)
+                .setProperty("jdbcUrl", "invalid-jdbc-url")
+                .setShared(true));
+
+        assertThatThrownBy(() -> jdbcDataConnection.getConnection())
+                .hasRootCauseInstanceOf(SQLException.class)
+                .hasRootCauseMessage("No suitable driver");
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/JdbcDataConnectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/JdbcDataConnectionTest.java
@@ -46,7 +46,9 @@ import static org.assertj.core.api.Assertions.entry;
 public class JdbcDataConnectionTest {
 
     private static final String TEST_CONFIG_NAME = JdbcDataConnectionTest.class.getSimpleName();
-    private static final String JDBC_URL_SHARED = "jdbc:h2:mem:" + JdbcDataConnectionTest.class.getSimpleName() + "_shared";
+    private static final String JDBC_URL_SHARED = "jdbc:h2:mem:"
+            + JdbcDataConnectionTest.class.getSimpleName() + "_shared"
+            + ";DB_CLOSE_DELAY=-1";
 
     private static final DataConnectionConfig SHARED_DATA_CONNECTION_CONFIG = new DataConnectionConfig()
             .setName(TEST_CONFIG_NAME)
@@ -69,6 +71,7 @@ public class JdbcDataConnectionTest {
         close(connection2);
         jdbcDataConnection.release();
         assertEventuallyNoHikariThreads(TEST_CONFIG_NAME);
+        executeJdbc(JDBC_URL_SHARED, "shutdown");
     }
 
     private static void close(Connection connection) throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/JdbcDataConnectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/dataconnection/impl/JdbcDataConnectionTest.java
@@ -195,7 +195,7 @@ public class JdbcDataConnectionTest {
     @Test
     public void shared_connection_should_be_initialized_lazy() {
         jdbcDataConnection = new JdbcDataConnection(new DataConnectionConfig()
-                .setName(TEST_CONFIG_NAME)
+                .setName(TEST_NAME)
                 .setProperty("jdbcUrl", "invalid-jdbc-url")
                 .setShared(true));
 

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/MSSQLDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/MSSQLDatabaseProvider.java
@@ -16,26 +16,32 @@
 
 package com.hazelcast.test.jdbc;
 
-import org.testcontainers.jdbc.ContainerDatabaseDriver;
+import org.testcontainers.containers.MSSQLServerContainer;
 
 public class MSSQLDatabaseProvider implements TestDatabaseProvider {
 
+    public static final String TEST_MSSQLSERVER_VERSION = System.getProperty("test.mssqlserver.version", "2017-CU12");
+
     private static final int LOGIN_TIMEOUT = 120;
 
-    private String jdbcUrl;
+    private MSSQLServerContainer<?> container;
 
     @Override
     public String createDatabase(String dbName) {
-        jdbcUrl = "jdbc:tc:sqlserver:2017-CU12:///" + dbName;
+        container = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:" + TEST_MSSQLSERVER_VERSION);
+        container.withUrlParam("user", container.getUsername())
+                 .withUrlParam("password", container.getPassword());
+        container.start();
+        String jdbcUrl = container.getJdbcUrl();
         waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
     }
 
     @Override
     public void shutdown() {
-        if (jdbcUrl != null) {
-            ContainerDatabaseDriver.killContainer(jdbcUrl);
-            jdbcUrl = null;
+        if (container != null) {
+            container.stop();
+            container = null;
         }
     }
 }


### PR DESCRIPTION
When the pool creation fails and throws an exception we get out of synch in InternalDataLinkService and in SQL catalog of data connections.

This change creates the pool lazily using ConcurrentMemoizingSupplier. The exception from pool creation will be thrown to the caller of `JdbcDataConnection#getConnection`, e.g. when `CREATE MAPPING ...` is excecuted.

Fixes #24315


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
