### PR TITLE
Run injected Step as first step of step-sequence

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/GetOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/GetOpSteps.java
@@ -16,13 +16,9 @@
 
 package com.hazelcast.map.impl.operation.steps;
 
-import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.util.ToHeapDataConverter;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
-import com.hazelcast.map.impl.mapstore.MapDataStores;
 import com.hazelcast.map.impl.operation.steps.engine.State;
 import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.record.Record;
@@ -38,8 +34,7 @@ public enum GetOpSteps implements IMapOpStep {
             Record record = recordStore.getRecordOrNull(state.getKey(), false);
             if (record != null) {
                 Object oldValue = record.getValue();
-                state.setOldValue(recordStore.getInMemoryFormat() == InMemoryFormat.NATIVE
-                        ? ToHeapDataConverter.toHeapData((Data) oldValue) : oldValue);
+                state.setOldValue(oldValue);
                 state.setRecordExistsInMemory(true);
             }
         }
@@ -59,9 +54,6 @@ public enum GetOpSteps implements IMapOpStep {
         @Override
         public void runStep(State state) {
             MapDataStore mapDataStore = state.getRecordStore().getMapDataStore();
-            if (mapDataStore == MapDataStores.EMPTY_MAP_DATA_STORE) {
-                return;
-            }
             Object load = mapDataStore.load(state.getKey());
             state.setOldValue(load);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PutOpSteps.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapServiceContext;
-import com.hazelcast.map.impl.mapstore.MapDataStores;
 import com.hazelcast.map.impl.operation.steps.engine.State;
 import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.record.Record;
@@ -57,10 +56,6 @@ public enum PutOpSteps implements IMapOpStep {
 
         @Override
         public void runStep(State state) {
-            if (state.getRecordStore().getMapDataStore() == MapDataStores.EMPTY_MAP_DATA_STORE) {
-                return;
-            }
-
             StaticParams staticParams = state.getStaticParams();
             if (staticParams.isPutVanilla()) {
                 state.setOldValue(((DefaultRecordStore) state.getRecordStore())

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/UtilSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/UtilSteps.java
@@ -41,8 +41,7 @@ public enum UtilSteps implements IMapOpStep {
 
         @Override
         public Step nextStep(State state) {
-            Step step = state.getRecordStore().getStorage().newInjectedStep();
-            return step == null ? UtilSteps.SEND_RESPONSE : step;
+            return UtilSteps.SEND_RESPONSE;
         }
     },
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/engine/StepSupplier.java
@@ -23,6 +23,7 @@ import com.hazelcast.memory.NativeOutOfMemoryError;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl;
 
+import javax.annotation.Nullable;
 import java.util.function.Supplier;
 
 import static com.hazelcast.internal.util.ThreadUtil.assertRunningOnPartitionThread;
@@ -58,12 +59,49 @@ public class StepSupplier implements Supplier<Runnable> {
         assert operation != null;
 
         this.state = operation.createState();
-        this.currentStep = operation.getStartingStep();
+        Step injectedStep = operation.getRecordStore().getStorage().newInjectedStep();
+        Step currentFirstStep = operation.getStartingStep();
+        this.currentStep = injectedStep == null
+                ? currentFirstStep : setAndGetInjectedStepAsFirstStep(currentFirstStep, injectedStep);
         this.operationRunner = UtilSteps.getPartitionOperationRunner(state);
         this.checkCurrentThread = checkCurrentThread;
 
         assert state != null;
-        assert currentStep != null;
+        assert this.currentStep != null;
+    }
+
+    /**
+     * Sets injected step as starting step.
+     * <p>
+     * Current starting step becomes 2nd step in this case.
+     * @param currentStep  starting step of operation
+     * @param injectedStep new step to inject before currentStep
+     * @return injected step after setting its next step to currentStep
+     */
+    private static Step setAndGetInjectedStepAsFirstStep(Step currentStep, Step injectedStep) {
+        return new Step<State>() {
+
+            @Override
+            public boolean isOffloadStep(State state) {
+                return injectedStep.isOffloadStep(state);
+            }
+
+            @Override
+            public void runStep(State state) {
+                injectedStep.runStep(state);
+            }
+
+            @Override
+            public String getExecutorName(State state) {
+                return injectedStep.getExecutorName(state);
+            }
+
+            @Nullable
+            @Override
+            public Step nextStep(State state) {
+                return currentStep;
+            }
+        };
     }
 
     @Override
@@ -179,9 +217,10 @@ public class StepSupplier implements Supplier<Runnable> {
         // check node and cluster health before running each step
         operationRunner.ensureNodeAndClusterHealth(state.getOperation());
 
-        // check timeout for only first step, as in regular
-        // flows which we don't do operation offloading
+        // check timeout for only first step,
+        // as in regular operation-runner
         if (firstStep) {
+            assert firstStep;
             firstStep = false;
             return !operationRunner.timeout(state.getOperation());
         }


### PR DESCRIPTION
ee: https://github.com/hazelcast/hazelcast-enterprise/pull/5939

followup of https://github.com/hazelcast/hazelcast/pull/24280, appeared after merge of it.

closes https://github.com/hazelcast/hazelcast-enterprise/issues/5934

**Modification:**
- Removed ToHeapDataConverter, it is not needed anymore.
- Made injected Step(compactor in this case) as first step of operation's step-sequence. This style fits better to step-engine's internal working. Otherwise some un-expected HD data access can happen during response sending and this can lead to jvm crashes. 