### PR TITLE
Make shared data connections lazy initialized

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/KafkaDataConnectionTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/KafkaDataConnectionTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.kafka.impl.KafkaTestSupport;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -169,6 +170,19 @@ public class KafkaDataConnectionTest {
         assertThatThrownBy(() -> p1.partitionsFor("my-topic"))
                 .isInstanceOf(KafkaException.class)
                 .hasMessage("Requested metadata update after close");
+    }
+
+    @Test
+    public void shared_producer_should_be_initialized_lazy() {
+        DataConnectionConfig config = new DataConnectionConfig("invalid-kafka-data-connection")
+                .setType("Kafka")
+                .setShared(true);
+
+        kafkaDataConnection = new KafkaDataConnection(config);
+
+        assertThatThrownBy(() -> kafkaDataConnection.getProducer(null)).isInstanceOf(ConfigException.class)
+                .hasMessageContaining("Missing required configuration");
+
     }
 
     private KafkaDataConnection createKafkaDataConnection(KafkaTestSupport kafkaTestSupport) {

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/dataconnection/MongoDataConnectionTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/dataconnection/MongoDataConnectionTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 
 import static com.hazelcast.jet.mongodb.dataconnection.MongoDataConnection.mongoDataConnectionConf;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -63,6 +64,15 @@ public class MongoDataConnectionTest extends AbstractMongoTest {
         assertThat(client1).isNotNull();
         assertThat(client2).isNotNull();
         assertThat(client1).isSameAs(client2);
+    }
+
+
+    @Test
+    public void should_initialize_lazy() {
+        dataConnection = new MongoDataConnection(mongoDataConnectionConf("mongo", "dummy"));
+        assertThatThrownBy(() -> dataConnection.getClient()).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("The connection string is invalid");
+
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/HazelcastDataConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/HazelcastDataConnection.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.dataconnection.impl.hazelcastdataconnection.HazelcastDataConnectionClientConfigBuilder;
 import com.hazelcast.dataconnection.impl.hazelcastdataconnection.HazelcastDataConnectionConfigLoader;
 import com.hazelcast.dataconnection.impl.hazelcastdataconnection.HazelcastDataConnectionConfigValidator;
+import com.hazelcast.jet.impl.util.ConcurrentMemoizingSupplier;
 import com.hazelcast.map.IMap;
 import com.hazelcast.spi.annotation.Beta;
 
@@ -67,21 +68,24 @@ public class HazelcastDataConnection extends DataConnectionBase {
     /**
      * The cached client instance
      */
-    private volatile HazelcastClientProxy proxy;
+    private ConcurrentMemoizingSupplier<HazelcastClientProxy> proxy;
 
     public HazelcastDataConnection(@Nonnull DataConnectionConfig dataConnectionConfig) {
         super(dataConnectionConfig);
         this.clientConfig = buildClientConfig();
 
         if (dataConnectionConfig.isShared()) {
-            HazelcastClientProxy hazelcastClientProxy = (HazelcastClientProxy) HazelcastClient
-                    .newHazelcastClient(clientConfig);
-            this.proxy = new HazelcastClientProxy(hazelcastClientProxy.client) {
-                @Override
-                public void shutdown() {
-                    release();
-                }
-            };
+
+            this.proxy = new ConcurrentMemoizingSupplier<>(() -> {
+                HazelcastClientProxy hazelcastClientProxy = (HazelcastClientProxy) HazelcastClient
+                        .newHazelcastClient(clientConfig);
+                return new HazelcastClientProxy(hazelcastClientProxy.client) {
+                    @Override
+                    public void shutdown() {
+                        release();
+                    }
+                };
+            });
         }
     }
 
@@ -133,7 +137,7 @@ public class HazelcastDataConnection extends DataConnectionBase {
     public HazelcastInstance getClient() {
         if (getConfig().isShared()) {
             retain();
-            return proxy;
+            return proxy.get();
         } else {
             return HazelcastClient.newHazelcastClient(clientConfig);
         }
@@ -142,8 +146,11 @@ public class HazelcastDataConnection extends DataConnectionBase {
     @Override
     public synchronized void destroy() {
         if (proxy != null) {
-            // the proxy has overridden shutdown method, need to close real client
-            proxy.client.shutdown();
+            HazelcastClientProxy rememberedProxy = proxy.remembered();
+            if (rememberedProxy != null) {
+                // the proxy has overridden shutdown method, need to close real client
+                rememberedProxy.client.shutdown();
+            }
             proxy = null;
         }
     }


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

INSERT_PR_DESCRIPTION_HERE

Fixes INSERT_LINK_TO_THE_ISSUE_HERE

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
