### PR TITLE
Explicitly obtaining map proxy to ensure of ListenerAdapter registration [HZ-2219]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -810,8 +810,8 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         assertClusterSizeEventually(2, hz1, hz2);
 
         IMap<Object, Object> map = hz1.getMap("test");
-        // give a time to initialize ListenerAdapters on members
-        sleepSeconds(2);
+        // explicitly obtaining map proxy to ensure of ListenerAdapter registration
+        hz2.getMap("test");
         map.put(1, 1);
 
         //Let post join continue only after put happened

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConfigAccessor;
-import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.StaticMemberNodeContext;

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -802,6 +802,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         EntryListenerConfig listenerConfig = new EntryListenerConfig();
         CountDownLatch entryAddedLatch = new CountDownLatch(2);
         listenerConfig.setImplementation((EntryAddedListener) event -> entryAddedLatch.countDown());
+        listenerConfig.setLocal(true);
         config.getMapConfig("test").addEntryListenerConfig(listenerConfig);
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
@@ -810,7 +811,11 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         assertClusterSizeEventually(2, hz1, hz2);
 
         IMap<Object, Object> map = hz1.getMap("test");
-        map.put(1, 1);
+
+        String keyForHz1 = generateKeyOwnedBy(hz1);
+        String keyForHz2 = generateKeyOwnedBy(hz2);
+        map.put(keyForHz1, 1);
+        map.put(keyForHz2, 2);
 
         //Let post join continue only after put happened
         latch.countDown();


### PR DESCRIPTION
An issue can be reproduced by introducing a delay during the `InternalMapListenerAdapter` registration.
In that case, the EntryAdded event could arrive before registering the `EntryAddedListener`.

Explicitly obtaining a map proxy should guarantee finishing the `InternalMapListenerAdapter` registration.

Fix https://github.com/hazelcast/hazelcast/issues/23214

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
