### PR TITLE
Make Kafka Connect tests more stable [HZ-2342]

### DIFF
--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectCouchbaseIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectCouchbaseIntegrationTest.java
@@ -55,7 +55,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletionException;
 
-import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static com.hazelcast.test.OverridePropertyRule.set;
 import static org.junit.Assert.assertEquals;
@@ -133,7 +132,6 @@ public class KafkaConnectCouchbaseIntegrationTest extends JetTestSupport {
         config.getJetConfig().setResourceUploadEnabled(true);
         LOGGER.info("Creating a job");
         Job job = createHazelcastInstance(config).getJet().newJob(pipeline, jobConfig);
-        assertJobStatusEventually(job, RUNNING);
 
         insertDocuments("items-2");
 

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectNeo4jIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectNeo4jIntegrationTest.java
@@ -49,7 +49,6 @@ import java.net.URL;
 import java.util.Properties;
 import java.util.concurrent.CompletionException;
 
-import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static com.hazelcast.test.OverridePropertyRule.set;
 import static org.junit.Assert.assertEquals;
@@ -120,7 +119,6 @@ public class KafkaConnectNeo4jIntegrationTest extends JetTestSupport {
         config.getJetConfig().setResourceUploadEnabled(true);
         LOGGER.info("Creating a job");
         Job job = createHazelcastInstance(config).getJet().newJob(pipeline, jobConfig);
-        assertJobStatusEventually(job, RUNNING);
 
         insertNodes("items-2");
 


### PR DESCRIPTION
Do not wait for jobs running as they could be finished before the assertions had been started

Fixes https://hazelcast.atlassian.net/browse/HZ-2342
Fixes https://github.com/hazelcast/hazelcast/issues/24276

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
