### PR TITLE
Fix PipeliningTest.test [HZ-2361]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/core/PipeliningTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/PipeliningTest.java
@@ -102,7 +102,7 @@ public class PipeliningTest extends HazelcastTestSupport {
 
     @Test
     public void test() throws Exception {
-        int maxValue  = 100_000;
+        int maxValue = 100_000;
         List<Integer> expected = new ArrayList<>();
         Map<Integer, Integer> entriesToAdd = new HashMap<>();
 
@@ -115,11 +115,11 @@ public class PipeliningTest extends HazelcastTestSupport {
                     expected.add(value);
                 });
         // Populate IMap
-        IMap<Integer,Integer> map = hz.getMap("map");
+        IMap<Integer, Integer> map = hz.getMap("map");
         map.putAll(entriesToAdd);
 
         Pipelining<Integer> pipelining = new Pipelining<>(1);
-        for (int index = 0; index < maxValue ; index++) {
+        for (int index = 0; index < maxValue; index++) {
             pipelining.add(map.getAsync(index));
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/core/PipeliningTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/PipeliningTest.java
@@ -28,10 +28,13 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.locks.LockSupport;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -54,14 +57,14 @@ public class PipeliningTest extends HazelcastTestSupport {
 
     @Test(expected = NullPointerException.class)
     public void add_whenNull() throws InterruptedException {
-        Pipelining<String> pipelining = new Pipelining<String>(1);
+        Pipelining<String> pipelining = new Pipelining<>(1);
         pipelining.add(null);
     }
 
 
     @Test
     public void testInterrupt() throws Exception {
-        final Pipelining<String> pipelining = new Pipelining<String>(1);
+        final Pipelining<String> pipelining = new Pipelining<>(1);
         pipelining.add(mock(CompletionStage.class));
 
         TestThread t = new TestThread() {
@@ -77,7 +80,7 @@ public class PipeliningTest extends HazelcastTestSupport {
 
     @Test
     public void testSpuriousWakeup() throws Exception {
-        final Pipelining<String> pipelining = new Pipelining<String>(1);
+        final Pipelining<String> pipelining = new Pipelining<>(1);
         pipelining.add(mock(CompletionStage.class));
 
         TestThread t = new TestThread() {
@@ -99,19 +102,25 @@ public class PipeliningTest extends HazelcastTestSupport {
 
     @Test
     public void test() throws Exception {
-        IMap map = hz.getMap("map");
-        int items = 100000;
+        int maxValue  = 100_000;
         List<Integer> expected = new ArrayList<>();
-        Random random = new Random();
-        for (int k = 0; k < items; k++) {
-            int item = random.nextInt();
-            expected.add(item);
-            map.put(k, item);
-        }
+        Map<Integer, Integer> entriesToAdd = new HashMap<>();
 
-        Pipelining<String> pipelining = new Pipelining<>(1);
-        for (int k = 0; k < items; k++) {
-            pipelining.add(map.getAsync(k));
+        // Populate data structures
+        Random random = new Random();
+        IntStream.range(0, maxValue)
+                .forEach(i -> {
+                    int value = random.nextInt();
+                    entriesToAdd.put(i, value);
+                    expected.add(value);
+                });
+        // Populate IMap
+        IMap<Integer,Integer> map = hz.getMap("map");
+        map.putAll(entriesToAdd);
+
+        Pipelining<Integer> pipelining = new Pipelining<>(1);
+        for (int index = 0; index < maxValue ; index++) {
+            pipelining.add(map.getAsync(index));
         }
 
         assertEquals(expected, pipelining.results());


### PR DESCRIPTION
The test is timing out at IMap.put(). Instead of making one hundred thousand put() calls use putAll(). Hopefully test will be faster

Fixes: https://github.com/hazelcast/hazelcast/issues/24286
Jira : https://hazelcast.atlassian.net/browse/HZ-2361
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible