### PR TITLE
Ignore ConfigMismatchOp shutdown requests if already in a cluster [HZ-2355]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
@@ -57,6 +57,13 @@ public class ConfigMismatchOp extends AbstractClusterOperation {
     public void run() {
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         Node node = nodeEngine.getNode();
+
+        // Ignore shutdown requests if we are already in a cluster, as being
+        // part of a cluster means our config was already verified & accepted
+        if (node.getClusterService().isJoined()) {
+            return;
+        }
+
         ILogger logger = nodeEngine.getLogger("com.hazelcast.cluster");
         logger.severe("Node could not join cluster. A Configuration mismatch was detected: "
                 + msg + " Node is going to shutdown now!");

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
@@ -58,13 +58,16 @@ public class ConfigMismatchOp extends AbstractClusterOperation {
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         Node node = nodeEngine.getNode();
 
+        ILogger logger = nodeEngine.getLogger("com.hazelcast.cluster");
+
         // Ignore shutdown requests if we are already in a cluster, as being
         // part of a cluster means our config was already verified & accepted
         if (node.getClusterService().isJoined()) {
+            logger.warning("Received ConfigMismatchOp when already joined with a cluster. " +
+                    "This node will not shutdown. Configuration mismatch: " + msg);
             return;
         }
 
-        ILogger logger = nodeEngine.getLogger("com.hazelcast.cluster");
         logger.severe("Node could not join cluster. A Configuration mismatch was detected: "
                 + msg + " Node is going to shutdown now!");
         node.shutdown(true);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
@@ -63,8 +63,8 @@ public class ConfigMismatchOp extends AbstractClusterOperation {
         // Ignore shutdown requests if we are already in a cluster, as being
         // part of a cluster means our config was already verified & accepted
         if (node.getClusterService().isJoined()) {
-            logger.warning("Received ConfigMismatchOp when already joined with a cluster. " +
-                    "This node will not shutdown. Configuration mismatch: " + msg);
+            logger.warning("Received ConfigMismatchOp when already joined with a cluster. "
+                    + "This node will not shutdown. Configuration mismatch: " + msg);
             return;
         }
 


### PR DESCRIPTION
As demonstrated in `TcpIpJoinTest#test_whenIncompatiblePartitionGroups` test failures, due to the nature of operation retry mechanics, it is possible for a younger node to receive a delayed `WhoIsMasterOp` from an older node which has already established itself as master. This can lead to the younger node responding with a `ConfigMismatchOp` if there is a configuration mismatch, which results in the older node being shutdown after processing the `ConfigMismatchOp`.

Since we can be sure that a node's configuration has been validated if it is already part of a cluster, we can ignore shutdown requests from a `ConfigMismatchOp` if our node returns true for `ClusterManager#isJoined`. This ensures that an already established node which is part of a cluster can no longer be shutdown by the race condition which is possible when `WhoIsMasterOp` operations are submitted after a retry delay.

This solution solves the problem at the end of the pipeline. The alternative solution  to resolve it at the beginning would be
to move the `ensureValidConfiguration()` check within the `ClusterJoinManager#answerWhoisMasterQuestion` method to
be within the `clusterService.isJoined()` conditional block. However, implementing the chosen solution (end of the pipeline)
results in the least behavioural changes, and so was selected.

Fixes https://github.com/hazelcast/hazelcast/issues/23384
