### PR TITLE
Fix some issues with ObjectType change [HZ-2312]

### DIFF
--- a/docs/design/sql/18-data-connections.md
+++ b/docs/design/sql/18-data-connections.md
@@ -613,8 +613,6 @@ FROM information_schema.data_connections;
 The list of data connections should also include links created in the config. In the
 `information_schema` there should be a flag for such data connections.
 
-`SHOW DATA CONNECTIONS` will show data connection name and a list of available object types.
-
 ## GET_DDL system function
 
 This is an alternative to the proposed DESCRIBE command. The DESCRIBE command is

--- a/docs/design/sql/18-data-connections.md
+++ b/docs/design/sql/18-data-connections.md
@@ -613,6 +613,8 @@ FROM information_schema.data_connections;
 The list of data connections should also include links created in the config. In the
 `information_schema` there should be a flag for such data connections.
 
+`SHOW DATA CONNECTIONS` will show data connection name and a list of available object types.
+
 ## GET_DDL system function
 
 This is an alternative to the proposed DESCRIBE command. The DESCRIBE command is

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -35,8 +35,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import static java.util.Collections.emptyMap;
@@ -214,24 +216,16 @@ public interface SqlConnector {
      * the user can see it by listing the catalog. Jet will later pass it to
      * {@link #createTable}.
      *
-     * @param nodeEngine         an instance of {@link NodeEngine}
-     * @param options            user-provided options
-     * @param userFields         user-provided list of fields, possibly empty
-     * @param externalName       external name of the table
-     * @param dataConnectionName name of the data connection to use, may be null if the connector supports specifying
-     *                           connection details in options
-     * @param objectType         the type of object for which fields will be resolved. Default value is the value
-     *                           returned by {@link #defaultObjectType()}.
+     * @param nodeEngine          an instance of {@link NodeEngine}
+     * @param sqlExternalResource an object for which fields should be resolved
+     * @param userFields          user-provided list of fields, possibly empty
      * @return final field list, must not be empty
      */
     @Nonnull
     List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields
     );
 
     /**
@@ -532,6 +526,29 @@ public interface SqlConnector {
         @Nonnull
         public Map<String, String> options() {
             return options == null ? emptyMap() : options;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SqlExternalResource that = (SqlExternalResource) o;
+            return Arrays.equals(externalName, that.externalName)
+                    && Objects.equals(dataConnection, that.dataConnection)
+                    && Objects.equals(connectorType, that.connectorType)
+                    && Objects.equals(objectType, that.objectType)
+                    && Objects.equals(options, that.options);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(dataConnection, connectorType, objectType, options);
+            result = 31 * result + Arrays.hashCode(externalName);
+            return result;
         }
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -216,15 +216,15 @@ public interface SqlConnector {
      * the user can see it by listing the catalog. Jet will later pass it to
      * {@link #createTable}.
      *
-     * @param nodeEngine          an instance of {@link NodeEngine}
-     * @param sqlExternalResource an object for which fields should be resolved
-     * @param userFields          user-provided list of fields, possibly empty
+     * @param nodeEngine       an instance of {@link NodeEngine}
+     * @param externalResource an object for which fields should be resolved
+     * @param userFields       user-provided list of fields, possibly empty
      * @return final field list, must not be empty
      */
     @Nonnull
     List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields
     );
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -241,16 +241,17 @@ public interface SqlConnector {
      * <p>
      * Jet calls this method for each statement execution and for each mapping.
      *
-     * @param nodeEngine         an instance of {@link NodeEngine}
-     * @param mappingContext     an object with the metadata of mapping from which this table is created
-     * @param resolvedFields     list of fields as returned from {@link
-     *                           #resolveAndValidateFields}
+     * @param nodeEngine       an instance of {@link NodeEngine}
+     * @param externalResource an object for which this table is created
+     * @param resolvedFields   list of fields as returned from {@link
+     *                         #resolveAndValidateFields}
      */
     @Nonnull
     Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext mappingContext,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields);
 
     /**
@@ -473,34 +474,24 @@ public interface SqlConnector {
     }
 
     /**
-     * Mapping specific metadata.
+     * Data describing external resource (table, topic, stream, IMap etc)
      *
      * @since 5.3
      */
-    class SqlMappingContext implements Serializable {
-        private final String name;
+    class SqlExternalResource implements Serializable {
         private final String[] externalName;
         private final String dataConnection;
         private final String connectorType;
         private final String objectType;
         private final Map<String, String> options;
 
-        public SqlMappingContext(String name, String[] externalName, String dataConnection, String connectorType,
-                                 String objectType, Map<String, String> options) {
-            this.name = requireNonNull(name, "name cannot be null");
+        public SqlExternalResource(@Nonnull String[] externalName, String dataConnection, @Nonnull String connectorType,
+                                   String objectType, Map<String, String> options) {
             this.externalName = requireNonNull(externalName, "externalName cannot be null");
             this.dataConnection = dataConnection;
             this.connectorType = requireNonNull(connectorType, "connectorType cannot be null");
             this.objectType = objectType;
             this.options = options;
-        }
-
-        /**
-         * Name of this mapping.
-         */
-        @Nonnull
-        public String name() {
-            return name;
         }
 
         /**

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/file/FileSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/file/FileSqlConnector.java
@@ -91,18 +91,19 @@ public class FileSqlConnector implements SqlConnector {
     public Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields) {
-        Metadata metadata = METADATA_RESOLVERS.resolveMetadata(resolvedFields, ctx.options());
+        Metadata metadata = METADATA_RESOLVERS.resolveMetadata(resolvedFields, externalResource.options());
 
         return new FileTable.SpecificFileTable(
                 INSTANCE,
                 schemaName,
-                ctx.name(),
+                mappingName,
                 metadata.fields(),
                 metadata.processorMetaSupplier(),
                 metadata.queryTargetSupplier(),
-                ctx.objectType()
+                externalResource.objectType()
         );
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/file/FileSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/file/FileSqlConnector.java
@@ -70,9 +70,9 @@ public class FileSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
-        return resolveAndValidateFields(sqlExternalResource.options(), userFields);
+        return resolveAndValidateFields(externalResource.options(), userFields);
     }
 
     @Nonnull

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/file/FileSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/file/FileSqlConnector.java
@@ -70,12 +70,9 @@ public class FileSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType) {
-        return resolveAndValidateFields(options, userFields);
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields) {
+        return resolveAndValidateFields(sqlExternalResource.options(), userFields);
     }
 
     @Nonnull

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
@@ -76,7 +76,8 @@ class SeriesSqlConnector implements SqlConnector {
     public Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields) {
         throw new UnsupportedOperationException("Creating table not supported for " + typeName());
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
@@ -62,7 +62,7 @@ class SeriesSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
         throw new UnsupportedOperationException("Resolving fields not supported for " + typeName());
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
@@ -37,7 +37,6 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Collections.singletonList;
 
@@ -63,11 +62,8 @@ class SeriesSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType) {
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields) {
         throw new UnsupportedOperationException("Resolving fields not supported for " + typeName());
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
@@ -62,7 +62,7 @@ public class StreamSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
         throw new UnsupportedOperationException("Resolving fields not supported for " + typeName());
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
@@ -76,7 +76,8 @@ public class StreamSqlConnector implements SqlConnector {
     public Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields) {
         throw new UnsupportedOperationException("Creating table not supported for " + typeName());
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
@@ -35,7 +35,6 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 
 import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.processor.Processors.insertWatermarksP;
@@ -63,11 +62,8 @@ public class StreamSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType) {
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields) {
         throw new UnsupportedOperationException("Resolving fields not supported for " + typeName());
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
@@ -79,7 +79,8 @@ final class InfoSchemaConnector implements SqlConnector {
     public Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields) {
         throw new UnsupportedOperationException();
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
@@ -66,7 +66,7 @@ final class InfoSchemaConnector implements SqlConnector {
     @Nonnull @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
         throw new UnsupportedOperationException();
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
@@ -37,7 +37,6 @@ import com.hazelcast.sql.impl.schema.Table;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.forceTotalParallelismOne;
 
@@ -67,11 +66,8 @@ final class InfoSchemaConnector implements SqlConnector {
     @Nonnull @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType) {
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields) {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -248,9 +248,10 @@ public class JdbcSqlConnector implements SqlConnector {
     public Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields) {
-        String dataConnectionName = ctx.dataConnection();
+        String dataConnectionName = externalResource.dataConnection();
         assert dataConnectionName != null;
 
         List<TableField> fields = new ArrayList<>(resolvedFields.size());
@@ -273,9 +274,10 @@ public class JdbcSqlConnector implements SqlConnector {
                 fields,
                 dialect,
                 schemaName,
-                ctx,
+                mappingName,
+                externalResource,
                 new ConstantTableStatistics(0),
-                parseInt(ctx.options().getOrDefault(OPTION_JDBC_BATCH_LIMIT, JDBC_BATCH_LIMIT_DEFAULT_VALUE)),
+                parseInt(externalResource.options().getOrDefault(OPTION_JDBC_BATCH_LIMIT, JDBC_BATCH_LIMIT_DEFAULT_VALUE)),
                 nodeEngine.getSerializationService()
         );
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -75,7 +75,7 @@ public class JdbcSqlConnector implements SqlConnector {
     @Nonnull
     @Override
     public String defaultObjectType() {
-        return "Table";
+        return JdbcDataConnection.OBJECT_TYPE_TABLE;
     }
 
     @Nonnull

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -82,17 +82,15 @@ public class JdbcSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType) {
-        if (dataConnectionName == null) {
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields) {
+        if (sqlExternalResource.dataConnection() == null) {
             throw QueryException.error("You must provide data connection when using the Jdbc connector");
         }
-        ExternalJdbcTableName.validateExternalName(externalName);
+        ExternalJdbcTableName.validateExternalName(sqlExternalResource.externalName());
 
-        Map<String, DbField> dbFields = readDbFields(nodeEngine, dataConnectionName, externalName);
+        Map<String, DbField> dbFields = readDbFields(nodeEngine,
+                sqlExternalResource.dataConnection(), sqlExternalResource.externalName());
 
         List<MappingField> resolvedFields = new ArrayList<>();
         if (userFields.isEmpty()) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -83,15 +83,15 @@ public class JdbcSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
-        if (sqlExternalResource.dataConnection() == null) {
+        if (externalResource.dataConnection() == null) {
             throw QueryException.error("You must provide data connection when using the Jdbc connector");
         }
-        ExternalJdbcTableName.validateExternalName(sqlExternalResource.externalName());
+        ExternalJdbcTableName.validateExternalName(externalResource.externalName());
 
         Map<String, DbField> dbFields = readDbFields(nodeEngine.getDataConnectionService(),
-                sqlExternalResource.dataConnection(), sqlExternalResource.externalName());
+                externalResource.dataConnection(), externalResource.externalName());
 
         List<MappingField> resolvedFields = new ArrayList<>();
         if (userFields.isEmpty()) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcTable.java
@@ -18,7 +18,7 @@ package com.hazelcast.jet.sql.impl.connector.jdbc;
 
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
-import com.hazelcast.jet.sql.impl.connector.SqlConnector.SqlMappingContext;
+import com.hazelcast.jet.sql.impl.connector.SqlConnector.SqlExternalResource;
 import com.hazelcast.jet.sql.impl.schema.JetTable;
 import com.hazelcast.sql.impl.optimizer.PlanObjectKey;
 import com.hazelcast.sql.impl.schema.TableField;
@@ -48,12 +48,13 @@ public class JdbcTable extends JetTable {
             @Nonnull List<TableField> fields,
             @Nonnull SqlDialect dialect,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource ctx,
             @Nonnull TableStatistics statistics,
             int batchLimit,
             @Nonnull SerializationService serializationService) {
 
-        super(sqlConnector, fields, schemaName, ctx.name(), statistics, ctx.objectType(), false);
+        super(sqlConnector, fields, schemaName, mappingName, statistics, ctx.objectType(), false);
 
         List<String> dbFieldNames = new ArrayList<>(fields.size());
         List<String> primaryKeyFieldNames = new ArrayList<>(1);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
@@ -45,7 +45,6 @@ import com.hazelcast.sql.impl.schema.TableField;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 
 import static com.hazelcast.jet.core.Edge.between;
@@ -86,17 +85,14 @@ public class KafkaSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType) {
-        if (externalName.length > 1) {
-            throw QueryException.error("Invalid external name " + quoteCompoundIdentifier(externalName)
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields) {
+        if (sqlExternalResource.externalName().length > 1) {
+            throw QueryException.error("Invalid external name " + quoteCompoundIdentifier(sqlExternalResource.externalName())
                     + ", external name for Kafka is allowed to have only a single component referencing the topic " +
                     "name");
         }
-        return METADATA_RESOLVERS.resolveAndValidateFields(userFields, options, nodeEngine);
+        return METADATA_RESOLVERS.resolveAndValidateFields(userFields, sqlExternalResource.options(), nodeEngine);
     }
 
     @Nonnull

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
@@ -85,14 +85,14 @@ public class KafkaSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
-        if (sqlExternalResource.externalName().length > 1) {
-            throw QueryException.error("Invalid external name " + quoteCompoundIdentifier(sqlExternalResource.externalName())
+        if (externalResource.externalName().length > 1) {
+            throw QueryException.error("Invalid external name " + quoteCompoundIdentifier(externalResource.externalName())
                     + ", external name for Kafka is allowed to have only a single component referencing the topic " +
                     "name");
         }
-        return METADATA_RESOLVERS.resolveAndValidateFields(userFields, sqlExternalResource.options(), nodeEngine);
+        return METADATA_RESOLVERS.resolveAndValidateFields(userFields, externalResource.options(), nodeEngine);
     }
 
     @Nonnull

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
@@ -104,27 +104,28 @@ public class KafkaSqlConnector implements SqlConnector {
     public Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields) {
-        KvMetadata keyMetadata = METADATA_RESOLVERS.resolveMetadata(true, resolvedFields, ctx.options(), null);
-        KvMetadata valueMetadata = METADATA_RESOLVERS.resolveMetadata(false, resolvedFields, ctx.options(), null);
+        KvMetadata keyMetadata = METADATA_RESOLVERS.resolveMetadata(true, resolvedFields, externalResource.options(), null);
+        KvMetadata valueMetadata = METADATA_RESOLVERS.resolveMetadata(false, resolvedFields, externalResource.options(), null);
         List<TableField> fields = concat(keyMetadata.getFields().stream(), valueMetadata.getFields().stream())
                 .collect(toList());
 
         return new KafkaTable(
                 this,
                 schemaName,
-                ctx.name(),
+                mappingName,
                 fields,
                 new ConstantTableStatistics(0),
-                ctx.externalName()[0],
-                ctx.dataConnection(),
-                ctx.options(),
+                externalResource.externalName()[0],
+                externalResource.dataConnection(),
+                externalResource.options(),
                 keyMetadata.getQueryTargetDescriptor(),
                 keyMetadata.getUpsertTargetDescriptor(),
                 valueMetadata.getQueryTargetDescriptor(),
                 valueMetadata.getUpsertTargetDescriptor(),
-                ctx.objectType()
+                externalResource.objectType()
         );
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -60,7 +60,6 @@ import com.hazelcast.sql.impl.schema.map.PartitionedMapTable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 
 import static com.hazelcast.internal.util.UuidUtil.newUnsecureUuidString;
 import static com.hazelcast.jet.core.Edge.between;
@@ -108,13 +107,10 @@ public class IMapSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType) {
-        checkImapName(externalName);
-        return METADATA_RESOLVERS_WITH_COMPACT.resolveAndValidateFields(userFields, options, nodeEngine);
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields) {
+        checkImapName(sqlExternalResource.externalName());
+        return METADATA_RESOLVERS_WITH_COMPACT.resolveAndValidateFields(userFields, sqlExternalResource.options(), nodeEngine);
     }
 
     @Nonnull

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -107,10 +107,10 @@ public class IMapSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
-        checkImapName(sqlExternalResource.externalName());
-        return METADATA_RESOLVERS_WITH_COMPACT.resolveAndValidateFields(userFields, sqlExternalResource.options(), nodeEngine);
+        checkImapName(externalResource.externalName());
+        return METADATA_RESOLVERS_WITH_COMPACT.resolveAndValidateFields(userFields, externalResource.options(), nodeEngine);
     }
 
     @Nonnull

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -83,6 +83,7 @@ public class IMapSqlConnector implements SqlConnector {
     public static final IMapSqlConnector INSTANCE = new IMapSqlConnector();
 
     public static final String TYPE_NAME = "IMap";
+    public static final String OBJECT_TYPE_IMAP = "IMap";
     public static final List<String> PRIMARY_KEY_LIST = singletonList(QueryPath.KEY);
 
     private static final KvMetadataResolvers METADATA_RESOLVERS_WITH_COMPACT = new KvMetadataResolvers(
@@ -100,7 +101,7 @@ public class IMapSqlConnector implements SqlConnector {
     @Nonnull
     @Override
     public String defaultObjectType() {
-        return "IMap";
+        return OBJECT_TYPE_IMAP;
     }
 
     @Nonnull

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -122,21 +122,22 @@ public class IMapSqlConnector implements SqlConnector {
     public Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields) {
-        checkImapName(ctx.externalName());
+        checkImapName(externalResource.externalName());
 
         InternalSerializationService ss = (InternalSerializationService) nodeEngine.getSerializationService();
 
         KvMetadata keyMetadata = METADATA_RESOLVERS_WITH_COMPACT.resolveMetadata(
                 true,
                 resolvedFields,
-                ctx.options(), ss
+                externalResource.options(), ss
         );
         KvMetadata valueMetadata = METADATA_RESOLVERS_WITH_COMPACT.resolveMetadata(
                 false,
                 resolvedFields,
-                ctx.options(),
+                externalResource.options(),
                 ss
         );
         List<TableField> fields = concat(keyMetadata.getFields().stream(), valueMetadata.getFields().stream())
@@ -144,7 +145,7 @@ public class IMapSqlConnector implements SqlConnector {
 
         MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
         MapServiceContext context = service.getMapServiceContext();
-        String mapName = ctx.externalName()[0];
+        String mapName = externalResource.externalName()[0];
         MapContainer container = context.getExistingMapContainer(mapName);
 
         long estimatedRowCount = estimatePartitionedMapRowCount(nodeEngine, context, mapName);
@@ -155,7 +156,7 @@ public class IMapSqlConnector implements SqlConnector {
 
         return new PartitionedMapTable(
                 schemaName,
-                ctx.name(),
+                mappingName,
                 mapName,
                 fields,
                 new ConstantTableStatistics(estimatedRowCount),

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
@@ -74,22 +74,22 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
-        if (sqlExternalResource.externalName().length > 2) {
-            throw QueryException.error("Invalid external name " + quoteCompoundIdentifier(sqlExternalResource.externalName())
+        if (externalResource.externalName().length > 2) {
+            throw QueryException.error("Invalid external name " + quoteCompoundIdentifier(externalResource.externalName())
                     + ", external name for Mongo is allowed to have only one component (collection)"
                     + " or two components (database and collection)");
         }
-        if (!ALLOWED_OBJECT_TYPES.contains(sqlExternalResource.objectType())) {
+        if (!ALLOWED_OBJECT_TYPES.contains(externalResource.objectType())) {
             throw QueryException.error("Mongo connector allows only object types: " + ALLOWED_OBJECT_TYPES);
         }
         FieldResolver fieldResolver = new FieldResolver(nodeEngine);
-        return fieldResolver.resolveFields(sqlExternalResource.externalName(),
-                sqlExternalResource.dataConnection(),
-                sqlExternalResource.options(),
+        return fieldResolver.resolveFields(externalResource.externalName(),
+                externalResource.dataConnection(),
+                externalResource.options(),
                 userFields,
-                isStream(sqlExternalResource.objectType()));
+                isStream(externalResource.objectType()));
     }
 
     private static boolean isStream(String objectType) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
@@ -111,19 +111,21 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
 
     @Nonnull
     @Override
-    public Table createTable(@Nonnull NodeEngine nodeEngine, @Nonnull String schemaName, @Nonnull SqlMappingContext ctx,
+    public Table createTable(@Nonnull NodeEngine nodeEngine,
+                             @Nonnull String schemaName, @Nonnull String mappingName,
+                             @Nonnull SqlExternalResource externalResource,
                              @Nonnull List<MappingField> resolvedFields) {
-        if (!ALLOWED_OBJECT_TYPES.contains(ctx.objectType())) {
+        if (!ALLOWED_OBJECT_TYPES.contains(externalResource.objectType())) {
             throw QueryException.error("Mongo connector allows only object types: " + ALLOWED_OBJECT_TYPES);
         }
-        String collectionName = ctx.externalName().length == 2 ? ctx.externalName()[1] : ctx.externalName()[0];
+        String collectionName = externalResource.externalName().length == 2 ? externalResource.externalName()[1] : externalResource.externalName()[0];
         FieldResolver fieldResolver = new FieldResolver(nodeEngine);
-        String databaseName = Options.getDatabaseName(nodeEngine, ctx.externalName(), ctx.dataConnection());
+        String databaseName = Options.getDatabaseName(nodeEngine, externalResource.externalName(), externalResource.dataConnection());
         ConstantTableStatistics stats = new ConstantTableStatistics(0);
 
         List<TableField> fields = new ArrayList<>(resolvedFields.size());
         boolean containsId = false;
-        boolean isStreaming = isStream(ctx.objectType());
+        boolean isStreaming = isStream(externalResource.objectType());
         boolean hasPK = false;
         for (MappingField resolvedField : resolvedFields) {
             String externalNameFromName = (isStreaming ? "fullDocument." : "") + resolvedField.name();
@@ -151,9 +153,9 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
                         "DOCUMENT", !hasPK));
             }
         }
-        return new MongoTable(schemaName, ctx.name(), databaseName, collectionName,
-                ctx.dataConnection(), ctx.options(), this,
-                fields, stats, ctx.objectType());
+        return new MongoTable(schemaName, mappingName, databaseName, collectionName,
+                externalResource.dataConnection(), externalResource.options(), this,
+                fields, stats, externalResource.objectType());
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/virtual/ViewTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/virtual/ViewTable.java
@@ -43,6 +43,7 @@ public class ViewTable extends Table {
     private RelNode viewRel;
 
     public ViewTable(String schemaName, String viewName, String viewQuery, TableStatistics statistics) {
+        // will determine if the view is streaming later, when it is used
         super(schemaName, viewName, null, statistics, "View", false);
         this.viewQuery = viewQuery;
     }
@@ -78,6 +79,12 @@ public class ViewTable extends Table {
         getFields(); // called for the side effect of calling initFields()
         assert viewRel != null;
         return viewRel;
+    }
+
+    @Override
+    public boolean isStreaming() {
+        getFields(); // called for the side effect of calling initFields()
+        return super.isStreaming();
     }
 
     static class ViewPlanObjectKey implements PlanObjectKey {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.dataconnection.impl.InternalDataConnectionService;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
-import com.hazelcast.jet.sql.impl.connector.SqlConnector.SqlMappingContext;
+import com.hazelcast.jet.sql.impl.connector.SqlConnector.SqlExternalResource;
 import com.hazelcast.jet.sql.impl.connector.SqlConnectorCache;
 import com.hazelcast.jet.sql.impl.connector.infoschema.MappingColumnsTable;
 import com.hazelcast.jet.sql.impl.connector.infoschema.MappingsTable;
@@ -309,9 +309,9 @@ public class TableResolverImpl implements TableResolver {
             return connector.createTable(
                     nodeEngine,
                     SCHEMA_NAME_PUBLIC,
-                    sqlMappingContextFrom(mapping, connector),
-                    mapping.fields()
-            );
+                    mapping.name(),
+                    sqlExternalResourceFrom(mapping, connector),
+                    mapping.fields());
         } catch (Throwable e) {
             // will fail later if invalid table is actually used in a query
             return new BadTable(SCHEMA_NAME_PUBLIC, mapping.name(), mapping.objectType(),
@@ -319,13 +319,13 @@ public class TableResolverImpl implements TableResolver {
         }
     }
 
-    private static SqlMappingContext sqlMappingContextFrom(Mapping internalMapping, SqlConnector connector) {
+    private static SqlExternalResource sqlExternalResourceFrom(Mapping internalMapping, SqlConnector connector) {
         String internalObjType = internalMapping.objectType() == null
                 ? connector.defaultObjectType()
                 : internalMapping.objectType();
         checkNotNull(internalObjType, "objectType cannot be null");
         String connectorType = connector.typeName();
-        return new SqlMappingContext(internalMapping.name(), internalMapping.externalName(),
+        return new SqlExternalResource(internalMapping.externalName(),
                 internalMapping.dataConnection(),
                 connectorType, internalObjType, internalMapping.options());
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
@@ -314,7 +314,7 @@ public class TableResolverImpl implements TableResolver {
             );
         } catch (Throwable e) {
             // will fail later if invalid table is actually used in a query
-            return new BadTable(SCHEMA_NAME_PUBLIC, mapping.name(),
+            return new BadTable(SCHEMA_NAME_PUBLIC, mapping.name(), mapping.objectType(),
                     e instanceof QueryException ? e.getCause() : e);
         }
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/TableResolverImpl.java
@@ -156,11 +156,13 @@ public class TableResolverImpl implements TableResolver {
         checkNotNull(objectType, "objectType cannot be null");
         resolvedFields = connector.resolveAndValidateFields(
                 nodeEngine,
-                options,
-                mapping.fields(),
-                mapping.externalName(),
-                mapping.dataConnection(),
-                objectType
+                new SqlExternalResource(
+                        mapping.externalName(),
+                        mapping.dataConnection(),
+                        connector.typeName(),
+                        objectType,
+                        options),
+                mapping.fields()
         );
 
         return new Mapping(

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/BadTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/BadTable.java
@@ -30,8 +30,8 @@ import java.util.List;
 public final class BadTable extends Table {
     private final Throwable cause;
 
-    public BadTable(String schemaName, String sqlName, Throwable cause) {
-        super(schemaName, sqlName, Collections.emptyList(), new ConstantTableStatistics(0), "Bad", false);
+    public BadTable(String schemaName, String sqlName, String objectType, Throwable cause) {
+        super(schemaName, sqlName, Collections.emptyList(), new ConstantTableStatistics(0), objectType, false);
         this.cause = cause;
     }
 
@@ -43,6 +43,11 @@ public final class BadTable extends Table {
 
     @Override
     public PlanObjectKey getObjectKey() {
+        throw createException();
+    }
+
+    @Override
+    public boolean isStreaming() {
         throw createException();
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/map/AbstractMapTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/map/AbstractMapTable.java
@@ -40,21 +40,23 @@ public abstract class AbstractMapTable extends Table {
     private final QueryException exception;
 
     /**
-     * @param sqlName Name of the table as it appears in the SQL
-     * @param mapName Name of the underlying map
+     * @param sqlName    Name of the table as it appears in the SQL
+     * @param mapName    Name of the underlying map
+     * @param objectType Type of the map
      */
     protected AbstractMapTable(
-        String schemaName,
-        String sqlName,
-        String mapName,
-        List<TableField> fields,
-        TableStatistics statistics,
-        QueryTargetDescriptor keyDescriptor,
-        QueryTargetDescriptor valueDescriptor,
-        Object keyJetMetadata,
-        Object valueJetMetadata
+            String schemaName,
+            String sqlName,
+            String mapName,
+            String objectType,
+            List<TableField> fields,
+            TableStatistics statistics,
+            QueryTargetDescriptor keyDescriptor,
+            QueryTargetDescriptor valueDescriptor,
+            Object keyJetMetadata,
+            Object valueJetMetadata
     ) {
-        super(schemaName, sqlName, fields, statistics, "IMap", false);
+        super(schemaName, sqlName, fields, statistics, objectType, false);
 
         this.mapName = requireNonNull(mapName);
         this.keyDescriptor = keyDescriptor;

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTable.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.sql.impl.schema.map;
 
+import com.hazelcast.jet.sql.impl.connector.map.IMapSqlConnector;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.extract.QueryTargetDescriptor;
 import com.hazelcast.sql.impl.optimizer.PlanObjectKey;
@@ -52,6 +53,7 @@ public class PartitionedMapTable extends AbstractMapTable {
             schemaName,
             tableName,
             mapName,
+            IMapSqlConnector.OBJECT_TYPE_IMAP,
             fields,
             statistics,
             keyDescriptor,

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/view/View.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/view/View.java
@@ -37,7 +37,6 @@ public class View implements Versioned, SqlCatalogObject {
     private String query;
     private List<String> viewColumnNames;
     private List<QueryDataType> viewColumnTypes;
-    private boolean streaming;
 
     public View() {
     }
@@ -83,7 +82,6 @@ public class View implements Versioned, SqlCatalogObject {
         }
         SerializationUtil.writeList(viewColumnNames, out);
         SerializationUtil.writeList(viewColumnTypes, out);
-        out.writeBoolean(streaming);
     }
 
     @Override
@@ -95,7 +93,6 @@ public class View implements Versioned, SqlCatalogObject {
         }
         viewColumnNames = SerializationUtil.readList(in);
         viewColumnTypes = SerializationUtil.readList(in);
-        streaming = in.readBoolean();
     }
 
     @Override
@@ -115,13 +112,12 @@ public class View implements Versioned, SqlCatalogObject {
         return Objects.equals(name, view.name)
                 && Objects.equals(query, view.query)
                 && Objects.equals(viewColumnNames, view.viewColumnNames)
-                && Objects.equals(viewColumnTypes, view.viewColumnTypes)
-                && streaming == view.streaming;
+                && Objects.equals(viewColumnTypes, view.viewColumnTypes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, query, viewColumnNames, viewColumnTypes, streaming);
+        return Objects.hash(name, query, viewColumnNames, viewColumnTypes);
     }
 
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAbstractSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAbstractSqlConnector.java
@@ -138,9 +138,10 @@ public abstract class TestAbstractSqlConnector implements SqlConnector {
     public Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields) {
-        Map<String, String> options = ctx.options();
+        Map<String, String> options = externalResource.options();
         String[] names = options.get(OPTION_NAMES).split(DELIMITER);
         String[] types = options.get(OPTION_TYPES).split(DELIMITER);
 
@@ -175,7 +176,7 @@ public abstract class TestAbstractSqlConnector implements SqlConnector {
         }
 
         boolean streaming = Boolean.parseBoolean(options.get(OPTION_STREAMING));
-        return new TestTable(this, schemaName, ctx.name(), fields, rows, streaming);
+        return new TestTable(this, schemaName, mappingName, fields, rows, streaming);
     }
 
     @Nonnull

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAbstractSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAbstractSqlConnector.java
@@ -112,14 +112,14 @@ public abstract class TestAbstractSqlConnector implements SqlConnector {
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
         if (userFields.size() > 0) {
             throw QueryException.error("Don't specify external fields, they are fixed");
         }
 
-        String[] names = sqlExternalResource.options().get(OPTION_NAMES).split(DELIMITER);
-        String[] types = sqlExternalResource.options().get(OPTION_TYPES).split(DELIMITER);
+        String[] names = externalResource.options().get(OPTION_NAMES).split(DELIMITER);
+        String[] types = externalResource.options().get(OPTION_TYPES).split(DELIMITER);
 
         assert names.length == types.length;
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAbstractSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAbstractSqlConnector.java
@@ -105,24 +105,21 @@ public abstract class TestAbstractSqlConnector implements SqlConnector {
                 + ", '" + OPTION_STREAMING + "'='" + streamingActual + "'"
                 + ")";
         System.out.println(sql);
-        sqlService.execute(sql).updateCount();
+        sqlService.executeUpdate(sql);
     }
 
     @Nonnull
     @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType) {
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields) {
         if (userFields.size() > 0) {
             throw QueryException.error("Don't specify external fields, they are fixed");
         }
 
-        String[] names = options.get(OPTION_NAMES).split(DELIMITER);
-        String[] types = options.get(OPTION_TYPES).split(DELIMITER);
+        String[] names = sqlExternalResource.options().get(OPTION_NAMES).split(DELIMITER);
+        String[] types = sqlExternalResource.options().get(OPTION_TYPES).split(DELIMITER);
 
         assert names.length == types.length;
 
@@ -187,7 +184,7 @@ public abstract class TestAbstractSqlConnector implements SqlConnector {
             @Nonnull List<HazelcastRexNode> projection,
             @Nullable FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider
     ) {
-        TestTable table = (TestTable) context.getTable();
+        TestTable table = context.getTable();
         List<Object[]> rows = table.rows;
         boolean streaming = table.streaming;
         Expression<Boolean> convertedPredicate = context.convertFilter(predicate);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAllTypesSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAllTypesSqlConnector.java
@@ -50,7 +50,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static com.hazelcast.jet.impl.util.Util.toList;
@@ -123,11 +122,8 @@ public class TestAllTypesSqlConnector implements SqlConnector {
     @Nonnull @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType) {
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields) {
         if (userFields.size() > 0) {
             throw QueryException.error("Don't specify external fields, they are fixed");
         }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAllTypesSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAllTypesSqlConnector.java
@@ -138,9 +138,10 @@ public class TestAllTypesSqlConnector implements SqlConnector {
     public Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields) {
-        return new TestAllTypesTable(this, schemaName, ctx.name());
+        return new TestAllTypesTable(this, schemaName, mappingName);
     }
 
     @Nonnull @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAllTypesSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestAllTypesSqlConnector.java
@@ -122,7 +122,7 @@ public class TestAllTypesSqlConnector implements SqlConnector {
     @Nonnull @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
         if (userFields.size() > 0) {
             throw QueryException.error("Don't specify external fields, they are fixed");

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestFailingSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestFailingSqlConnector.java
@@ -37,7 +37,6 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static com.hazelcast.jet.impl.util.Util.toList;
@@ -66,11 +65,8 @@ public class TestFailingSqlConnector implements SqlConnector {
     @Nonnull @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull Map<String, String> options,
-            @Nonnull List<MappingField> userFields,
-            @Nonnull String[] externalName,
-            @Nullable String dataConnectionName,
-            @Nullable String objectType) {
+            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull List<MappingField> userFields) {
         if (userFields.size() > 0) {
             throw QueryException.error("Don't specify external fields, they are fixed");
         }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestFailingSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestFailingSqlConnector.java
@@ -81,12 +81,13 @@ public class TestFailingSqlConnector implements SqlConnector {
     public Table createTable(
             @Nonnull NodeEngine nodeEngine,
             @Nonnull String schemaName,
-            @Nonnull SqlMappingContext ctx,
+            @Nonnull String mappingName,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> resolvedFields) {
         return new TestFailingTable(
                 this,
                 schemaName,
-                ctx.name(),
+                mappingName,
                 toList(resolvedFields, field -> new TableField(field.name(), field.type(), false))
         );
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestFailingSqlConnector.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/test/TestFailingSqlConnector.java
@@ -65,7 +65,7 @@ public class TestFailingSqlConnector implements SqlConnector {
     @Nonnull @Override
     public List<MappingField> resolveAndValidateFields(
             @Nonnull NodeEngine nodeEngine,
-            @Nonnull SqlExternalResource sqlExternalResource,
+            @Nonnull SqlExternalResource externalResource,
             @Nonnull List<MappingField> userFields) {
         if (userFields.size() > 0) {
             throw QueryException.error("Don't specify external fields, they are fixed");

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TableResolverImplTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/TableResolverImplTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.sql.impl.schema;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
+import com.hazelcast.jet.sql.impl.connector.SqlConnector.SqlExternalResource;
 import com.hazelcast.jet.sql.impl.connector.SqlConnectorCache;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.QueryException;
@@ -98,9 +99,12 @@ public class TableResolverImplTest {
         Mapping mapping = mapping();
 
         given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
+        given(connector.typeName()).willReturn(mapping.connectorType());
         given(connector.defaultObjectType()).willReturn("Dummy");
-        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
-                mapping.externalName(), mapping.dataConnection(), "Dummy"))
+        given(connector.resolveAndValidateFields(nodeEngine,
+                new SqlExternalResource(mapping.externalName(), mapping.dataConnection(), mapping.connectorType(), "Dummy", mapping.options()),
+                mapping.fields()
+        ))
                 .willThrow(new RuntimeException("expected test exception"));
 
         // when
@@ -118,9 +122,12 @@ public class TableResolverImplTest {
         Mapping mapping = mapping();
 
         given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
-        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
-                mapping.externalName(), mapping.dataConnection(), null))
+        given(connector.resolveAndValidateFields(nodeEngine,
+                new SqlExternalResource(mapping.externalName(), mapping.dataConnection(), "Dummy", null, mapping.options()),
+                mapping.fields()
+        ))
                 .willReturn(singletonList(new MappingField("field_name", INT)));
+        given(connector.typeName()).willReturn("Dummy");
         given(connector.defaultObjectType()).willReturn("Dummy");
         given(relationsStorage.putIfAbsent(eq(mapping.name()), isA(Mapping.class))).willReturn(false);
 
@@ -138,9 +145,12 @@ public class TableResolverImplTest {
         Mapping mapping = mapping();
 
         given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
+        given(connector.typeName()).willReturn(mapping.connectorType());
         given(connector.defaultObjectType()).willReturn("Dummy");
-        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
-                mapping.externalName(), mapping.dataConnection(), null))
+        given(connector.resolveAndValidateFields(nodeEngine,
+                new SqlExternalResource(mapping.externalName(), mapping.dataConnection(), mapping.connectorType(), null, mapping.options()),
+                mapping.fields()
+        ))
                 .willReturn(singletonList(new MappingField("field_name", INT)));
         given(relationsStorage.putIfAbsent(eq(mapping.name()), isA(Mapping.class))).willReturn(false);
 
@@ -157,9 +167,12 @@ public class TableResolverImplTest {
         Mapping mapping = mapping();
 
         given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
+        given(connector.typeName()).willReturn(mapping.connectorType());
         given(connector.defaultObjectType()).willReturn("Dummy");
-        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
-                mapping.externalName(), mapping.dataConnection(), null))
+        given(connector.resolveAndValidateFields(nodeEngine,
+                new SqlExternalResource(mapping.externalName(), mapping.dataConnection(), mapping.connectorType(), null, mapping.options()),
+                mapping.fields()
+        ))
                 .willReturn(singletonList(new MappingField("field_name", INT)));
 
         // when
@@ -176,13 +189,18 @@ public class TableResolverImplTest {
         Mapping mapping = mapping();
 
         given(connectorCache.forType(mapping.connectorType())).willReturn(connector);
-        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
-                mapping.externalName(), mapping.dataConnection(), "MyDummyType"))
+        given(connector.resolveAndValidateFields(nodeEngine,
+                new SqlExternalResource(mapping.externalName(), mapping.dataConnection(), mapping.connectorType(), "MyDummyType", mapping.options()),
+                mapping.fields()
+        ))
                 .willReturn(singletonList(new MappingField("field_name", INT)));
         // in case of mistake, throw error:
-        given(connector.resolveAndValidateFields(nodeEngine, mapping.options(), mapping.fields(),
-                mapping.externalName(), mapping.dataConnection(), null))
+        given(connector.resolveAndValidateFields(nodeEngine,
+                new SqlExternalResource(mapping.externalName(), mapping.dataConnection(), mapping.connectorType(), null, mapping.options()),
+                mapping.fields()
+        ))
                 .willThrow(new AssertionError("Object type must not be null"));
+        given(connector.typeName()).willReturn(mapping.connectorType());
         given(connector.defaultObjectType()).willReturn("MyDummyType");
 
         // when

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/DataConnectionResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/DataConnectionResource.java
@@ -20,6 +20,7 @@ import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.Locale;
 
 import static java.util.Objects.requireNonNull;
 
@@ -88,7 +89,7 @@ public class DataConnectionResource {
 
         DataConnectionResource dataConnectionResource = (DataConnectionResource) o;
 
-        if (!type.equals(dataConnectionResource.type)) {
+        if (!type.equalsIgnoreCase(dataConnectionResource.type)) {
             return false;
         }
         return Arrays.equals(name, dataConnectionResource.name);
@@ -96,7 +97,7 @@ public class DataConnectionResource {
 
     @Override
     public int hashCode() {
-        int result = type.hashCode();
+        int result = type.toLowerCase(Locale.ROOT).hashCode();
         result = 31 * result + Arrays.hashCode(name);
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/HazelcastDataConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/HazelcastDataConnection.java
@@ -64,6 +64,8 @@ public class HazelcastDataConnection extends DataConnectionBase {
      */
     public static final String CLIENT_YML_PATH = "client_yml_path";
 
+    public static final String OBJECT_TYPE_IMAP = "IMap";
+
     private final ClientConfig clientConfig;
 
     /**
@@ -109,7 +111,7 @@ public class HazelcastDataConnection extends DataConnectionBase {
     @Nonnull
     @Override
     public Collection<String> resourceTypes() {
-        return Collections.singleton("IMap");
+        return Collections.singleton(OBJECT_TYPE_IMAP);
     }
 
     @Nonnull
@@ -120,7 +122,7 @@ public class HazelcastDataConnection extends DataConnectionBase {
             return instance.getDistributedObjects()
                     .stream()
                     .filter(IMap.class::isInstance)
-                    .map(o -> new DataConnectionResource("IMap", o.getName()))
+                    .map(o -> new DataConnectionResource(OBJECT_TYPE_IMAP, o.getName()))
                     .collect(Collectors.toList());
         } finally {
             instance.shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/HazelcastDataConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/HazelcastDataConnection.java
@@ -65,9 +65,9 @@ public class HazelcastDataConnection extends DataConnectionBase {
     public static final String CLIENT_YML_PATH = "client_yml_path";
 
     /**
-     * IMap resource type name
+     * IMap Journal resource type name
      */
-    public static final String OBJECT_TYPE_IMAP = "IMap";
+    public static final String OBJECT_TYPE_IMAP_JOURNAL = "IMapJournal";
 
     private final ClientConfig clientConfig;
 
@@ -114,7 +114,7 @@ public class HazelcastDataConnection extends DataConnectionBase {
     @Nonnull
     @Override
     public Collection<String> resourceTypes() {
-        return Collections.singleton(OBJECT_TYPE_IMAP);
+        return Collections.singleton(OBJECT_TYPE_IMAP_JOURNAL);
     }
 
     @Nonnull
@@ -125,7 +125,7 @@ public class HazelcastDataConnection extends DataConnectionBase {
             return instance.getDistributedObjects()
                     .stream()
                     .filter(IMap.class::isInstance)
-                    .map(o -> new DataConnectionResource(OBJECT_TYPE_IMAP, o.getName()))
+                    .map(o -> new DataConnectionResource(OBJECT_TYPE_IMAP_JOURNAL, o.getName()))
                     .collect(Collectors.toList());
         } finally {
             instance.shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/HazelcastDataConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/HazelcastDataConnection.java
@@ -64,6 +64,9 @@ public class HazelcastDataConnection extends DataConnectionBase {
      */
     public static final String CLIENT_YML_PATH = "client_yml_path";
 
+    /**
+     * IMap resource type name
+     */
     public static final String OBJECT_TYPE_IMAP = "IMap";
 
     private final ClientConfig clientConfig;

--- a/hazelcast/src/main/java/com/hazelcast/dataconnection/impl/JdbcDataConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/dataconnection/impl/JdbcDataConnection.java
@@ -54,6 +54,7 @@ import java.util.stream.Stream;
 @Beta
 public class JdbcDataConnection extends DataConnectionBase {
 
+    public static final String OBJECT_TYPE_TABLE = "Table";
     private static final AtomicInteger DATA_SOURCE_COUNTER = new AtomicInteger();
 
     private volatile ConcurrentMemoizingSupplier<HikariDataSource> pooledDataSourceSup;
@@ -103,7 +104,7 @@ public class JdbcDataConnection extends DataConnectionBase {
     @Nonnull
     @Override
     public Collection<String> resourceTypes() {
-        return Collections.singleton("Table");
+        return Collections.singleton(OBJECT_TYPE_TABLE);
     }
 
     @Nonnull
@@ -121,7 +122,7 @@ public class JdbcDataConnection extends DataConnectionBase {
                                       .filter(Objects::nonNull)
                                       .toArray(String[]::new);
 
-                result.add(new DataConnectionResource("TABLE", name));
+                result.add(new DataConnectionResource(OBJECT_TYPE_TABLE, name));
             }
             return result;
         } catch (Exception e) {

--- a/hazelcast/src/test/java/com/hazelcast/dataconnection/HazelcastDataConnectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/dataconnection/HazelcastDataConnectionTest.java
@@ -80,7 +80,7 @@ public class HazelcastDataConnectionTest extends HazelcastTestSupport {
         hazelcastDataConnection = new HazelcastDataConnection(dataConnectionConfig);
         Collection<DataConnectionResource> resources = hazelcastDataConnection.listResources();
 
-        assertThat(resources).contains(new DataConnectionResource("IMap", "my_map"));
+        assertThat(resources).contains(new DataConnectionResource("IMapJournal", "my_map"));
     }
 
     @Test
@@ -204,7 +204,7 @@ public class HazelcastDataConnectionTest extends HazelcastTestSupport {
         //then
         assertThat(resourcedTypes)
                 .map(r -> r.toLowerCase(Locale.ROOT))
-                .containsExactlyInAnyOrder("imap");
+                .containsExactlyInAnyOrder("imapjournal");
     }
 
     private static DataConnectionConfig nonSharedDataConnectionConfig(String clusterName) {


### PR DESCRIPTION
Follow-up to #24356

Changes:
- Remove View.streaming field completely, Ensure that isStreaming for view is determined
- Use original object type for bad table
- Update SHOW DATA CONNECTIONS description in TDD
- Use constants for object type
- Refactor SqlMappingContext and simplify SqlConnector.resolveAndValidateFields
- Resource type is case-insensitive

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
