### PR TITLE
Move tests of GenericMapStore with non-embedded DBs to nightly

### DIFF
--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/mariadb/MariaDBGenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/mariadb/MariaDBGenericMapStoreIntegrationTest.java
@@ -17,9 +17,12 @@
 package com.hazelcast.mapstore.mariadb;
 
 import com.hazelcast.mapstore.GenericMapStoreIntegrationTest;
+import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.jdbc.MariaDBDatabaseProvider;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+@Category({NightlyTest.class})
 public class MariaDBGenericMapStoreIntegrationTest extends GenericMapStoreIntegrationTest {
 
     public MariaDBGenericMapStoreIntegrationTest() {

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/mssql/MSSQLGenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/mssql/MSSQLGenericMapStoreIntegrationTest.java
@@ -17,9 +17,12 @@
 package com.hazelcast.mapstore.mssql;
 
 import com.hazelcast.mapstore.GenericMapStoreIntegrationTest;
+import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.jdbc.MSSQLDatabaseProvider;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+@Category({NightlyTest.class})
 public class MSSQLGenericMapStoreIntegrationTest extends GenericMapStoreIntegrationTest {
 
     public MSSQLGenericMapStoreIntegrationTest() {

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/mysql/MySQLGenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/mysql/MySQLGenericMapStoreIntegrationTest.java
@@ -17,9 +17,12 @@
 package com.hazelcast.mapstore.mysql;
 
 import com.hazelcast.mapstore.GenericMapStoreIntegrationTest;
+import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+@Category({NightlyTest.class})
 public class MySQLGenericMapStoreIntegrationTest extends GenericMapStoreIntegrationTest {
 
     public MySQLGenericMapStoreIntegrationTest() {

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/postgres/PostgreGenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/postgres/PostgreGenericMapStoreIntegrationTest.java
@@ -17,12 +17,15 @@
 package com.hazelcast.mapstore.postgres;
 
 import com.hazelcast.mapstore.GenericMapStoreIntegrationTest;
+import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
-public class PostgreSQLGenericMapStoreIntegrationTest extends GenericMapStoreIntegrationTest {
+@Category({NightlyTest.class})
+public class PostgreGenericMapStoreIntegrationTest extends GenericMapStoreIntegrationTest {
 
-    public PostgreSQLGenericMapStoreIntegrationTest() {
+    public PostgreGenericMapStoreIntegrationTest() {
         setPrefix("postgre_");
     }
 

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/postgres/PostgresGenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/postgres/PostgresGenericMapStoreTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.mapstore.postgres;
 
 import com.hazelcast.mapstore.GenericMapStoreTest;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-@Category({NightlyTest.class, ParallelJVMTest.class})
+@Category(NightlyTest.class)
 public class PostgresGenericMapStoreTest extends GenericMapStoreTest {
 
     @BeforeClass

--- a/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/GenericMapStoreIT.java
+++ b/hazelcast-it/distribution-it/src/test/java/com/hazelcast/it/GenericMapStoreIT.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.it;
+
+public class GenericMapStoreIT {
+
+
+}


### PR DESCRIPTION
These take too long to run in PR builder. Eventually, we can prepare a runner for these.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
