### PR TITLE
Shutdown executors in tests to prevent thread/memory leaks

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/AbstractNearCacheBasicTest.java
@@ -1500,6 +1500,7 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
         // the Near Cache is empty, we shouldn't see memory costs anymore
         assertNearCacheSizeEventually(context, 0);
         assertThatMemoryCostsAreZero(context);
+        executorService.shutdownNow();
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/FutureUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/FutureUtilTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionTimedOutException;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -58,10 +59,16 @@ public class FutureUtilTest extends HazelcastTestSupport {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    private ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+    @After
+    public void tearDown() throws Exception {
+        executorService.shutdownNow();
+    }
+
     @Test
     public void test_waitWithDeadline_first_wait_second_finished() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
 
         List<Future> futures = new ArrayList<Future>();
         for (int i = 0; i < 2; i++) {
@@ -69,12 +76,12 @@ public class FutureUtilTest extends HazelcastTestSupport {
         }
 
         waitWithDeadline(futures, 10, TimeUnit.SECONDS, logAllExceptions(Level.WARNING));
+        executorService.shutdownNow();
     }
 
     @Test
     public void test_waitWithDeadline_first_finished_second_wait() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
 
         List<Future> futures = new ArrayList<Future>();
         for (int i = 0; i < 2; i++) {
@@ -87,7 +94,6 @@ public class FutureUtilTest extends HazelcastTestSupport {
     @Test
     public void test_returnWithDeadline_first_wait_second_finished() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
 
         List<Future<Integer>> futures = new ArrayList<Future<Integer>>();
         for (int i = 0; i < 2; i++) {
@@ -105,7 +111,6 @@ public class FutureUtilTest extends HazelcastTestSupport {
     @Test
     public void test_returnWithDeadline_first_finished_second_wait() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
 
         List<Future<Integer>> futures = new ArrayList<Future<Integer>>();
         for (int i = 0; i < 2; i++) {
@@ -123,7 +128,6 @@ public class FutureUtilTest extends HazelcastTestSupport {
     @Test(expected = TimeoutException.class)
     public void test_returnWithDeadline_timeout_exception() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
 
         List<Future<Integer>> futures = new ArrayList<Future<Integer>>();
         for (int i = 0; i < 2; i++) {
@@ -145,7 +149,6 @@ public class FutureUtilTest extends HazelcastTestSupport {
     @Test
     public void test_waitWithDeadline_failing_second() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
 
         List<Future> futures = new ArrayList<Future>();
         for (int i = 0; i < 2; i++) {
@@ -164,7 +167,6 @@ public class FutureUtilTest extends HazelcastTestSupport {
     @Test
     public void test_returnWithDeadline_failing_second() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
 
         List<Future<Integer>> futures = new ArrayList<Future<Integer>>();
         for (int i = 0; i < 2; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/ParallelStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/ParallelStressTest.java
@@ -59,8 +59,12 @@ public class ParallelStressTest extends JetTestSupport {
         for (int i = 0; i < 100; i++) {
             futures.add(executor.submit(() -> instance.getJet().newJob(dag)));
         }
-        for (Future<Job> future : futures) {
-            future.get().join();
+        try {
+            for (Future<Job> future : futures) {
+                future.get().join();
+            }
+        } finally {
+            executor.shutdownNow();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/execute/JobExecuteClientSuccessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/execute/JobExecuteClientSuccessTest.java
@@ -168,7 +168,11 @@ public class JobExecuteClientSuccessTest extends JetTestSupport {
 
         HazelcastInstance client = createHazelcastClient();
         JetService jetService = client.getJet();
-        assertEqualsEventually(() -> jetService.getJobs().size(), jobLimit);
+        try {
+            assertEqualsEventually(() -> jetService.getJobs().size(), jobLimit);
+        } finally {
+            executorService.shutdownNow();
+        }
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/submitjob/clientside/upload/JobUploadClientSuccessTest.java
@@ -210,6 +210,8 @@ public class JobUploadClientSuccessTest extends JetTestSupport {
 
             assertThat(jobNames).containsAll(submittedJobNames);
         });
+
+        executorService.shutdownNow();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
@@ -123,6 +123,8 @@ public final class JobSubmissionSlownessRegressionTest extends JetTestSupport {
 
         assertTrue("Job submission rate should not decrease. First rate: " + measurementARate
                 + ", second rate: " + measurementBRate, measurementARate * 0.8 < measurementBRate);
+
+        executorService.shutdownNow();
     }
 
     private static DAG twoVertex() {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
@@ -181,6 +181,7 @@ public class NearCacheTestSupport extends HazelcastTestSupport {
                 0, getNearCacheStats(map).getOwnedEntryMemoryCost());
         // this assert will work in all scenarios, since the default value should be 0 if no costs are calculated
         assertEquals("The Near Cache is empty, there should be no heap costs", 0, map.getLocalMapStats().getHeapCost());
+        executorService.shutdownNow();
     }
 
     protected NearCacheConfig newNearCacheConfigWithEntryCountEviction(EvictionPolicy evictionPolicy, int size) {

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/DelegatingScheduledFutureStripperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/DelegatingScheduledFutureStripperTest.java
@@ -50,10 +50,11 @@ public class DelegatingScheduledFutureStripperTest {
 
     private ScheduledExecutorService scheduler;
     private DelegatingTaskScheduler taskScheduler;
+    private ExecutorService executor;
 
     @Before
     public void setup() {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor = Executors.newSingleThreadExecutor();
         scheduler = Executors.newSingleThreadScheduledExecutor();
         taskScheduler = new DelegatingTaskScheduler(scheduler, executor);
     }
@@ -62,6 +63,7 @@ public class DelegatingScheduledFutureStripperTest {
     public void teardown() throws Exception {
         scheduler.shutdownNow();
         scheduler.awaitTermination(10, TimeUnit.SECONDS);
+        executor.shutdownNow();
     }
 
     @Test(expected = NullPointerException.class)

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceSlowTest.java
@@ -33,6 +33,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -430,7 +431,8 @@ public class ScheduledExecutorServiceSlowTest extends ScheduledExecutorServiceTe
         long counter = 0;
         long limit = 2000000;
 
-        Executors.newSingleThreadExecutor().submit(new Runnable() {
+        ExecutorService singleThreadExecutor = Executors.newSingleThreadExecutor();
+        singleThreadExecutor.submit(new Runnable() {
             @Override
             public void run() {
                 while (running.get()) {
@@ -465,5 +467,7 @@ public class ScheduledExecutorServiceSlowTest extends ScheduledExecutorServiceTe
 
         // wait for running tasks to finish, keeping log clean of PassiveMode exceptions
         sleepSeconds(5);
+        singleThreadExecutor.shutdownNow();
+        executorService.shutdown();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
@@ -20,10 +20,12 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
 import org.junit.Before;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -34,7 +36,7 @@ import static com.hazelcast.spi.impl.operationservice.impl.InvocationFuture.retu
 public abstract class AbstractInvocationFuture_AbstractTest extends HazelcastTestSupport {
 
     protected ILogger logger;
-    protected Executor executor;
+    protected ExecutorService executor;
     protected TestFuture future;
     protected Object value = "somevalue";
 
@@ -45,6 +47,10 @@ public abstract class AbstractInvocationFuture_AbstractTest extends HazelcastTes
         future = new TestFuture();
     }
 
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdownNow();
+    }
 
     class TestFuture extends AbstractInvocationFuture {
         volatile boolean interruptDetected;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/executionservice/impl/DelegateAndSkipOnConcurrentExecutionDecoratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/executionservice/impl/DelegateAndSkipOnConcurrentExecutionDecoratorTest.java
@@ -50,6 +50,7 @@ public class DelegateAndSkipOnConcurrentExecutionDecoratorTest
         task.resumeExecution();
 
         assertEquals(1, task.getExecutionCount());
+        executor.shutdownNow();
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/topic/TopicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/TopicTest.java
@@ -582,6 +582,7 @@ public class TopicTest extends HazelcastTestSupport {
         }
 
         assertTrue(latch.await(20, TimeUnit.SECONDS));
+        ex.shutdownNow();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXATest.java
+++ b/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXATest.java
@@ -234,6 +234,7 @@ public class HazelcastXATest extends HazelcastTestSupport {
         for (int i = 0; i < 10; i++) {
             assertFalse(map.isLocked(i));
         }
+        executorService.shutdownNow();
     }
 
     @Test


### PR DESCRIPTION
During test failure's thread dump investigations i'm seeing many unrelated threads alive, this PR targets to reduce the number of lingering threads.