### PR TITLE
Bump snakeyaml from 1.33 to 2.0 [5.1.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <scala.version>2.12</scala.version>
         <slf4j.version>1.7.36</slf4j.version>
         <spring.version>4.3.0.RELEASE</spring.version>
-        <snakeyaml.version>1.33</snakeyaml.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <snakeyaml.engine.version>2.3</snakeyaml.engine.version>
 
         <!-- test dependencies -->


### PR DESCRIPTION
Backport of: https://github.com/hazelcast/hazelcast/pull/23794

Bumps [snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml) from 1.33 to 2.0.

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
