### PR TITLE
Async Impl for values() for IMap

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientProxy.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientDestroyProxyCodec;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
+import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
 import com.hazelcast.client.impl.spi.impl.ListenerMessageCodec;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.internal.serialization.Data;
@@ -182,6 +183,11 @@ public abstract class ClientProxy implements DistributedObject {
         return invokeOnPartition(clientMessage, partitionId);
     }
 
+    protected ClientInvocationFuture invokeAsync(ClientMessage clientMessage, Object key) {
+        final int partitionId = getContext().getPartitionService().getPartitionId(key);
+        return invokeOnPartitionAsync(clientMessage, partitionId);
+    }
+
     protected <T> T invokeOnPartition(ClientMessage clientMessage, int partitionId) {
         try {
             final Future future = new ClientInvocation(getClient(), clientMessage, getName(), partitionId).invoke();
@@ -189,6 +195,9 @@ public abstract class ClientProxy implements DistributedObject {
         } catch (Exception e) {
             throw rethrow(e);
         }
+    }
+    protected ClientInvocationFuture invokeOnPartitionAsync(ClientMessage clientMessage, int partitionId) {
+        return new ClientInvocation(getClient(), clientMessage, getName(), partitionId).invoke();
     }
 
     protected <T> T invokeOnMember(ClientMessage clientMessage, UUID uuid) {
@@ -216,6 +225,9 @@ public abstract class ClientProxy implements DistributedObject {
         } catch (Exception e) {
             throw rethrow(e);
         }
+    }
+    protected ClientInvocationFuture invokeAsync(ClientMessage clientMessage) {
+        return new ClientInvocation(getClient(), clientMessage, getName()).invoke();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/IMap.java
@@ -2369,6 +2369,27 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V>, Iterable
     Collection<V> values();
 
     /**
+     * Returns a {@link CompletionStage} of an immutable collection clone of the values
+     * contained in this map.
+     * <p>
+     * <b>Warning:</b>
+     * <p>
+     * The collection is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the collection.
+     * <p>
+     * This method is always executed by a distributed query,
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link ClusterProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
+     *
+     * @return a CompletionStage an immutable collection clone of the values contained
+     * in this map
+     * @throws QueryResultSizeExceededException if query result size limit is exceeded
+     * @see ClusterProperty#QUERY_RESULT_SIZE_LIMIT
+     */
+    @Nonnull
+    CompletionStage<Collection<V>> valuesAsync();
+
+    /**
      * Returns an immutable {@link Set} clone of the mappings contained in this map.
      * <p>
      * <b>Warning:</b>
@@ -2454,6 +2475,31 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V>, Iterable
      * @see ClusterProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Collection<V> values(@Nonnull Predicate<K, V> predicate);
+
+    /**
+     * Queries the map based on the specified predicate and returns a
+     * {@link CompletionStage} of an immutable collection of the values
+     * of matching entries.
+     * <p>
+     * Specified predicate runs on all members in parallel.
+     * <p>
+     * <b>Warning:</b>
+     * <p>
+     * The collection is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the collection.
+     * <p>
+     * This method is always executed by a distributed query,
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link ClusterProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
+     *
+     * @param predicate specified query criteria
+     * @return a CompletionStage of the result value collection of the query
+     * @throws QueryResultSizeExceededException if query result size limit is exceeded
+     * @throws NullPointerException             if the predicate is {@code null}
+     * @see ClusterProperty#QUERY_RESULT_SIZE_LIMIT
+     */
+
+    CompletionStage<Collection<V>> valuesAsync(@Nonnull Predicate<K, V> predicate);
 
     /**
      * Returns the locally owned immutable set of keys.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngine.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.map.impl.query;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Responsible for executing queries on the IMap.
  */
@@ -30,4 +32,15 @@ public interface QueryEngine {
      * @return Result of the specific type
      */
     <T extends Result> T execute(Query query, Target target);
+
+
+    /**
+     * Executes the given query on the given target in Asynchronous Manner.
+     *
+     * @param query  query to execute
+     * @param target target where to execute the query
+     * @param <T>    Type of the result
+     * @return CompletableFuture of a Result of the specific type
+     */
+    <T extends Result> CompletableFuture<T> executeAsync(Query query, Target target);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngineImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.partition.IPartitionService;
+import com.hazelcast.internal.util.ConcurrencyUtil;
 import com.hazelcast.internal.util.IterationType;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.logging.ILogger;
@@ -43,11 +44,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.PrimitiveIterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Future;
 import java.util.function.IntConsumer;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
+import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.SetUtil.allPartitionIds;
 import static java.util.Collections.singletonList;
@@ -102,24 +106,10 @@ public class QueryEngineImpl implements QueryEngine {
     @SuppressWarnings("unchecked")
     @Override
     public Result execute(Query query, Target target) {
-        Query adjustedQuery = adjustQuery(query);
-        switch (target.mode()) {
-            case ALL_NODES:
-                adjustedQuery = Query.of(adjustedQuery).partitionIdSet(getAllPartitionIds()).build();
-                return runOnGivenPartitions(adjustedQuery, adjustedQuery.getPartitionIdSet(), TargetMode.ALL_NODES);
-            case LOCAL_NODE:
-                adjustedQuery = Query.of(adjustedQuery).partitionIdSet(getLocalPartitionIds()).build();
-                return runOnGivenPartitions(adjustedQuery, adjustedQuery.getPartitionIdSet(), TargetMode.LOCAL_NODE);
-            case PARTITION_OWNER:
-                int solePartition = target.partitions().solePartition();
-                adjustedQuery = Query.of(adjustedQuery).partitionIdSet(target.partitions()).build();
-                if (solePartition >= 0) {
-                    return runOnGivenPartition(adjustedQuery, solePartition);
-                } else {
-                    return runOnGivenPartitions(adjustedQuery, adjustedQuery.getPartitionIdSet(), TargetMode.ALL_NODES);
-                }
-            default:
-                throw new IllegalArgumentException("Illegal target " + target);
+        try {
+            return executeAsync(query, target).join();
+        } catch (CompletionException ex) {
+            throw peel(ex.getCause());
         }
     }
 
@@ -138,36 +128,39 @@ public class QueryEngineImpl implements QueryEngine {
     }
 
     // query thread first, fallback to partition thread
-    private Result runOnGivenPartitions(Query query, PartitionIdSet partitions, TargetMode targetMode) {
-        Result result = doRunOnQueryThreads(query, partitions, targetMode);
-        if (!disableMigrationFallback) {
-            if (isResultFromAnyPartitionMissing(partitions)) {
-                doRunOnPartitionThreads(query, partitions, result);
+    private CompletableFuture<Result> runOnGivenPartitions(Query query, PartitionIdSet partitions, TargetMode targetMode) {
+        CompletableFuture<Result> futureResult = doRunOnQueryThreads(query, partitions, targetMode);
+        return futureResult.thenComposeAsync(result -> {
+            if (!disableMigrationFallback) {
+                if (isResultFromAnyPartitionMissing(partitions)) {
+                    return doRunOnPartitionThreads(query, partitions, result);
+                }
             }
-        }
-        assertAllPartitionsQueried(partitions);
-
-        return result;
+            return CompletableFuture.supplyAsync(() -> result);
+        }, ConcurrencyUtil.getDefaultAsyncExecutor()).thenApplyAsync(result -> {
+            // by now all partition must have been queried
+            assertAllPartitionsQueried(partitions);
+            return result;
+        }, ConcurrencyUtil.getDefaultAsyncExecutor());
     }
 
     // partition thread ONLY (for now)
-    private Result runOnGivenPartition(Query query, int partitionId) {
+    private CompletableFuture<Result> runOnGivenPartition(Query query, int partitionId) {
         try {
             return dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
-                    query, partitionId).get();
+                    query, partitionId);
         } catch (Throwable t) {
             throw rethrow(t);
         }
     }
 
-    private Result doRunOnQueryThreads(Query query, PartitionIdSet partitionIds, TargetMode targetMode) {
+    private CompletableFuture<Result> doRunOnQueryThreads(Query query, PartitionIdSet partitionIds, TargetMode targetMode) {
         Result result = populateResult(query);
-        List<Future<Result>> futures = dispatchOnQueryThreads(query, targetMode);
-        addResultsOfPredicate(futures, result, partitionIds, disableMigrationFallback);
-        return result;
+        List<CompletableFuture<Result>> futures = dispatchOnQueryThreads(query, targetMode);
+        return addResultsOfPredicate(futures, result, partitionIds, disableMigrationFallback);
     }
 
-    private List<Future<Result>> dispatchOnQueryThreads(Query query, TargetMode targetMode) {
+    private List<CompletableFuture<Result>> dispatchOnQueryThreads(Query query, TargetMode targetMode) {
         try {
             return dispatchFullQueryOnQueryThread(query, targetMode);
         } catch (Throwable t) {
@@ -194,20 +187,18 @@ public class QueryEngineImpl implements QueryEngine {
                 queryResultSizeLimiter.getNodeResultLimit(query.getPartitionIdSet().size()));
     }
 
-    private void doRunOnPartitionThreads(Query query, PartitionIdSet partitionIds, Result result) {
-        try {
-            List<Future<Result>> futures = dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
+    private CompletableFuture<Result> doRunOnPartitionThreads(Query query, PartitionIdSet partitionIds, Result result) {
+
+        List<CompletableFuture<Result>> futures = dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
                     query, partitionIds);
-            addResultsOfPredicate(futures, result, partitionIds, true);
-        } catch (Throwable t) {
-            throw rethrow(t);
-        }
+        return addResultsOfPredicate(futures, result, partitionIds, true);
+
     }
 
     @SuppressWarnings("unchecked")
     // modifies partitionIds list! Optimization not to allocate an extra collection with collected partitionIds
-    private void addResultsOfPredicate(List<Future<Result>> futures, Result result,
-                                       PartitionIdSet unfinishedPartitionIds, boolean rethrowAll) {
+    private CompletableFuture<Result> addResultsOfPredicate(List<CompletableFuture<Result>> futures, Result result,
+                                                            PartitionIdSet unfinishedPartitionIds, boolean rethrowAll) {
         for (Future<Result> future : futures) {
             Result queryResult = null;
 
@@ -235,6 +226,7 @@ public class QueryEngineImpl implements QueryEngine {
                 result.combine(queryResult);
             }
         }
+        return CompletableFuture.completedFuture(result);
     }
 
     private void assertAllPartitionsQueried(PartitionIdSet mutablePartitionIds) {
@@ -279,7 +271,7 @@ public class QueryEngineImpl implements QueryEngine {
         return queryResultSizeLimiter;
     }
 
-    protected List<Future<Result>> dispatchFullQueryOnQueryThread(Query query, TargetMode targetMode) {
+    protected List<CompletableFuture<Result>> dispatchFullQueryOnQueryThread(Query query, TargetMode targetMode) {
         switch (targetMode) {
             case ALL_NODES:
                 return dispatchFullQueryOnAllMembersOnQueryThread(query);
@@ -290,14 +282,14 @@ public class QueryEngineImpl implements QueryEngine {
         }
     }
 
-    private List<Future<Result>> dispatchFullQueryOnLocalMemberOnQueryThread(Query query) {
+    private List<CompletableFuture<Result>> dispatchFullQueryOnLocalMemberOnQueryThread(Query query) {
         Operation operation = mapServiceContext.getMapOperationProvider(query.getMapName()).createQueryOperation(query);
-        Future<Result> result = operationService.invokeOnTarget(
+        CompletableFuture<Result> result = operationService.invokeOnTarget(
                 MapService.SERVICE_NAME, operation, nodeEngine.getThisAddress());
         return singletonList(result);
     }
 
-    private List<Future<Result>> dispatchFullQueryOnAllMembersOnQueryThread(Query query) {
+    private List<CompletableFuture<Result>> dispatchFullQueryOnAllMembersOnQueryThread(Query query) {
         Collection<Address> members;
         if (query.getPartitionIdSet().size() == partitionService.getPartitionCount()) {
             members = clusterService.getMembers(DATA_MEMBER_SELECTOR).stream()
@@ -310,10 +302,10 @@ public class QueryEngineImpl implements QueryEngine {
             }
         }
 
-        List<Future<Result>> futures = new ArrayList<>(members.size());
+        List<CompletableFuture<Result>> futures = new ArrayList<>(members.size());
         for (Address address : members) {
             Operation operation = createQueryOperation(query);
-            Future<Result> future = operationService.invokeOnTarget(
+            CompletableFuture<Result> future = operationService.invokeOnTarget(
                     MapService.SERVICE_NAME, operation, address);
             futures.add(future);
         }
@@ -324,18 +316,18 @@ public class QueryEngineImpl implements QueryEngine {
         return mapServiceContext.getMapOperationProvider(query.getMapName()).createQueryOperation(query);
     }
 
-    protected List<Future<Result>> dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
+    protected List<CompletableFuture<Result>> dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
             Query query, PartitionIdSet partitionIds) {
         if (shouldSkipPartitionsQuery(partitionIds)) {
             return Collections.emptyList();
         }
-        List<Future<Result>> futures = new ArrayList<>(partitionIds.size());
+        List<CompletableFuture<Result>> futures = new ArrayList<>(partitionIds.size());
         partitionIds.intIterator().forEachRemaining((IntConsumer) partitionId ->
                 futures.add(dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(query, partitionId)));
         return futures;
     }
 
-    protected Future<Result> dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(Query query, int partitionId) {
+    protected CompletableFuture<Result> dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(Query query, int partitionId) {
         Operation op = createQueryPartitionOperation(query);
         op.setPartitionId(partitionId);
         try {
@@ -351,5 +343,28 @@ public class QueryEngineImpl implements QueryEngine {
 
     private static boolean shouldSkipPartitionsQuery(PartitionIdSet partitionIds) {
         return partitionIds == null || partitionIds.isEmpty();
+    }
+
+    @Override
+    public CompletableFuture<Result> executeAsync(Query query, Target target) {
+        Query adjustedQuery = adjustQuery(query);
+        switch (target.mode()) {
+            case ALL_NODES:
+                adjustedQuery = Query.of(adjustedQuery).partitionIdSet(getAllPartitionIds()).build();
+                return runOnGivenPartitions(adjustedQuery, adjustedQuery.getPartitionIdSet(), TargetMode.ALL_NODES);
+            case LOCAL_NODE:
+                adjustedQuery = Query.of(adjustedQuery).partitionIdSet(getLocalPartitionIds()).build();
+                return runOnGivenPartitions(adjustedQuery, adjustedQuery.getPartitionIdSet(), TargetMode.LOCAL_NODE);
+            case PARTITION_OWNER:
+                int solePartition = target.partitions().solePartition();
+                adjustedQuery = Query.of(adjustedQuery).partitionIdSet(target.partitions()).build();
+                if (solePartition >= 0) {
+                    return runOnGivenPartition(adjustedQuery, solePartition);
+                } else {
+                    return runOnGivenPartitions(adjustedQuery, adjustedQuery.getPartitionIdSet(), TargetMode.ALL_NODES);
+                }
+            default:
+                throw new IllegalArgumentException("Illegal target " + target);
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -695,6 +695,26 @@ public class ClientMapTest extends HazelcastTestSupport {
         assertEquals("value1", set1.iterator().next().getValue());
     }
 
+    @Test
+    public void testAsyncValuesWithPredicate() throws Exception {
+        IMap<String, String> map = createMap();
+        fillMap(map);
+
+        Future<Collection<String>> futureValues = map.valuesAsync(Predicates.sql("this == value1")).toCompletableFuture();
+        assertEquals(1, futureValues.get().size());
+        assertEquals("value1", futureValues.get().iterator().next());
+    }
+
+
+    @Test
+    public void testAsyncValues() throws Exception {
+        IMap<String, String> map = createMap();
+        fillMap(map);
+
+        Future<Collection<String>> futureValues = map.valuesAsync().toCompletableFuture();
+        assertEquals(10, futureValues.get().size());
+    }
+
     /**
      * Issue #923
      */


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->
Adding Async Implementation for valuesAsync() and valuesAsync(Predicate<K,V> predicate) in IMap interface

Fixes #17370 

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [X] New public APIs have `@Nonnull/@Nullable` annotations
- [X] New public APIs have `@since` tags in Javadoc

