### PR TITLE
Do not invalidate keys from near cache if an update is happening

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -206,8 +206,14 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
                 nearCacheStats.decrementOwnedEntryCount();
                 nearCacheStats.decrementOwnedEntryMemoryCost(getTotalStorageMemoryCost(key, record));
                 nearCacheStats.incrementInvalidations();
+
+                // Invalidate the record only if there is no update
+                // happening on it, i.e. the reservation id is equal
+                // to READ_PERMITTED.
+                return null;
             }
-            return null;
+
+            return record;
         };
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStoreTest.java
@@ -100,6 +100,21 @@ public class AbstractNearCacheRecordStoreTest {
         assertEquals(1, store.getNearCacheStats().getOwnedEntryCount());
     }
 
+    @Test
+    public void testInvalidate() {
+        // cannot invalidate the key when an update is happening
+        long reservationId = store.tryReserveForUpdate(KEY, serializationService.toData(KEY), READ_UPDATE);
+        store.invalidate(KEY);
+        assertRecordState(reservationId);
+
+        store.tryPublishReserved(KEY, VALUE1, reservationId, true);
+
+        // can invalidate the key when no update is happening
+        assertRecordState(READ_PERMITTED);
+        store.invalidate(KEY);
+        assertNull(store.getRecord(KEY));
+    }
+
     @SuppressWarnings("unchecked")
     private void assertRecordState(long recordState) {
         assertEquals(recordState, store.getRecord(KEY).getReservationId());


### PR DESCRIPTION
While investigating an issue, I saw a case where the reported owned entry count was more than the actual size of the near cache.

Upon investigation, it turned out that we allow keys to be invalidated even if an update is happening. (i.e. when the reservation id != READ_PERMITTED). However, we only decrement the owned entry count if no update is happening.

That causes the owned entry count to be more than the actual value in scenarios like below:

- THREAD_A sees that the read for the KEY_1 is stale so it initiates the invalidation of KEY_1.
- THREAD_B sees the same thing, and also starts the invalidation process, and completes it before THREAD_A. After invalidation, it reserves an update for the KEY_1, so that its reservation id is no longer equal to READ_PERMITTED.
- THREAD_A continues its invalidation, but sees that the reservation id is no longer equal to READ_PERMITTED and skips updating the near cache stats for the invalidation of KEY_1. However, it performs the invalidation nevertheless. So, we end up with N-1 entries in the record store, but the value of the owned entry count stays at N.

To avoid wrong stats and invalidating an entry while a separate update is in place, we no longer invalidate the record, if we can't update the stats.

The issue I saw this problem: https://github.com/hazelcast/hazelcast/issues/24275