### PR TITLE
Assert non-negative value for listener count in CacheContext [HZ-2371]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
@@ -63,7 +63,8 @@ public class CacheContext {
     }
 
     public void decreaseCacheEntryListenerCount() {
-        cacheEntryListenerCount.decrementAndGet();
+        int newCount = cacheEntryListenerCount.decrementAndGet();
+        assert newCount >= 0 : "CacheEntryListenerCount decremented to a value below zero! New value: " + newCount;
     }
 
     public void resetCacheEntryListenerCount() {


### PR DESCRIPTION
There was a recent test failure in the `CacheContextTest` that resulted in the `cacheEntryListenerCount` reaching a negative value of `-1` instead of the expected value of `0`. Due to the assertations made within that test, we know the count was successfully incremented to `1` as expected in both cache contexts, and decreased for the "driver" instance's context to `0`. However, the 2nd instance's context produced a value of `-1` for this count, resulting in a test failure.

After numerous attempts to reproduce this issue, we have been unable to do so on local machines or on clones of the failing Jenkins build. There was potential concern over recent changes to the `EventService` being related to this issue, but after reviewing the code changed I don't see any correlations to this test failure. See: https://github.com/hazelcast/hazelcast/pull/23193

We know that the only way for this value to reach `-1` as reached in the test failure is for the `CacheContext#decreaseCacheEntryListenerCount` method to be called more than once on the offending context object. To help identify the root cause of potential future test failures like this, I have introduced an assertion within this method that checks if the resultant value is >= 0, and if not throws an assertion error in the test environment. We can use this stack trace in the future to identify where the call originates from and investigate further.

Closes https://github.com/hazelcast/hazelcast/issues/24375