### PR TITLE
Enhance cp leader rebalance target selection

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
@@ -588,7 +588,6 @@ class RaftGroupMembershipManager {
                                                 Collection<CPGroupSummary> cpGroupSummaries,
                                                 Collection<CPMember> allMembers) {
             final int avgGroupsPerMember = cpGroupSummaries.size() / priorityMembers.size();
-            final boolean overAvgAllowed = cpGroupSummaries.size() % priorityMembers.size() != 0;
 
             logger.fine("Searching for leadership imbalance in " + cpGroupSummaries.size() + " CPGroups, "
                     + "average groups per member is " + avgGroupsPerMember);
@@ -615,25 +614,8 @@ class RaftGroupMembershipManager {
                 Collection<CPGroupSummary> groups
                         = getLeaderGroupsOf(from.element1, leaderships.get(from.element1), cpGroupSummaries);
 
-                int maxLeaderships;
-                if (overAvgAllowed) {
-                    // - When from-member has more than (avg + 1), then leadership can be transferred to any member
-                    // which has leaderships equal to or less than avg.
-                    // - When from-member has equal to (avg + 1), then leadership can be transferred to only members
-                    // which have leaderships less than avg.
-                    if (from.element2 > avgGroupsPerMember + 1) {
-                        maxLeaderships = avgGroupsPerMember;
-                    } else {
-                        maxLeaderships = avgGroupsPerMember - 1;
-                    }
-                } else {
-                    maxLeaderships = avgGroupsPerMember;
-                }
-                BiTuple<CPMember, CPGroupId> to = getEndpointWithMinLeaderships(groups, leaderships, maxLeaderships);
-
-                if (to.element1 == null) {
-                    to = getEndpointWithMinLeaderships(groups, leaderships, from.element2 - 2);
-                }
+                // if there is at least 2 leadership difference, this transfer will make overall state more even
+                BiTuple<CPMember, CPGroupId> to = getEndpointWithMinLeaderships(groups, leaderships, from.element2 - 2);
 
                 if (to.element1 == null) {
                     logger.info("No candidate could be found to get leadership from " + from.element1 + ". Skipping to next...");

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
@@ -70,8 +70,8 @@ import static com.hazelcast.internal.util.ExceptionUtil.peel;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -630,6 +630,11 @@ class RaftGroupMembershipManager {
                     maxLeaderships = avgGroupsPerMember;
                 }
                 BiTuple<CPMember, CPGroupId> to = getEndpointWithMinLeaderships(groups, leaderships, maxLeaderships);
+
+                if (to.element1 == null) {
+                    to = getEndpointWithMinLeaderships(groups, leaderships, from.element2 - 2);
+                }
+
                 if (to.element1 == null) {
                     logger.info("No candidate could be found to get leadership from " + from.element1 + ". Skipping to next...");
                     // could not found target member to transfer membership


### PR DESCRIPTION
There are 2 facts before this PR:

1. `CPGroupMembershipChange` only happens during member add and remove.
   And during this change, we don't enforce each member to be part of 
   equal number of groups. 
2. During `RaftGroupLeadershipBalanceTask`, we only move leadership from
   a member with more than average to member with less than average.

This leads to:
  - https://github.com/hazelcast/hazelcast/issues/23367 or,
  - https://github.com/hazelcast/hazelcast-enterprise/issues/5674.

These PR change the second fact, so that if there is no member with a
leadership below average, we still can transfer leadership if this will 
result in a more even leadership distribution.

http://jenkins.hazelcast.com/job/ramiz-Hazelcast-EE-master-tests-using-docker/3/

Fixes https://github.com/hazelcast/hazelcast/issues/23367
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/5674