### PR TITLE
Create config lazily for bouncing member rule

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBouncingMemberTest.java
@@ -60,9 +60,11 @@ public class MapPutAllWithBouncingMemberTest extends HazelcastTestSupport {
         return cfg;
     }
 
-    @Rule
+    @Rule(order = 10)
     public BounceMemberRule bounceMemberRule =
-            BounceMemberRule.with(getConfig())
+            BounceMemberRule.with(() -> {
+                        return getConfig();
+                    })
                     .driverType(BounceTestConfiguration.DriverType.MEMBER)
                     .clusterSize(2)
                     .build();

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Supplier;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.StringUtil.timeToString;
@@ -278,7 +279,11 @@ public class BounceMemberRule implements TestRule {
     }
 
     public static Builder with(Config memberConfig) {
-        return new Builder(memberConfig);
+        return with(() -> memberConfig);
+    }
+
+    public static Builder with(Supplier<Config> memberConfigSupplier) {
+        return new Builder(memberConfigSupplier);
     }
 
     @Override
@@ -317,9 +322,9 @@ public class BounceMemberRule implements TestRule {
         } else {
             factory = new TestHazelcastInstanceFactory();
         }
-        Config memberConfig = bounceTestConfig.getMemberConfig();
+        Supplier<Config> memberConfigSupplier = bounceTestConfig.getMemberConfigSupplier();
         for (int i = 0; i < bounceTestConfig.getClusterSize(); i++) {
-            members.set(i, factory.newHazelcastInstance(memberConfig));
+            members.set(i, factory.newHazelcastInstance(memberConfigSupplier.get()));
         }
 
         // setup drivers
@@ -442,7 +447,7 @@ public class BounceMemberRule implements TestRule {
 
     public static class Builder {
 
-        private final Config memberConfig;
+        private final Supplier<Config> memberConfigSupplier;
 
         private int clusterSize = DEFAULT_CLUSTER_SIZE;
         private int driversCount = DEFAULT_DRIVERS_COUNT;
@@ -452,12 +457,11 @@ public class BounceMemberRule implements TestRule {
         private int bouncingIntervalSeconds = DEFAULT_BOUNCING_INTERVAL_SECONDS;
         private long maximumStaleSeconds = DEFAULT_MAXIMUM_STALE_SECONDS;
 
-        private Builder(Config memberConfig) {
-            this.memberConfig = memberConfig;
+        private Builder(Supplier<Config> memberConfigSupplier) {
+            this.memberConfigSupplier = memberConfigSupplier;
         }
 
         public BounceMemberRule build() {
-
             if (testDriverType == null) {
                 throw new AssertionError("testDriverType must be set");
             }
@@ -481,7 +485,7 @@ public class BounceMemberRule implements TestRule {
                         throw new AssertionError("Cannot instantiate driver factory for driver type " + testDriverType);
                 }
             }
-            return new BounceMemberRule(new BounceTestConfiguration(clusterSize, testDriverType, memberConfig,
+            return new BounceMemberRule(new BounceTestConfiguration(clusterSize, testDriverType, memberConfigSupplier,
                     driversCount, driverFactory, useTerminate, bouncingIntervalSeconds, maximumStaleSeconds));
         }
 
@@ -554,7 +558,8 @@ public class BounceMemberRule implements TestRule {
                     if (!testRunning.get()) {
                         break;
                     }
-                    members.set(i, factory.newHazelcastInstance(bounceTestConfig.getMemberConfig()));
+                    Supplier<Config> memberConfigSupplier = bounceTestConfig.getMemberConfigSupplier();
+                    members.set(i, factory.newHazelcastInstance(memberConfigSupplier.get()));
                     sleepSecondsWhenRunning(bouncingIntervalSeconds);
                     // move to next member
                     i = nextInstance;

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceTestConfiguration.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceTestConfiguration.java
@@ -18,6 +18,8 @@ package com.hazelcast.test.bounce;
 
 import com.hazelcast.config.Config;
 
+import java.util.function.Supplier;
+
 /**
  * Configuration for a member bounce test.
  */
@@ -25,7 +27,7 @@ public class BounceTestConfiguration {
 
     private final int clusterSize;
     private final DriverType driverType;
-    private final Config memberConfig;
+    private final Supplier<Config> memberConfigSupplier;
     private final int driverCount;
     private final DriverFactory driverFactory;
     private final boolean useTerminate;
@@ -51,11 +53,12 @@ public class BounceTestConfiguration {
     }
 
     BounceTestConfiguration(int clusterSize, DriverType driverType,
-                            Config memberConfig, int driverCount, DriverFactory driverFactory, boolean useTerminate,
+                            Supplier<Config> memberConfigSupplier, int driverCount,
+                            DriverFactory driverFactory, boolean useTerminate,
                             int bouncingIntervalSeconds, long maximumStaleSeconds) {
         this.clusterSize = clusterSize;
         this.driverType = driverType;
-        this.memberConfig = memberConfig;
+        this.memberConfigSupplier = memberConfigSupplier;
         this.driverCount = driverCount;
         this.driverFactory = driverFactory;
         this.useTerminate = useTerminate;
@@ -71,8 +74,8 @@ public class BounceTestConfiguration {
         return driverType;
     }
 
-    public Config getMemberConfig() {
-        return memberConfig;
+    public Supplier<Config> getMemberConfigSupplier() {
+        return memberConfigSupplier;
     }
 
     public int getDriverCount() {

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/MemberDriverFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/MemberDriverFactory.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 import static com.hazelcast.test.HazelcastTestSupport.waitAllForSafeState;
 
@@ -40,8 +41,8 @@ public class MemberDriverFactory implements DriverFactory {
                 return drivers;
             case MEMBER:
                 for (int i = 0; i < drivers.length; i++) {
-                    Config driverConfig = getDriverConfig(testConfiguration);
-                    drivers[i] = rule.getFactory().newHazelcastInstance(driverConfig);
+                    Supplier<Config> driverConfigSupplier = getDriverConfig(testConfiguration);
+                    drivers[i] = rule.getFactory().newHazelcastInstance(driverConfigSupplier.get());
                 }
                 waitAllForSafeState(drivers);
                 return drivers;
@@ -51,12 +52,13 @@ public class MemberDriverFactory implements DriverFactory {
         }
     }
 
-    private Config getDriverConfig(BounceTestConfiguration testConfiguration) {
-        Config driverConfig = getConfig();
-        if (driverConfig == null) {
-            driverConfig = testConfiguration.getMemberConfig();
+    private Supplier<Config> getDriverConfig(BounceTestConfiguration testConfiguration) {
+        Config config = getConfig();
+        Supplier<Config> driverConfigSupplier = () -> config;
+        if (config == null) {
+            driverConfigSupplier = testConfiguration.getMemberConfigSupplier();
         }
-        return driverConfig;
+        return driverConfigSupplier;
     }
 
     /**


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/5985

Goal is to create config lazily, this way is more appropriate if you have multiple rules running together and one of the rules is needed inside getConfig call for example.

This change must have no impact on current tests.
This change is used in https://github.com/hazelcast/hazelcast-enterprise/pull/5976