### PR TITLE
Add UT for context Injection for predicate and projection

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientMapProxy.java
@@ -109,6 +109,7 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
+import com.hazelcast.core.ManagedContext;
 import com.hazelcast.core.ReadOnly;
 import com.hazelcast.internal.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.internal.journal.EventJournalReader;
@@ -1873,6 +1874,9 @@ public class ClientMapProxy<K, V> extends ClientProxy
                     + " must be greater or equal to minSize " + minSize);
         }
         final SerializationService ss = getSerializationService();
+        final ManagedContext context = ss.getManagedContext();
+        predicate = (java.util.function.Predicate<? super EventJournalMapEvent<K, V>>) context.initialize(predicate);
+        projection = (Function<? super EventJournalMapEvent<K, V>, ? extends T>) context.initialize(projection);
         final ClientMessage request = MapEventJournalReadCodec.encodeRequest(
                 name, startSequence, minSize, maxSize, ss.toData(predicate), ss.toData(projection));
         final ClientInvocationFuture fut = new ClientInvocation(getClient(), request, getName(), partitionId).invoke();

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapEventJournalBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapEventJournalBasicTest.java
@@ -26,12 +26,17 @@ import org.junit.After;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientMapEventJournalBasicTest extends MapEventJournalBasicTest {
 
     private TestHazelcastFactory factory;
     private HazelcastInstance client;
+
+    private final AtomicBoolean isPredicateContextInjected = new AtomicBoolean(false);
+    private final AtomicBoolean isProjectionContextInjected = new AtomicBoolean(false);
 
     @Override
     protected HazelcastInstance getRandomInstance() {
@@ -45,6 +50,26 @@ public class ClientMapEventJournalBasicTest extends MapEventJournalBasicTest {
         client = factory.newHazelcastClient();
         return instances;
     }
+
+    @Override
+    public void setPredicate(boolean value) {
+        this.isPredicateContextInjected.set(value);
+    }
+
+    @Override
+    public void setProjection(boolean value) {
+        this.isProjectionContextInjected.set(value);
+    }
+    @Override
+    public AtomicBoolean getPredicate() {
+        return this.isPredicateContextInjected;
+    }
+
+    @Override
+    public AtomicBoolean getProjection() {
+        return this.isProjectionContextInjected;
+    }
+
 
     @After
     public final void terminate() {

--- a/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalBasicTest.java
@@ -713,7 +713,7 @@ public abstract class AbstractEventJournalBasicTest<EJ_TYPE> extends HazelcastTe
      *                      if the projection is {@code null} or it is the identity projection
      * @return the future with the filtered and projected journal items
      */
-    private <K, V, PROJ_TYPE> CompletionStage<ReadResultSet<PROJ_TYPE>> readFromEventJournal(
+    public <K, V, PROJ_TYPE> CompletionStage<ReadResultSet<PROJ_TYPE>> readFromEventJournal(
             EventJournalDataStructureAdapter<K, V, EJ_TYPE> adapter,
             long startSequence,
             int maxSize,

--- a/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/journal/AbstractEventJournalBasicTest.java
@@ -713,7 +713,7 @@ public abstract class AbstractEventJournalBasicTest<EJ_TYPE> extends HazelcastTe
      *                      if the projection is {@code null} or it is the identity projection
      * @return the future with the filtered and projected journal items
      */
-    public <K, V, PROJ_TYPE> CompletionStage<ReadResultSet<PROJ_TYPE>> readFromEventJournal(
+    protected <K, V, PROJ_TYPE> CompletionStage<ReadResultSet<PROJ_TYPE>> readFromEventJournal(
             EventJournalDataStructureAdapter<K, V, EJ_TYPE> adapter,
             long startSequence,
             int maxSize,

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/MapEventJournalBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/MapEventJournalBasicTest.java
@@ -37,7 +37,6 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/MapEventJournalBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/MapEventJournalBasicTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.journal.EventJournalDataStructureAdapter;
 import com.hazelcast.map.MapStore;
 import com.hazelcast.journal.AbstractEventJournalBasicTest;
 import com.hazelcast.journal.EventJournalTestContext;
@@ -28,12 +29,18 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.internal.util.MapUtil;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.hazelcast.config.MapStoreConfig.InitialLoadMode.EAGER;
 
@@ -44,6 +51,8 @@ public class MapEventJournalBasicTest<K, V> extends AbstractEventJournalBasicTes
     private static final String NON_EXPIRING_MAP = "mappy";
     private static final String EXPIRING_MAP = "expiring";
 
+    public final AtomicBoolean isPredicateContextInjected = new AtomicBoolean(false);
+    public final AtomicBoolean isProjectionContextInjected = new AtomicBoolean(false);
     @Override
     protected Config getConfig() {
         Config config = super.getConfig();
@@ -58,7 +67,15 @@ public class MapEventJournalBasicTest<K, V> extends AbstractEventJournalBasicTes
 
         config.getMapConfig(EXPIRING_MAP).setTimeToLiveSeconds(1)
               .setInMemoryFormat(getInMemoryFormat());
-
+        config.setManagedContext(obj -> {
+            if (obj instanceof PredicateWithContext) {
+                setPredicate(true);
+            }
+            if (obj instanceof ProjectionWithContext) {
+                setProjection(true);
+            }
+            return obj;
+        });
         return config;
     }
 
@@ -73,6 +90,31 @@ public class MapEventJournalBasicTest<K, V> extends AbstractEventJournalBasicTes
                 new EventJournalMapDataStructureAdapter<K, V>(getRandomInstance().<K, V>getMap(EXPIRING_MAP)),
                 new EventJournalMapEventAdapter<K, V>()
         );
+    }
+
+    @Test
+    public void testPredicateAndProjectionContextInjection() {
+        final EventJournalTestContext<K, V, EventJournalMapEvent<K, V>> context = createContext();
+        readFromEventJournal((EventJournalDataStructureAdapter) context.dataAdapter, 0,
+                1, 1, new PredicateWithContext(), new ProjectionWithContext());
+        assertAtomicEventually("Predicate Must be injected with ManagedContext", true, getPredicate(), 30);
+        assertAtomicEventually("Projection must injected with ManagedContext", true, getProjection(), 30);
+    }
+
+    public void setPredicate(boolean value) {
+        this.isPredicateContextInjected.set(value);
+    }
+
+    public void setProjection(boolean value) {
+        this.isProjectionContextInjected.set(value);
+    }
+
+    public AtomicBoolean getProjection() {
+        return this.isProjectionContextInjected;
+    }
+
+    public AtomicBoolean getPredicate() {
+        return this.isPredicateContextInjected;
     }
 
     public static class CustomMapStore implements MapStore<Object, Object> {
@@ -114,6 +156,18 @@ public class MapEventJournalBasicTest<K, V> extends AbstractEventJournalBasicTes
         @Override
         public Iterable<Object> loadAllKeys() {
             return Collections.emptySet();
+        }
+    }
+    public static class PredicateWithContext implements Predicate, Serializable {
+        @Override
+        public boolean test(Object o) {
+            return true;
+        }
+    }
+    public static class ProjectionWithContext implements Function , Serializable {
+        @Override
+        public Object apply(Object o) {
+            return null;
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
@@ -124,14 +124,6 @@ public class MapProjectionTest extends HazelcastTestSupport {
         assertThat(result, containsInAnyOrder((Double) null, null, null));
     }
 
-    @Test
-    public void testProjectionContextInjection() {
-        IMap<String, Double> map = getMapWithNodeCount(1);
-        populateMap(map);
-        Collection<Double> result = map.project(new ProjectionWithContext());
-        assertTrue("Projection must be injected with ManagedContext ", isProjectionContextInjected.get());
-    }
-
 
     @Test
     public void projection_1Node_objectValue() {

--- a/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
@@ -47,7 +47,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.google.common.primitives.Ints.asList;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->


Fixes #16957 
Added Unit test and code changes for testing context Injection for Predicates and projection in IMap 

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
