### PR TITLE
Fix wrong results for select count(distinct column) on IMap [HZ-2403]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/AggregateAbstractPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/AggregateAbstractPhysicalRule.java
@@ -86,11 +86,12 @@ public abstract class AggregateAbstractPhysicalRule extends RelRule<Config> {
                     if (distinct) {
                         int countIndex = aggregateCallArguments.get(0);
                         aggregationProviders.add(new AggregateCountSupplier(true, true));
-                        // getMaybeSerialized is safe for COUNT because the aggregation only looks whether it is null or not
-                        valueProviders.add(new RowGetMaybeSerializedFn(countIndex));
+                        // must deserialize value to check uniqueness, items received from other members may be HeapData
+                        valueProviders.add(new RowGetFn(countIndex));
                     } else if (aggregateCallArguments.size() == 1) {
                         int countIndex = aggregateCallArguments.get(0);
                         aggregationProviders.add(new AggregateCountSupplier(true, false));
+                        // getMaybeSerialized is safe for COUNT because the aggregation only looks whether it is null or not
                         valueProviders.add(new RowGetMaybeSerializedFn(countIndex));
                     } else {
                         aggregationProviders.add(new AggregateCountSupplier(false, false));

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlCountDistinctTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlCountDistinctTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql;
+
+import com.hazelcast.jet.sql.impl.connector.map.model.Person;
+import com.hazelcast.map.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class SqlCountDistinctTest extends SqlTestSupport {
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(2, null);
+    }
+
+    @Test
+    public void test_countDistinct() {
+        String mapName = generateRandomString(16);
+        createMapping(mapName, Integer.class, Person.class);
+
+        IMap<Object, Object> map = instance().getMap(mapName);
+
+        for (int i = 0; i < 900; i++) {
+            String key = "key" + i;
+            map.put(key, new Person(i, key));
+        }
+        for (int i = 0; i < 100; i++) {
+            String key = "key" + i;
+            map.put(key + "_", new Person(i, null));
+        }
+
+        assertRowsAnyOrder("select count(*) from (select distinct id from " + mapName + ")", rows(1, 900L));
+        assertRowsAnyOrder("select count(id) from " + mapName, rows(1, 1000L));
+        assertRowsAnyOrder("select count(distinct id) from " + mapName, rows(1, 900L));
+        assertRowsAnyOrder("select count(distinct name) from " + mapName, rows(1, 900L));
+    }
+}


### PR DESCRIPTION
For count(distinct) query it is necessary to deserialize value for distinct check. Sometimes the value in `JetRow` can be `HeapData` and sometimes in deserialized form.

Fixes HZ-2403

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

