### PR TITLE
Fix zero-config compact serialization for objects with a UUID field

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactUtil.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.serialization.impl.compact;
 import com.hazelcast.nio.serialization.FieldKind;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 
+import java.util.UUID;
 import javax.annotation.Nonnull;
 import java.lang.reflect.Array;
 
@@ -173,6 +174,46 @@ public final class CompactUtil {
         }
         return shortArray;
     }
+
+
+    public static UUID uuidFromString(String uuidString) {
+        if (uuidString == null) {
+            return null;
+        }
+        return UUID.fromString(uuidString);
+    }
+
+    public static String uuidAsString(UUID uuid) {
+        if (uuid == null) {
+            return null;
+        }
+        return uuid.toString();
+    }
+
+    public static String[] uuidArrayAsStringArray(UUID[] uuidArray) {
+        if (uuidArray == null) {
+            return null;
+        }
+
+        String[] stringArray = new String[uuidArray.length];
+        for (int i = 0; i < uuidArray.length; i++) {
+            stringArray[i] = uuidAsString(uuidArray[i]);
+        }
+        return stringArray;
+    }
+
+    public static UUID[] uuidArrayFromStringArray(String[] stringArray) {
+        if (stringArray == null) {
+            return null;
+        }
+
+        UUID[] uuidArray = new UUID[stringArray.length];
+        for (int i = 0; i < stringArray.length; i++) {
+            uuidArray[i] = uuidFromString(stringArray[i]);
+        }
+        return uuidArray;
+    }
+
 
     public static void verifyClassIsCompactSerializable(Class<?> clazz) {
         if (canBeSerializedAsCompact(clazz)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/zeroconfig/ValueReaderWriters.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Function;
 
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.charArrayAsShortArray;
@@ -50,6 +51,10 @@ import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.enum
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.enumArrayFromStringNameArray;
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.enumAsStringName;
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.enumFromStringName;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.uuidArrayAsStringArray;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.uuidArrayFromStringArray;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.uuidAsString;
+import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.uuidFromString;
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.isFieldExist;
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.verifyFieldClassIsCompactSerializable;
 import static com.hazelcast.internal.serialization.impl.compact.CompactUtil.verifyFieldClassShouldBeSerializedAsCompact;
@@ -123,6 +128,9 @@ public final class ValueReaderWriters {
 
         CONSTRUCTORS.put(OffsetDateTime.class, OffsetDateTimeReaderWriter::new);
         ARRAY_CONSTRUCTORS.put(OffsetDateTime.class, OffsetDateTimeArrayReaderWriter::new);
+
+        CONSTRUCTORS.put(UUID.class, UuidReaderWriter::new);
+        ARRAY_CONSTRUCTORS.put(UUID.class, UuidArrayReaderWriter::new);
 
         CONSTRUCTORS.put(Boolean.class, NullableBooleanReaderWriter::new);
         CONSTRUCTORS.put(Boolean.TYPE, BooleanReaderWriter::new);
@@ -542,6 +550,46 @@ public final class ValueReaderWriters {
         @Override
         public void write(CompactWriter writer, OffsetDateTime[] value) {
             writer.writeArrayOfTimestampWithTimezone(fieldName, value);
+        }
+    }
+
+    private static final class UuidReaderWriter extends ValueReaderWriter<UUID> {
+
+        private UuidReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public UUID read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, STRING)) {
+                return null;
+            }
+            return uuidFromString(reader.readString(fieldName));
+        }
+
+        @Override
+        public void write(CompactWriter writer, UUID value) {
+            writer.writeString(fieldName, uuidAsString(value));
+        }
+    }
+
+    private static final class UuidArrayReaderWriter extends ValueReaderWriter<UUID[]> {
+
+        private UuidArrayReaderWriter(String fieldName) {
+            super(fieldName);
+        }
+
+        @Override
+        public UUID[] read(CompactReader reader, Schema schema) {
+            if (!isFieldExist(schema, fieldName, ARRAY_OF_STRING)) {
+                return null;
+            }
+            return uuidArrayFromStringArray(reader.readArrayOfString(fieldName));
+        }
+
+        @Override
+        public void write(CompactWriter writer, UUID[] value) {
+            writer.writeArrayOfString(fieldName, uuidArrayAsStringArray(value));
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -38,6 +38,7 @@ import example.serialization.MainDTOSerializer;
 import example.serialization.SameClassEmployeeDTOSerializer;
 import example.serialization.SameTypeNameEmployeeDTOSerializer;
 import example.serialization.SerializableEmployeeDTO;
+import java.util.Currency;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -56,7 +57,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalDouble;
 import java.util.Set;
-import java.util.UUID;
 
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createSerializationService;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -371,21 +371,21 @@ public class CompactSerializationTest {
         assertThatThrownBy(() -> {
             service.toData(new ClassWithUnsupportedArrayListField());
         }).isInstanceOf(HazelcastSerializationException.class)
-                .hasStackTraceContaining("UUID")
+                .hasStackTraceContaining("Currency")
                 .hasStackTraceContaining("cannot be serialized with zero configuration Compact serialization")
                 .hasStackTraceContaining("which uses this class in its fields");
 
         assertThatThrownBy(() -> {
             service.toData(new ClassWithUnsupportedHashSetField());
         }).isInstanceOf(HazelcastSerializationException.class)
-                .hasStackTraceContaining("UUID")
+                .hasStackTraceContaining("Currency")
                 .hasStackTraceContaining("cannot be serialized with zero configuration Compact serialization")
                 .hasStackTraceContaining("which uses this class in its fields");
 
         assertThatThrownBy(() -> {
             service.toData(new ClassWithUnsupportedHashMapField());
         }).isInstanceOf(HazelcastSerializationException.class)
-                .hasStackTraceContaining("UUID")
+                .hasStackTraceContaining("Currency")
                 .hasStackTraceContaining("cannot be serialized with zero configuration Compact serialization")
                 .hasStackTraceContaining("which uses this class in its fields");
     }
@@ -691,15 +691,15 @@ public class CompactSerializationTest {
     }
 
     private static class ClassWithUnsupportedArrayListField {
-        private ArrayList<UUID> list;
+        private ArrayList<Currency> list;
     }
 
     private static class ClassWithUnsupportedHashSetField {
-        private HashSet<UUID> set;
+        private HashSet<Currency> set;
     }
 
     private static class ClassWithUnsupportedHashMapField {
-        private HashMap<UUID, Long> map;
+        private HashMap<Currency, Long> map;
     }
 
     private static class Foo {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
@@ -43,6 +43,7 @@ import example.serialization.MainDTO;
 import example.serialization.MainDTOSerializer;
 import example.serialization.NamedDTO;
 import example.serialization.NodeDTO;
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -181,6 +182,7 @@ public class CompactStreamSerializerTest {
         assertEquals(LocalDate.of(1, 1, 1), actual.localDate);
         assertEquals(LocalDateTime.of(1, 1, 1, 1, 1, 1), actual.localDateTime);
         assertEquals(OffsetDateTime.of(1, 1, 1, 1, 1, 1, 1, ZoneOffset.ofHours(1)), actual.offsetDateTime);
+        assertEquals(UUID.fromString("11111111-1111-1111-1111-111111111111"), actual.uuid);
         assertEquals(Byte.valueOf((byte) 1), actual.nullableB);
         assertEquals(Boolean.FALSE, actual.nullableBool);
         assertEquals(Short.valueOf((short) 1), actual.nullableS);
@@ -206,6 +208,7 @@ public class CompactStreamSerializerTest {
         assertArrayEquals(new LocalDate[0], innerDTO.localDates);
         assertArrayEquals(new LocalDateTime[0], innerDTO.localDateTimes);
         assertArrayEquals(new OffsetDateTime[0], innerDTO.offsetDateTimes);
+        assertArrayEquals(new UUID[0], innerDTO.uuids);
         assertArrayEquals(new Boolean[0], innerDTO.nullableBools);
         assertArrayEquals(new Byte[0], innerDTO.nullableBytes);
         assertArrayEquals(new Short[0], innerDTO.nullableShorts);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
@@ -34,6 +34,7 @@ import example.serialization.NamedDTO;
 import example.serialization.AllFieldsDTO;
 import example.serialization.SerializableEmployeeDTO;
 
+import java.util.UUID;
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -134,6 +135,7 @@ public final class CompactTestUtil {
                 new LocalDate[]{LocalDate.of(2022, 12, 23), null, LocalDate.of(999_999_999, 1, 2)},
                 new LocalDateTime[]{LocalDateTime.of(2022, 12, 23, 22, 13, 15, 123123), null},
                 new OffsetDateTime[]{OffsetDateTime.of(2022, 12, 23, 22, 13, 15, 123123, ZoneOffset.MAX)},
+                new UUID[]{UUID.fromString("11111111-1111-1111-1111-111111111111")},
                 new Boolean[]{true, false, null},
                 new Byte[]{0, 1, 2, null}, new Character[]{'i', null, '9'},
                 new Short[]{3, 4, 5, null}, new Integer[]{9, 8, 7, 6, null}, new Long[]{0L, 1L, 5L, 7L, 9L, 11L},
@@ -146,8 +148,8 @@ public final class CompactTestUtil {
         return new MainDTO((byte) 113, true, '\u1256', (short) -500, 56789, -50992225L, 900.5678f,
                 -897543.3678909d, "this is main object created for testing!", inner,
                 new BigDecimal("12312313"), LocalTime.now(), LocalDate.now(), LocalDateTime.now(), OffsetDateTime.now(),
-                (byte) 113, true, '\u4567', (short) -500, 56789, -50992225L, 900.5678f,
-                -897543.3678909d);
+                UUID.fromString("11111111-1111-1111-1111-111111111111"), (byte) 113, true, '\u4567', (short) -500, 56789,
+                -50992225L, 900.5678f, -897543.3678909d);
     }
 
     @Nonnull

--- a/hazelcast/src/test/java/example/serialization/InnerDTO.java
+++ b/hazelcast/src/test/java/example/serialization/InnerDTO.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.UUID;
 
 public class InnerDTO {
 
@@ -40,6 +41,7 @@ public class InnerDTO {
     public LocalDate[] localDates;
     public LocalDateTime[] localDateTimes;
     public OffsetDateTime[] offsetDateTimes;
+    public UUID[] uuids;
     public Boolean[] nullableBools;
     public Byte[] nullableBytes;
     public Character[] nullableCharacters;
@@ -56,7 +58,7 @@ public class InnerDTO {
     public InnerDTO(boolean[] bools, byte[] bb, char[] cc, short[] ss, int[] ii, long[] ll, float[] ff, double[] dd,
                     String[] strings, NamedDTO[] nn,
                     BigDecimal[] bigDecimals, LocalTime[] localTimes, LocalDate[] localDates,
-                    LocalDateTime[] localDateTimes, OffsetDateTime[] offsetDateTimes,
+                    LocalDateTime[] localDateTimes, OffsetDateTime[] offsetDateTimes, UUID[] uuids,
                     Boolean[] nullableBools, Byte[] nullableBytes, Character[] nullableCharacters, Short[] nullableShorts,
                     Integer[] nullableIntegers, Long[] nullableLongs, Float[] nullableFloats, Double[] nullableDoubles) {
         this.bools = bools;
@@ -74,6 +76,7 @@ public class InnerDTO {
         this.localDates = localDates;
         this.localDateTimes = localDateTimes;
         this.offsetDateTimes = offsetDateTimes;
+        this.uuids = uuids;
         this.nullableBools = nullableBools;
         this.nullableBytes = nullableBytes;
         this.nullableCharacters = nullableCharacters;
@@ -108,6 +111,7 @@ public class InnerDTO {
                 && Arrays.equals(localDates, that.localDates)
                 && Arrays.equals(localDateTimes, that.localDateTimes)
                 && Arrays.equals(offsetDateTimes, that.offsetDateTimes)
+                && Arrays.equals(uuids, that.uuids)
                 && Arrays.equals(nullableBools, that.nullableBools)
                 && Arrays.equals(nullableCharacters, that.nullableCharacters)
                 && Arrays.equals(nullableShorts, that.nullableShorts)
@@ -134,6 +138,7 @@ public class InnerDTO {
         result = 31 * result + Arrays.hashCode(localDates);
         result = 31 * result + Arrays.hashCode(localDateTimes);
         result = 31 * result + Arrays.hashCode(offsetDateTimes);
+        result = 31 * result + Arrays.hashCode(uuids);
         result = 31 * result + Arrays.hashCode(nullableBools);
         result = 31 * result + Arrays.hashCode(nullableBytes);
         result = 31 * result + Arrays.hashCode(nullableCharacters);
@@ -163,6 +168,7 @@ public class InnerDTO {
                 + ", + localDates=" + Arrays.toString(localDates)
                 + ", + localDateTimes=" + Arrays.toString(localDateTimes)
                 + ", + offsetDateTimes=" + Arrays.toString(offsetDateTimes)
+                + ", + uuids=" + Arrays.toString(uuids)
                 + ", + nullableBools=" + Arrays.toString(nullableBools)
                 + ", + nullableBytes=" + Arrays.toString(nullableBytes)
                 + ", + nullableCharacters=" + Arrays.toString(nullableCharacters)

--- a/hazelcast/src/test/java/example/serialization/InnerDTOSerializer.java
+++ b/hazelcast/src/test/java/example/serialization/InnerDTOSerializer.java
@@ -21,6 +21,8 @@ import com.hazelcast.nio.serialization.compact.CompactReader;
 import com.hazelcast.nio.serialization.compact.CompactSerializer;
 import com.hazelcast.nio.serialization.compact.CompactWriter;
 
+import java.util.Arrays;
+import java.util.UUID;
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -92,6 +94,10 @@ public class InnerDTOSerializer implements CompactSerializer<InnerDTO> {
                 ? reader.readArrayOfTimestampWithTimezone("offsetDateTimes")
                 : new OffsetDateTime[0];
 
+        UUID[] uuids = reader.getFieldKind("uuids") == FieldKind.ARRAY_OF_STRING
+                ? Arrays.stream(reader.readArrayOfString("uuids")).map(UUID::fromString).toArray(UUID[]::new)
+                : new UUID[0];
+
         Boolean[] nullableBools = reader.getFieldKind("nullableBools") == FieldKind.ARRAY_OF_NULLABLE_BOOLEAN
                 ? reader.readArrayOfNullableBoolean("nullableBools")
                 : new Boolean[0];
@@ -125,7 +131,7 @@ public class InnerDTOSerializer implements CompactSerializer<InnerDTO> {
                 : new Double[0];
 
         return new InnerDTO(bools, bytes, chars, shorts, ints, longs, floats, doubles, strings, namedDTOS,
-                bigDecimals, localTimes, localDates, localDateTimes, offsetDateTimes, nullableBools, nullableBytes,
+                bigDecimals, localTimes, localDates, localDateTimes, offsetDateTimes, uuids, nullableBools, nullableBytes,
                 nullableCharacters, nullableShorts, nullableIntegers, nullableLongs, nullableFloats, nullableDoubles);
     }
 
@@ -146,6 +152,7 @@ public class InnerDTOSerializer implements CompactSerializer<InnerDTO> {
         writer.writeArrayOfDate("localDates", object.localDates);
         writer.writeArrayOfTimestamp("localDateTimes", object.localDateTimes);
         writer.writeArrayOfTimestampWithTimezone("offsetDateTimes", object.offsetDateTimes);
+        writer.writeArrayOfString("uuids", Arrays.stream(object.uuids).map(UUID::toString).toArray(String[]::new));
         writer.writeArrayOfNullableBoolean("nullableBools", object.nullableBools);
         writer.writeArrayOfNullableInt8("nullableBytes", object.nullableBytes);
         writer.writeArrayOfNullableInt16("nullableCharacters", CompactUtil.characterArrayAsShortArray(object.nullableCharacters));

--- a/hazelcast/src/test/java/example/serialization/MainDTO.java
+++ b/hazelcast/src/test/java/example/serialization/MainDTO.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Objects;
+import java.util.UUID;
 
 @SuppressWarnings({"checkstyle:ParameterNumber"})
 public class MainDTO {
@@ -41,6 +42,7 @@ public class MainDTO {
     public LocalDate localDate;
     public LocalDateTime localDateTime;
     public OffsetDateTime offsetDateTime;
+    public UUID uuid;
     public Byte nullableB;
     public Boolean nullableBool;
     public Character nullableC;
@@ -55,7 +57,7 @@ public class MainDTO {
 
     public MainDTO(byte b, boolean bool, char c, short s, int i, long l, float f, double d, String str, InnerDTO p,
                    BigDecimal bigDecimal, LocalTime localTime, LocalDate localDate, LocalDateTime localDateTime,
-                   OffsetDateTime offsetDateTime,
+                   OffsetDateTime offsetDateTime, UUID uuid,
                    Byte nullableB, Boolean nullableBool, Character nullableC, Short nullableS, Integer nullableI,
                    Long nullableL, Float nullableF, Double nullableD) {
         this.b = b;
@@ -73,6 +75,7 @@ public class MainDTO {
         this.localDate = localDate;
         this.localDateTime = localDateTime;
         this.offsetDateTime = offsetDateTime;
+        this.uuid = uuid;
         this.nullableB = nullableB;
         this.nullableBool = nullableBool;
         this.nullableC = nullableC;
@@ -140,6 +143,9 @@ public class MainDTO {
         if (!Objects.equals(offsetDateTime, mainDTO.offsetDateTime)) {
             return false;
         }
+        if (!Objects.equals(uuid, mainDTO.uuid)) {
+            return false;
+        }
         if (!Objects.equals(nullableB, mainDTO.nullableB)) {
             return false;
         }
@@ -187,6 +193,7 @@ public class MainDTO {
         result = 31 * result + (localDate != null ? localDate.hashCode() : 0);
         result = 31 * result + (localDateTime != null ? localDateTime.hashCode() : 0);
         result = 31 * result + (offsetDateTime != null ? offsetDateTime.hashCode() : 0);
+        result = 31 * result + (uuid != null ? uuid.hashCode() : 0);
         result = 31 * result + (nullableB != null ? nullableB.hashCode() : 0);
         result = 31 * result + (nullableBool != null ? nullableBool.hashCode() : 0);
         result = 31 * result + (nullableC != null ? nullableC.hashCode() : 0);
@@ -216,6 +223,7 @@ public class MainDTO {
                 + ", + localDate=" + localDate
                 + ", + localDateTime=" + localDateTime
                 + ", + offsetDateTime=" + offsetDateTime
+                + ", + uuid=" + uuid
                 + ", + nullableB=" + nullableB
                 + ", + nullableBool=" + nullableBool
                 + ", + nullableC=" + nullableC

--- a/hazelcast/src/test/java/example/serialization/MainDTOSerializer.java
+++ b/hazelcast/src/test/java/example/serialization/MainDTOSerializer.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.serialization.compact.CompactReader;
 import com.hazelcast.nio.serialization.compact.CompactSerializer;
 import com.hazelcast.nio.serialization.compact.CompactWriter;
 
+import java.util.UUID;
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -93,6 +94,10 @@ public class MainDTOSerializer implements CompactSerializer<MainDTO> {
                 ? reader.readTimestampWithTimezone("offsetDateTime")
                 : OffsetDateTime.of(1, 1, 1, 1, 1, 1, 1, ZoneOffset.ofHours(1));
 
+        UUID uuid = reader.getFieldKind("uuid") == FieldKind.STRING
+                ? UUID.fromString(reader.readString("uuid"))
+                : UUID.fromString("11111111-1111-1111-1111-111111111111");
+
         Byte nullableB = reader.getFieldKind("nullableB") == FieldKind.NULLABLE_INT8
                 ? reader.readNullableInt8("nullableB")
                 : Byte.valueOf((byte) 1);
@@ -126,7 +131,7 @@ public class MainDTOSerializer implements CompactSerializer<MainDTO> {
                 : Double.valueOf(1.0);
 
         return new MainDTO(b, bool, c, s, i, l, f, d, str, p, bigDecimal, localTime, localDate, localDateTime,
-                offsetDateTime, nullableB, nullableBool, nullableC, nullableS, nullableI, nullableL, nullableF, nullableD);
+                offsetDateTime, uuid, nullableB, nullableBool, nullableC, nullableS, nullableI, nullableL, nullableF, nullableD);
     }
 
     @Override
@@ -146,6 +151,7 @@ public class MainDTOSerializer implements CompactSerializer<MainDTO> {
         writer.writeDate("localDate", object.localDate);
         writer.writeTimestamp("localDateTime", object.localDateTime);
         writer.writeTimestampWithTimezone("offsetDateTime", object.offsetDateTime);
+        writer.writeString("uuid", object.uuid.toString());
         writer.writeNullableInt8("nullableB", object.nullableB);
         writer.writeNullableBoolean("nullableBool", object.nullableBool);
         writer.writeNullableInt16("nullableC", CompactUtil.characterAsShort(object.nullableC));


### PR DESCRIPTION
This PR adds java.util.UUID to the list of supported type for zero-config compact serialization.

Fixes [23698](https://github.com/hazelcast/hazelcast/issues/23698)

Breaking changes (list specific methods/types/messages):
* Breaking change is that expected failures for serialization of UUID are not expected any longer. (e.g. see CompactSerializationTest.testSerializingClassReflectively_withCollectionTypes_whenCollectionsHasUnsupportedGenericTypes)

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
