### PR TITLE
Show SQL exceptions in verbose mode [HZ-2383]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/HazelcastCommandLine.java
@@ -33,6 +33,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.impl.HazelcastBootstrap;
@@ -443,11 +444,16 @@ public class HazelcastCommandLine implements Runnable {
 
     private void runWithHazelcast(GlobalMixin global, boolean retryClusterConnectForever,
                                   ConsumerEx<HazelcastInstance> consumer) {
+        runWithHazelcast(global, retryClusterConnectForever, (hz, verbose) -> consumer.accept(hz));
+    }
+
+    private void runWithHazelcast(GlobalMixin global, boolean retryClusterConnectForever,
+                                  BiConsumerEx<HazelcastInstance, Boolean> consumer) {
         this.global.merge(global);
         configureLogging();
         HazelcastInstance hz = getHazelcastClient(retryClusterConnectForever);
         try {
-            consumer.accept(hz);
+            consumer.accept(hz, this.global.isVerbose);
         } finally {
             hz.shutdown();
         }


### PR DESCRIPTION
Shows exceptions from SQL commands when `hz-cli` is started in verbose mode (with `-v`)

Fixes: https://github.com/hazelcast/hazelcast/issues/24389
Fixes: https://hazelcast.atlassian.net//browse/HZ-2383

Without verbose
```
./hz-cli sql
Connected to Hazelcast 5.3.0-SNAPSHOT at [127.0.0.1]:5701 (+1 more)
Type 'help' for instructions
sql> select * from my;
Object 'my' not found, did you forget to CREATE MAPPING?
sql>
sql>
Exiting from SQL console
```
With verbose
```
./hz-cli -v sql
Verbose mode is on, setting logging level to INFO
10:42:17.254 [ INFO] [c.h.i.c.AbstractConfigLocator] Loading configuration '/Users/luk/projects/hazelcast/hazelcast/distribution/target/hazelcast-5.3.0-SNAPSHOT/config/hazelcast-client.xml' from System property 'hazelcast.client.config'
10:42:17.262 [ INFO] [c.h.i.c.AbstractConfigLocator] Using configuration file at /Users/luk/projects/hazelcast/hazelcast/distribution/target/hazelcast-5.3.0-SNAPSHOT/config/hazelcast-client.xml
10:42:17.511 [ INFO] [c.h.c.i.s.ClientInvocationService] hz.client_1 [dev] [5.3.0-SNAPSHOT] Running with 2 response threads, dynamic=true
10:42:17.542 [ INFO] [c.h.c.LifecycleService] hz.client_1 [dev] [5.3.0-SNAPSHOT] HazelcastClient 5.3.0-SNAPSHOT (20230508 - d68e36a) is STARTING
10:42:17.542 [ INFO] [c.h.c.LifecycleService] hz.client_1 [dev] [5.3.0-SNAPSHOT] HazelcastClient 5.3.0-SNAPSHOT (20230508 - d68e36a) is STARTED
10:42:17.562 [ INFO] [c.h.c.i.c.ClientConnectionManager] hz.client_1 [dev] [5.3.0-SNAPSHOT] Trying to connect to cluster: dev
10:42:17.565 [ INFO] [c.h.c.i.c.ClientConnectionManager] hz.client_1 [dev] [5.3.0-SNAPSHOT] Trying to connect to [127.0.0.1]:5701
10:42:17.628 [ INFO] [c.h.c.LifecycleService] hz.client_1 [dev] [5.3.0-SNAPSHOT] HazelcastClient 5.3.0-SNAPSHOT (20230508 - d68e36a) is CLIENT_CONNECTED
10:42:17.628 [ INFO] [c.h.c.i.c.ClientConnectionManager] hz.client_1 [dev] [5.3.0-SNAPSHOT] Authenticated with server [127.0.0.1]:5701:85787244-35d5-4913-99e3-e4334901302a, server version: 5.3.0-SNAPSHOT, local address: /127.0.0.1:49755
10:42:17.629 [ INFO] [c.h.i.d.Diagnostics] hz.client_1 [dev] [5.3.0-SNAPSHOT] Diagnostics disabled. To enable add -Dhazelcast.diagnostics.enabled=true to the JVM arguments.
10:42:17.634 [ INFO] [c.h.c.i.s.ClientClusterService] hz.client_1 [dev] [5.3.0-SNAPSHOT]

Members [2] {
	Member [127.0.0.1]:5701 - 85787244-35d5-4913-99e3-e4334901302a
	Member [127.0.0.1]:5702 - a340522f-68df-47f2-b916-5645b1706d92
}

10:42:17.651 [ INFO] [c.h.c.i.s.ClientStatisticsService] Client statistics is enabled with period 5 seconds.
Connected to Hazelcast 5.3.0-SNAPSHOT at [127.0.0.1]:5701 (+1 more)
Type 'help' for instructions
sql> select * from my;
Object 'my' not found, did you forget to CREATE MAPPING?
com.hazelcast.sql.HazelcastSqlException: Object 'my' not found, did you forget to CREATE MAPPING?
	at com.hazelcast.sql.impl.client.SqlClientService.handleExecuteResponse(SqlClientService.java:303)
	at com.hazelcast.sql.impl.client.SqlClientService.execute(SqlClientService.java:145)
	at com.hazelcast.sql.SqlService.execute(SqlService.java:89)
	at com.hazelcast.client.console.SqlConsole.executeSqlCmd(SqlConsole.java:180)
	at com.hazelcast.client.console.SqlConsole.run(SqlConsole.java:169)
	at com.hazelcast.function.BiConsumerEx.accept(BiConsumerEx.java:47)
	at com.hazelcast.client.console.HazelcastCommandLine.runWithHazelcast(HazelcastCommandLine.java:456)
	at com.hazelcast.client.console.HazelcastCommandLine.sql(HazelcastCommandLine.java:151)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2066)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunAll.recursivelyExecuteUserObject(CommandLine.java:2536)
	at picocli.CommandLine$RunAll.recursivelyExecuteUserObject(CommandLine.java:2538)
	at picocli.CommandLine$RunAll.handle(CommandLine.java:2532)
	at picocli.CommandLine$RunAll.handle(CommandLine.java:2492)
	at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:2264)
	at picocli.CommandLine.parseWithHandlers(CommandLine.java:2664)
	at com.hazelcast.client.console.HazelcastCommandLine.runCommandLine(HazelcastCommandLine.java:560)
	at com.hazelcast.client.console.HazelcastCommandLine.main(HazelcastCommandLine.java:135)

sql>
```


Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
