### PR TITLE
Forbid shared data connections for reading from kafka [HZ-2396]

### DIFF
--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaDataConnection.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaDataConnection.java
@@ -63,6 +63,7 @@ import java.util.stream.Collectors;
 @Beta
 public class KafkaDataConnection extends DataConnectionBase {
 
+    private static final Properties EMPTY_PROPERTIES = new Properties();
     private volatile ConcurrentMemoizingSupplier<NonClosingKafkaProducer<?, ?>> producerSupplier;
 
     /**
@@ -106,7 +107,7 @@ public class KafkaDataConnection extends DataConnectionBase {
      */
     @Nonnull
     public <K, V> Consumer<K, V> newConsumer() {
-        return new KafkaConsumer<>(getConfig().getProperties());
+        return newConsumer(EMPTY_PROPERTIES);
     }
 
     /**
@@ -121,6 +122,10 @@ public class KafkaDataConnection extends DataConnectionBase {
      */
     @Nonnull
     public <K, V> Consumer<K, V> newConsumer(Properties properties) {
+        if (getConfig().isShared()) {
+            throw new IllegalArgumentException("KafkaConsumer is not thread-safe and can't be used "
+                    + "with shared DataConnection '" + getConfig().getName() + "'");
+        }
         return new KafkaConsumer<>(Util.mergeProps(getConfig().getProperties(), properties));
     }
 

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/KafkaDataConnectionTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/KafkaDataConnectionTest.java
@@ -69,12 +69,27 @@ public class KafkaDataConnectionTest {
 
     @Test
     public void should_create_new_consumer_for_each_call() {
-        kafkaDataConnection = createKafkaDataConnection(kafkaTestSupport);
+        kafkaDataConnection = createNonSharedKafkaDataConnection();
 
         try (Consumer<Object, Object> c1 = kafkaDataConnection.newConsumer();
              Consumer<Object, Object> c2 = kafkaDataConnection.newConsumer()) {
             assertThat(c1).isNotSameAs(c2);
         }
+    }
+
+    @Test
+    public void newConsumer_should_fail_with_shared_data_connection() {
+        kafkaDataConnection = createKafkaDataConnection(kafkaTestSupport);
+
+        assertThatThrownBy(() -> kafkaDataConnection.newConsumer())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("KafkaConsumer is not thread-safe and can't be used"
+                        + " with shared DataConnection 'kafka-data-connection'");
+
+        assertThatThrownBy(() -> kafkaDataConnection.newConsumer(new Properties()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("KafkaConsumer is not thread-safe and can't be used"
+                        + " with shared DataConnection 'kafka-data-connection'");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaDataConnectionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaDataConnectionIntegrationTest.java
@@ -100,8 +100,6 @@ public class KafkaDataConnectionIntegrationTest extends KafkaSqlTestSupport {
         try (SqlResult r = sqlService.execute("INSERT INTO " + name + " VALUES (0, 'value-0')")) {
             assertThat(r.updateCount()).isZero();
         }
-
-        assertTipOfStream("SELECT * FROM " + name, singletonList(new Row(0, "value-0")));
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/24444
Fixes https://hazelcast.atlassian.net//browse/HZ-2396

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
