### PR TITLE
Bump parquet-avro from 1.12.3 to 1.13.0 (#24210) [5.2.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <netty.version>4.1.86.Final</netty.version>
         <objenesis.version>3.2</objenesis.version>
         <osgi.version>4.2.0</osgi.version>
-        <parquet.version>1.12.3</parquet.version>
+        <parquet.version>1.13.0</parquet.version>
         <picocli.version>4.6.3</picocli.version>
         <postgresql.version>42.4.2</postgresql.version>
         <prometheus.version>0.18.0</prometheus.version>


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/24210

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
