### PR TITLE
Bump parquet-avro to 2.13.0 [5.2.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <netty.version>4.1.86.Final</netty.version>
         <objenesis.version>3.2</objenesis.version>
         <osgi.version>4.2.0</osgi.version>
-        <parquet.version>1.12.3</parquet.version>
+        <parquet.version>1.13.0</parquet.version>
         <picocli.version>4.6.3</picocli.version>
         <postgresql.version>42.4.2</postgresql.version>
         <prometheus.version>0.17.1</prometheus.version>


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/22407

Backport of: https://github.com/hazelcast/hazelcast/pull/24210

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible