### PR TITLE
Bump Woodstox to fix CVE-2022-40152 [5.0.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1651,9 +1651,14 @@
                 <version>6.4.0</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>6.4.0</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.8.9</version>
+                <version>2.9.1</version>
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/23788

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
