### PR TITLE
Change order of operations in AbstractCacheService#deleteCache [HZ-2412]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -361,9 +361,9 @@ public abstract class AbstractCacheService implements ICacheService,
 
         WanReplicationService wanService = nodeEngine.getWanReplicationService();
         wanService.removeWanEventCounters(ICacheService.SERVICE_NAME, cacheNameWithPrefix);
-        cacheContexts.remove(cacheNameWithPrefix);
         operationProviderCache.remove(cacheNameWithPrefix);
         deregisterAllListener(cacheNameWithPrefix);
+        cacheContexts.remove(cacheNameWithPrefix);
         setStatisticsEnabled(config, cacheNameWithPrefix, false);
         setManagementEnabled(config, cacheNameWithPrefix, false);
         deleteCacheStat(cacheNameWithPrefix);


### PR DESCRIPTION
**Background**

We recently encountered a test failure on the JCache-TCK jenkins project related to the `assert` added in this commit: https://github.com/hazelcast/hazelcast/commit/4c8057d2470b4a628e13793a1cce6a8a1f0c6268 This assert was added to help diagnose a niche issue where the listener count was able to reach -1 and cause an assertion failure where it was expecting 0 (https://github.com/hazelcast/hazelcast/issues/24375).

While I was unable to reproduce the issue for that test failure, the tests conducted in the JCache-TCK are able to reproduce a negative value listener count on almost every run (resulting in the failure seen in the issue below).

Using this handy reproducer I was able to dive deeper into the calls surrounding `CacheContext.cacheEntryListenerCount` manipulation. I found that the `CacheListenerTest` was introducing a scenario where the listener count could become negative due to the following aspects:
- All tests within the `CacheListenerTest` use the same cache name (important)
- All tests are followed by a call to `onAfterEachTest()` which calls `cache.getCacheManager().destroyCache(cacheName);`
- Tests are run in quick succession; the whole class finishes in 1-2s

**Issue breakdown**

This scenario allows for the cache used by all tests to be deleted in an `onAfterEachTest()` call despite having listeners still active. This deletion is handled through a `DistributedObjectDestroyOperation` which calls `AbstractCacheService#deleteCache()`. Within this function, there are various calls, but I want to focus on these:
```java
        cacheContexts.remove(cacheNameWithPrefix);
        operationProviderCache.remove(cacheNameWithPrefix);
        deregisterAllListener(cacheNameWithPrefix);
```

The issue is the order of these, in particular `cacheContexts#remove` being called before `#deregisterAllListener`, which itself calls `CacheAddEntryListenerMessageTask#onDeregister()`. In this `onDeregister` function the following code is executed:
```java
		CacheContext cacheContext = service.getOrCreateCacheContext(topic);
		cacheContext.decreaseCacheEntryListenerCount();
```
Due to `cacheContext#remove` being called first, this block will result in a new `CacheContext` being created (due to `getOrCreateCacheContext`) which is immediately decreased to a negative value (as it's created with a value of 0). Subsequent fetching of this `CacheContext` (as done in these tests as they all use the same cache name) now results in an inaccurate value.

Additionally, due to the above, `cacheContexts.get(cacheNameWithPrefix)` is null in `AbstractCacheService#deregisterAllListener`, so the listener count is not reset back to zero either.

**Solutions**

Given this issue, I see 2 possible solutions:

1) Re-order the operations in `AbstractCacheService#deleteCache()` such that the `cacheContexts#remove` call is made after `deregisterAllListener`. This will prevent a new `CacheContext` being created and decreased.

2) Change `CacheAddEntryListenerMessageTask#onDeregister()` to use a call to `#getCacheContext()` instead of `#getOrCreateCacheContext` so it does not create a new instance (with starting value 0) only to decrease it to -1.

I believe the first solution is one that results in the least amount of behaviour changes, so that is what I opted for in this PR. I ran the full JCache-TCK test suite with this solution and it passes successfully.

Related to https://github.com/hazelcast/hazelcast/issues/24375
Fixes https://github.com/hazelcast/hazelcast/issues/24478
Fixes https://github.com/hazelcast/hazelcast/issues/24470