### PR TITLE
Fix GenericMapStoreIntegrationTest.testInstanceShutdown [HZ-2421]

### DIFF
--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
@@ -400,7 +400,7 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
 
         ExceptionRecorder recorder = new ExceptionRecorder(hz3, Level.WARNING);
         // fill the map with some values so each member gets some items
-        long itemSize = 1000;
+        Integer itemSize = 1000;
         for (int i = 1; i < itemSize; i++) {
             map.put(i, new Person(i, "name-" + i));
         }
@@ -410,8 +410,8 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
         assertEqualsEventually(() -> {
                     List<Row> rows = jdbcRows("SELECT COUNT(*) FROM " + tableName);
                     Object[] values = rows.get(0).getValues();
-                    return (long) values[0];
-                }, itemSize
+                    return (Long) values[0];
+                }, itemSize.longValue()
         );
 
         // shutdown the member - this will call destroy on the MapStore on this member,


### PR DESCRIPTION
Fix the test by waiting for asynchronous put operations to be inserted to DB 

Fixes : https://github.com/hazelcast/hazelcast/issues/24413
Jira : https://hazelcast.atlassian.net/browse/HZ-2421

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible