### PR TITLE
Decrease local parallelism of processors in JdbcSqlConnector [HZ-1637]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -354,7 +354,7 @@ public class JdbcSqlConnector implements SqlConnector {
                         builder.query(),
                         table.getBatchLimit()
                 )
-        ));
+        ).localParallelism(1));
     }
 
     @Nonnull
@@ -501,7 +501,7 @@ public class JdbcSqlConnector implements SqlConnector {
                             upsertStatement,
                             jdbcTable.getBatchLimit()
                     )
-            );
+            ).localParallelism(1);
         }
         // Unsupported dialect. Create Vertex with the INSERT statement
         VertexWithInputConfig vertexWithInputConfig = insertProcessor(context);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -448,27 +448,27 @@ public class JdbcSqlConnector implements SqlConnector {
     ) {
 
         if (!hasInput) {
-            // There is no input, we push the whole update query to the database, but we need single dummy item
-            // to execute the update in WriteJdbcP
+            // There is no input, we push the whole update/delete query to the database, but we need single dummy item
+            // to execute the update/delete in WriteJdbcP
             // We can consider refactoring the WriteJdbcP, so it doesn't need the dummy item in the future.
 
             // Use local member address to run the dummy source and processor on the same member
             Address localAddress = context.getNodeEngine().getThisAddress();
 
             Vertex v = dummySourceVertex(context, "DummySourceFor" + statement, localAddress);
-            Vertex updateVertex = context.getDag().newUniqueVertex(
+            Vertex dmlVertex = context.getDag().newUniqueVertex(
                     statement + "(" + table.getExternalNameList() + ")",
                     forceTotalParallelismOne(processorSupplier, localAddress)
             );
 
-            context.getDag().edge(Edge.between(v, updateVertex));
-            return updateVertex;
+            context.getDag().edge(Edge.between(v, dmlVertex));
+            return dmlVertex;
         } else {
-            Vertex updateVertex = context.getDag().newUniqueVertex(
+            Vertex dmlVertex = context.getDag().newUniqueVertex(
                     statement + "(" + table.getExternalNameList() + ")",
                     processorSupplier
             ).localParallelism(1);
-            return updateVertex;
+            return dmlVertex;
         }
     }
 


### PR DESCRIPTION
The call to `Map#clear` with enabled `MapStore` results in at least 1 call to `MapStore#deleteAll` for each partition.  The ultimate fix would be to add `MapStore#deleteAll` method, but the benefit of such API in MapStore is unclear.

However, it made the following issue visible:

When not explicitly set via forceTotalParallelismOne or setLocalParallelism the local parallelism default value is larger than
1. This results in 2 or more processors being created for each insert/update/delete/sink into.  Each processor requests a connection from a pool. It is possible that 2 concurrently running queries borrow 1 connection each, exhausting the pool and resulting in a deadlock, which ends after a 30 s timeout (default) from the connection pool.

It is arguably a user error that the connection pool size is too low, but with localParallelism>1 it is really easy to hit this issue (as seen in the `Map#clear`)

Also, it is theoretically possible to hit this issue across multiple members (the processor on one member successfully obtains a connection from the pool, but waits on another member and vice versa), but I didn't manage to reproduce this, so I didn't focus on fixing that issue.

In the future, we can make this behaviour smarter for insert/sink into or update/delete which have input and could make use of higher local parallelism.

Fixes #22567


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
