### PR TITLE
Fix TINY/SMALL INT type handling in JdbcSqlConnector

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/FromSqlRowConverter.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/FromSqlRowConverter.java
@@ -54,7 +54,13 @@ final class FromSqlRowConverter {
                     break;
 
                 case TINYINT:
+                    builder.setInt8(columnName, sqlRow.getObject(i));
+                    break;
+
                 case SMALLINT:
+                    builder.setInt16(columnName, sqlRow.getObject(i));
+                    break;
+
                 case INTEGER:
                     builder.setInt32(columnName, sqlRow.getObject(i));
                     break;

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/AllTypesGenericMapStoreTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/AllTypesGenericMapStoreTest.java
@@ -79,10 +79,10 @@ public class AllTypesGenericMapStoreTest extends JdbcSqlTestSupport {
                         (r, s) -> assertThat(r.getBoolean(s)).isTrue(),
                         (BiConsumer<GenericRecordBuilder, String>) (rb, s) -> rb.setBoolean(s, true)},
                 {"TINYINT", "1", (BiConsumer<GenericRecord, String>)
-                        (r, s) -> assertThat(r.getInt32(s)).isEqualTo(1),
+                        (r, s) -> assertThat(r.getInt8(s)).isEqualTo((byte) 1),
                         (BiConsumer<GenericRecordBuilder, String>) (rb, s) -> rb.setInt8(s, (byte) 1)},
                 {"SMALLINT", "2", (BiConsumer<GenericRecord, String>)
-                        (r, s) -> assertThat(r.getInt32(s)).isEqualTo(2),
+                        (r, s) -> assertThat(r.getInt16(s)).isEqualTo((short) 2),
                         (BiConsumer<GenericRecordBuilder, String>) (rb, s) -> rb.setInt16(s, (short) 2)},
                 {"INTEGER", "3", (BiConsumer<GenericRecord, String>)
                         (r, s) -> assertThat(r.getInt32(s)).isEqualTo(3),

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/AllTypesSelectJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/AllTypesSelectJdbcSqlConnectorTest.java
@@ -61,8 +61,8 @@ public class AllTypesSelectJdbcSqlConnectorTest extends JdbcSqlTestSupport {
         return asList(new Object[][]{
                 {"VARCHAR(100)", "VARCHAR", "'dummy'", "dummy"},
                 {"BOOLEAN", "BOOLEAN", "TRUE", true},
-                {"TINYINT", "TINYINT", "1", 1},
-                {"SMALLINT", "SMALLINT", "2", 2},
+                {"TINYINT", "TINYINT", "1", (byte) 1},
+                {"SMALLINT", "SMALLINT", "2", (short) 2},
                 {"INTEGER", "INTEGER", "3", 3},
                 {"BIGINT", "BIGINT", "4", 4L},
                 {"DECIMAL (10,5)", "DECIMAL", "1.12345", new BigDecimal("1.12345")},


### PR DESCRIPTION
Using `getObject` doesn't return the correct type for tiny/small int due to backwards compatibility issue, from JDBC spec:

> The JDBC 1.0 specification defined the Java object mapping for the
SMALLINT and TINYINT JDBC types to be Integer. The Java language did not include the Byte and Short data types when the JDBC 1.0 specification was finalized. The mapping of SMALLINT and TINYINT to Integer is maintained to preserve backwards compatibility.


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
