### PR TITLE
Cleanup few code style issues in JdbcSqlConnector

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/JdbcSqlConnector.java
@@ -101,23 +101,19 @@ public class JdbcSqlConnector implements SqlConnector {
         List<MappingField> resolvedFields = new ArrayList<>();
         if (userFields.isEmpty()) {
             for (DbField dbField : dbFields.values()) {
-                try {
-                    MappingField mappingField = new MappingField(
-                            dbField.columnName,
-                            resolveType(dbField.columnTypeName)
-                    );
-                    mappingField.setPrimaryKey(dbField.primaryKey);
-                    resolvedFields.add(mappingField);
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalStateException("Could not load column class " + dbField.columnTypeName, e);
-                }
+                MappingField mappingField = new MappingField(
+                        dbField.columnName,
+                        resolveType(dbField.columnTypeName)
+                );
+                mappingField.setPrimaryKey(dbField.primaryKey);
+                resolvedFields.add(mappingField);
             }
         } else {
             for (MappingField f : userFields) {
                 if (f.externalName() != null) {
                     DbField dbField = dbFields.get(f.externalName());
                     if (dbField == null) {
-                        throw new IllegalStateException("Could not resolve field with external name " + f.externalName());
+                        throw QueryException.error("Could not resolve field with external name " + f.externalName());
                     }
                     validateType(f, dbField);
                     MappingField mappingField = new MappingField(f.name(), f.type(), f.externalName(),
@@ -127,7 +123,7 @@ public class JdbcSqlConnector implements SqlConnector {
                 } else {
                     DbField dbField = dbFields.get(f.name());
                     if (dbField == null) {
-                        throw new IllegalStateException("Could not resolve field with name " + f.name());
+                        throw QueryException.error("Could not resolve field with name " + f.name());
                     }
                     validateType(f, dbField);
                     MappingField mappingField = new MappingField(f.name(), f.type());
@@ -568,7 +564,7 @@ public class JdbcSqlConnector implements SqlConnector {
                 return QueryDataType.TIMESTAMP_WITH_TZ_OFFSET_DATE_TIME;
 
             default:
-                throw new IllegalArgumentException("Unknown column type: " + columnTypeName);
+                throw new IllegalArgumentException("Unsupported column type: " + columnTypeName);
         }
     }
 
@@ -632,7 +628,7 @@ public class JdbcSqlConnector implements SqlConnector {
                 table = externalName[2];
             } else {
                 // external name length was validated earlier, we should never get here
-                throw new IllegalStateException("Invalid external name length");
+                throw QueryException.error("Invalid external name length");
             }
         }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/SupportedDatabases.java
@@ -54,7 +54,8 @@ final class SupportedDatabases {
 
         boolean newDatabaseName = isNewDatabase(uppercaseProductName);
         if (newDatabaseName) {
-            LOGGER.warning("Database " + uppercaseProductName + " is not officially supported");
+            LOGGER.warning("Database " + uppercaseProductName + " is not supported, it may or may not work. "
+                    + "If you come across any issues please report them on Github.");
         }
     }
 


### PR DESCRIPTION
Fixes #22412

From the issue list:
1,3 was fixed previously
2,4,5,6 is fixed in this PR.

Answer to questions:
Q1: We changed the code and use `connection.getMetaData().getColumns()` now.
Q2: `getColumnTypeName` provides the best info about the column type in the database, everything else is not precise enough.


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
