### PR TITLE
Fix test compatibility issue

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
@@ -532,15 +532,17 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
      * java serialization for both key and value with the given classes.
      */
     public static void createMapping(HazelcastInstance instance, String name, Class<?> keyClass, Class<?> valueClass) {
-        long updateCount = instance.getSql().executeUpdate("CREATE OR REPLACE MAPPING " + name + " TYPE " + IMapSqlConnector.TYPE_NAME + "\n"
+        try (SqlResult result = instance.getSql().execute("CREATE OR REPLACE MAPPING " + name
+                + " TYPE " + IMapSqlConnector.TYPE_NAME + "\n"
                 + "OPTIONS (\n"
                 + '\'' + OPTION_KEY_FORMAT + "'='" + JAVA_FORMAT + "'\n"
                 + ", '" + OPTION_KEY_CLASS + "'='" + keyClass.getName() + "'\n"
                 + ", '" + OPTION_VALUE_FORMAT + "'='" + JAVA_FORMAT + "'\n"
                 + ", '" + OPTION_VALUE_CLASS + "'='" + valueClass.getName() + "'\n"
                 + ")"
-        );
-        assertThat(updateCount).isEqualTo(0);
+        )) {
+            assertThat(result.updateCount()).isEqualTo(0);
+        }
     }
 
     /**


### PR DESCRIPTION
Do not use newly introduced executeUpdate, because it break compatibility.

Fixes https://github.com/hazelcast/hazelcast-enterprise/pull/5966

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
