### PR TITLE
Add missing client side setup for TaskletExecutionException

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionException.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionException.java
@@ -19,10 +19,10 @@ package com.hazelcast.jet.impl.execution;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.spi.exception.SilentException;
 
-class TaskletExecutionException extends JetException implements SilentException {
+public class TaskletExecutionException extends JetException implements SilentException {
     private static final long serialVersionUID = 1L;
 
-    TaskletExecutionException(String message, Throwable cause) {
+    public TaskletExecutionException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -33,6 +33,7 @@ import com.hazelcast.jet.impl.exception.EnteringPassiveClusterStateException;
 import com.hazelcast.jet.impl.exception.JetDisabledException;
 import com.hazelcast.jet.impl.exception.JobTerminateRequestedException;
 import com.hazelcast.jet.impl.exception.TerminatedWithSnapshotException;
+import com.hazelcast.jet.impl.execution.TaskletExecutionException;
 import com.hazelcast.jet.impl.operation.InitExecutionOperation;
 import com.hazelcast.jet.impl.operation.StartExecutionOperation;
 import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
@@ -64,8 +65,9 @@ public final class ExceptionUtil {
             tuple3(JET_EXCEPTIONS_RANGE_START + 3, JobAlreadyExistsException.class, JobAlreadyExistsException::new),
             tuple3(JET_EXCEPTIONS_RANGE_START + 4, AssertionCompletedException.class, AssertionCompletedException::new),
             tuple3(JET_EXCEPTIONS_RANGE_START + 5, JetDisabledException.class, JetDisabledException::new),
-            tuple3(JET_EXCEPTIONS_RANGE_START + 6, CancellationByUserException.class, CancellationByUserException::new)
-        );
+            tuple3(JET_EXCEPTIONS_RANGE_START + 6, CancellationByUserException.class, CancellationByUserException::new),
+            tuple3(JET_EXCEPTIONS_RANGE_START + 7, TaskletExecutionException.class, TaskletExecutionException::new)
+    );
 
     private ExceptionUtil() { }
 


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/6000 
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/5999

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
