### PR TITLE
Add lifecycle listener before client starts in ConfiguredBehaviorTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
@@ -134,16 +134,15 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
         clientUserCodeDeploymentConfig.setEnabled(true);
         clientConfig.setUserCodeDeploymentConfig(clientUserCodeDeploymentConfig);
         clientConfig.getConnectionStrategyConfig().setAsyncStart(true);
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         CountDownLatch connectedLatch = new CountDownLatch(1);
-
-        client.getLifecycleService().addLifecycleListener(event -> {
+        clientConfig.addListenerConfig(new ListenerConfig((LifecycleListener) event -> {
             if (event.getState().equals(CLIENT_CONNECTED)) {
                 connectedLatch.countDown();
             }
-        });
+        }));
 
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         assertOpenEventually(connectedLatch);
 
         // The following logic verifies user code deployment works


### PR DESCRIPTION
In the `testAsyncStartTrueShouldNotBlock_whenThereIsClientStateToSend` we add a lifecycle listener after the client starts, and wait until the client moves into the connected state.

However, the client might move to the connected state even before we have added that listener, as the listener is added after the client starts.

I have moved the listener registration to the configuration so that we would receive the connected event for sure.

closes https://github.com/hazelcast/hazelcast/issues/24538