### PR TITLE
Update GitHub actions to ones using Node.js 16

### DIFF
--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -31,11 +31,12 @@ jobs:
       )
     steps:
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           architecture: x64
           distribution: adopt
+          cache: 'maven'
 
       - name: Decide which ref to checkout
         id: decide-ref
@@ -47,17 +48,9 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
           ref: ${{steps.decide-ref.outputs.ref}}
-
-      - name: Setup Local Maven Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
         run: |

--- a/.github/workflows/azure-terraform-integration-tests.yml
+++ b/.github/workflows/azure-terraform-integration-tests.yml
@@ -33,11 +33,12 @@ jobs:
       )
     steps:
       - name: Setup JDK
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           architecture: x64
           distribution: adopt
+          cache: 'maven'
 
       - name: Decide which ref to checkout
         id: decide-ref
@@ -49,17 +50,9 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
           ref: ${{steps.decide-ref.outputs.ref}}
-
-      - name: Setup Local Maven Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
         run: |

--- a/.github/workflows/gcp-terraform-integration-tests.yml
+++ b/.github/workflows/gcp-terraform-integration-tests.yml
@@ -30,11 +30,12 @@ jobs:
       )
     steps:
       - name: Setup JDK
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           architecture: x64
           distribution: adopt
+          cache: 'maven'
 
       - name: Decide which ref to checkout
         id: decide-ref
@@ -46,17 +47,9 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
           ref: ${{steps.decide-ref.outputs.ref}}
-
-      - name: Setup Local Maven Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
         run: |


### PR DESCRIPTION
Upgrade due to disabling Node.js 12 support in GHA.

https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/