### PR TITLE
Forcing shutdown executors after node shutdown to prevent thread leak [HZ-2414] [5.3.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
@@ -40,8 +40,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
+import static com.hazelcast.internal.util.ExceptionUtil.peel;
+import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.internal.util.ThreadUtil.assertRunningOnPartitionThread;
 import static com.hazelcast.internal.util.ThreadUtil.isRunningOnPartitionThread;
 import static java.util.Collections.emptyList;
@@ -70,7 +73,11 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
             UrgentPartitionRunnable<Collection<Operation>> runnable = new UrgentPartitionRunnable<>(
                     event.getPartitionId(), () -> createReplicationOperations(event, true));
             getNodeEngine().getOperationService().execute(runnable);
-            return runnable.future.joinInternal();
+            try {
+                return runnable.future.get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw sneakyThrow(peel(e));
+            }
         }
     }
 
@@ -182,7 +189,12 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
         UrgentPartitionRunnable<ChunkSupplier> partitionThreadRunnable = new UrgentPartitionRunnable<>(
                 event.getPartitionId(), () -> service.newChunkSupplier(event, singleton(ns)));
         getNodeEngine().getOperationService().execute(partitionThreadRunnable);
-        ChunkSupplier supplier = partitionThreadRunnable.future.joinInternal();
+        ChunkSupplier supplier;
+        try {
+            supplier = partitionThreadRunnable.future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw sneakyThrow(peel(e));
+        }
         return appendNewElement(chunkSuppliers, supplier);
     }
 
@@ -286,7 +298,12 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
                 event.getPartitionId(),
                 () -> prepareReplicationOperation(event, ns, service, serviceName));
         getNodeEngine().getOperationService().execute(partitionThreadRunnable);
-        Operation op = partitionThreadRunnable.future.joinInternal();
+        Operation op;
+        try {
+            op = partitionThreadRunnable.future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw sneakyThrow(peel(e));
+        }
         return appendNewElement(operations, op);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequestOffloadable.java
@@ -42,12 +42,15 @@ import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readCollection;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeCollection;
 import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
 import static com.hazelcast.internal.util.CollectionUtil.isNotEmpty;
+import static com.hazelcast.internal.util.ExceptionUtil.peel;
+import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.internal.util.ThreadUtil.isRunningOnPartitionThread;
 
 /**
@@ -158,7 +161,11 @@ public final class PartitionReplicaSyncRequestOffloadable
                     }
                 });
         operationService.execute(gatherReplicaVersionsRunnable);
-        gatherReplicaVersionsRunnable.future.joinInternal();
+        try {
+            gatherReplicaVersionsRunnable.future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw sneakyThrow(peel(e));
+        }
     }
 
     @Override
@@ -175,7 +182,11 @@ public final class PartitionReplicaSyncRequestOffloadable
             UrgentPartitionRunnable partitionRunnable = new UrgentPartitionRunnable(partitionId(),
                     () -> sendOperations(operations, chunkSuppliers, ns));
             getNodeEngine().getOperationService().execute(partitionRunnable);
-            partitionRunnable.future.joinInternal();
+            try {
+                partitionRunnable.future.get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw sneakyThrow(peel(e));
+            }
         }
     }
 
@@ -269,7 +280,11 @@ public final class PartitionReplicaSyncRequestOffloadable
         UrgentPartitionRunnable<Boolean> trySetMigrating = new UrgentPartitionRunnable<>(partitionId(),
                 () -> partitionStateManager.trySetMigratingFlag(partitionId()));
         getNodeEngine().getOperationService().execute(trySetMigrating);
-        return trySetMigrating.future.joinInternal();
+        try {
+            return trySetMigrating.future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw sneakyThrow(peel(e));
+        }
     }
 
     private void clearMigratingFlag() {
@@ -278,6 +293,10 @@ public final class PartitionReplicaSyncRequestOffloadable
         UrgentPartitionRunnable<Void> trySetMigrating = new UrgentPartitionRunnable<>(partitionId(),
                 () -> partitionStateManager.clearMigratingFlag(partitionId()));
         getNodeEngine().getOperationService().execute(trySetMigrating);
-        trySetMigrating.future.joinInternal();
+        try {
+            trySetMigrating.future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw sneakyThrow(peel(e));
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -39,6 +39,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.executionservice.TaskScheduler;
 
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -56,6 +57,7 @@ import static com.hazelcast.internal.metrics.MetricDescriptorConstants.EXECUTOR_
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.EXECUTOR_PREFIX_INTERNAL;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.EXECUTOR_PREFIX_SCHEDULED_INTERNAL;
 import static com.hazelcast.internal.metrics.MetricTarget.MANAGEMENT_CENTER;
+import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.ThreadUtil.createThreadPoolName;
 import static java.lang.Thread.currentThread;
 
@@ -316,34 +318,47 @@ public final class ExecutionServiceImpl implements ExecutionService {
     public void shutdown() {
         logger.finest("Stopping executors...");
         scheduledExecutorService.notifyShutdownInitiated();
-        for (ExecutorService executorService : executors.values()) {
-            executorService.shutdown();
-        }
-        for (ExecutorService executorService : durableExecutors.values()) {
-            executorService.shutdown();
-        }
-        for (ExecutorService executorService : scheduleDurableExecutors.values()) {
-            executorService.shutdown();
-        }
+
+        shutdown(executors);
+        shutdown(durableExecutors);
+        shutdown(scheduleDurableExecutors);
         scheduledExecutorService.shutdownNow();
         cachedExecutorService.shutdown();
-        try {
-            scheduledExecutorService.awaitTermination(AWAIT_TIME, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            currentThread().interrupt();
-            logger.finest(e);
+
+        awaitAndForceShutdown(executors);
+        awaitAndForceShutdown(scheduledExecutorService);
+        awaitAndForceShutdown(cachedExecutorService);
+
+        executors.clear();
+        durableExecutors.clear();
+        scheduleDurableExecutors.clear();
+    }
+
+    private void shutdown(Map<?, ? extends ExecutorService> executorServiceMap) {
+        for (ExecutorService executorService : executorServiceMap.values()) {
+            executorService.shutdown();
         }
+    }
+
+    private void awaitAndForceShutdown(Map<?, ? extends ExecutorService> executorServiceMap) {
+        for (ExecutorService executorService : executorServiceMap.values()) {
+            awaitAndForceShutdown(executorService);
+        }
+    }
+
+    private void awaitAndForceShutdown(ExecutorService executorService) {
         try {
-            if (!cachedExecutorService.awaitTermination(AWAIT_TIME, TimeUnit.SECONDS)) {
-                cachedExecutorService.shutdownNow();
+            // Some of our ExecutorService implementations (such as CachedExecutorServiceDelegate) do not support
+            // the awaitTermination method. So we should handle the UnsupportedOperationException.
+            if (!executorService.awaitTermination(AWAIT_TIME, TimeUnit.MILLISECONDS)) {
+                executorService.shutdownNow();
             }
         } catch (InterruptedException e) {
             currentThread().interrupt();
             logger.finest(e);
+        } catch (UnsupportedOperationException e) {
+            ignore(e);
         }
-        executors.clear();
-        durableExecutors.clear();
-        scheduleDurableExecutors.clear();
     }
 
     @Override

--- a/hazelcast/src/test/java/classloading/ThreadLeakTest.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTest.java
@@ -18,6 +18,10 @@ package classloading;
 
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -27,10 +31,15 @@ import org.junit.runner.RunWith;
 
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 
 import static classloading.ThreadLeakTestUtils.assertHazelcastThreadShutdown;
 import static classloading.ThreadLeakTestUtils.getAndLogThreads;
 import static classloading.ThreadLeakTestUtils.getThreads;
+import static com.hazelcast.instance.impl.TestUtil.getNode;
+import static com.hazelcast.internal.util.ExceptionUtil.peel;
+import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.test.HazelcastTestSupport.assertJoinable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -81,5 +90,42 @@ public class ThreadLeakTest {
         assertNull("Expected to get null, but found running threads", runningThreads);
 
         assertHazelcastThreadShutdown(threads);
+    }
+
+    // Fixes https://github.com/hazelcast/hazelcast/issues/24484
+    @Test
+    public void testThreadLeakWithAsynExecutor() {
+        Set<Thread> oldThreads = getThreads();
+        HazelcastInstance hz = Hazelcast.newHazelcastInstance();
+
+        Node node = getNode(hz);
+        ExecutorService executorService =
+                node.getNodeEngine().getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR);
+
+        executorService.submit(
+                () -> {
+                    InternalCompletableFuture<String> future = new InternalCompletableFuture<>();
+                    PartitionSpecificRunnable task = new PartitionSpecificRunnable() {
+                        @Override
+                        public void run() {
+                            future.complete("X");
+                        }
+
+                        @Override
+                        public int getPartitionId() {
+                            return 0;
+                        }
+                    };
+
+                    hz.shutdown();
+                    node.getNodeEngine().getOperationService().execute(task);
+                    try {
+                        future.get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        throw sneakyThrow(peel(e));
+                    }
+                });
+
+        assertHazelcastThreadShutdown(oldThreads);
     }
 }


### PR DESCRIPTION
To prevent async-threads leaking:
- calling the `shutdownNow` for `executors`
- replace `Future#joinInternal` on `Future#get`

Fixes https://github.com/hazelcast/hazelcast/issues/24484
Backport of: https://github.com/hazelcast/hazelcast/pull/24528

(cherry picked from commit a1c8240187eccbfdcd9002b86bed9fbfaea69094)

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
