### PR TITLE
Do not delete Jet job snapshots prematurely with LosslessRestart enabled [HZ-2415] [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -845,6 +845,24 @@ public class JobCoordinationService {
         return true;
     }
 
+    boolean shouldScanJobs() {
+        if (!jobRepository.jobRecordsMapExists()) {
+            // It does not make sense to scan for jobs when the IMap does not exist.
+            //
+            // It is possible that master node does not see IMap when other members
+            // are going through after-hot-restart tasks. To avoid possible snapshot
+            // deletion we cannot scan for jobs in such case.
+            //
+            // The only drawback is that after job records IMap is somehow deleted,
+            // old snapshots will not be cleared until new a job is submitted.
+            // But that should usually not happen.
+            logger.fine("Not scanning jobs because job records IMap does not exist.");
+            return false;
+        }
+
+        return true;
+    }
+
     private CompletableFuture<Void> runWithJob(
             long jobId,
             @Nonnull Consumer<MasterContext> masterContextHandler,
@@ -1240,7 +1258,7 @@ public class JobCoordinationService {
             // explicit check for master because we don't want to use shorter delay on non-master nodes
             // it will be checked again in shouldStartJobs()
             if (isMaster()) {
-                if (shouldStartJobs()) {
+                if (shouldStartJobs() && shouldScanJobs()) {
                     doScanJobs();
                 } else {
                     // use a smaller delay when cluster is not in ready state

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -428,6 +428,18 @@ public class JobRepository {
      * Cleans up stale maps related to jobs
      */
     void cleanup(NodeEngine nodeEngine) {
+        if (!jobRecordsMapExists()) {
+            // It is possible that master node does not see IMap when other members
+            // are going through after-hot-restart tasks. To avoid possible snapshot
+            // deletion we cannot perform cleanup in such case.
+            //
+            // The only drawback is that after job records IMap is somehow deleted,
+            // old snapshots will not be cleared until new a job is submitted.
+            // But that should usually not happen.
+            logger.fine("Skipping job cleanup because job records IMap does not exist");
+            return;
+        }
+
         long start = System.nanoTime();
 
         cleanupMaps(nodeEngine);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -554,9 +554,12 @@ public class JobRepository {
         return jobRecordsMap().values();
     }
 
+    public boolean jobRecordsMapExists() {
+        return ((AbstractJetInstance) instance.getJet()).existsDistributedObject(SERVICE_NAME, JOB_RECORDS_MAP_NAME);
+    }
+
     private Map<Long, JobRecord> jobRecordsMap() {
-        if (jobRecords.remembered() != null ||
-                ((AbstractJetInstance) instance.getJet()).existsDistributedObject(SERVICE_NAME, JOB_RECORDS_MAP_NAME)) {
+        if (jobRecords.remembered() != null || jobRecordsMapExists()) {
             return jobRecords.get();
         }
         return Collections.emptyMap();

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -434,7 +434,7 @@ public class JobRepository {
             // deletion we cannot perform cleanup in such case.
             //
             // The only drawback is that after job records IMap is somehow deleted,
-            // old snapshots will not be cleared until new a job is submitted.
+            // old snapshots and resources will not be cleared until new a job is submitted.
             // But that should usually not happen.
             logger.fine("Skipping job cleanup because job records IMap does not exist");
             return;

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
@@ -110,6 +110,9 @@ public class JobRepositoryTest extends JetTestSupport {
 
     @Test
     public void when_onlyJobResourcesExist_then_jobResourcesClearedAfterExpiration() {
+        // ensure that job records IMap exists - prerequisite for cleanup
+        assertNotNull(instance.getMap(JobRepository.JOB_RECORDS_MAP_NAME));
+
         long jobId = uploadResourcesForNewJob();
 
         sleepUntilJobExpires();


### PR DESCRIPTION
Fixes HZ-2415
Backport of: #24489
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6024
