### PR TITLE
Verify JoinOperation can shutdown [HZ-2429]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.internal.cluster;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Cluster;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.cluster.MemberSelector;
 import com.hazelcast.cluster.impl.MemberImpl;
-import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.services.CoreService;
 
 import javax.annotation.Nonnull;
@@ -103,6 +103,15 @@ public interface ClusterService extends CoreService, Cluster {
      * @return {@code true} if this member is joined to a cluster, {@code false} otherwise
      */
     boolean isJoined();
+
+    /**
+     * Returns whether this member joined to a cluster before. If a member
+     * joins a cluster and then split brain resets the join state, still true
+     * will be returned.
+     *
+     * @return {@code true} if this member is joined to a cluster before, {@code false} otherwise
+     */
+    boolean isJoinedBefore();
 
     /**
      * Gets the address of this member.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -75,6 +75,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -119,6 +120,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     private final ReentrantLock clusterServiceLock = new ReentrantLock();
     private final AtomicReference<JoinHolder> joined =
             new AtomicReference<>(new JoinHolder(false));
+    private final AtomicBoolean joinedBefore = new AtomicBoolean();
 
     private volatile UUID clusterId;
     private volatile Address masterAddress;
@@ -686,11 +688,17 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     void setJoined(boolean val) {
         assert clusterServiceLock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         joined.getAndUpdate(holder -> new JoinHolder(val)).latch.countDown();
+        joinedBefore.compareAndSet(false, val);
     }
 
     @Override
     public boolean isJoined() {
         return joined.get().isJoined;
+    }
+
+    @Override
+    public boolean isJoinedBefore() {
+        return joinedBefore.get();
     }
 
     @Probe(name = CLUSTER_METRIC_CLUSTER_SERVICE_SIZE)

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AuthenticationFailureOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AuthenticationFailureOp.java
@@ -30,6 +30,7 @@ public class AuthenticationFailureOp extends AbstractClusterOperation {
     public void run() {
         final NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         final Node node = nodeEngine.getNode();
+        JoinOperation.verifyCanShutdown(node, "Authentication failed on master node!");
         final ILogger logger = nodeEngine.getLogger("com.hazelcast.security");
         logger.severe("Node could not join cluster. Authentication failed on master node! Node is going to shutdown now!");
         node.shutdown(true);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/BeforeJoinCheckFailureOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/BeforeJoinCheckFailureOp.java
@@ -50,10 +50,7 @@ public class BeforeJoinCheckFailureOp extends AbstractClusterOperation {
     public void run() {
         final NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         final Node node = nodeEngine.getNode();
-        if (node.getClusterService().isJoined()) {
-            throw new IllegalStateException("Node is already joined but received a termination message! "
-                + "Reason: " + failReasonMsg);
-        }
+        JoinOperation.verifyCanShutdown(node, failReasonMsg);
 
         final ILogger logger = nodeEngine.getLogger("com.hazelcast.security");
         logger.severe("Node could not join cluster. Before join check failed node is going to shutdown now!");

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
@@ -62,11 +62,7 @@ public class ConfigMismatchOp extends AbstractClusterOperation {
 
         // Ignore shutdown requests if we are already in a cluster, as being
         // part of a cluster means our config was already verified & accepted
-        if (node.getClusterService().isJoined()) {
-            logger.warning("Received ConfigMismatchOp when already joined with a cluster. "
-                    + "This node will not shutdown. Configuration mismatch: " + msg);
-            return;
-        }
+        JoinOperation.verifyCanShutdown(node, msg);
 
         logger.severe("Node could not join cluster. A Configuration mismatch was detected: "
                 + msg + " Node is going to shutdown now!");

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
@@ -126,6 +126,7 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         if (deserializationFailure != null) {
             getLogger().severe("Node could not join cluster.", deserializationFailure);
             Node node = clusterService.getNodeEngine().getNode();
+            JoinOperation.verifyCanShutdown(node, deserializationFailure.getMessage());
             node.shutdown(true);
             throw ExceptionUtil.rethrow(deserializationFailure);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinOperation.java
@@ -16,12 +16,36 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
+import com.hazelcast.instance.impl.Node;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.spi.impl.operationservice.UrgentSystemOperation;
 
 /**
  * Marker interface for join and post-join operations.
  */
 public interface JoinOperation extends UrgentSystemOperation, AllowedDuringPassiveState, IdentifiedDataSerializable {
+
+    /**
+     * Join operations are not authenticated. This means that if any join
+     * operation includes node shutdown, a third party can just send that
+     * operation to any member and shutdown the node. To prevent this we only
+     * allow shutdown if the node isn't joined to the cluster. Furthermore, we
+     * don't allow shutdown if a member is joined before. This is to prevent
+     * vulnerabilities during split brain.
+     *
+     * @param node   node to shutdown
+     * @param reason reason of the shutdown request
+     * @throws IllegalStateException if the node is joined before
+     * @see ShutdownNodeOp
+     */
+    static void verifyCanShutdown(Node node, String reason) {
+        if (node.getClusterService().isJoined()) {
+            throw new IllegalStateException(
+                    "Node is already joined but received a termination message! Reason: " + reason);
+        } else if (node.getClusterService().isJoinedBefore()) {
+            throw new IllegalStateException(
+                    "Node is already joined before but received a termination message! Reason: " + reason);
+        }
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/operations/JoinShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/operations/JoinShutdownTest.java
@@ -1,0 +1,169 @@
+package com.hazelcast.internal.cluster.impl.operations;
+
+import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.cluster.impl.ClusterClockImpl;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.ClusterStateManager;
+import com.hazelcast.internal.nio.Packet;
+import com.hazelcast.internal.nio.PacketIOHelper;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.impl.operationservice.OperationAccessor;
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.Collections;
+
+import static com.hazelcast.instance.impl.TestUtil.getNode;
+import static com.hazelcast.instance.impl.TestUtil.toData;
+import static org.jgroups.util.Util.assertTrue;
+
+@RunWith(HazelcastParametrizedRunner.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+// Quick test -> NightlyTest before merge.
+// We don't need this test in PR builder IMO.
+@Category(QuickTest.class)
+public class JoinShutdownTest extends HazelcastTestSupport {
+
+    private HazelcastInstance hz;
+
+    @Parameter
+    public boolean joinedBefore;
+
+    @Parameters(name = "joinedBefore:{0}")
+    public static Object[] data() {
+        return new Object[]{false, true};
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        hz = Hazelcast.newHazelcastInstance();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        hz.shutdown();
+    }
+
+    @Test
+    public void joinedMemberShouldNotShutdown_whenFinalizeJoinOp() throws Exception {
+        assertTrueEventually(() -> getNode(hz).getClusterService().isJoined());
+
+        Node node = getNode(hz);
+        ClusterServiceImpl clusterService = node.getClusterService();
+        ClusterClockImpl clusterClock = clusterService.getClusterClock();
+        ClusterStateManager clusterStateManager = clusterService.getClusterStateManager();
+        MemberImpl member = clusterService.getLocalMember();
+        Operation op = new FinalizeJoinOp(
+                member.getUuid(),
+                clusterService.getMembershipManager().getMembersView(),
+                new OnJoinOp(Collections.emptyList()),
+                new OnJoinOp(Collections.emptyList()),
+                clusterClock.getClusterTime(),
+                clusterService.getClusterId(),
+                clusterClock.getClusterStartTime(),
+                clusterStateManager.getState(),
+                clusterService.getClusterVersion(),
+                node.getPartitionService().createPartitionState(),
+                false,
+                node.getClusterTopologyIntent()
+        );
+        OperationAccessor.setCallId(op, 1);
+
+        ByteBuffer buffer = toBuffer(op);
+        int position = buffer.position();
+        buffer.position(286);
+        buffer.putInt(42_000_000);
+        buffer.position(position);
+        buffer.flip();
+
+        if (joinedBefore) {
+            node.getClusterService().resetJoinState();
+        }
+        send(buffer);
+        assertTrue(hz.getLifecycleService().isRunning());
+    }
+
+    @Test
+    public void joinedMemberShouldNotShutdown_whenConfigMismatchOp() throws Exception {
+        assertTrueEventually(() -> getNode(hz).getClusterService().isJoined());
+        if (joinedBefore) {
+            getNode(hz).getClusterService().resetJoinState();
+        }
+        send(new ConfigMismatchOp("Random reason"));
+        assertTrue(hz.getLifecycleService().isRunning());
+    }
+
+    @Test
+    public void joinedMemberShouldNotShutdown_whenBeforeJoinCheckFailureOp() throws Exception {
+        assertTrueEventually(() -> getNode(hz).getClusterService().isJoined());
+        if (joinedBefore) {
+            getNode(hz).getClusterService().resetJoinState();
+        }
+        send(new BeforeJoinCheckFailureOp("Random reason"));
+        assertTrue(hz.getLifecycleService().isRunning());
+    }
+
+    @Test
+    public void joinedMemberShouldNotShutdown_whenAuthenticationFailureOp() throws Exception {
+        assertTrueEventually(() -> getNode(hz).getClusterService().isJoined());
+        if (joinedBefore) {
+            getNode(hz).getClusterService().resetJoinState();
+        }
+        send(new AuthenticationFailureOp());
+        assertTrue(hz.getLifecycleService().isRunning());
+    }
+
+    private static void send(Operation operation) throws Exception {
+        send((ByteBuffer) toBuffer(operation).flip());
+    }
+
+    private static void send(ByteBuffer buffer) throws Exception {
+        // send bytebuffer
+        try (SocketChannel socketChannel = SocketChannel.open()) {
+            socketChannel.connect(new InetSocketAddress("127.0.0.1", 5701));
+            while (buffer.hasRemaining()) {
+                socketChannel.write(buffer);
+            }
+        }
+
+        // sleep for member to process the operation
+        Thread.sleep(100);
+    }
+
+    private static ByteBuffer toBuffer(Operation operation) {
+        // op -> packet
+        Data data = toData(operation);
+        Packet packet = new Packet(data.toByteArray());
+        packet.setPacketType(Packet.Type.OPERATION);
+
+        //packet -> bytebuffer
+        ByteBuffer buffer = ByteBuffer.allocate(packet.getFrameLength() + 3);
+        buffer.put("HZC".getBytes());
+        PacketIOHelper packetIOHelper = new PacketIOHelper();
+        packetIOHelper.writeTo(packet, buffer);
+        return buffer;
+    }
+
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfigWithoutJetAndMetrics();
+    }
+}


### PR DESCRIPTION
`JoinOperation`s are not authenticated. So if they do a node shutdown,
a 3rd party can easily shutdown the node. To prevent this, we do not
allow shutting down the node if it ever joined a cluster.

`WanOperation`s are also susceptible to this but I couldn't find any
shutdown there.

ShutdownNodeOp also does a shutdown and JoinOperation. But I can't
disallow shutting down there because that operation needs to shutdown
the node even if the node is joined. It requires a passive cluster
state, so maybe it's a lesser problem than the other operations.

Fixes https://hazelcast.atlassian.net/browse/HZ-2429
