### PR TITLE
Serialize DAG for non-reusable processor meta-suppliers [HZ-1934] [5.2.z]

### DIFF
--- a/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplier.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplier.java
@@ -139,4 +139,8 @@ public class ElasticSourcePMetaSupplier<T> implements ProcessorMetaSupplier {
         }
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplier.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplier.java
@@ -139,4 +139,8 @@ public class ElasticSourcePMetaSupplier<T> implements ProcessorMetaSupplier {
         }
     }
 
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
 }

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHadoopNewApiP.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHadoopNewApiP.java
@@ -227,6 +227,11 @@ public final class ReadHadoopNewApiP<K, V, R> extends AbstractProcessor {
         public Permission getRequiredPermission() {
             return permission;
         }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return true;
+        }
     }
 
     private static final class Supplier<K, V, R> implements ProcessorSupplier {

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHadoopOldApiP.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHadoopOldApiP.java
@@ -147,6 +147,11 @@ public final class ReadHadoopOldApiP<K, V, R> extends AbstractProcessor {
         public FileTraverser<R> traverser() throws Exception {
             return new HadoopFileTraverser<>(jobConf, asList(getSplits(jobConf, 1)), projectionFn);
         }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return true;
+        }
     }
 
     private static final class Supplier<K, V, R> implements ProcessorSupplier {

--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/KinesisSourcePMetaSupplier.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/source/KinesisSourcePMetaSupplier.java
@@ -113,4 +113,14 @@ public class KinesisSourcePMetaSupplier<T> implements ProcessorMetaSupplier {
         }
         return addressRanges;
     }
+
+    @Override
+    public boolean initIsCooperative() {
+        return true;
+    }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
+    }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinByEquiJoinProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/JoinByEquiJoinProcessorSupplier.java
@@ -267,6 +267,16 @@ final class JoinByEquiJoinProcessorSupplier implements ProcessorSupplier, DataSe
         }
 
         @Override
+        public boolean initIsCooperative() {
+            return true;
+        }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return true;
+        }
+
+        @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeObject(joinInfo);
             out.writeObject(mapName);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlStatefulDagTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlStatefulDagTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static java.util.Arrays.asList;
+
+public class SqlStatefulDagTest extends SqlTestSupport {
+    private static MiniDFSCluster cluster;
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        assumeThatNoWindowsOS();
+        assumeHadoopSupportsIbmPlatform();
+
+        initialize(1, null);
+
+        File directory = Files.createTempDirectory("sql-test-hdfs").toFile().getAbsoluteFile();
+        directory.deleteOnExit();
+
+        Configuration configuration = new Configuration();
+        configuration.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, directory.getAbsolutePath());
+        cluster = new MiniDFSCluster.Builder(configuration).build();
+        cluster.waitClusterUp();
+    }
+
+    @Test
+    public void testReadHadoop() throws IOException {
+        store("/csv/file.csv", "id,name\n1,Alice\n2,Bob");
+
+        String name = randomName();
+        instance().getSql().execute(
+                "CREATE MAPPING " + name + " (id INT, name VARCHAR) " +
+                "TYPE File " +
+                "OPTIONS (" +
+                "  'format' = 'csv'," +
+                "  'path' = '" + cluster.getFileSystem().getUri() + "/csv'" +
+                ");");
+
+        for (int i = 0; i < 2; i++) {
+            assertRowsAnyOrder("SELECT * FROM " + name, asList(
+                    new Row(1, "Alice"),
+                    new Row(2, "Bob")));
+        }
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        if (cluster != null) {
+            cluster.shutdown();
+        }
+    }
+
+    private static void store(String path, String content) throws IOException {
+        try (FSDataOutputStream output = cluster.getFileSystem().create(new Path(path))) {
+            output.writeBytes(content);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/DAG.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/DAG.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -291,6 +292,16 @@ public class DAG implements IdentifiedDataSerializable, Iterable<Vertex> {
     @Nullable
     public Vertex getVertex(@Nonnull String vertexName) {
         return nameToVertex.get(vertexName);
+    }
+
+    /**
+     * Returns a copy of the DAG's vertices. Adding a vertex to or removing a
+     * vertex from the returned {@link Set} will not be reflected in the DAG,
+     * and vice-versa.
+     */
+    @Nonnull
+    public Set<Vertex> vertices() {
+        return new HashSet<>(verticesByIdentity);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
@@ -54,16 +54,18 @@ import static com.hazelcast.jet.impl.util.Util.arrayIndexOf;
 import static java.util.Collections.singletonList;
 
 /**
- * Factory of {@link ProcessorSupplier} instances. The starting point of
- * the chain leading to the eventual creation of {@code Processor} instances
- * on each cluster member:
+ * Factory of {@link ProcessorSupplier} instances. The starting point of the
+ * chain leading to the eventual creation of {@link Processor} instances on
+ * each cluster member:
  * <ol><li>
- * client creates {@code ProcessorMetaSupplier} as a part of the DAG;
+ * client or member creates {@code ProcessorMetaSupplier} as a part of the DAG;
  * </li><li>
- * serializes it and sends to a cluster member;
+ * client or member sends it to the job coordinator (if the member is job coordinator
+ * and the DAG consists of {@linkplain #isReusable reusable} {@code
+ * ProcessorMetaSupplier}s, the serialization may be skipped);
  * </li><li>
- * the member deserializes and uses it to create one {@code ProcessorSupplier}
- * for each cluster member;
+ * the job coordinator uses it to create one {@code
+ * ProcessorSupplier} for each cluster member;
  * </li><li>
  * serializes each {@code ProcessorSupplier} and sends it to its target member;
  * </li><li>
@@ -71,11 +73,11 @@ import static java.util.Collections.singletonList;
  * of {@code Processor} as requested by the <em>parallelism</em> property on
  * the corresponding {@code Vertex}.
  * </li></ol>
- * Before being asked to create {@code ProcessorSupplier}s this meta-supplier will
- * be given access to the Hazelcast instance and, in particular, its cluster topology
- * and partitioning services. It can use the information from these services to
- * precisely parameterize each {@code Processor} instance that will be created on
- * each member.
+ * Before being asked to create {@code ProcessorSupplier}s this meta-supplier
+ * will be given access to the Hazelcast instance and, in particular, its
+ * cluster topology and partitioning services. It can use the information from
+ * these services to precisely parameterize each {@code Processor} instance
+ * that will be created on each member.
  *
  * @since Jet 3.0
  */
@@ -113,10 +115,11 @@ public interface ProcessorMetaSupplier extends Serializable {
     }
 
     /**
-     * Called on the cluster member that receives the client request, after
-     * deserializing the meta-supplier instance. Gives access to the Hazelcast
-     * instance's services and provides the parallelism parameters determined
-     * from the cluster size.
+     * Called on the cluster member that receives the job request. Gives access
+     * to the Hazelcast instance's services and provides the parallelism
+     * parameters determined from the cluster size.
+     *
+     * @see #isReusable()
      */
     default void init(@Nonnull Context context) throws Exception {
     }
@@ -142,6 +145,8 @@ public interface ProcessorMetaSupplier extends Serializable {
      * The method will be called once per job execution on the job's
      * <em>coordinator</em> member. {@code init()} will have already
      * been called.
+     *
+     * @see #isReusable()
      */
     @Nonnull
     Function<? super Address, ? extends ProcessorSupplier> get(@Nonnull List<Address> addresses);
@@ -178,8 +183,52 @@ public interface ProcessorMetaSupplier extends Serializable {
      *              Note that it might not be the actual error that caused the job
      *              to fail - it can be several other exceptions. We only guarantee
      *              that it's non-null if the job didn't complete successfully.
+     * @see #isReusable()
      */
     default void close(@Nullable Throwable error) throws Exception {
+    }
+
+    /**
+     * Returns {@code true} if the same instance can be reused in different job
+     * executions or in different vertices. In that case, {@link #init}, {@link
+     * #get} and {@link #close} methods must be thread-safe and obey additional
+     * conditions defined below.
+     * <p>
+     * When a job is submitted from a client, the job definition is serialized,
+     * so the job coordinator will receive a different copy of processor
+     * meta-suppliers even if they are used multiple times within the same DAG,
+     * or across different DAGs, or submitted through different jobs. While this
+     * serialization mechanism ensures that processor meta-supplier instances do
+     * not share any internal state, it is unnecessary —and avoided— for jobs
+     * consisting of reusable meta-suppliers and submitted from the job
+     * coordinator —which is always the case for member-originated light jobs.
+     * <p>
+     * Non-reusable meta-suppliers <em>(default)</em> have a simple order of
+     * method executions: {@link #init} (once), {@link #get} (at most once after
+     * {@link #init}, {@link #close} (last).
+     * <p>
+     * Reusable meta-suppliers differ because the meta supplier instance may be
+     * shared and reused. That is why: <ol>
+     * <li> {@link #init} can be invoked multiple times (also after
+     *      {@link #close}).
+     * <li> {@link #get} can be invoked multiple times, but each {@link #get}
+     *      invocation will be preceded by {@link #init} invocation for given
+     *      job execution.
+     * <li> {@link #close} can be invoked multiple times with or without
+     *      preceding invocations of the other methods.
+     * <li> Meta-supplier method invocation sequences for different concurrent
+     *      job executions may be interleaved.
+     * </ol>
+     * It is recommended that reusable meta-supplier does not have any mutable
+     * state that is changed by any of the methods. It is, however, allowed to
+     * initialize some thread-safe constant fields in {@link #init} method, for
+     * example, save some constant data from {@link Context} for further usage.
+     * Note, however, that cluster topology may change and should not be stored.
+     *
+     * @since 5.3
+     */
+    default boolean isReusable() {
+        return false;
     }
 
     /**
@@ -282,6 +331,21 @@ public interface ProcessorMetaSupplier extends Serializable {
             @Nonnull @Override
             public Function<? super Address, ? extends ProcessorSupplier> get(@Nonnull List<Address> addresses) {
                 return addressToSupplier;
+            }
+
+            @Override
+            public boolean isReusable() {
+                return true;
+            }
+
+            @Override
+            public boolean initIsCooperative() {
+                return true;
+            }
+
+            @Override
+            public boolean closeIsCooperative() {
+                return true;
             }
         };
     }
@@ -440,6 +504,16 @@ public interface ProcessorMetaSupplier extends Serializable {
             public Permission getRequiredPermission() {
                 return permission;
             }
+
+            @Override
+            public boolean initIsCooperative() {
+                return true;
+            }
+
+            @Override
+            public boolean closeIsCooperative() {
+                return true;
+            }
         };
     }
 
@@ -510,6 +584,21 @@ public interface ProcessorMetaSupplier extends Serializable {
         @Override
         public int preferredLocalParallelism() {
             return 1;
+        }
+
+        @Override
+        public boolean isReusable() {
+            return true;
+        }
+
+        @Override
+        public boolean initIsCooperative() {
+            return true;
+        }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return true;
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
@@ -173,6 +173,7 @@ public final class HazelcastWriters {
                 new WriteListPSupplier<>(clientXml, name));
     }
 
+    @SuppressWarnings("AnonInnerLength")
     public static ProcessorMetaSupplier writeObservableSupplier(@Nonnull String name) {
         return new ProcessorMetaSupplier() {
             @Nonnull
@@ -194,6 +195,21 @@ public final class HazelcastWriters {
             @Override
             public Permission getRequiredPermission() {
                 return new RingBufferPermission(name, ACTION_CREATE, ACTION_PUT);
+            }
+
+            @Override
+            public boolean isReusable() {
+                return true;
+            }
+
+            @Override
+            public boolean initIsCooperative() {
+                return true;
+            }
+
+            @Override
+            public boolean closeIsCooperative() {
+                return true;
             }
         };
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
@@ -192,6 +192,21 @@ public final class ReadFilesP<T> extends AbstractProcessor {
         public Permission getRequiredPermission() {
             return ConnectorPermission.file(directory, ACTION_READ);
         }
+
+        @Override
+        public boolean isReusable() {
+            return true;
+        }
+
+        @Override
+        public boolean initIsCooperative() {
+            return true;
+        }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return true;
+        }
     }
 
     private static final class LocalFileTraverser<T> implements FileTraverser<T> {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
@@ -286,6 +286,21 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
 
         @Override
         public abstract Permission getRequiredPermission();
+
+        @Override
+        public boolean isReusable() {
+            return true;
+        }
+
+        @Override
+        public boolean initIsCooperative() {
+            return true;
+        }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return true;
+        }
     }
 
     public static final class LocalProcessorSupplier<F extends CompletableFuture, B, R> implements ProcessorSupplier,

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
@@ -427,6 +427,16 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
             }
             return permissionFn.get();
         }
+
+        @Override
+        public boolean initIsCooperative() {
+            return clientXml == null;
+        }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return true;
+        }
     }
 
     private static class ClusterProcessorSupplier<E, T> implements ProcessorSupplier {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/MetaSupplierFromProcessorSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/MetaSupplierFromProcessorSupplier.java
@@ -58,16 +58,6 @@ public class MetaSupplierFromProcessorSupplier implements ProcessorMetaSupplier,
     }
 
     @Override
-    public boolean initIsCooperative() {
-        return true;
-    }
-
-    @Override
-    public boolean closeIsCooperative() {
-        return true;
-    }
-
-    @Override
     public int preferredLocalParallelism() {
         return preferredLocalParallelism;
     }
@@ -75,6 +65,26 @@ public class MetaSupplierFromProcessorSupplier implements ProcessorMetaSupplier,
     @Nonnull @Override
     public Function<? super Address, ? extends ProcessorSupplier> get(@Nonnull List<Address> addresses) {
         return address -> processorSupplier;
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return permission;
+    }
+
+    @Override
+    public boolean isReusable() {
+        return true;
+    }
+
+    @Override
+    public boolean initIsCooperative() {
+        return true;
+    }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return true;
     }
 
     @Override
@@ -89,10 +99,5 @@ public class MetaSupplierFromProcessorSupplier implements ProcessorMetaSupplier,
         preferredLocalParallelism = in.readInt();
         processorSupplier = in.readObject();
         permission = in.readObject();
-    }
-
-    @Override
-    public Permission getRequiredPermission() {
-        return permission;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplier.java
@@ -27,6 +27,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.security.Permission;
 import java.util.List;
@@ -65,11 +66,6 @@ public final class WrappingProcessorMetaSupplier implements ProcessorMetaSupplie
     }
 
     @Override
-    public boolean initIsCooperative() {
-        return wrapped.initIsCooperative();
-    }
-
-    @Override
     public void init(@Nonnull Context context) throws Exception {
         wrapped.init(context);
     }
@@ -81,18 +77,28 @@ public final class WrappingProcessorMetaSupplier implements ProcessorMetaSupplie
     }
 
     @Override
-    public boolean closeIsCooperative() {
-        return wrapped.closeIsCooperative();
-    }
-
-    @Override
-    public void close(Throwable error) throws Exception {
+    public void close(@Nullable Throwable error) throws Exception {
         wrapped.close(error);
     }
 
     @Override
     public Permission getRequiredPermission() {
         return wrapped.getRequiredPermission();
+    }
+
+    @Override
+    public boolean isReusable() {
+        return wrapped.isReusable();
+    }
+
+    @Override
+    public boolean initIsCooperative() {
+        return wrapped.initIsCooperative();
+    }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return wrapped.closeIsCooperative();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/jet/TestContextSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/TestContextSupport.java
@@ -31,6 +31,7 @@ import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -74,6 +75,26 @@ public final class TestContextSupport {
         @Override
         public void init(@Nonnull Context context) throws Exception {
             delegate.init(context);
+        }
+
+        @Override
+        public void close(@Nullable Throwable error) throws Exception {
+            delegate.close(error);
+        }
+
+        @Override
+        public boolean isReusable() {
+            return delegate.isReusable();
+        }
+
+        @Override
+        public boolean initIsCooperative() {
+            return delegate.initIsCooperative();
+        }
+
+        @Override
+        public boolean closeIsCooperative() {
+            return delegate.closeIsCooperative();
         }
     }
 


### PR DESCRIPTION
When a job is to be submitted, the job definition is serialized. [This serialization is avoided for local jobs][1] since the local member is the job coordinator. However, if the DAG is not reusable, i.e. it has non-reusable processor meta-suppliers, this optimization should be suppressed, i.e. the DAG must be serialized.

Backports #23723

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@since` tags in Javadoc

[1]: https://github.com/hazelcast/hazelcast/pull/21006