### PR TITLE
Cleanup code for rolling upgrade compatibility

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/view/View.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/view/View.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.sql.impl.schema.view;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.jet.sql.impl.parse.SqlCreateView;
 import com.hazelcast.nio.ObjectDataInput;
@@ -77,9 +76,6 @@ public class View implements Versioned, SqlCatalogObject {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeString(name);
         out.writeString(query);
-        if (out.getVersion().isLessThan(Versions.V5_2)) {
-            out.writeBoolean(false);
-        }
         SerializationUtil.writeList(viewColumnNames, out);
         SerializationUtil.writeList(viewColumnTypes, out);
     }
@@ -88,9 +84,6 @@ public class View implements Versioned, SqlCatalogObject {
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readString();
         query = in.readString();
-        if (in.getVersion().isLessThan(Versions.V5_2)) {
-            in.readBoolean();
-        }
         viewColumnNames = SerializationUtil.readList(in);
         viewColumnTypes = SerializationUtil.readList(in);
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/IndexConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/IndexConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -257,11 +256,7 @@ public class IndexConfig implements IdentifiedDataSerializable, Versioned {
         out.writeInt(type.getId());
         writeNullableList(attributes, out);
         out.writeObject(bitmapIndexOptions);
-
-        // RU_COMPAT 5.1
-        if (out.getVersion().isGreaterOrEqual(Versions.V5_2)) {
-            out.writeObject(bTreeIndexConfig);
-        }
+        out.writeObject(bTreeIndexConfig);
     }
 
     @Override
@@ -270,11 +265,7 @@ public class IndexConfig implements IdentifiedDataSerializable, Versioned {
         type = IndexType.getById(in.readInt());
         attributes = readNullableList(in);
         bitmapIndexOptions = in.readObject();
-
-        // RU_COMPAT 5.1
-        if (in.getVersion().isGreaterOrEqual(Versions.V5_2)) {
-            bTreeIndexConfig = in.readObject();
-        }
+        bTreeIndexConfig = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
 import com.hazelcast.map.MapStore;
 import com.hazelcast.nio.ObjectDataInput;
@@ -438,10 +437,7 @@ public class MapStoreConfig implements IdentifiedDataSerializable, Versioned {
         out.writeObject(factoryImplementation);
         out.writeObject(properties);
         out.writeString(initialLoadMode.name());
-
-        if (out.getVersion().isGreaterOrEqual(Versions.V5_2)) {
-            out.writeBoolean(offload);
-        }
+        out.writeBoolean(offload);
     }
 
     @Override
@@ -456,10 +452,6 @@ public class MapStoreConfig implements IdentifiedDataSerializable, Versioned {
         factoryImplementation = in.readObject();
         properties = in.readObject();
         initialLoadMode = InitialLoadMode.valueOf(in.readString());
-
-        if (in.getVersion().isGreaterOrEqual(Versions.V5_2)) {
-            offload = in.readBoolean();
-        }
-
+        offload = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -68,7 +68,6 @@ import com.hazelcast.cp.internal.raftop.metadata.RaftServicePreJoinOp;
 import com.hazelcast.cp.internal.raftop.metadata.RemoveCPMemberOp;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.cluster.MemberInfo;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.diagnostics.MetricsPlugin;
 import com.hazelcast.internal.metrics.DynamicMetricsProvider;
 import com.hazelcast.internal.metrics.MetricDescriptor;
@@ -596,9 +595,6 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
 
     private void publishGroupAvailabilityEvents(MemberImpl removedMember) {
         ClusterService clusterService = nodeEngine.getClusterService();
-        if (clusterService.getClusterVersion().isUnknownOrLessThan(Versions.V4_1)) {
-            return;
-        }
 
         // since only the Metadata CP group members keep the CP groups,
         // they will be the ones that keep track of unreachable CP members.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -24,7 +24,6 @@ import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.version.MemberVersion;
 
 import javax.annotation.Nullable;
@@ -39,8 +38,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationUtil.readMa
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeMap;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 
-// RU_COMPAT 5.2 No need to implement Versioned after 5.3 release
-public class MemberInfo implements IdentifiedDataSerializable, Versioned {
+public class MemberInfo implements IdentifiedDataSerializable {
 
     private Address address;
     private UUID uuid;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Cluster;
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.operations.CommitClusterStateOp;
 import com.hazelcast.internal.cluster.impl.operations.LockClusterStateOp;
 import com.hazelcast.internal.cluster.impl.operations.RollbackClusterStateOp;
@@ -27,7 +26,6 @@ import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.transaction.impl.TargetAwareTransactionLogRecord;
 
@@ -40,7 +38,7 @@ import java.util.UUID;
  * @see ClusterState
  * @see Cluster#changeClusterState(ClusterState, com.hazelcast.transaction.TransactionOptions)
  */
-public class ClusterStateTransactionLogRecord implements TargetAwareTransactionLogRecord, Versioned {
+public class ClusterStateTransactionLogRecord implements TargetAwareTransactionLogRecord {
 
     ClusterStateChange stateChange;
     Address initiator;
@@ -105,11 +103,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         out.writeObject(target);
         UUIDSerializationUtil.writeUUID(out, txnId);
         out.writeLong(leaseTime);
-        if (out.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            out.writeLong(partitionStateStamp);
-        } else {
-            out.writeInt((int) partitionStateStamp);
-        }
+        out.writeLong(partitionStateStamp);
         out.writeBoolean(isTransient);
         out.writeInt(memberListVersion);
     }
@@ -121,11 +115,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         target = in.readObject();
         txnId = UUIDSerializationUtil.readUUID(in);
         leaseTime = in.readLong();
-        if (in.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            partitionStateStamp = in.readLong();
-        } else {
-            partitionStateStamp = in.readInt();
-        }
+        partitionStateStamp = in.readLong();
         isTransient = in.readBoolean();
         memberListVersion = in.readInt();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
@@ -41,10 +41,6 @@ import static java.util.Collections.unmodifiableSet;
 
 public class JoinRequest extends JoinMessage {
 
-    // RU_COMPAT 5.2
-    private static final String VERSION_5_3_0 = "5.3.0";
-    private static final MemberVersion CURRENT = MemberVersion.of(VERSION_5_3_0);
-
     private Credentials credentials;
     private int tryCount;
     private Map<String, String> attributes;
@@ -130,10 +126,7 @@ public class JoinRequest extends JoinMessage {
         this.excludedMemberUuids = unmodifiableSet(excludedMemberUuids);
         this.addresses = readMap(in);
         cpMemberUUID = UUIDSerializationUtil.readUUID(in);
-        // RU_COMPAT 5.2
-        if (MemberVersion.MAJOR_MINOR_VERSION_COMPARATOR.compare(this.memberVersion, CURRENT) >= 0) {
-            preJoinOperation = in.readObject();
-        }
+        preJoinOperation = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.UUID;
 
-import static com.hazelcast.internal.cluster.Versions.V5_2;
 import static com.hazelcast.spi.impl.operationservice.OperationResponseHandlerFactory.createEmptyResponseHandler;
 
 /**
@@ -201,10 +200,7 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
         out.writeObject(preJoinOp);
         out.writeObject(postJoinOp);
         out.writeBoolean(deferPartitionProcessing);
-        // RU_COMPAT 5.1
-        if (clusterVersion.isGreaterOrEqual(V5_2)) {
-            out.writeByte(clusterTopologyIntent.getId());
-        }
+        out.writeByte(clusterTopologyIntent.getId());
     }
 
     @Override
@@ -223,11 +219,8 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
             return;
         }
         deferPartitionProcessing = in.readBoolean();
-        // RU_COMPAT 5.1
-        if (clusterVersion.isGreaterOrEqual(V5_2)) {
-            byte topologyIntentId = in.readByte();
-            clusterTopologyIntent = ClusterTopologyIntent.of(topologyIntentId);
-        }
+        byte topologyIntentId = in.readByte();
+        clusterTopologyIntent = ClusterTopologyIntent.of(topologyIntentId);
     }
 
     private OnJoinOp readOnJoinOp(ObjectDataInput in) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.internal.cluster.MemberInfo;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.internal.cluster.impl.ClusterHeartbeatManager;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
@@ -25,16 +24,14 @@ import com.hazelcast.internal.cluster.impl.MembersViewMetadata;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.UUID;
 
 /** A heartbeat sent from one cluster member to another. The sent timestamp is the cluster clock time of the sending member */
-public final class HeartbeatOp extends AbstractClusterOperation implements Versioned {
+public final class HeartbeatOp extends AbstractClusterOperation {
 
     private MembersViewMetadata senderMembersViewMetadata;
     private UUID targetUuid;
@@ -70,11 +67,9 @@ public final class HeartbeatOp extends AbstractClusterOperation implements Versi
         out.writeObject(senderMembersViewMetadata);
         UUIDSerializationUtil.writeUUID(out, targetUuid);
         out.writeLong(timestamp);
-        if (out.getVersion().isGreaterThan(Versions.V4_0)) {
-            out.writeInt(suspectedMembers.size());
-            for (MemberInfo m : suspectedMembers) {
-                out.writeObject(m);
-            }
+        out.writeInt(suspectedMembers.size());
+        for (MemberInfo m : suspectedMembers) {
+            out.writeObject(m);
         }
     }
 
@@ -84,15 +79,11 @@ public final class HeartbeatOp extends AbstractClusterOperation implements Versi
         senderMembersViewMetadata = in.readObject();
         targetUuid = UUIDSerializationUtil.readUUID(in);
         timestamp = in.readLong();
-        if (in.getVersion().isGreaterThan(Versions.V4_0)) {
-            int suspectedMemberCount = in.readInt();
-            suspectedMembers = new HashSet<>(suspectedMemberCount);
-            for (int i = 0; i < suspectedMemberCount; i++) {
-                MemberInfo m = in.readObject();
-                suspectedMembers.add(m);
-            }
-        } else {
-            suspectedMembers = Collections.emptySet();
+        int suspectedMemberCount = in.readInt();
+        suspectedMembers = new HashSet<>(suspectedMemberCount);
+        for (int i = 0; i < suspectedMemberCount; i++) {
+            MemberInfo m = in.readObject();
+            suspectedMembers.add(m);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.cluster.impl.operations;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ClusterStateChange;
@@ -28,7 +27,6 @@ import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.operationservice.ExceptionAction;
@@ -40,7 +38,7 @@ import java.io.IOException;
 import java.util.UUID;
 
 public class LockClusterStateOp  extends Operation implements AllowedDuringPassiveState, UrgentSystemOperation,
-        IdentifiedDataSerializable, Versioned {
+        IdentifiedDataSerializable {
 
     private ClusterStateChange stateChange;
     private Address initiator;
@@ -114,11 +112,7 @@ public class LockClusterStateOp  extends Operation implements AllowedDuringPassi
         out.writeObject(initiator);
         UUIDSerializationUtil.writeUUID(out, txnId);
         out.writeLong(leaseTime);
-        if (out.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            out.writeLong(partitionStateStamp);
-        } else {
-            out.writeInt((int) partitionStateStamp);
-        }
+        out.writeLong(partitionStateStamp);
         out.writeInt(memberListVersion);
     }
 
@@ -129,11 +123,7 @@ public class LockClusterStateOp  extends Operation implements AllowedDuringPassi
         initiator = in.readObject();
         txnId = UUIDSerializationUtil.readUUID(in);
         leaseTime = in.readLong();
-        if (in.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            partitionStateStamp = in.readLong();
-        } else {
-            partitionStateStamp = in.readInt();
-        }
+        partitionStateStamp = in.readLong();
         memberListVersion = in.readInt();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -556,10 +556,6 @@ public class ClusterWideConfigurationService implements
 
     @Override
     public void updateTcpIpConfigMemberList(List<String> memberList) {
-        if (version.isLessThan(V5_2)) {
-            throw new UnsupportedOperationException("TCP-IP member list update is not supported"
-                    + " for the cluster version less than 5.2");
-        }
         invokeOnStableClusterSerial(
                 nodeEngine,
                 () -> new UpdateTcpIpMemberListOperation(memberList), CONFIG_PUBLISH_MAX_ATTEMPT_COUNT

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalRecordStoreStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalRecordStoreStatsImpl.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.monitor.impl;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.monitor.LocalRecordStoreStats;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
@@ -121,12 +120,8 @@ public class LocalRecordStoreStatsImpl
         out.writeLong(hits);
         out.writeLong(lastAccessTime);
         out.writeLong(lastUpdateTime);
-
-        // RU_COMPAT 5.2
-        if (out.getVersion().isGreaterOrEqual(Versions.V5_3)) {
-            out.writeLong(evictionCount);
-            out.writeLong(expirationCount);
-        }
+        out.writeLong(evictionCount);
+        out.writeLong(expirationCount);
     }
 
     @Override
@@ -134,12 +129,8 @@ public class LocalRecordStoreStatsImpl
         hits = in.readLong();
         lastAccessTime = in.readLong();
         lastUpdateTime = in.readLong();
-
-        // RU_COMPAT 5.2
-        if (in.getVersion().isGreaterOrEqual(Versions.V5_3)) {
-            evictionCount = in.readLong();
-            expirationCount = in.readLong();
-        }
+        evictionCount = in.readLong();
+        expirationCount = in.readLong();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.partition.operation;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.MigrationInfo;
@@ -197,10 +196,6 @@ public class PromotionCommitOperation extends AbstractPartitionOperation impleme
     }
 
     private void filterAlreadyAppliedPromotions() {
-        if (getNodeEngine().getClusterService().getClusterVersion().isUnknownOrLessOrEqual(Versions.V4_0)) {
-            return;
-        }
-
         ILogger logger = getLogger();
         InternalPartitionServiceImpl partitionService = getService();
         PartitionStateManager stateManager = partitionService.getPartitionStateManager();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.partition.operation;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
@@ -58,8 +57,7 @@ public class ShutdownRequestOperation
                 if (logger.isFinestEnabled()) {
                     logger.finest("Received shutdown request from " + caller);
                 }
-                // RU_COMPAT 5.1
-                 if (isClusterVersionLessThanV52() || member.getUuid().equals(uuid)) {
+                 if (member.getUuid().equals(uuid)) {
                     partitionService.onShutdownRequest(member);
                 } else {
                     logger.warning("Ignoring shutdown request from " + uuid + " because it is not a member");
@@ -70,12 +68,6 @@ public class ShutdownRequestOperation
         } else {
             logger.warning("Received shutdown request from " + caller + " but this node is not master.");
         }
-    }
-
-    // RU_COMPAT 5.1
-    private boolean isClusterVersionLessThanV52() {
-        return getNodeEngine().getClusterService()
-                .getClusterVersion().isLessThan(Versions.V5_2);
     }
 
     @Override
@@ -96,20 +88,12 @@ public class ShutdownRequestOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-
-        // RU_COMPAT 5.1
-        if (out.getVersion().isGreaterThan(Versions.V5_1)) {
-            UUIDSerializationUtil.writeUUID(out, uuid);
-        }
+        UUIDSerializationUtil.writeUUID(out, uuid);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-
-        // RU_COMPAT 5.1
-        if (in.getVersion().isGreaterThan(Versions.V5_1)) {
-            uuid = UUIDSerializationUtil.readUUID(in);
-        }
+        uuid = UUIDSerializationUtil.readUUID(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.partition.operation;
 
 import com.hazelcast.cluster.Address;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
@@ -61,8 +60,7 @@ public class ShutdownResponseOperation
                 logger.finest("Received shutdown response from " + caller);
             }
 
-            if (isClusterVersionLessThanV52()
-                    || nodeEngine.getLocalMember().getUuid().equals(uuid)) {
+            if (nodeEngine.getLocalMember().getUuid().equals(uuid)) {
                 partitionService.onShutdownResponse();
             } else {
                 logger.warning("Ignoring shutdown response for " + uuid + " since it's not the expected member");
@@ -70,12 +68,6 @@ public class ShutdownResponseOperation
         } else {
             logger.warning("Received shutdown response from " + caller + " but it's not the known master");
         }
-    }
-
-    // RU_COMPAT 5.1
-    private boolean isClusterVersionLessThanV52() {
-        return getNodeEngine().getClusterService()
-                .getClusterVersion().isLessThan(Versions.V5_2);
     }
 
     @Override
@@ -96,20 +88,12 @@ public class ShutdownResponseOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-
-        // RU_COMPAT 5.1
-        if (out.getVersion().isGreaterThan(Versions.V5_1)) {
-            UUIDSerializationUtil.writeUUID(out, uuid);
-        }
+        UUIDSerializationUtil.writeUUID(out, uuid);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-
-        // RU_COMPAT 5.1
-        if (in.getVersion().isGreaterThan(Versions.V5_1)) {
-            uuid = UUIDSerializationUtil.readUUID(in);
-        }
+        uuid = UUIDSerializationUtil.readUUID(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.locksupport.LockWaitNotifyKey;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.Data;
@@ -163,11 +162,7 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
         out.writeLong(begin);
         out.writeObject(entryBackupProcessor);
         out.writeLong(newTtl);
-
-        // RU_COMPAT 5.1
-        if (out.getVersion().isGreaterOrEqual(Versions.V5_2)) {
-            out.writeBoolean(changeExpiryOnUpdate);
-        }
+        out.writeBoolean(changeExpiryOnUpdate);
     }
 
     @Override
@@ -182,10 +177,6 @@ public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
         begin = in.readLong();
         entryBackupProcessor = in.readObject();
         newTtl = in.readLong();
-
-        // RU_COMPAT 5.1
-        if (in.getVersion().isGreaterOrEqual(Versions.V5_2)) {
-            changeExpiryOnUpdate = in.readBoolean();
-        }
+        changeExpiryOnUpdate = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -17,18 +17,16 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapEntries;
-import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.operation.steps.PutAllOpSteps;
 import com.hazelcast.map.impl.operation.steps.engine.State;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -53,7 +51,7 @@ import static com.hazelcast.map.impl.record.Record.UNSET;
  */
 public class PutAllOperation extends MapOperation
         implements PartitionAwareOperation, BackupAwareOperation,
-        MutatingOperation, Versioned {
+        MutatingOperation {
 
     private transient int currentIndex;
     private MapEntries mapEntries;
@@ -261,20 +259,14 @@ public class PutAllOperation extends MapOperation
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(mapEntries);
-        if (out.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            out.writeBoolean(triggerMapLoader);
-        }
+        out.writeBoolean(triggerMapLoader);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         mapEntries = in.readObject();
-        if (in.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            triggerMapLoader = in.readBoolean();
-        } else {
-            triggerMapLoader = true;
-        }
+        triggerMapLoader = in.readBoolean();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactory.java
@@ -16,13 +16,11 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -36,7 +34,7 @@ import java.util.Map;
  * <p>
  * Used to reduce the number of remote invocations of an {@link IMap#putAll(Map)} or {@link IMap#setAll(Map)} call.
  */
-public class PutAllPartitionAwareOperationFactory extends PartitionAwareOperationFactory implements Versioned {
+public class PutAllPartitionAwareOperationFactory extends PartitionAwareOperationFactory {
 
     protected String name;
     protected MapEntries[] mapEntries;
@@ -71,9 +69,7 @@ public class PutAllPartitionAwareOperationFactory extends PartitionAwareOperatio
         for (MapEntries entry : mapEntries) {
             entry.writeData(out);
         }
-        if (out.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            out.writeBoolean(triggerMapLoader);
-        }
+        out.writeBoolean(triggerMapLoader);
     }
 
     @Override
@@ -86,11 +82,7 @@ public class PutAllPartitionAwareOperationFactory extends PartitionAwareOperatio
             entry.readData(in);
             mapEntries[i] = entry;
         }
-        if (in.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            triggerMapLoader = in.readBoolean();
-        } else {
-            triggerMapLoader = true;
-        }
+        triggerMapLoader = in.readBoolean();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -20,7 +20,6 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ManagedContext;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.internal.journal.EventJournalReader;
 import com.hazelcast.internal.serialization.Data;
@@ -86,7 +85,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import static com.hazelcast.query.impl.predicates.PredicateUtils.checkDoesNotContainPagingPredicate;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static com.hazelcast.internal.util.Preconditions.checkNoNullInside;
@@ -99,6 +97,7 @@ import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.query.QueryResultUtils.transformToSet;
 import static com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest.newQueryCacheRequest;
 import static com.hazelcast.map.impl.record.Record.UNSET;
+import static com.hazelcast.query.impl.predicates.PredicateUtils.checkDoesNotContainPagingPredicate;
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newDelegatingFuture;
 import static java.util.Collections.emptyMap;
@@ -1258,8 +1257,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(remappingFunction, NULL_BIFUNCTION_IS_NOT_ALLOWED);
 
-        if (SerializationUtil.isClassStaticAndSerializable(remappingFunction)
-                && isClusterVersionGreaterOrEqual(Versions.V4_1)) {
+        if (SerializationUtil.isClassStaticAndSerializable(remappingFunction)) {
             ComputeIfPresentEntryProcessor<K, V> ep = new ComputeIfPresentEntryProcessor<>(remappingFunction);
             return executeOnKey(key, ep);
         } else {
@@ -1293,8 +1291,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(mappingFunction, NULL_FUNCTION_IS_NOT_ALLOWED);
 
-        if (SerializationUtil.isClassStaticAndSerializable(mappingFunction)
-                && isClusterVersionGreaterOrEqual(Versions.V4_1)) {
+        if (SerializationUtil.isClassStaticAndSerializable(mappingFunction)) {
             ComputeIfAbsentEntryProcessor<K, V> ep = new ComputeIfAbsentEntryProcessor<>(mappingFunction);
             return executeOnKey(key, ep);
         } else {
@@ -1325,8 +1322,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public void forEach(@Nonnull BiConsumer<? super K, ? super V> action) {
         checkNotNull(action, NULL_CONSUMER_IS_NOT_ALLOWED);
 
-        if (SerializationUtil.isClassStaticAndSerializable(action)
-                && isClusterVersionGreaterOrEqual(Versions.V4_1)) {
+        if (SerializationUtil.isClassStaticAndSerializable(action)) {
             KeyValueConsumingEntryProcessor<K, V> ep = new KeyValueConsumingEntryProcessor<>(action);
             executeOnEntries(ep);
         } else {
@@ -1338,8 +1334,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(remappingFunction, NULL_BIFUNCTION_IS_NOT_ALLOWED);
 
-        if (SerializationUtil.isClassStaticAndSerializable(remappingFunction)
-                && isClusterVersionGreaterOrEqual(Versions.V4_1)) {
+        if (SerializationUtil.isClassStaticAndSerializable(remappingFunction)) {
             ComputeEntryProcessor<K, V> ep = new ComputeEntryProcessor<>(remappingFunction);
             return executeOnKey(key, ep);
         } else {
@@ -1383,8 +1378,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
         checkNotNull(remappingFunction, NULL_BIFUNCTION_IS_NOT_ALLOWED);
 
-        if (SerializationUtil.isClassStaticAndSerializable(remappingFunction)
-                && isClusterVersionGreaterOrEqual(Versions.V4_1)) {
+        if (SerializationUtil.isClassStaticAndSerializable(remappingFunction)) {
             MergeEntryProcessor<K, V> ep = new MergeEntryProcessor<>(remappingFunction, value);
             return executeOnKey(key, ep);
         } else {
@@ -1421,8 +1415,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
         checkNotNull(function, NULL_BIFUNCTION_IS_NOT_ALLOWED);
 
-        if (SerializationUtil.isClassStaticAndSerializable(function)
-                && isClusterVersionGreaterOrEqual(Versions.V4_1)) {
+        if (SerializationUtil.isClassStaticAndSerializable(function)) {
             MapEntryReplacingEntryProcessor<K, V> ep = new MapEntryReplacingEntryProcessor<>(function);
             executeOnEntries(ep);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Query.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Query.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl.query;
 
 import com.hazelcast.aggregation.Aggregator;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.util.IterationType;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
@@ -25,7 +24,6 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
@@ -38,7 +36,7 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 /**
  * Object representing a Query together with all possible co-variants: like a predicate, iterationType, etc.
  */
-public class Query implements IdentifiedDataSerializable, Versioned {
+public class Query implements IdentifiedDataSerializable {
 
     private String mapName;
     private Predicate predicate;
@@ -145,9 +143,7 @@ public class Query implements IdentifiedDataSerializable, Versioned {
         out.writeByte(iterationType.getId());
         out.writeObject(aggregator);
         out.writeObject(projection);
-        if (out.getVersion().isGreaterOrEqual(Versions.V4_2)) {
-            out.writeObject(partitionIdSet);
-        }
+        out.writeObject(partitionIdSet);
     }
 
     @Override
@@ -157,9 +153,7 @@ public class Query implements IdentifiedDataSerializable, Versioned {
         this.iterationType = IterationType.getById(in.readByte());
         this.aggregator = in.readObject();
         this.projection = in.readObject();
-        if (in.getVersion().isGreaterOrEqual(Versions.V4_2)) {
-            this.partitionIdSet = in.readObject();
-        }
+        this.partitionIdSet = in.readObject();
     }
 
     public static final class QueryBuilder {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxyImpl.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstanceAware;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.CollectionUtil;
@@ -37,7 +36,6 @@ import com.hazelcast.splitbrainprotection.SplitBrainProtectionOn;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.EventListener;
 import java.util.HashMap;
@@ -53,7 +51,6 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.internal.util.Preconditions.checkInstanceOf;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
-import static com.hazelcast.internal.util.Preconditions.checkTrueUnsupportedOperation;
 import static com.hazelcast.internal.util.SetUtil.createHashSet;
 
 @SuppressWarnings("checkstyle:methodcount")
@@ -64,9 +61,6 @@ public class MultiMapProxyImpl<K, V>
     protected static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
     protected static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
-    protected static final String MINIMUM_VERSION_ERROR_FORMAT = "{0} is only available with cluster version {1} or greater";
-    protected static final String MINIMUM_VERSION_ERROR_4_1 = MessageFormat.format(MINIMUM_VERSION_ERROR_FORMAT,
-            "MultiMap#putAllAsync", "4.1");
 
     public MultiMapProxyImpl(MultiMapConfig config, MultiMapService service, NodeEngine nodeEngine, String name) {
         super(config, service, nodeEngine, name);
@@ -105,7 +99,6 @@ public class MultiMapProxyImpl<K, V>
 
     @Override
     public CompletionStage<Void> putAllAsync(@Nonnull Map<? extends K, Collection<? extends V>> m) {
-        checkTrueUnsupportedOperation(isClusterVersionGreaterOrEqual(Versions.V4_1), MINIMUM_VERSION_ERROR_4_1);
         InternalCompletableFuture<Void> future = new InternalCompletableFuture<>();
         Map<Data, Data> dataMap = new HashMap<>();
 
@@ -122,7 +115,6 @@ public class MultiMapProxyImpl<K, V>
 
     @Override
     public CompletionStage<Void> putAllAsync(@Nonnull K key, @Nonnull Collection<? extends V> value) {
-        checkTrueUnsupportedOperation(isClusterVersionGreaterOrEqual(Versions.V4_1), MINIMUM_VERSION_ERROR_4_1);
         InternalCompletableFuture<Void> future = new InternalCompletableFuture<>();
         Map<Data, Data> dataMap = new HashMap<>();
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/NamedTaskDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/NamedTaskDecorator.java
@@ -16,17 +16,15 @@
 
 package com.hazelcast.scheduledexecutor.impl;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.scheduledexecutor.NamedTask;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
 public class NamedTaskDecorator<V> extends AbstractTaskDecorator<V>
-        implements NamedTask, Versioned {
+        implements NamedTask {
 
     private String name;
 
@@ -58,25 +56,15 @@ public class NamedTaskDecorator<V> extends AbstractTaskDecorator<V>
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
-        if (out.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            super.writeData(out);
-            out.writeString(name);
-        } else {
-            out.writeString(name);
-            out.writeObject(delegate);
-        }
+        super.writeData(out);
+        out.writeString(name);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
-        if (in.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            super.readData(in);
-            name = in.readString();
-        } else {
-            name = in.readString();
-            delegate = in.readObject();
-        }
+        super.readData(in);
+        name = in.readString();
     }
 
     public static Runnable named(String name, Runnable runnable) {

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/TaskDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/TaskDefinition.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.scheduledexecutor.impl;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -131,9 +130,7 @@ public class TaskDefinition<V>
         out.writeLong(initialDelay);
         out.writeLong(period);
         out.writeString(unit.name());
-        if (out.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            out.writeBoolean(autoDisposable);
-        }
+        out.writeBoolean(autoDisposable);
     }
 
     @Override
@@ -145,9 +142,7 @@ public class TaskDefinition<V>
         initialDelay = in.readLong();
         period = in.readLong();
         unit = TimeUnit.valueOf(in.readString());
-        if (in.getVersion().isGreaterOrEqual(Versions.V4_1)) {
-            autoDisposable = in.readBoolean();
-        }
+        autoDisposable = in.readBoolean();
     }
 
     @Override


### PR DESCRIPTION
Remove code that was added to support rolling member upgrades from previous versions which are not relevant for 5.4 development.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6032

(for first-time reviewers of this kind of PRs, [this](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/4330094593/Developing+for+rolling+member+upgrade+compatibility) can be useful reading)