### PR TITLE
Explicitly obtaining map proxy to ensure of ListenerAdapter registration [HZ-2219] [5.3.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -810,6 +810,8 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         assertClusterSizeEventually(2, hz1, hz2);
 
         IMap<Object, Object> map = hz1.getMap("test");
+        // explicitly obtaining map proxy to ensure of ListenerAdapter registration
+        hz2.getMap("test");
         map.put(1, 1);
 
         //Let post join continue only after put happened


### PR DESCRIPTION
An issue can be reproduced by introducing a delay during the `InternalMapListenerAdapter` registration.
In that case, the EntryAdded event could arrive before registering the `EntryAddedListener`.

Explicitly obtaining a map proxy should guarantee to finish the`InternalMapListenerAdapter` registration.

Fix https://github.com/hazelcast/hazelcast/issues/23214
Backport of: https://github.com/hazelcast/hazelcast/pull/24382

(cherry picked from commit f7c6bdfde2f644e3ba351516f9fabb142acb9a39)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
