### PR TITLE
Add option to run Kafka tests against Redpanda [HZ-2454]

### DIFF
--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -104,6 +104,12 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>redpanda</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/DockerizedRedPandaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/DockerizedRedPandaTestSupport.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.impl;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.redpanda.RedpandaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.testcontainers.utility.DockerImageName.parse;
+
+class DockerizedRedPandaTestSupport extends KafkaTestSupport {
+
+    private static final String TEST_REDPANDA_VERSION = System.getProperty("test.redpanda.version", "v22.3.20");
+    private static final Logger LOGGER = LoggerFactory.getLogger(DockerizedRedPandaTestSupport.class);
+
+    private RedpandaContainer redpandaContainer;
+
+    public void createKafkaCluster() throws IOException {
+        DockerImageName imageName = parse("docker.redpanda.com/redpandadata/redpanda:" + TEST_REDPANDA_VERSION);
+        redpandaContainer = new RedpandaContainer(imageName)
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER));
+        redpandaContainer.start();
+
+        brokerConnectionString = redpandaContainer.getBootstrapServers();
+        Properties props = new Properties();
+        props.setProperty("bootstrap.servers", brokerConnectionString);
+        admin = Admin.create(props);
+    }
+
+    public void shutdownKafkaCluster() {
+        if (redpandaContainer != null) {
+            redpandaContainer.stop();
+            if (admin != null) {
+                admin.close();
+            }
+            if (producer != null) {
+                producer.close();
+            }
+            producer = null;
+            admin = null;
+            redpandaContainer = null;
+            brokerConnectionString = null;
+        }
+    }
+
+}

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -64,12 +64,22 @@ public abstract class KafkaTestSupport {
 
     public static KafkaTestSupport create() {
         if (!dockerEnabled()) {
-            if (System.getProperties().containsKey("test.kafka.version")) {
-                throw new IllegalArgumentException("'test.kafka.version' system property requires docker enabled");
-            }
+            assertPropertyNotSet("test.kafka.version");
+            assertPropertyNotSet("test.redpanda.version");
+            assertPropertyNotSet("test.use.redpanda");
             return new EmbeddedKafkaTestSupport();
         } else {
-            return new DockerizedKafkaTestSupport();
+            if (System.getProperties().containsKey("test.use.redpanda")) {
+                return new DockerizedRedPandaTestSupport();
+            } else {
+                return new DockerizedKafkaTestSupport();
+            }
+        }
+    }
+
+    private static void assertPropertyNotSet(String key) {
+        if (System.getProperties().containsKey(key)) {
+            throw new IllegalArgumentException("'" + key + "' system property requires docker enabled");
         }
     }
 

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -66,10 +66,10 @@ public abstract class KafkaTestSupport {
         if (!dockerEnabled()) {
             assertPropertyNotSet("test.kafka.version");
             assertPropertyNotSet("test.redpanda.version");
-            assertPropertyNotSet("test.use.redpanda");
+            assertPropertyNotSet("test.kafka.use.redpanda");
             return new EmbeddedKafkaTestSupport();
         } else {
-            if (System.getProperties().containsKey("test.use.redpanda")) {
+            if (System.getProperties().containsKey("test.kafka.use.redpanda")) {
                 return new DockerizedRedPandaTestSupport();
             } else {
                 return new DockerizedKafkaTestSupport();

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -643,7 +643,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
                 );
 
         StreamKafkaP<Integer, String, Entry<Integer, String>> processor = createProcessor(
-                properties, topicsConfig, r -> entry(r.key(), r.value()), 10_000);
+                properties, topicsConfig, r -> entry(r.key(), r.value()), 60_000);
         TestOutbox outbox = new TestOutbox(new int[]{10}, 10);
         TestProcessorContext context = new TestProcessorContext();
         context.setProcessingGuarantee(AT_LEAST_ONCE);


### PR DESCRIPTION
Adds an option to run our Kafka tests against Redpanda.

There are two new system properties:
- `test.use.redpanda` - switches tests from Kafka broker to Redpanda
- `test.redpanda.version` - overrides Redpanda version in tests, defaults to `v22.3.20`


You can test it out by running:
```shell
mvn test -pl extensions/kafka -Dtest.kafka.use.redpanda
```

So far I've noticed only a single test failing: `StreamKafkaPTest.when_partitionAddedWhilePartitionsInitialOffsetsProvided_then_consumedFromBeginning`:
```
java.lang.AssertionError: 
Expected :[2=2, 3=3, 4=4, 5=5, 6=6, 7=7, 8=8, 9=9, 10=10, 11=11]
Actual   :[8=8, 5=5, 3=3, 4=4, 7=7, 2=2, 6=6, 10=10, 11=11, Watermark{ts=01:00:00.002, key=0}]
<Click to see difference>


	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at com.hazelcast.jet.kafka.impl.StreamKafkaPTest.when_partitionAddedWhilePartitionsInitialOffsetsProvided_then_consumedFromBeginning(StreamKafkaPTest.java:675)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:115)
	at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:107)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

It turned tests with Redpanda takes more time, so as @frant-hartm suggested I've increased idleTimeoutMillis in the event time policy: https://github.com/hazelcast/hazelcast/pull/24599/commits/97c28c67af96cf94ca9189e64b8af41e46eca683

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
