### PR TITLE
Fix TLS 1.3 support in RestClient

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
@@ -259,7 +259,7 @@ public final class RestClient {
             TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             tmf.init(keyStore);
 
-            SSLContext context = SSLContext.getInstance("TLSv1.2");
+            SSLContext context = SSLContext.getInstance("TLS");
             context.init(null, tmf.getTrustManagers(), null);
             return context.getSocketFactory();
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/utils/RestClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/utils/RestClientTest.java
@@ -17,6 +17,9 @@
 package com.hazelcast.spi.utils;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.exception.RestClientException;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,9 +33,22 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static com.hazelcast.internal.nio.IOUtil.close;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RestClientTest {
     private static final String API_ENDPOINT = "/some/endpoint";
@@ -213,4 +229,131 @@ public class RestClientTest {
         assertEquals(responseCode, response.getCode());
         assertEquals(responseMessage, response.getBody());
     }
+
+    @Test
+    public void tls13SupportDefaultCacert() throws IOException {
+        Tls13CipherCheckingServer server = new Tls13CipherCheckingServer(new ServerSocket(0));
+        try {
+            new Thread(server).start();
+            RestClient.create("https://127.0.0.1:" + server.serverSocket.getLocalPort()).get();
+        } catch (Exception e) {
+            // whatever
+        } finally {
+            server.shutdownRequested = true;
+        }
+        assertTrue("No TLS 1.3 cipher used", server.tls13CipherFound.get());
+    }
+
+    @Test
+    public void tls13SupportCustomCacert() throws IOException {
+        Tls13CipherCheckingServer server = new Tls13CipherCheckingServer(new ServerSocket(0));
+        try {
+            new Thread(server).start();
+            RestClient.create("https://127.0.0.1:" + server.serverSocket.getLocalPort())
+                    .withCaCertificates(readFile("src/test/resources/kubernetes/ca.crt")).get();
+        } catch (Exception e) {
+            // whatever
+        } finally {
+            server.shutdownRequested = true;
+        }
+        assertTrue("No TLS 1.3 cipher used", server.tls13CipherFound.get());
+    }
+
+    private String readFile(String fileName) throws IOException {
+        return StringUtil.bytesToString(Files.readAllBytes(Paths.get(fileName)));
+    }
+
+    static final class Tls13CipherCheckingServer implements Runnable {
+        private static final ILogger LOGGER = Logger.getLogger(Tls13CipherCheckingServer.class);
+
+        final ServerSocket serverSocket;
+        volatile boolean shutdownRequested;
+        final AtomicBoolean tls13CipherFound = new AtomicBoolean();
+
+        Tls13CipherCheckingServer(ServerSocket serverSocket) {
+            this.serverSocket = serverSocket;
+            try {
+                this.serverSocket.setSoTimeout(500);
+            } catch (SocketException e) {
+                throw new RuntimeException(e);
+            }
+            LOGGER.info("The server will be listening on port " + serverSocket.getLocalPort());
+        }
+
+        public void run() {
+            try {
+                while (!(shutdownRequested || tls13CipherFound.get())) {
+                    try {
+                        Socket socket = serverSocket.accept();
+                        new Thread(() -> {
+                            LOGGER.info("Socket accepted " + socket);
+                            try {
+                                socket.setSoTimeout(5000);
+                                tls13CipherFound.compareAndSet(false, hasTls13Cipher(socket.getInputStream()));
+                            } catch (IOException e) {
+                                LOGGER.warning("Reading from the socket failed", e);
+                            } finally {
+                                close(socket);
+                            }
+                        }).start();
+                    } catch (SocketTimeoutException e) {
+                        // it's fine
+                    }
+                }
+            } catch (IOException e) {
+                LOGGER.warning("The test server thrown an exception", e);
+            } finally {
+                close(serverSocket);
+            }
+        }
+
+        void stop() {
+            shutdownRequested = true;
+        }
+
+        static boolean hasTls13Cipher(InputStream is) throws IOException {
+            try (DataInputStream dis = new DataInputStream(is)) {
+                int type = dis.readUnsignedByte();
+                // HANDSHAKE record
+                if (type != 0x16) {
+                    throw new IOException("Not a handshake record");
+                }
+                // skip protocol version
+                skip(dis, 2);
+                // skip record size
+                dis.readUnsignedShort();
+                int msgType = dis.readUnsignedByte();
+                if (msgType != 0x01) {
+                    throw new IOException("Not a ClientHello message");
+                }
+                // skip length
+                skip(dis, 3);
+                // skip client version
+                skip(dis, 2);
+                // skip client random
+                skip(dis, 32);
+                // skip sessionId
+                skip(dis, dis.readUnsignedByte());
+                // cipher suites
+                int cipherCount = dis.readUnsignedShort() / 2;
+                // check if at least one of TLS 1.3 mandatory cipher suites is present
+                for (int i = 0; i < cipherCount; i++) {
+                    int b1 = dis.readUnsignedByte();
+                    int b2 = dis.readUnsignedByte();
+                    // https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.4
+                    if (b1 == 0x13 && b2 >= 1 && b2 <= 3) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private static void skip(DataInputStream dis, int toSkip) throws IOException {
+            for (int i = 0; i < toSkip; i++) {
+                dis.readByte();
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
When custom CA certificates was used, `TLSv1.2` was enforced.
The REST calls failed in TLSv1.3-only Kubernetes environments.

This PR removes the explicit TLS version specification while creating the `SSLContext`.