### PR TITLE
Fix HealthMonitor related issues

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
@@ -290,33 +290,47 @@ public class HealthMonitor {
         private final StringBuilder sb = new StringBuilder();
         private double memoryUsedOfTotalPercentage;
         private double memoryUsedOfMaxPercentage;
+        private long runtimeUsedMemory0;
+        private long runtimeTotalMemory0;
+        private long runtimeMaxMemory0;
+        private double osProcessCpuLoad0;
+        private double osSystemCpuLoad0;
+        private double operationServicePendingInvocationsPercentage0;
+        private long operationServicePendingInvocationsCount0;
 
         public void update() {
-            memoryUsedOfTotalPercentage = (PERCENTAGE_MULTIPLIER * runtimeUsedMemory.read()) / runtimeTotalMemory.read();
-            memoryUsedOfMaxPercentage = (PERCENTAGE_MULTIPLIER * runtimeUsedMemory.read()) / runtimeMaxMemory.read();
+            runtimeUsedMemory0 = runtimeUsedMemory.read();
+            runtimeTotalMemory0 = runtimeTotalMemory.read();
+            runtimeMaxMemory0 = runtimeMaxMemory.read();
+            osProcessCpuLoad0 = osProcessCpuLoad.read();
+            osSystemCpuLoad0 = osSystemCpuLoad.read();
+            operationServicePendingInvocationsPercentage0 = operationServicePendingInvocationsPercentage.read();
+            operationServicePendingInvocationsCount0 = operationServicePendingInvocationsCount.read();
+
+            memoryUsedOfTotalPercentage = (PERCENTAGE_MULTIPLIER * runtimeUsedMemory0) / runtimeTotalMemory0;
+            memoryUsedOfMaxPercentage = (PERCENTAGE_MULTIPLIER * runtimeUsedMemory0) / runtimeMaxMemory0;
         }
 
         boolean exceedsThreshold() {
             if (memoryUsedOfMaxPercentage > thresholdMemoryPercentage) {
                 return true;
             }
-            if (osProcessCpuLoad.read() > thresholdCPUPercentage) {
+            if (osProcessCpuLoad0 > thresholdCPUPercentage) {
                 return true;
             }
-            if (osSystemCpuLoad.read() > thresholdCPUPercentage) {
+            if (osSystemCpuLoad0 > thresholdCPUPercentage) {
                 return true;
             }
-            if (operationServicePendingInvocationsPercentage.read() > THRESHOLD_PERCENTAGE_INVOCATIONS) {
+            if (operationServicePendingInvocationsPercentage0 > THRESHOLD_PERCENTAGE_INVOCATIONS) {
                 return true;
             }
-            if (operationServicePendingInvocationsCount.read() > THRESHOLD_INVOCATIONS) {
+            if (operationServicePendingInvocationsCount0 > THRESHOLD_INVOCATIONS) {
                 return true;
             }
             return false;
         }
 
         public String render() {
-            update();
             sb.setLength(0);
             renderProcessors();
             renderPhysicalMemory();
@@ -357,16 +371,16 @@ public class HealthMonitor {
 
         private void renderLoad() {
             sb.append("load.process").append('=')
-                    .append(format("%.2f", osProcessCpuLoad.read())).append("%, ");
+                    .append(format("%.2f", osProcessCpuLoad0)).append("%, ");
             sb.append("load.system").append('=')
-                    .append(format("%.2f", osSystemCpuLoad.read())).append("%, ");
+                    .append(format("%.2f", osSystemCpuLoad0)).append("%, ");
 
             double value = osSystemLoadAverage.read();
             if (value < 0) {
                 sb.append("load.systemAverage").append("=n/a ");
             } else {
                 sb.append("load.systemAverage").append('=')
-                        .append(format("%.2f", osSystemLoadAverage.read())).append(", ");
+                        .append(format("%.2f", value)).append(", ");
             }
         }
 
@@ -391,13 +405,13 @@ public class HealthMonitor {
 
         private void renderHeap() {
             sb.append("heap.memory.used=")
-                    .append(numberToUnit(runtimeUsedMemory.read())).append(", ");
+                    .append(numberToUnit(runtimeUsedMemory0)).append(", ");
             sb.append("heap.memory.free=")
                     .append(numberToUnit(runtimeFreeMemory.read())).append(", ");
             sb.append("heap.memory.total=")
-                    .append(numberToUnit(runtimeTotalMemory.read())).append(", ");
+                    .append(numberToUnit(runtimeTotalMemory0)).append(", ");
             sb.append("heap.memory.max=")
-                    .append(numberToUnit(runtimeMaxMemory.read())).append(", ");
+                    .append(numberToUnit(runtimeMaxMemory0)).append(", ");
             sb.append("heap.memory.used/total=")
                     .append(percentageString(memoryUsedOfTotalPercentage)).append(", ");
             sb.append("heap.memory.used/max=")
@@ -502,9 +516,9 @@ public class HealthMonitor {
             sb.append("operations.running.count=")
                     .append(operationServiceRunningOperationsCount.read()).append(", ");
             sb.append("operations.pending.invocations.percentage=")
-                    .append(format("%.2f", operationServicePendingInvocationsPercentage.read())).append("%, ");
+                    .append(format("%.2f", operationServicePendingInvocationsPercentage0)).append("%, ");
             sb.append("operations.pending.invocations.count=")
-                    .append(operationServicePendingInvocationsCount.read()).append(", ");
+                    .append(operationServicePendingInvocationsCount0).append(", ");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
@@ -275,7 +275,7 @@ public class HealthMonitor {
         final LongGauge operationServicePendingInvocationsCount
                 = metricRegistry.newLongGauge("operation.invocations.pending");
         final DoubleGauge operationServicePendingInvocationsPercentage
-                = metricRegistry.newDoubleGauge("operation.invocations.used");
+                = metricRegistry.newDoubleGauge("operation.invocations.usedPercentage");
 
         final LongGauge proxyCount
                 = metricRegistry.newLongGauge("proxy.proxyCount");

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -403,9 +403,9 @@ public final class MetricDescriptorConstants {
     public static final String OPERATION_METRIC_INVOCATION_MONITOR_HEARTBEAT_BROADCAST_PERIOD_MILLIS =
             "heartbeatBroadcastPeriodMillis";
     public static final String OPERATION_METRIC_INVOCATION_MONITOR_INVOCATION_SCAN_PERIOD_MILLIS = "invocationScanPeriodMillis";
-    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_USED_PERCENTAGE = "invocations.usedPercentage";
-    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_LAST_CALL_ID = "invocations.lastCallId";
-    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_PENDING = "invocations.pending";
+    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_USED_PERCENTAGE = "usedPercentage";
+    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_LAST_CALL_ID = "lastCallId";
+    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_PENDING = "pending";
     public static final String OPERATION_METRIC_OPERATION_RUNNER_EXECUTED_OPERATIONS_COUNT = "executedOperationsCount";
     public static final String OPERATION_METRIC_OPERATION_SERVICE_ASYNC_OPERATIONS = "asyncOperations";
     public static final String OPERATION_METRIC_OPERATION_SERVICE_TIMEOUT_COUNT = "operationTimeoutCount";

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -285,7 +285,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
 
     private MetricDescriptorImpl createDescriptor(String name) {
         MetricDescriptorImpl descriptor = new MetricDescriptorImpl(staticDescriptorSupplier);
-        int dotIdx = name.lastIndexOf('.');
+        int dotIdx = name.indexOf('.');
 
         if (dotIdx < 0) {
             // simple metric name

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -285,7 +285,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
 
     private MetricDescriptorImpl createDescriptor(String name) {
         MetricDescriptorImpl descriptor = new MetricDescriptorImpl(staticDescriptorSupplier);
-        int dotIdx = name.indexOf('.');
+        int dotIdx = name.lastIndexOf('.');
 
         if (dotIdx < 0) {
             // simple metric name

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ConcurrentMap;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_LAST_CALL_ID;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_PENDING;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_USED_PERCENTAGE;
-import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_PREFIX;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_PREFIX_INVOCATIONS;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.metrics.ProbeUnit.PERCENT;
 import static com.hazelcast.spi.impl.operationservice.OperationAccessor.deactivate;
@@ -96,7 +96,7 @@ public class InvocationRegistry implements Iterable<Invocation>, StaticMetricsPr
 
     @Override
     public void provideStaticMetrics(MetricsRegistry registry) {
-        registry.registerStaticMetrics(this, OPERATION_PREFIX);
+        registry.registerStaticMetrics(this, OPERATION_PREFIX_INVOCATIONS);
     }
 
     @Probe(name = OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_USED_PERCENTAGE, unit = PERCENT)

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/HealthMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/HealthMonitorTest.java
@@ -80,6 +80,7 @@ public class HealthMonitorTest extends HazelcastTestSupport {
     @Test
     public void exceedsThreshold_when_osProcessCpuLoad_tooHigh() {
         registerMetric(metrics.osProcessCpuLoad, 90);
+        metrics.update();
         boolean result = metrics.exceedsThreshold();
         assertTrue(result);
     }
@@ -87,6 +88,7 @@ public class HealthMonitorTest extends HazelcastTestSupport {
     @Test
     public void exceedsThreshold_when_osSystemCpuLoad_TooHigh() {
         registerMetric(metrics.osSystemCpuLoad, 90);
+        metrics.update();
         boolean result = metrics.exceedsThreshold();
         assertTrue(result);
     }
@@ -94,6 +96,7 @@ public class HealthMonitorTest extends HazelcastTestSupport {
     @Test
     public void exceedsThreshold_operationServicePendingInvocationsPercentage() {
         registerMetric(metrics.operationServicePendingInvocationsPercentage, 90);
+        metrics.update();
         boolean result = metrics.exceedsThreshold();
         assertTrue(result);
     }


### PR DESCRIPTION
This PR solves 3 issues related to `HealthMonitor`:

1. `operation.invocations.used` isn't a metric name. Correct name
   should be `operation.invocations.usedPercentage`.
2. ~Metric prefix was calculated wrong previously. For example, for
   metric `operation.invocations.usedPercentage`, the prefix was
   `operation.invocations` previously. This is fixed now, and we
   use first index of `.` as prefix.~ It seems using last index was
   normal, so I changed prefix of `InvocationRegistry`.
3. Reading some metrics twice was creating problems. I think this is a
   jdk issue. Sometimes, if `getSystemCpuLoad()` called back to back,
   2nd call was returning 0 instead of actual usage. Since these are
   native methods, I don't know the exact reason. I cached some metrics
   in `update()` method and tried to call `read()` only once for each
   metric for each `HealthMonitor` collection cycle. See also the
   following code:

```
import com.sun.management.OperatingSystemMXBean;

import java.lang.management.ManagementFactory;

public class ZZMain {
    public static void main(String[] args) throws InterruptedException {
        OperatingSystemMXBean bean = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);

        while (true) {
            System.out.println(bean.getSystemCpuLoad());
            Thread.sleep(100);
        }
    }
}
```

See also: https://hazelcast.slack.com/archives/C034YQBTG/p1684148394186779