### PR TITLE
Add option to run Kafka SQL tests against Redpanda

### DIFF
--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -784,6 +784,13 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>redpanda</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
Allow to use options from https://github.com/hazelcast/hazelcast/pull/24599 also for Kafka SQL tests.