### PR TITLE
Fix TLS 1.3 support in RestClient [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/utils/RestClient.java
@@ -259,7 +259,7 @@ public final class RestClient {
             TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             tmf.init(keyStore);
 
-            SSLContext context = SSLContext.getInstance("TLSv1.2");
+            SSLContext context = SSLContext.getInstance("TLS");
             context.init(null, tmf.getTrustManagers(), null);
             return context.getSocketFactory();
 


### PR DESCRIPTION
Backports #24616 to `5.2.z`