### PR TITLE
[TPC] Remove SO_TIMEOUT option

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocketOptions.java
@@ -46,11 +46,6 @@ public interface AsyncSocketOptions {
     Option<Boolean> SO_REUSEPORT = new Option<>("SO_REUSEPORT", Boolean.class);
 
     /**
-     * See {@link java.net.SocketOptions#SO_TIMEOUT}
-     */
-    Option<Integer> SO_TIMEOUT = new Option<>("SO_TIMEOUT", Integer.class);
-
-    /**
      * See {@link java.net.SocketOptions#SO_REUSEADDR}
      */
     Option<Boolean> SO_REUSEADDR = new Option<>("SO_REUSEADDR", Boolean.class);

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -45,7 +45,6 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
         this.socketChannel = socketChannel;
     }
 
-    // SO_TIMEOUT unfortunately doesn't have a SocketOption version.
     private static SocketOption toSocketOption(Option option) {
         if (TCP_NODELAY.equals(option)) {
             return StandardSocketOptions.TCP_NODELAY;
@@ -72,12 +71,7 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
     public boolean isSupported(Option option) {
         checkNotNull(option, "option");
 
-        if (option.equals(SO_TIMEOUT)) {
-            return true;
-        } else {
-            SocketOption socketOption = toSocketOption(option);
-            return isSupported(socketOption);
-        }
+        return isSupported(toSocketOption(option));
     }
 
     private boolean isSupported(SocketOption socketOption) {
@@ -89,15 +83,11 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
         checkNotNull(option, "option");
 
         try {
-            if (option.equals(SO_TIMEOUT)) {
-                return (T) (Integer) socketChannel.socket().getSoTimeout();
+            SocketOption socketOption = toSocketOption(option);
+            if (isSupported(socketOption)) {
+                return (T) socketChannel.getOption(socketOption);
             } else {
-                SocketOption socketOption = toSocketOption(option);
-                if (isSupported(socketOption)) {
-                    return (T) socketChannel.getOption(socketOption);
-                } else {
-                    return null;
-                }
+                return null;
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -110,17 +100,12 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
         checkNotNull(value, "value");
 
         try {
-            if (option.equals(SO_TIMEOUT)) {
-                socketChannel.socket().setSoTimeout((Integer) value);
+            SocketOption socketOption = toSocketOption(option);
+            if (isSupported(socketOption)) {
+                socketChannel.setOption(socketOption, value);
                 return true;
             } else {
-                SocketOption socketOption = toSocketOption(option);
-                if (isSupported(socketOption)) {
-                    socketChannel.setOption(socketOption, value);
-                    return true;
-                } else {
-                    return false;
-                }
+                return false;
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketOptionsTest.java
@@ -32,7 +32,6 @@ import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_KEEPALI
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_RCVBUF;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_REUSEADDR;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_SNDBUF;
-import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_TIMEOUT;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.TCP_KEEPCOUNT;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.TCP_KEEPIDLE;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.TCP_KEEPINTERVAL;
@@ -159,14 +158,6 @@ public abstract class AsyncSocketOptionsTest {
         assertEquals(Boolean.TRUE, options.get(SO_KEEPALIVE));
         options.set(SO_KEEPALIVE, false);
         assertEquals(Boolean.FALSE, options.get(SO_KEEPALIVE));
-    }
-
-    @Test
-    public void test_SO_TIMEOUT() {
-        AsyncSocket socket = newSocket();
-        AsyncSocketOptions options = socket.options();
-        options.set(SO_TIMEOUT, 3600);
-        assertEquals(Integer.valueOf(3600), options.get(SO_TIMEOUT));
     }
 
     @Test


### PR DESCRIPTION
Socket timeout is only relevant for blocking socket operations.
Hence it makes no sense to offer it as part of our AsyncSocket internals.
