### PR TITLE
Fix HealthMonitor related issues (#24618) [5.3.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -403,9 +403,9 @@ public final class MetricDescriptorConstants {
     public static final String OPERATION_METRIC_INVOCATION_MONITOR_HEARTBEAT_BROADCAST_PERIOD_MILLIS =
             "heartbeatBroadcastPeriodMillis";
     public static final String OPERATION_METRIC_INVOCATION_MONITOR_INVOCATION_SCAN_PERIOD_MILLIS = "invocationScanPeriodMillis";
-    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_USED_PERCENTAGE = "invocations.usedPercentage";
-    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_LAST_CALL_ID = "invocations.lastCallId";
-    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_PENDING = "invocations.pending";
+    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_USED_PERCENTAGE = "usedPercentage";
+    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_LAST_CALL_ID = "lastCallId";
+    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_PENDING = "pending";
     public static final String OPERATION_METRIC_OPERATION_RUNNER_EXECUTED_OPERATIONS_COUNT = "executedOperationsCount";
     public static final String OPERATION_METRIC_OPERATION_SERVICE_ASYNC_OPERATIONS = "asyncOperations";
     public static final String OPERATION_METRIC_OPERATION_SERVICE_TIMEOUT_COUNT = "operationTimeoutCount";

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ConcurrentMap;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_LAST_CALL_ID;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_PENDING;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_USED_PERCENTAGE;
-import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_PREFIX;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_PREFIX_INVOCATIONS;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.metrics.ProbeUnit.PERCENT;
 import static com.hazelcast.spi.impl.operationservice.OperationAccessor.deactivate;
@@ -96,7 +96,7 @@ public class InvocationRegistry implements Iterable<Invocation>, StaticMetricsPr
 
     @Override
     public void provideStaticMetrics(MetricsRegistry registry) {
-        registry.registerStaticMetrics(this, OPERATION_PREFIX);
+        registry.registerStaticMetrics(this, OPERATION_PREFIX_INVOCATIONS);
     }
 
     @Probe(name = OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_USED_PERCENTAGE, unit = PERCENT)

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/HealthMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/HealthMonitorTest.java
@@ -80,6 +80,7 @@ public class HealthMonitorTest extends HazelcastTestSupport {
     @Test
     public void exceedsThreshold_when_osProcessCpuLoad_tooHigh() {
         registerMetric(metrics.osProcessCpuLoad, 90);
+        metrics.update();
         boolean result = metrics.exceedsThreshold();
         assertTrue(result);
     }
@@ -87,6 +88,7 @@ public class HealthMonitorTest extends HazelcastTestSupport {
     @Test
     public void exceedsThreshold_when_osSystemCpuLoad_TooHigh() {
         registerMetric(metrics.osSystemCpuLoad, 90);
+        metrics.update();
         boolean result = metrics.exceedsThreshold();
         assertTrue(result);
     }
@@ -94,6 +96,7 @@ public class HealthMonitorTest extends HazelcastTestSupport {
     @Test
     public void exceedsThreshold_operationServicePendingInvocationsPercentage() {
         registerMetric(metrics.operationServicePendingInvocationsPercentage, 90);
+        metrics.update();
         boolean result = metrics.exceedsThreshold();
         assertTrue(result);
     }


### PR DESCRIPTION
This PR solves 3 issues related to `HealthMonitor`:

1. `operation.invocations.used` isn't a metric name. Correct name should be `operation.invocations.usedPercentage`.
2. ~Metric prefix was calculated wrong previously. For example, for metric `operation.invocations.usedPercentage`, the prefix was `operation.invocations` previously. This is fixed now, and we use first index of `.` as prefix.~ It seems using last index was normal, so I changed prefix of `InvocationRegistry`.
3. Reading some metrics twice was creating problems. I think this is a jdk issue. Sometimes, if `getSystemCpuLoad()` called back to back, 2nd call was returning 0 instead of actual usage. Since these are native methods, I don't know the exact reason. I cached some metrics in `update()` method and tried to call `read()` only once for each metric for each `HealthMonitor` collection cycle. See also the following code:

```
import com.sun.management.OperatingSystemMXBean;

import java.lang.management.ManagementFactory;

public class ZZMain {
    public static void main(String[] args) throws InterruptedException {
        OperatingSystemMXBean bean = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);

        while (true) {
            System.out.println(bean.getSystemCpuLoad());
            Thread.sleep(100);
        }
    }
}
```

See also:
https://hazelcast.slack.com/archives/C034YQBTG/p1684148394186779

Backport of: https://github.com/hazelcast/hazelcast/pull/24618