### PR TITLE
Remove duplicated json-smart entry in pom and bump it to 2.4.11 [5.0.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1591,11 +1591,6 @@
                 <version>1.21</version>
             </dependency>
             <dependency>
-                <groupId>net.minidev</groupId>
-                <artifactId>json-smart</artifactId>
-                <version>2.4.7</version>
-            </dependency>
-            <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
                 <version>2.10.1</version>
@@ -1729,7 +1724,7 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>2.4.10</version>
+                <version>2.4.11</version>
             </dependency>
             <dependency>
               <groupId>org.wildfly.openssl</groupId>


### PR DESCRIPTION
Fixes CVE-2023-1370
Related to https://github.com/hazelcast/hazelcast/pull/24181

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
