### PR TITLE
Use actual config filename in DefaultAddressPicker error message [HZ-…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultAddressPicker.java
@@ -31,6 +31,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -214,8 +215,7 @@ class DefaultAddressPicker
         }
 
         if (interfacesConfig.isEnabled()) {
-            String msg = "Hazelcast CANNOT start on this node. No matching network interface found.\n"
-                    + "Interface matching must be either disabled or updated in the hazelcast.xml config file.";
+            String msg = errorMsgForNoMatchingInterface();
             logger.severe(msg);
             throw new RuntimeException(msg);
         }
@@ -223,6 +223,15 @@ class DefaultAddressPicker
             logger.warning("Could not find a matching address to start with! Picking one of non-loopback addresses.");
         }
         return pickMatchingAddress(null);
+    }
+
+    private String errorMsgForNoMatchingInterface() {
+        File file = config.getConfigurationFile();
+        String configSource = file != null && file.exists() && file.isFile()
+                ? "the " + file.getName() + " config file." : "the member configuration.";
+        String msg = "Hazelcast CANNOT start on this node. No matching network interface found.\n"
+                + "Interface matching must be either disabled or updated in " + configSource;
+        return msg;
     }
 
     private List<InterfaceDefinition> getInterfaces() {

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
@@ -38,8 +38,10 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
+import java.io.File;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -60,6 +62,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -78,6 +81,8 @@ public class DefaultAddressPickerTest {
     public final OverridePropertyRule ruleSysPropPreferIpv4Stack = set(PREFER_IPV4_STACK, "false");
     @Rule
     public final OverridePropertyRule ruleSysPropPreferIpv6Addresses = clear(PREFER_IPV6_ADDRESSES);
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     private final ILogger logger = Logger.getLogger(AddressPicker.class);
     private final Config config = new Config();
@@ -364,6 +369,29 @@ public class DefaultAddressPickerTest {
         assertNotEquals(addressDefinition.hashCode(), addressDefinitionOtherInetAddress.hashCode());
     }
 
+    @Test
+    public void testNotMatchingInterface_forCustomConfigFile() throws Exception {
+        Config config = new Config();
+        File cfgFile = tempFolder.newFile("custom_file.xml");
+        config.setConfigurationFile(cfgFile);
+        config.getNetworkConfig().getInterfaces().setEnabled(true);
+        config.getNetworkConfig().getInterfaces().addInterface("123.456.789");
+        RuntimeException thrown =  assertThrows(RuntimeException.class,
+                () -> HazelcastInstanceFactory.newHazelcastInstance(config));
+        assertTrue(thrown.getMessage().contentEquals("Hazelcast CANNOT start on this node. No matching network interface found.\n"
+                + "Interface matching must be either disabled or updated in the custom_file.xml config file."));
+    }
+
+    @Test
+    public void testNotMatchingInterface_forNoConfigFile() throws Exception {
+        Config config = new Config();
+        config.getNetworkConfig().getInterfaces().setEnabled(true);
+        config.getNetworkConfig().getInterfaces().addInterface("123.456.789");
+        RuntimeException thrown =  assertThrows(RuntimeException.class,
+                () -> HazelcastInstanceFactory.newHazelcastInstance(config));
+        assertTrue(thrown.getMessage().contentEquals("Hazelcast CANNOT start on this node. No matching network interface found.\n"
+                + "Interface matching must be either disabled or updated in the member configuration."));
+    }
     private static InetAddress findAnyNonLoopbackInterface() {
         return findNonLoopbackInterface(false, false);
     }


### PR DESCRIPTION
…2420] (#24571)

Log the actual config filename(if present) in error, instead of hard coding as hazelcast.xml

Fix: [HZ-2420](https://hazelcast.atlassian.net/browse/HZ-2420)

Breaking changes (list specific methods/types/messages): None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc

[HZ-2420]:
https://hazelcast.atlassian.net/browse/HZ-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---------

Co-authored-by: Vassilis Bekiaris <vbekiaris@gmail.com>
(cherry picked from commit 95642c3a5967f6c1cad03948ed6e761288e7be30)

<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

Log the actual config filename(if present) in error, instead of hard coding as hazelcast.xml


Fixes [HZ-2420](https://hazelcast.atlassian.net/browse/HZ-2420)

Backport of: [Original PR](https://github.com/hazelcast/hazelcast/pull/24571)

Breaking changes (list specific methods/types/messages): None

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc


[HZ-2420]: https://hazelcast.atlassian.net/browse/HZ-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HZ-2420]: https://hazelcast.atlassian.net/browse/HZ-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HZ-2420]: https://hazelcast.atlassian.net/browse/HZ-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ