### PR TITLE
Prevent sending empty map interceptors information to new members (#24639) [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -60,6 +60,10 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
     public void addMapInterceptors(MapContainer mapContainer) {
         InterceptorRegistry interceptorRegistry = mapContainer.getInterceptorRegistry();
         List<MapInterceptor> interceptorList = interceptorRegistry.getInterceptors();
+        // we do not send info for maps that do not have interceptors
+        if (interceptorList.isEmpty()) {
+            return;
+        }
         Map<String, MapInterceptor> interceptorMap = interceptorRegistry.getId2InterceptorMap();
         Map<MapInterceptor, String> revMap = createHashMap(interceptorMap.size());
         for (Map.Entry<String, MapInterceptor> entry : interceptorMap.entrySet()) {


### PR DESCRIPTION
Resolves https://github.com/hazelcast/hazelcast/issues/24635
Backport of https://github.com/hazelcast/hazelcast/pull/24639