### PR TITLE
Feature: Improve batching in write-behind processor.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -76,55 +76,55 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
         }
         final Map<Integer, List<DelayedEntry>> failuresByPartition = new HashMap<>();
 
-		// copied from callHandler() below
-		final DelayedEntry[] delayedEntriesArray = delayedEntries.toArray(new DelayedEntry[0]);
-		final Map<Object, DelayedEntry> batchMap = prepareBatchMap(delayedEntriesArray);
+        // copied from callHandler() below
+        final DelayedEntry[] delayedEntriesArray = delayedEntries.toArray(new DelayedEntry[0]);
+        final Map<Object, DelayedEntry> batchMap = prepareBatchMap(delayedEntriesArray);
 
-		// if there are no duplicate keys, we do not need to preserve order
-		if (batchMap.size() == delayedEntries.size()) {
+        // if there are no duplicate keys, we do not need to preserve order
+        if (batchMap.size() == delayedEntries.size()) {
 
-			// split into delete and write
-			final List<DelayedEntry> entriesToProcessDelete = new ArrayList<>();
-			final List<DelayedEntry> entriesToProcessWrite = new ArrayList<>();
-			for (final DelayedEntry<Data, Object> entry : delayedEntries) {
-				if (entry.getValue() == null) { // delete
-					entriesToProcessDelete.add(entry);
-				} else { // write
-					entriesToProcessWrite.add(entry);
-				}
-			}
-			final List<DelayedEntry> failuresDelete = callHandler(entriesToProcessDelete, StoreOperationType.DELETE);
-			addFailsTo(failuresByPartition, failuresDelete);
-			entriesToProcessDelete.clear();
-			final List<DelayedEntry> failuresWrite = callHandler(entriesToProcessWrite, StoreOperationType.WRITE);
-			addFailsTo(failuresByPartition, failuresWrite);
-			entriesToProcessWrite.clear();
+            // split into delete and write
+            final List<DelayedEntry> entriesToProcessDelete = new ArrayList<>();
+            final List<DelayedEntry> entriesToProcessWrite = new ArrayList<>();
+            for (final DelayedEntry<Data, Object> entry : delayedEntries) {
+                if (entry.getValue() == null) {
+                    entriesToProcessDelete.add(entry);
+                } else {
+                    entriesToProcessWrite.add(entry);
+                }
+            }
+            final List<DelayedEntry> failuresDelete = callHandler(entriesToProcessDelete, StoreOperationType.DELETE);
+            addFailsTo(failuresByPartition, failuresDelete);
+            entriesToProcessDelete.clear();
+            final List<DelayedEntry> failuresWrite = callHandler(entriesToProcessWrite, StoreOperationType.WRITE);
+            addFailsTo(failuresByPartition, failuresWrite);
+            entriesToProcessWrite.clear();
 
-		} else {
+        } else {
 
-			final List<DelayedEntry> entriesToProcess = new ArrayList<>();
-			StoreOperationType operationType = null;
-			StoreOperationType previousOperationType;
+            final List<DelayedEntry> entriesToProcess = new ArrayList<>();
+            StoreOperationType operationType = null;
+            StoreOperationType previousOperationType;
 
-			// process entries by preserving order.
-			for (final DelayedEntry<Data, Object> entry : delayedEntries) {
-				previousOperationType = operationType;
-				if (entry.getValue() == null) {
-					operationType = StoreOperationType.DELETE;
-				} else {
-					operationType = StoreOperationType.WRITE;
-				}
-				if (previousOperationType != null && !previousOperationType.equals(operationType)) {
-					final List<DelayedEntry> failures = callHandler(entriesToProcess, previousOperationType);
-					addFailsTo(failuresByPartition, failures);
-					entriesToProcess.clear();
-				}
-				entriesToProcess.add(entry);
-			}
-			final List<DelayedEntry> failures = callHandler(entriesToProcess, operationType);
-			addFailsTo(failuresByPartition, failures);
-			entriesToProcess.clear();
-		}
+            // process entries by preserving order.
+            for (final DelayedEntry<Data, Object> entry : delayedEntries) {
+                previousOperationType = operationType;
+                if (entry.getValue() == null) {
+                    operationType = StoreOperationType.DELETE;
+                } else {
+                    operationType = StoreOperationType.WRITE;
+                }
+                if (previousOperationType != null && !previousOperationType.equals(operationType)) {
+                    final List<DelayedEntry> failures = callHandler(entriesToProcess, previousOperationType);
+                    addFailsTo(failuresByPartition, failures);
+                    entriesToProcess.clear();
+                }
+                entriesToProcess.add(entry);
+            }
+            final List<DelayedEntry> failures = callHandler(entriesToProcess, operationType);
+            addFailsTo(failuresByPartition, failures);
+            entriesToProcess.clear();
+        }
         return failuresByPartition;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -74,57 +74,55 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
         if (delayedEntries == null || delayedEntries.isEmpty()) {
             return Collections.emptyMap();
         }
+        return writeCoalescing
+                ? processInternalWithNoOrder(delayedEntries)
+                : processInternalWithOrder(delayedEntries);
+    }
+
+    private Map<Integer, List<DelayedEntry>> processInternalWithNoOrder(List<DelayedEntry> delayedEntries) {
         final Map<Integer, List<DelayedEntry>> failuresByPartition = new HashMap<>();
-
-        // copied from callHandler() below
-        final DelayedEntry[] delayedEntriesArray = delayedEntries.toArray(new DelayedEntry[0]);
-        final Map<Object, DelayedEntry> batchMap = prepareBatchMap(delayedEntriesArray);
-
-        // if there are no duplicate keys, we do not need to preserve order
-        if (batchMap.size() == delayedEntries.size()) {
-
-            // split into delete and write
-            final List<DelayedEntry> entriesToProcessDelete = new ArrayList<>();
-            final List<DelayedEntry> entriesToProcessWrite = new ArrayList<>();
-            for (final DelayedEntry<Data, Object> entry : delayedEntries) {
-                if (entry.getValue() == null) {
-                    entriesToProcessDelete.add(entry);
-                } else {
-                    entriesToProcessWrite.add(entry);
-                }
+        // split into delete and write.
+        final List<DelayedEntry> entriesToProcessDelete = new ArrayList<>();
+        final List<DelayedEntry> entriesToProcessWrite = new ArrayList<>();
+        for (final DelayedEntry<Data, Object> entry : delayedEntries) {
+            if (entry.getValue() == null) {
+                entriesToProcessDelete.add(entry);
+            } else {
+                entriesToProcessWrite.add(entry);
             }
-            final List<DelayedEntry> failuresDelete = callHandler(entriesToProcessDelete, StoreOperationType.DELETE);
-            addFailsTo(failuresByPartition, failuresDelete);
-            entriesToProcessDelete.clear();
-            final List<DelayedEntry> failuresWrite = callHandler(entriesToProcessWrite, StoreOperationType.WRITE);
-            addFailsTo(failuresByPartition, failuresWrite);
-            entriesToProcessWrite.clear();
-
-        } else {
-
-            final List<DelayedEntry> entriesToProcess = new ArrayList<>();
-            StoreOperationType operationType = null;
-            StoreOperationType previousOperationType;
-
-            // process entries by preserving order.
-            for (final DelayedEntry<Data, Object> entry : delayedEntries) {
-                previousOperationType = operationType;
-                if (entry.getValue() == null) {
-                    operationType = StoreOperationType.DELETE;
-                } else {
-                    operationType = StoreOperationType.WRITE;
-                }
-                if (previousOperationType != null && !previousOperationType.equals(operationType)) {
-                    final List<DelayedEntry> failures = callHandler(entriesToProcess, previousOperationType);
-                    addFailsTo(failuresByPartition, failures);
-                    entriesToProcess.clear();
-                }
-                entriesToProcess.add(entry);
-            }
-            final List<DelayedEntry> failures = callHandler(entriesToProcess, operationType);
-            addFailsTo(failuresByPartition, failures);
-            entriesToProcess.clear();
         }
+        final List<DelayedEntry> failuresDelete = callHandler(entriesToProcessDelete, StoreOperationType.DELETE);
+        addFailsTo(failuresByPartition, failuresDelete);
+        entriesToProcessDelete.clear();
+        final List<DelayedEntry> failuresWrite = callHandler(entriesToProcessWrite, StoreOperationType.WRITE);
+        addFailsTo(failuresByPartition, failuresWrite);
+        entriesToProcessWrite.clear();
+        return failuresByPartition;
+    }
+
+    private Map<Integer, List<DelayedEntry>> processInternalWithOrder(List<DelayedEntry> delayedEntries) {
+        final Map<Integer, List<DelayedEntry>> failuresByPartition = new HashMap<>();
+        final List<DelayedEntry> entriesToProcess = new ArrayList<>();
+        StoreOperationType operationType = null;
+        StoreOperationType previousOperationType;
+        // process entries by preserving order.
+        for (final DelayedEntry<Data, Object> entry : delayedEntries) {
+            previousOperationType = operationType;
+            if (entry.getValue() == null) {
+                operationType = StoreOperationType.DELETE;
+            } else {
+                operationType = StoreOperationType.WRITE;
+            }
+            if (previousOperationType != null && !previousOperationType.equals(operationType)) {
+                final List<DelayedEntry> failures = callHandler(entriesToProcess, previousOperationType);
+                addFailsTo(failuresByPartition, failures);
+                entriesToProcess.clear();
+            }
+            entriesToProcess.add(entry);
+        }
+        final List<DelayedEntry> failures = callHandler(entriesToProcess, operationType);
+        addFailsTo(failuresByPartition, failures);
+        entriesToProcess.clear();
         return failuresByPartition;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindCoalescingBatchingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindCoalescingBatchingTest.java
@@ -1,0 +1,182 @@
+package com.hazelcast.map.impl.mapstore.writebehind;
+
+import static org.junit.Assert.assertEquals;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import com.hazelcast.map.MapStore;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * A test to check batching in the write-behind processor when using
+ * coalescing writes.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({ QuickTest.class, ParallelJVMTest.class })
+public class WriteBehindCoalescingBatchingTest extends HazelcastTestSupport {
+
+    @Test
+    public void testWriteBehindQueues_flushed_onNodeShutdown() throws Exception {
+
+        // create hazelcast config
+        Config config = getConfig();
+
+        // create a coalescing write-behind store
+        // with a delay of 10s and a batch size of 1000
+        final String mapName = randomMapName();
+        final int writeDelaySeconds = 10;
+        final int batchSize = 1000;
+
+        CountingMapStore mapStore = new CountingMapStore();
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig
+                .setWriteCoalescing(true)
+                .setImplementation(mapStore)
+                .setWriteDelaySeconds(writeDelaySeconds)
+                .setWriteBatchSize(batchSize);
+
+        config.getMapConfig(mapName).setMapStoreConfig(mapStoreConfig);
+
+        // create 1 node
+        HazelcastInstance hcInstance = createHazelcastInstance(config);
+
+        // during 1st write-behind interval:
+        // populate map -> 1 storeAll call
+        final int mapSize = 300;
+        IMap<String, String> map = hcInstance.getMap(mapName);
+        for (int i = 0; i < mapSize; i++) {
+            map.put("key" + i, "val" + i + "init");
+        }
+
+        // wait until write delay has passed
+        sleep(writeDelaySeconds + 3);
+
+        // during 2nd write-behind interval:
+        // perform puts and removes -> 1 storeAll, 1 deleteAll call
+        for (int i = 0; i < mapSize; i++) {
+
+            // every 5th operation is a remove
+            if (i % 5 == 0) {
+                map.remove("key" + i);
+            } else {
+                map.put("key" + i, "val" + i);
+            }
+        }
+
+        // wait until write delay has passed
+        sleep(writeDelaySeconds + 3);
+
+        // assert
+        System.out.println("countDelete         = " + mapStore.countDelete.get());
+        System.out.println("countDeleteAll      = " + mapStore.countDeleteAll.get());
+        System.out.println("countDeletedEntries = " + mapStore.countDeletedEntries.get());
+        System.out.println("countStore          = " + mapStore.countStore.get());
+        System.out.println("countStoreAll       = " + mapStore.countStoreAll.get());
+        System.out.println("countStoredEntries  = " + mapStore.countStoredEntries.get());
+        assertEquals(0, mapStore.countDelete.get());
+        assertEquals(1, mapStore.countDeleteAll.get());
+        assertEquals(60, mapStore.countDeletedEntries.get());
+        assertEquals(0, mapStore.countStore.get());
+        assertEquals(2, mapStore.countStoreAll.get());
+        assertEquals(540, mapStore.countStoredEntries.get());
+    }
+
+    private static void sleep(long seconds) {
+        try {
+            System.out.println("Starting to sleep for " + seconds + "s...");
+            Thread.sleep(seconds * 1000);
+            System.out.println("Slept " + seconds + "s.");
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private class CountingMapStore implements MapStore<String, String> {
+
+        AtomicInteger countStore = new AtomicInteger();
+        AtomicInteger countStoreAll = new AtomicInteger();
+        AtomicInteger countStoredEntries = new AtomicInteger();
+
+        AtomicInteger countDelete = new AtomicInteger();
+        AtomicInteger countDeleteAll = new AtomicInteger();
+        AtomicInteger countDeletedEntries = new AtomicInteger();
+
+        private ConcurrentHashMap<String, String> inMemoryStore = new ConcurrentHashMap<>();
+
+        @Override
+        public Set<String> loadAllKeys() {
+            return new HashSet<String>(inMemoryStore.keySet());
+        }
+
+        @Override
+        public String load(String key) {
+            return inMemoryStore.get(key);
+        }
+
+        @Override
+        public Map<String, String> loadAll(Collection<String> keys) {
+            Map<String, String> result = new HashMap<>();
+            for (String key : keys) {
+                String value = inMemoryStore.get(key);
+                if (value != null) {
+                    result.put(key, value);
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public void store(String key, String value) {
+            System.out.println("store called. key=" + key);
+            countStore.incrementAndGet();
+            countStoredEntries.incrementAndGet();
+            inMemoryStore.put(key, value);
+        }
+
+        @Override
+        public void storeAll(Map<String, String> map) {
+            System.out.println("storeAll called. map size=" + map.size());
+            countStoreAll.incrementAndGet();
+            countStoredEntries.addAndGet(map.size());
+            for (Entry<String, String> entry : map.entrySet()) {
+                inMemoryStore.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        @Override
+        public void delete(String key) {
+            System.out.println("delete called. key=" + key);
+            countDelete.incrementAndGet();
+            countDeletedEntries.incrementAndGet();
+            inMemoryStore.remove(key);
+        }
+
+        @Override
+        public void deleteAll(Collection<String> keys) {
+            System.out.println("deleteAll called. keys size=" + keys.size());
+            countDeleteAll.incrementAndGet();
+            countDeletedEntries.addAndGet(keys.size());
+            for (String key : keys) {
+                inMemoryStore.remove(key);
+            }
+        }
+
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindCoalescingBatchingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindCoalescingBatchingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.map.impl.mapstore.writebehind;
 
 import static org.junit.Assert.assertEquals;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindCoalescingBatchingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindCoalescingBatchingTest.java
@@ -25,8 +25,7 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapStore;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,7 +43,7 @@ import org.junit.runner.RunWith;
  * coalescing writes.
  */
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({ QuickTest.class, ParallelJVMTest.class })
+@Category(SlowTest.class)
 public class WriteBehindCoalescingBatchingTest extends HazelcastTestSupport {
 
     @Test


### PR DESCRIPTION
This PR improves the batching in the write-behind processor when used with coalescing write-behind queues.

Without this PR and having many store and delete operations mixed in the write-behind queue, you will end up with many small callbacks to your MapStore implementation. This is bad for performance, because it pretty much disables the advantages of batching.

With this PR and using write coalescing, when having many store and delete operations mixed in the write-behind queue, you will end up with just two callbacks to your MapStore implementation - one for all the store operations and one for all the delete operations.

Fixes #24763 