### PR TITLE
Skip archunit tests for JDK 21 [HZ-2496]

### DIFF
--- a/extensions/avro/src/test/java/com/hazelcast/jet/avro/AvroSerializableTest.java
+++ b/extensions/avro/src/test/java/com/hazelcast/jet/avro/AvroSerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.avro;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class AvroSerializableTest {
+public class AvroSerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/CdcDebeziumSerializableTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/CdcDebeziumSerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.cdc;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class CdcDebeziumSerializableTest {
+public class CdcDebeziumSerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/CdcMysqlSerializableTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/CdcMysqlSerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.cdc.mysql;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class CdcMysqlSerializableTest {
+public class CdcMysqlSerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/CdcPostgresSerializableTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/CdcPostgresSerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.cdc.postgres;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class CdcPostgresSerializableTest {
+public class CdcPostgresSerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/csv/src/test/java/com/hazelcast/jet/csv/CsvSerializableTest.java
+++ b/extensions/csv/src/test/java/com/hazelcast/jet/csv/CsvSerializableTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.jet.csv.impl.CsvReadFileFnProvider;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -30,7 +31,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class CsvSerializableTest {
+public class CsvSerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/Elastic6SerializableTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/Elastic6SerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.elastic;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class Elastic6SerializableTest {
+public class Elastic6SerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/Elastic7SerializableTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/Elastic7SerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.elastic;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class Elastic7SerializableTest {
+public class Elastic7SerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/grpc/src/test/java/com/hazelcast/jet/grpc/GrpcSerializableTest.java
+++ b/extensions/grpc/src/test/java/com/hazelcast/jet/grpc/GrpcSerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.grpc;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class GrpcSerializableTest {
+public class GrpcSerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/HadoopSerializableTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/HadoopSerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.hadoop;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class HadoopSerializableTest {
+public class HadoopSerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/KafkaSerializableTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/KafkaSerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.kafka;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class KafkaSerializableTest {
+public class KafkaSerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisSerializableTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisSerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.kinesis;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class KinesisSerializableTest {
+public class KinesisSerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonSerializableTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonSerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.python;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class PythonSerializableTest {
+public class PythonSerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SerializableTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.s3;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class S3SerializableTest {
+public class S3SerializableTest extends ArchUnitTestSupport {
 
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {

--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -53,10 +53,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>compile</scope>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
         </dependency>
     </dependencies>
 

--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -81,6 +81,20 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-third-party</id>
+                        <configuration>
+                            <includedLicenses combine.children="append">
+                                <includedLicense>Eclipse Public License 1.0</includedLicense>
+                            </includedLicenses>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -46,6 +46,18 @@
             <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitTestSupport.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitTestSupport.java
@@ -16,11 +16,9 @@
 
 package com.hazelcast.test.archunit;
 
-import org.hamcrest.Matchers;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 
-import java.lang.reflect.Method;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public abstract class ArchUnitTestSupport {
 
@@ -29,19 +27,13 @@ public abstract class ArchUnitTestSupport {
     // ArchUnit releases lag behind the JDK releases.
     // Skip the test if JDK version is higher than the specified assumption
     @BeforeClass
-    public static void beforeClass() throws Throwable {
-        Assume.assumeThat("Skipping as ASM shaded within ArchUnit 1.0.1 doesn't support Java 21", getCurrentJavaVersion(),
-                Matchers.is(Matchers.lessThan(HIGHEST_JDK)));
+    public static void beforeClass() {
+        assumeThat(getMajorJavaVersion())
+                .as("Skipping as ASM shaded within ArchUnit 1.0.1 doesn't support Java 21")
+                .isLessThan(HIGHEST_JDK);
     }
 
-    private static int getCurrentJavaVersion() throws Throwable {
-        Class runtimeClass = Runtime.class;
-
-        Class versionClass = Class.forName("java.lang.Runtime$Version");
-        Method versionMethod = runtimeClass.getDeclaredMethod("version");
-        Object versionObj = versionMethod.invoke(Runtime.getRuntime());
-        Method majorMethod = versionClass.getDeclaredMethod("major");
-        return (int) majorMethod.invoke(versionObj);
-
+    private static int getMajorJavaVersion() {
+        return Runtime.version().feature();
     }
 }

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitTestSupport.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitTestSupport.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.archunit;
+
+import org.hamcrest.Matchers;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+import java.lang.reflect.Method;
+
+public abstract class ArchUnitTestSupport {
+
+    private static final int HIGHEST_JDK = 21;
+
+    // ArchUnit releases lag behind the JDK releases.
+    // Skip the test if JDK version is higher than the specified assumption
+    @BeforeClass
+    public static void beforeClass() throws Throwable {
+        Assume.assumeThat("Skipping as ASM shaded within ArchUnit 1.0.1 doesn't support Java 21", getCurrentJavaVersion(),
+                Matchers.is(Matchers.lessThan(HIGHEST_JDK)));
+    }
+
+    private static int getCurrentJavaVersion() throws Throwable {
+        Class runtimeClass = Runtime.class;
+
+        Class versionClass = Class.forName("java.lang.Runtime$Version");
+        Method versionMethod = runtimeClass.getDeclaredMethod("version");
+        Object versionObj = versionMethod.invoke(Runtime.getRuntime());
+        Method majorMethod = versionClass.getDeclaredMethod("major");
+        return (int) majorMethod.invoke(versionObj);
+
+    }
+}

--- a/hazelcast-archunit-rules/src/test/java/com/hazelcast/test/archunit/ArchUnitRulesTest.java
+++ b/hazelcast-archunit-rules/src/test/java/com/hazelcast/test/archunit/ArchUnitRulesTest.java
@@ -18,27 +18,13 @@ package com.hazelcast.test.archunit;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
-
-import static org.junit.Assume.assumeThat;
-
-import java.lang.reflect.Method;
-
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.ONLY_INCLUDE_TESTS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
 
-public class ArchUnitRulesTest {
-
-    @BeforeClass
-    public static void beforeClass() {
-        assumeThat("Skipping as ASM shaded within ArchUnit 1.0.0 doesn't support Java 20", getCurrentJavaVersion(),
-                is(lessThan(20)));
-    }
+public class ArchUnitRulesTest extends ArchUnitTestSupport {
 
     @Test
     public void should_fail_with_non_compliant_class() {
@@ -60,19 +46,5 @@ public class ArchUnitRulesTest {
         assertThat(classes).isNotEmpty();
 
         ArchUnitRules.SERIALIZABLE_SHOULD_HAVE_VALID_SERIAL_VERSION_UID.check(classes);
-    }
-
-    private static int getCurrentJavaVersion() {
-        Class runtimeClass = Runtime.class;
-
-        try {
-            Class versionClass = Class.forName("java.lang.Runtime$Version");
-            Method versionMethod = runtimeClass.getDeclaredMethod("version");
-            Object versionObj = versionMethod.invoke(Runtime.getRuntime());
-            Method majorMethod = versionClass.getDeclaredMethod("major");
-            return (int) majorMethod.invoke(versionObj);
-        } catch (Exception e) {
-            return 8;
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/HazelcastCompletableFutureAsyncUsageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/HazelcastCompletableFutureAsyncUsageTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast;
 
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -25,8 +26,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
-
-public class HazelcastCompletableFutureAsyncUsageTest {
+public class HazelcastCompletableFutureAsyncUsageTest extends ArchUnitTestSupport {
 
     @Test
     public void noClassUsesCompletableFuture() {

--- a/hazelcast/src/test/java/com/hazelcast/jet/JetSerializableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/JetSerializableTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModule;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(ParallelJVMTest.class)
-public class JetSerializableTest {
+public class JetSerializableTest extends ArchUnitTestSupport {
     @Test
     public void serializable_classes_should_have_valid_serialVersionUID() {
         String basePackage = JetService.class.getPackage().getName();


### PR DESCRIPTION
Skip archunit tests for JDK 21, because ArchUnit can not read JDK 21 classees

Fixes : https://github.com/hazelcast/hazelcast/issues/24678
Fixes : https://github.com/hazelcast/hazelcast/issues/24677
Fixes : https://github.com/hazelcast/hazelcast-enterprise/issues/6064
Fixes : https://github.com/hazelcast/hazelcast-enterprise/issues/6065
Jira : https://hazelcast.atlassian.net/browse/HZ-2496

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
