### PR TITLE
Fix leading zero calculation [HZ-2492] [5.3.z] (#24674)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/Sha256Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/Sha256Util.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.util;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.DigestInputStream;
@@ -50,10 +49,8 @@ public final class Sha256Util {
         MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
         messageDigest.update(data, 0, length);
 
-        BigInteger bigInteger = new BigInteger(1, messageDigest.digest());
-        final int radix = 16;
-        return bigInteger.toString(radix);
-
+        byte[] digest = messageDigest.digest();
+        return bytesToHex(digest);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/Sha256UtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/Sha256UtilTest.java
@@ -38,8 +38,32 @@ public class Sha256UtilTest {
     @Test
     public void testCalculateSha256Hex() throws Exception {
         byte[] data = {(byte) 0};
-        String result = Sha256Util.calculateSha256Hex(data, data.length);
+        String result = Sha256Util.calculateSha256Hex(data);
         assertEquals("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d", result);
+    }
+
+    @Test
+    public void testLeadingZeroWithLength() throws Exception {
+        byte[] data = {11, 52, -94, -104, 3, 89, -126, 7, 49, -84, 67, 111, -81, 15, 69, -19, 69, 99, -112, -110, -89,
+                -42, 87, -12, 37, -114, -116, -47, -83, -28, 5, -83};
+        String result = Sha256Util.calculateSha256Hex(data, 32);
+        assertEquals("0dd0af6f7fe8a8816856fadf34cbf7ca5ff7c5af088da656c94c49ff60aea20f", result);
+    }
+
+    @Test
+    public void testLeadingZero() throws Exception {
+        byte[] data = {-103, -109, 6, 90, -72, 68, 41, 7, -45, 42, 12, -38, -50, 123, -100, 102, 95, 65, 5, 30, 64, 85,
+                126, -26, 5, 54, 18, -98, -85, -101, 109, -91};
+        String result = Sha256Util.calculateSha256Hex(data);
+        assertEquals("07b18fecd4bcb1a726fbab1bd4c017e57e20f6f962a342789c57e531667f603b", result);
+    }
+
+    @Test
+    public void testTwoLeadingZeros() throws Exception {
+        byte[] data = {-67, 65, -32, -95, 16, 21, -123, 112, -40, -40, -58, -97, -59, 48, 100, 79, 67, -86, 68, 119,
+                -104, 77, -63, 9, -55, -74, -27, 123, -125, 64, 85, -7};
+        String result = Sha256Util.calculateSha256Hex(data);
+        assertEquals("0078723ef3412533bfc5f362ce0de7d9e18b847a0360dfa4d9a37c3923585097", result);
     }
 
     @Test


### PR DESCRIPTION
The leading zero fix for sha-256 hash calculation was overlooked for parts. It is applied to parts too.

Jira : https://hazelcast.atlassian.net/browse/HZ-2492

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

(cherry picked from commit f5984a1e6ffc821789c7616b17d897d1c42b08cb)
