### PR TITLE
Remove PowerMock [HZ-774]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutorTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.ReflectionUtils;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,7 +35,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-import org.powermock.reflect.Whitebox;
 
 import java.util.List;
 import java.util.UUID;
@@ -79,11 +79,11 @@ public class ParallelPartitionScanExecutorTest {
     }
 
     @Test
-    public void execute_success() {
+    public void execute_success() throws Exception {
         IPartitionService partitionService = mock(IPartitionService.class);
         when(partitionService.getPartitionCount()).thenReturn(271);
         PartitionScanRunner runner = mock(PartitionScanRunner.class);
-        Whitebox.setInternalState(runner, "partitionService", partitionService);
+        ReflectionUtils.setFieldValueReflectively(runner, "partitionService", partitionService);
         ParallelPartitionScanExecutor executor = executor(runner);
         Predicate predicate = Predicates.equal("attribute", 1);
         QueryResult queryResult = new QueryResult(IterationType.ENTRY, null, null, Long.MAX_VALUE, false);

--- a/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRuleMockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRuleMockTest.java
@@ -22,7 +22,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import static com.hazelcast.test.OverridePropertyRule.set;
 import static org.junit.Assert.assertEquals;
@@ -34,9 +33,8 @@ import static org.mockito.Mockito.when;
 /**
  * Tests the {@link OverridePropertyRule} with multiple instances.
  */
-@PrepareForTest(OverridePropertyRulePowerMockTest.TestClass.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class OverridePropertyRulePowerMockTest {
+public class OverridePropertyRuleMockTest {
 
     @Rule
     public OverridePropertyRule overridePropertyRule = set("hazelcast.custom.system.property", "5");
@@ -69,14 +67,14 @@ public class OverridePropertyRulePowerMockTest {
     }
 
     @Test
-    public void testCustomPropertyWithPowerMock() throws Exception {
+    public void testCustomPropertyWithMock() throws Exception {
         TestClass testClass = createTestClass();
 
         assertEquals("5", testClass.getProperty("hazelcast.custom.system.property"));
     }
 
     @Test
-    public void testHazelcastPropertyWithPowerMock() throws Exception {
+    public void testHazelcastPropertyWithMock() throws Exception {
         TestClass testClass = createTestClass();
 
         assertEquals("true", testClass.getProperty("java.net.preferIPv4Stack"));
@@ -90,7 +88,6 @@ public class OverridePropertyRulePowerMockTest {
     public class TestClass {
 
         String getProperty(String property) throws Exception {
-            // assert that PowerMock is working
             assertEquals("mocked-name", OtherClass.getName());
 
             return System.getProperty(property);

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,6 @@
         <jsr107.tck.version>1.1.1</jsr107.tck.version>
         <junit.version>4.13.2</junit.version>
         <mockito.version>5.3.1</mockito.version>
-        <powermock.version>2.0.9</powermock.version>
         <reflections.version>0.9.10</reflections.version>
         <testcontainers.version>1.18.1</testcontainers.version>
         <jna.version>5.13.0</jna.version>
@@ -201,9 +200,6 @@
            open java.base/java.lang
         TimedMemberStateFactoryHelper:
            open java.management/sun.management
-
-        Powermock issue workaround (https://github.com/powermock/powermock/issues/905):
-           export java.xml/jdk.xml.internal
         -->
         <javaModuleArgs>
             --add-exports java.base/jdk.internal.ref=${hazelcast.module.name}
@@ -211,7 +207,6 @@
             --add-opens java.base/sun.nio.ch=${hazelcast.module.name}
             --add-opens java.base/java.lang=${hazelcast.module.name}
             --add-opens java.management/sun.management=${hazelcast.module.name}
-            --add-exports java.xml/jdk.xml.internal=${hazelcast.module.name}
             --add-exports jdk.management/com.ibm.lang.management.internal=${hazelcast.module.name}
             --illegal-access=deny
         </javaModuleArgs>
@@ -1999,18 +1994,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Removes PowerMock from the code 

Fixes https://hazelcast.atlassian.net/browse/HZ-774

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
