### PR TITLE
Fix deprecations without annotation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/security/LdapAuthenticationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/LdapAuthenticationConfig.java
@@ -102,6 +102,7 @@ public class LdapAuthenticationConfig extends AbstractClusterLoginConfig<LdapAut
      *
      * @deprecated Use {@link #getParseDn()}
      */
+    @Deprecated
     public boolean isParseDn() {
         return parseDn != null && parseDn.booleanValue();
     }

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/package-info.java
@@ -18,4 +18,5 @@
  * @deprecated since 5.0
  * Please use {@link com.hazelcast.persistence} for the replacement.
  */
+@Deprecated
 package com.hazelcast.hotrestart;

--- a/hazelcast/src/main/java/com/hazelcast/jet/JetCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/JetCacheManager.java
@@ -31,5 +31,6 @@ public interface JetCacheManager {
      * @deprecated since 5.0
      * Use {@link com.hazelcast.core.ICacheManager#getCache(String)} instead.
      */
+    @Deprecated
     <K, V> ICache<K, V> getCache(String name);
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/config/InstanceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/InstanceConfig.java
@@ -34,6 +34,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * @since Jet 3.0
  * @deprecated since 5.0, use {@link JetConfig} instead.
  */
+@Deprecated
 public class InstanceConfig {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/FileSourceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/FileSourceBuilder.java
@@ -107,6 +107,7 @@ public final class FileSourceBuilder {
      *
      * @deprecated Use {@link FileSources#files}. Will be removed in Jet 5.0.
      */
+    @Deprecated
     @Nonnull
     public BatchSource<String> build() {
         return build((filename, line) -> line);
@@ -132,6 +133,7 @@ public final class FileSourceBuilder {
      *
      * @deprecated Use {@link FileSources#files}. Will be removed in Jet 5.0.
      */
+    @Deprecated
     @Nonnull
     public <T> BatchSource<T> build(@Nonnull BiFunctionEx<String, String, ? extends T> mapOutputFn) {
         String charsetName = charset.name();
@@ -161,6 +163,7 @@ public final class FileSourceBuilder {
      *
      * @deprecated Use {@link FileSources#files}. Will be removed in Jet 5.0.
      */
+    @Deprecated
     @Nonnull
     public <T> BatchSource<T> build(@Nonnull FunctionEx<? super Path, ? extends Stream<T>> readFileFn) {
         return batchFromProcessor("filesSource(" + new File(directory, glob) + ')',

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
@@ -290,6 +290,7 @@ public interface GeneralStageWithKey<T, K> {
      * @deprecated Jet now has first-class support for data rebalancing, see
      * {@link GeneralStage#rebalance()} and {@link GeneralStage#rebalance(FunctionEx)}.
      */
+    @Deprecated
     @Nonnull
     <S, R> GeneralStage<R> mapUsingService(
             @Nonnull ServiceFactory<?, S> serviceFactory,
@@ -331,6 +332,7 @@ public interface GeneralStageWithKey<T, K> {
      * @deprecated Jet now has first-class support for data rebalancing, see
      * {@link GeneralStage#rebalance()} and {@link GeneralStage#rebalance(FunctionEx)}.
      */
+    @Deprecated
     @Nonnull
     default <S, R> GeneralStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
@@ -372,6 +374,7 @@ public interface GeneralStageWithKey<T, K> {
      * @deprecated Jet now has first-class support for data rebalancing, see
      * {@link GeneralStage#rebalance()} and {@link GeneralStage#rebalance(FunctionEx)}.
      */
+    @Deprecated
     @Nonnull
     <S, R> GeneralStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
@@ -423,6 +426,7 @@ public interface GeneralStageWithKey<T, K> {
      * @deprecated Jet now has first-class support for data rebalancing, see
      * {@link GeneralStage#rebalance()} and {@link GeneralStage#rebalance(FunctionEx)}.
      */
+    @Deprecated
     @Nonnull
     <S, R> GeneralStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
@@ -478,6 +482,7 @@ public interface GeneralStageWithKey<T, K> {
      * @deprecated Jet now has first-class support for data rebalancing, see
      * {@link GeneralStage#rebalance()} and {@link GeneralStage#rebalance(FunctionEx)}.
      */
+    @Deprecated
     @Nonnull
     <S, R> GeneralStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
@@ -531,6 +536,7 @@ public interface GeneralStageWithKey<T, K> {
      * @deprecated Jet now has first-class support for data rebalancing, see
      * {@link GeneralStage#rebalance()} and {@link GeneralStage#rebalance(FunctionEx)}.
      */
+    @Deprecated
     @Nonnull
     <S> GeneralStage<T> filterUsingService(
             @Nonnull ServiceFactory<?, S> serviceFactory,
@@ -584,6 +590,7 @@ public interface GeneralStageWithKey<T, K> {
      * @deprecated Jet now has first-class support for data rebalancing, see
      * {@link GeneralStage#rebalance()} and {@link GeneralStage#rebalance(FunctionEx)}.
      */
+    @Deprecated
     @Nonnull
     <S, R> GeneralStage<R> flatMapUsingService(
             @Nonnull ServiceFactory<?, S> serviceFactory,

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Pipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Pipeline.java
@@ -127,7 +127,7 @@ public interface Pipeline extends Serializable {
      * @deprecated since Jet 4.3, Jet performs this transformation on the server-side.
      */
     @Nonnull
-    @Deprecated()
+    @Deprecated
     DAG toDag();
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/memory/MemorySize.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemorySize.java
@@ -25,6 +25,7 @@ package com.hazelcast.memory;
  *
  * @deprecated  Since 5.1, {@link Capacity} should be used instead.
  */
+@Deprecated
 public final class MemorySize extends Capacity {
 
     public MemorySize(long value) {
@@ -51,6 +52,7 @@ public final class MemorySize extends Capacity {
      *
      * @deprecated since 5.1, use {@link Capacity#parse(String)} instead.
      */
+    @Deprecated
     public static MemorySize parse(String value) {
         return parse(value, MemoryUnit.BYTES);
     }
@@ -71,6 +73,7 @@ public final class MemorySize extends Capacity {
      *
      * @deprecated since 5.1, use {@link Capacity#parse(String, MemoryUnit)} instead
      */
+    @Deprecated
     public static MemorySize parse(String value, MemoryUnit defaultUnit) {
         if (value == null || value.length() == 0) {
             return new MemorySize(0, MemoryUnit.BYTES);


### PR DESCRIPTION

Breaking changes (list specific methods/types/messages):
* deprecated items are now also marked with annotation `Deprecated`, but I wouldn't consider that a breaking change.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
