### PR TITLE
Do not try to connect to the old member list after the cluster changes [API-2038]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -522,7 +522,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             do {
                 Set<Address> triedAddressesPerAttempt = new HashSet<>();
 
-                List<Member> memberList = new ArrayList<>(client.getClientClusterService().getMemberList());
+                List<Member> memberList = new ArrayList<>(client.getClientClusterService().getEffectiveMemberList());
                 if (shuffleMemberList) {
                     Collections.shuffle(memberList);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientClusterService.java
@@ -48,6 +48,15 @@ public interface ClientClusterService {
     Collection<Member> getMemberList();
 
     /**
+     * Gets the collection of members, or an empty list if the client
+     * changed the cluster and the new member list is not received yet.
+     *
+     * @return The collection of members.
+     */
+    @Nonnull
+    Collection<Member> getEffectiveMemberList();
+
+    /**
      * Returns a collection of the members that satisfy the given {@link MemberSelector}.
      *
      * @param selector {@link MemberSelector} instance to filter members to return

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -36,6 +36,7 @@ import com.hazelcast.logging.ILogger;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EventListener;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -106,6 +107,17 @@ public class ClientClusterServiceImpl implements ClientClusterService {
     @Override
     public Collection<Member> getMemberList() {
         return memberListSnapshot.get().members.values();
+    }
+
+    @Nonnull
+    @Override
+    public Collection<Member> getEffectiveMemberList() {
+        MemberListSnapshot snapshot = memberListSnapshot.get();
+        if (snapshot.version == INITIAL_MEMBER_LIST_VERSION) {
+            return Collections.emptyList();
+        }
+
+        return snapshot.members.values();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImplTest.java
@@ -511,18 +511,21 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
 
         MemberInfo member = member("127.0.0.1");
         List<MemberInfo> members = Collections.singletonList(member);
-        clusterService.handleMembersViewEvent(1, members, UUID.randomUUID());
 
-        // Returns the member list after the members view event
-        assertCollection(
-                members.stream()
-                        .map(MemberInfo::toMember)
-                        .collect(Collectors.toList()),
-                clusterService.getEffectiveMemberList());
+        for (int i = 0; i < 3; i++) {
+            clusterService.handleMembersViewEvent(i, members, UUID.randomUUID());
 
-        clusterService.onTryToConnectNextCluster();
+            // Returns the member list after the members view event
+            assertCollection(
+                    members.stream()
+                            .map(MemberInfo::toMember)
+                            .collect(Collectors.toList()),
+                    clusterService.getEffectiveMemberList());
 
-        // Returns an empty list after reset
-        assertCollection(Collections.emptyList(), clusterService.getEffectiveMemberList());
+            clusterService.onTryToConnectNextCluster();
+
+            // Returns an empty list after reset
+            assertCollection(Collections.emptyList(), clusterService.getEffectiveMemberList());
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImplTest.java
@@ -41,6 +41,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -499,5 +500,29 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
         clusterService.handleMembersViewEvent(1, asList(masterMember, liteMember("127.0.0.2"),
                 member("127.0.0.3")), UUID.randomUUID());
         clusterService.waitInitialMemberListFetched();
+    }
+
+    @Test
+    public void testGetEffectiveMemberList() {
+        ClientClusterServiceImpl clusterService = new ClientClusterServiceImpl(mock(ILogger.class));
+
+        // Returns an empty list on startup, till the members view event
+        assertCollection(Collections.emptyList(), clusterService.getEffectiveMemberList());
+
+        MemberInfo member = member("127.0.0.1");
+        List<MemberInfo> members = Collections.singletonList(member);
+        clusterService.handleMembersViewEvent(1, members, UUID.randomUUID());
+
+        // Returns the member list after the members view event
+        assertCollection(
+                members.stream()
+                        .map(MemberInfo::toMember)
+                        .collect(Collectors.toList()),
+                clusterService.getEffectiveMemberList());
+
+        clusterService.onTryToConnectNextCluster();
+
+        // Returns an empty list after reset
+        assertCollection(Collections.emptyList(), clusterService.getEffectiveMemberList());
     }
 }


### PR DESCRIPTION
During failover, when the client is about to try to connect to the next cluster, it resets some services including the cluster service.

In its reset logic, cluster service clears the member list version, but leaves the members as it is, as there are some services/proxies that rely on the fact that the member list cannot be empty.

This creates a problem for the failover case. After the cluster change, the client still tries to connect to the last known member list, which is the members of the previous cluster.

To solve the problem, I have introduced a new method to the cluster service, which returns the "effective" member list. That is, it returns an empty list after the service is reset, but returns the member list as expected otherwise. With that, the connection logic simply skips the old member list after the client decides to change the cluster to try to connect to.