### PR TITLE
Reduce the size of entries because test is timing out [HZ-2361] (#24728)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/core/PipeliningTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/PipeliningTest.java
@@ -102,7 +102,7 @@ public class PipeliningTest extends HazelcastTestSupport {
 
     @Test
     public void test() throws Exception {
-        int maxValue = 100_000;
+        int maxValue = 10_000;
         List<Integer> expected = new ArrayList<>();
         Map<Integer, Integer> entriesToAdd = new HashMap<>();
 


### PR DESCRIPTION
The test was timing out before too. It was changed to populate the IMap with putAll() call instead of put() calls in a loop. But it is still timing out. So I am reducing the number of entries

Fixes : https://github.com/hazelcast/hazelcast/issues/24286

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

(cherry picked from commit 77b0a953627b4302d8ed5081f5776d888c51fa42)