### PR TITLE
Fix NioAsyncServerSocketOptionsTest.test_set [HZ-2543]

### DIFF
--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketOptionsTest.java
@@ -32,6 +32,7 @@ import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_RCVBUF;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_REUSEADDR;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_REUSEPORT;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_SNDBUF;
+import static com.hazelcast.internal.tpcengine.util.TpcTestSupport.assumeThatNoWindowsOS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -71,78 +72,88 @@ public abstract class AsyncServerSocketOptionsTest {
 
     @Test
     public void test_set() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        assertTrue(options.set(SUPPORTED_OPTION, true));
+        assumeThatNoWindowsOS();
+        try (AsyncServerSocket serverSocket = newServerSocket()) {
+            AsyncSocketOptions options = serverSocket.options();
+            assertTrue(options.set(SUPPORTED_OPTION, true));
+        }
     }
 
     @Test
     public void test_set_nullOption() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        assertThrows(NullPointerException.class, () -> options.set(null, 1));
+        try (AsyncServerSocket serverSocket = newServerSocket()) {
+            AsyncSocketOptions options = serverSocket.options();
+            assertThrows(NullPointerException.class, () -> options.set(null, 1));
+        }
     }
 
     @Test
     public void test_set_nullValue() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        assertThrows(NullPointerException.class, () -> options.set(SO_RCVBUF, null));
+        try (AsyncServerSocket serverSocket = newServerSocket()) {
+            AsyncSocketOptions options = serverSocket.options();
+            assertThrows(NullPointerException.class, () -> options.set(SO_RCVBUF, null));
+        }
     }
 
     @Test
     public void test_set_unsupportedOption() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        // SO_SNDBUF is not supported for server sockets.
-        assertFalse(options.set(SO_SNDBUF, 64 * 1024));
+        try (AsyncServerSocket serverSocket = newServerSocket()) {
+            AsyncSocketOptions options = serverSocket.options();
+            // SO_SNDBUF is not supported for server sockets.
+            assertFalse(options.set(SO_SNDBUF, 64 * 1024));
+        }
     }
 
     @Test
     public void test_get_unsupportedOption() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        // SO_SNDBUF is not supported for server sockets.
-        assertNull(options.get(SO_SNDBUF));
+        try (AsyncServerSocket serverSocket = newServerSocket()) {
+            AsyncSocketOptions options = serverSocket.options();
+            // SO_SNDBUF is not supported for server sockets.
+            assertNull(options.get(SO_SNDBUF));
+        }
     }
 
     @Test
     public void test_get_nullOption() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        assertThrows(NullPointerException.class, () -> options.get(null));
+        try (AsyncServerSocket serverSocket = newServerSocket()) {
+            AsyncSocketOptions options = serverSocket.options();
+            assertThrows(NullPointerException.class, () -> options.get(null));
+        }
     }
 
     @Test
     public void test_SO_RCVBUF() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        options.set(SO_RCVBUF, 64 * 1024);
-        assertEquals(Integer.valueOf(64 * 1024), options.get(SO_RCVBUF));
+        try (AsyncServerSocket serverSocket = newServerSocket()) {
+            AsyncSocketOptions options = serverSocket.options();
+            options.set(SO_RCVBUF, 64 * 1024);
+            assertEquals(Integer.valueOf(64 * 1024), options.get(SO_RCVBUF));
+        }
     }
 
     @Test
     public void test_SO_REUSEADDR() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        options.set(SO_REUSEADDR, true);
-        assertEquals(Boolean.TRUE, options.get(SO_REUSEADDR));
-        options.set(SO_REUSEADDR, false);
-        assertEquals(Boolean.FALSE, options.get(SO_REUSEADDR));
+        try (AsyncServerSocket serverSocket = newServerSocket()) {
+            AsyncSocketOptions options = serverSocket.options();
+            options.set(SO_REUSEADDR, true);
+            assertEquals(Boolean.TRUE, options.get(SO_REUSEADDR));
+            options.set(SO_REUSEADDR, false);
+            assertEquals(Boolean.FALSE, options.get(SO_REUSEADDR));
+        }
     }
 
     @Test
     public void test_SO_REUSE_PORT() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        if (options.isSupported(SO_REUSEPORT)) {
-            options.set(SO_REUSEPORT, true);
-            assertEquals(Boolean.TRUE, options.get(SO_REUSEPORT));
-            options.set(SO_REUSEPORT, false);
-            assertEquals(Boolean.FALSE, options.get(SO_REUSEPORT));
-        } else {
-            assertFalse(options.set(SO_REUSEPORT, true));
-            assertNull(options.get(SO_REUSEPORT));
+        try (AsyncServerSocket serverSocket = newServerSocket()) {
+            AsyncSocketOptions options = serverSocket.options();
+            if (options.isSupported(SO_REUSEPORT)) {
+                options.set(SO_REUSEPORT, true);
+                assertEquals(Boolean.TRUE, options.get(SO_REUSEPORT));
+                options.set(SO_REUSEPORT, false);
+                assertEquals(Boolean.FALSE, options.get(SO_REUSEPORT));
+            } else {
+                assertFalse(options.set(SO_REUSEPORT, true));
+                assertNull(options.get(SO_REUSEPORT));
+            }
         }
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/util/TpcTestSupport.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/util/TpcTestSupport.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpcengine.util;
+
+import static org.junit.Assume.assumeFalse;
+
+public class TpcTestSupport {
+
+    private TpcTestSupport() {
+    }
+
+    public static void assumeThatNoWindowsOS() {
+        String property = System.getProperty("os.name");
+        boolean windowsOS = property.toLowerCase().startsWith("win");
+        assumeFalse("Skipping on Windows", windowsOS);
+    }
+}


### PR DESCRIPTION
- SO_REUSEPORT option is not supported on Windows OS. Ignore the test_set() test
- Close the socket after all tests via try with resources construct 

Fixes : https://github.com/hazelcast/hazelcast/issues/24663
Jira : https://hazelcast.atlassian.net/browse/HZ-2543

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible