### PR TITLE
Replace Mockito spy usage in QueryIndexingTest [HZ-2491]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexingTest.java
@@ -21,11 +21,11 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
-import com.hazelcast.mock.MockUtil;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.PredicateBuilder.EntryObject;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.SampleTestObjects.Employee;
+import com.hazelcast.query.SampleTestObjects.SpiedEmployee;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -45,8 +45,6 @@ import java.util.Map;
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -114,13 +112,12 @@ public class QueryIndexingTest extends HazelcastTestSupport {
     private static Map<Integer, Employee> newEmployees(int employeeCount) {
         Map<Integer, Employee> employees = new HashMap<>();
         for (int i = 0; i < employeeCount; i++) {
-            Employee val;
+            Employee spy;
             if (i % 2 == 0) {
-                val = new Employee(i, null, null, 0, true, i);
+                spy = new SpiedEmployee(i, null, null, 0, true, i);
             } else {
-                val = new Employee(i, "name" + i, "city" + i, 0, true, i);
+                spy = new SpiedEmployee(i, "name" + i, "city" + i, 0, true, i);
             }
-            Employee spy = MockUtil.serializableSpy(Employee.class, val);
             employees.put(i, spy);
         }
         return employees;
@@ -145,8 +142,9 @@ public class QueryIndexingTest extends HazelcastTestSupport {
 
     private static void assertGettersCalledNTimes(Collection<Employee> matchingEmployees, int expectedCalls) {
         for (Employee employee : matchingEmployees) {
-            verify(employee, times(expectedCalls)).getCity();
-            verify(employee, times(expectedCalls)).getName();
+            SpiedEmployee spy = (SpiedEmployee) employee;
+            assertEquals(expectedCalls, spy.getInvocationCount("getCity"));
+            assertEquals(expectedCalls, spy.getInvocationCount("getName"));
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/SampleTestObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SampleTestObjects.java
@@ -26,8 +26,11 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public final class SampleTestObjects {
 
@@ -388,6 +391,86 @@ public final class SampleTestObjects {
                     + ", active=" + active
                     + ", salary=" + salary
                     + '}';
+        }
+    }
+
+    // Mockito encounters non-deterministic failures in some tests when mocking
+    // the Employee object - to avoid further time spent investigating that issue,
+    // we simply provide our own basic spied invocation counter instead
+    public static class SpiedEmployee extends Employee {
+        private final Map<String, AtomicInteger> invocationCounters = new ConcurrentHashMap<>();
+
+        public SpiedEmployee(long id, String name, int age, boolean live, double salary, State state) {
+            super(id, name, age, live, salary, state);
+        }
+
+        public SpiedEmployee(long id, String name, int age, boolean live, double salary) {
+            super(id, name, age, live, salary);
+        }
+
+        public SpiedEmployee(String name, int age, boolean live, double salary) {
+            super(name, age, live, salary);
+        }
+
+        public SpiedEmployee(String name, String city, int age, boolean live, double salary) {
+            super(name, city, age, live, salary);
+        }
+
+        public SpiedEmployee(long id, String name, String city, int age, boolean live, double salary) {
+            super(id, name, city, age, live, salary);
+        }
+
+        public SpiedEmployee() {
+        }
+
+        public long getId() {
+            invocationCounters.computeIfAbsent("getId", i -> new AtomicInteger(0)).getAndIncrement();
+            return super.getId();
+        }
+
+        public Date getCreateDate() {
+            invocationCounters.computeIfAbsent("getCreateDate", i -> new AtomicInteger(0)).getAndIncrement();
+            return super.getCreateDate();
+        }
+
+        public Timestamp getDate() {
+            invocationCounters.computeIfAbsent("getDate", i -> new AtomicInteger(0)).getAndIncrement();
+            return super.getDate();
+        }
+
+        public String getName() {
+            invocationCounters.computeIfAbsent("getName", i -> new AtomicInteger(0)).getAndIncrement();
+            return super.getName();
+        }
+
+        public String getCity() {
+            invocationCounters.computeIfAbsent("getCity", i -> new AtomicInteger(0)).getAndIncrement();
+            return super.getCity();
+        }
+
+        public int getAge() {
+            invocationCounters.computeIfAbsent("getAge", i -> new AtomicInteger(0)).getAndIncrement();
+            return super.getAge();
+        }
+
+        public double getSalary() {
+            invocationCounters.computeIfAbsent("getSalary", i -> new AtomicInteger(0)).getAndIncrement();
+            return super.getSalary();
+        }
+
+        public boolean isActive() {
+            invocationCounters.computeIfAbsent("isActive", i -> new AtomicInteger(0)).getAndIncrement();
+            return super.isActive();
+        }
+
+        public State getState() {
+            invocationCounters.computeIfAbsent("getState", i -> new AtomicInteger(0)).getAndIncrement();
+            return super.getState();
+        }
+
+        public int getInvocationCount(String methodName) {
+            AtomicInteger counter = invocationCounters.get(methodName);
+            return counter == null ? 0 : counter.get();
         }
     }
 


### PR DESCRIPTION
We have recently been encountering a variety of edge-case issues with Mockito related failures in some of our tests - these tests are generally non-deterministic, but surface during long-running test jobs on Jenkins. There has been extensive investigation of these issues by multiple team members, but the issues always point towards an issue within Mockito itself (although exact causes have not been identified).

The QueryIndexingTest encounters the same failures consistently while running on a Sonar code coverage Jenkins job. The failures are always related to instantiating a _serialized spy_ instance, with various debugging sessions showing that non-serialized spy instances are created successfully. As with other similar Mockito failures, this failure is reproduced consistently in long-running tests, but not in isolation.

Due to the functionality of this being simple in this test, we have decided to avoid spending more time investigating the specifics of why Mockito is struggling here and simply replace the problematic Mockito functionality with our own implementation. In this test that is a simple wrapper for the `Employee` class which uses a `Map` keyed by method names to an `AtomicInteger` which counts the invocations of each method.

Fixes https://github.com/hazelcast/hazelcast/issues/23645
