### PR TITLE
Fix THIRD-PARTY.txt file in distribution

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -39,7 +39,17 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-third-party</id>
+                        <goals>
+                            <goal>add-third-party</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
                 <configuration>
+                    <force>true</force>
                     <acceptPomPackaging>true</acceptPomPackaging>
                     <includedLicenses combine.children="append">
                         <includedLicense>CDDL</includedLicense>


### PR DESCRIPTION
Due to the wrong ordering of plugins the dummy THIRD-PARTY.txt file 
ended in the distribution package instead of the real file.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
