### PR TITLE
Wrap TABLE operator in subquery for better scoping [HZ-2453] [5.3.z]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/s2sjoin/SqlStreamToStreamJoinTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/s2sjoin/SqlStreamToStreamJoinTest.java
@@ -608,6 +608,24 @@ public class SqlStreamToStreamJoinTest extends SqlTestSupport {
     }
 
     @Test
+    public void test_joinWithoutViewsAndSubqueries() {
+        TestStreamSqlConnector.create(
+                sqlService,
+                "stream1",
+                singletonList("a"),
+                singletonList(TIMESTAMP_WITH_TIME_ZONE),
+                row(timestampTz(42L)));
+
+        assertRowsEventuallyInAnyOrder(
+                "SELECT * FROM " +
+                        "TABLE(IMPOSE_ORDER(TABLE stream1, DESCRIPTOR(a), INTERVAL '1' SECONDS)) s1 " +
+                        "INNER JOIN " +
+                        "TABLE(IMPOSE_ORDER(TABLE stream1, DESCRIPTOR(a), INTERVAL '1' SECONDS)) s2 " +
+                        "ON s1.a=s2.a",
+                singletonList(new Row(timestampTz(42L), timestampTz(42L))));
+    }
+
+    @Test
     public void test_joinWithUsingClause() {
         TestStreamSqlConnector.create(
                 sqlService,


### PR DESCRIPTION
`TABLE(...)` expressions do not create a separate scope; that’s why when they are used as join operands, the operators they enclose, such as `DESCRIPTOR(...)`, are assigned the `JoinScope`. This results in incorrect indexing after resolving identifiers or name clashes due to combined namespaces.

Backports #24598
Fixes [HZ-2453]

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases


[HZ-2453]: https://hazelcast.atlassian.net/browse/HZ-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ