### PR TITLE
Fixes after Hamcrest removal

### DIFF
--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ArchUnitRules.java
@@ -22,6 +22,7 @@ import com.tngtech.archunit.lang.ArchRule;
 import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
 
+import static com.hazelcast.test.archunit.MatchersUsageCondition.notUseHamcrestMatchers;
 import static com.hazelcast.test.archunit.SerialVersionUidFieldCondition.haveValidSerialVersionUid;
 import static com.hazelcast.test.archunit.CompletableFutureUsageCondition.useExplicitExecutorServiceInCFAsyncMethods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
@@ -46,6 +47,13 @@ public final class ArchUnitRules {
      */
     public static final ArchRule COMPLETABLE_FUTURE_USED_ONLY_WITH_EXPLICIT_EXECUTOR = classes()
             .should(useExplicitExecutorServiceInCFAsyncMethods());
+
+    /**
+     * ArchUnit rule checking that Hamcrest matchers are not mixed with AssertJ.
+     */
+    public static final ArchRule MATCHERS_USAGE = classes()
+            .that().haveSimpleNameEndingWith("Test")
+            .should(notUseHamcrestMatchers());
 
     private ArchUnitRules() {
     }

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/MatchersUsageCondition.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/MatchersUsageCondition.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.test.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+
+/**
+ * Hamcrest is great, but AssertJ is even better.
+ * Also, Hamcrest matchers tend to cause the usage of {@code org.junit.Assert#assertThat}
+ * (didn't add link to not depend on deprecated method), which is deprecated - and AssertJ is better for fluent assertions.
+ */
+public class MatchersUsageCondition extends ArchCondition<JavaClass> {
+
+    public MatchersUsageCondition() {
+        super("Use AssertJ instead of Hamcrest matchers");
+    }
+
+    @Override
+    public void check(JavaClass item, ConditionEvents events) {
+        for (JavaMethodCall methodCall : item.getMethodCallsFromSelf()) {
+            if (methodCall.getTarget().getFullName().contains("org.hamcrest")) {
+                String violatingMethodName = methodCall.getOwner().getFullName();
+                events.add(violated(item, violatingMethodName + ":" + methodCall.getLineNumber()
+                        + " calls Hamcrest Matcher " + methodCall.getName() + ". You should consider AssertJ matchers."));
+            }
+        }
+    }
+
+    public static ArchCondition<JavaClass> notUseHamcrestMatchers() {
+        return new MatchersUsageCondition();
+    }
+}

--- a/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ModuleImportOptions.java
+++ b/hazelcast-archunit-rules/src/main/java/com/hazelcast/test/archunit/ModuleImportOptions.java
@@ -31,4 +31,10 @@ public final class ModuleImportOptions {
         Pattern projectModulePattern = Pattern.compile(".*/" + moduleName + "/target/classes/.*");
         return location -> location.matches(projectModulePattern);
     }
+
+    public static ImportOption onlyCurrentModuleTests() {
+        String moduleName = Paths.get("").toAbsolutePath().getFileName().toString();
+        Pattern projectModulePattern = Pattern.compile(".*/" + moduleName + "/target/test-classes/.*");
+        return location -> location.matches(projectModulePattern);
+    }
 }

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -570,6 +570,15 @@
             <version>${jsr107.tck.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Required as dependency of cache-tests -->
+        <!-- Tests like CacheExpiryTest won't work if it's not provided, -->
+        <!-- although javax.cache does not declare dependency -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-tests</artifactId>

--- a/hazelcast/src/test/java/com/hazelcast/NoHamcrestInOurTestSourcesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/NoHamcrestInOurTestSourcesTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast;
+
+import com.hazelcast.test.archunit.ArchUnitRules;
+import com.hazelcast.test.archunit.ArchUnitTestSupport;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.hazelcast.test.archunit.ModuleImportOptions.onlyCurrentModuleTests;
+
+/**
+ * Hamcrest is great, but AssertJ is even better.
+ * Also, Hamcrest matchers tend to cause the usage of {@code org.junit.Assert#assertThat}
+ * (didn't add link to not depend on deprecated method), which is deprecated - and AssertJ is better for fluent assertions.
+ *
+ */
+public class NoHamcrestInOurTestSourcesTest extends ArchUnitTestSupport {
+
+    @Test
+    public void noClassUsesHamcrest() {
+        String basePackage = "com.hazelcast";
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(onlyCurrentModuleTests())
+                .importPackages(basePackage);
+
+        ArchUnitRules.MATCHERS_USAGE.check(classes);
+    }
+}


### PR DESCRIPTION
JCache requires Hamcrest to be declared, so I added it, but also added an arch test to check that it's not used directly.

Hamcrest is great, don't get me wrong, but mixing assertion libraries and using deprecated "assertThat" is not great.

Fixes #24781

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
