### PR TITLE
Improvements to RestClientTest TLS 1.3 support tests [HZ-2541]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/utils/RestClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/utils/RestClientTest.java
@@ -90,9 +90,9 @@ public class RestClientTest {
 
         // when
         String result = RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                .withHeaders(singletonMap(headerKey, headerValue))
-                .get()
-                .getBody();
+                                  .withHeaders(singletonMap(headerKey, headerValue))
+                                  .get()
+                                  .getBody();
 
         // then
         assertEquals(BODY_RESPONSE, result);
@@ -113,11 +113,11 @@ public class RestClientTest {
 
         // when
         String result = RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                .withReadTimeoutSeconds(1200)
-                .withConnectTimeoutSeconds(1200)
-                .withRetries(1)
-                .get()
-                .getBody();
+                                  .withReadTimeoutSeconds(1200)
+                                  .withConnectTimeoutSeconds(1200)
+                                  .withRetries(1)
+                                  .get()
+                                  .getBody();
 
         // then
         assertEquals(BODY_RESPONSE, result);
@@ -145,9 +145,9 @@ public class RestClientTest {
 
         // when
         String result = RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                .withBody(BODY_REQUEST)
-                .post()
-                .getBody();
+                                  .withBody(BODY_REQUEST)
+                                  .post()
+                                  .getBody();
 
         // then
         assertEquals(BODY_RESPONSE, result);
@@ -164,10 +164,10 @@ public class RestClientTest {
 
         // when
         String result = RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                .withBody(BODY_REQUEST)
-                .expectResponseCodes(expectedCode1, expectedCode2)
-                .post()
-                .getBody();
+                                  .withBody(BODY_REQUEST)
+                                  .expectResponseCodes(expectedCode1, expectedCode2)
+                                  .post()
+                                  .getBody();
 
         // then
         assertEquals(BODY_RESPONSE, result);
@@ -184,8 +184,8 @@ public class RestClientTest {
         // when
         RestClientException exception = assertThrows(RestClientException.class, () ->
                 RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                        .withBody(BODY_REQUEST)
-                        .get());
+                          .withBody(BODY_REQUEST)
+                          .get());
 
         // then
         assertEquals(responseCode, exception.getHttpErrorCode());
@@ -203,9 +203,9 @@ public class RestClientTest {
         // when
         RestClientException exception = assertThrows(RestClientException.class, () ->
                 RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                        .withBody(BODY_REQUEST)
-                        .expectResponseCodes(expectedCode)
-                        .post());
+                          .withBody(BODY_REQUEST)
+                          .expectResponseCodes(expectedCode)
+                          .post());
 
         // then
         assertEquals(unexpectedCode, exception.getHttpErrorCode());
@@ -222,9 +222,9 @@ public class RestClientTest {
 
         // when
         RestClient.Response response = RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                .withBody(BODY_REQUEST)
-                .expectResponseCodes(responseCode)
-                .get();
+                                                 .withBody(BODY_REQUEST)
+                                                 .expectResponseCodes(responseCode)
+                                                 .get();
 
         // then
         assertEquals(responseCode, response.getCode());
@@ -257,7 +257,7 @@ public class RestClientTest {
         try {
             new Thread(server).start();
             RestClient.create("https://127.0.0.1:" + server.serverSocket.getLocalPort())
-                    .withCaCertificates(readFile("src/test/resources/kubernetes/ca.crt")).get();
+                      .withCaCertificates(readFile("src/test/resources/kubernetes/ca.crt")).get();
         } catch (Exception e) {
             // whatever
         } finally {

--- a/hazelcast/src/test/java/com/hazelcast/spi/utils/RestClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/utils/RestClientTest.java
@@ -17,13 +17,34 @@
 package com.hazelcast.spi.utils;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.exception.RestClientException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -34,23 +55,10 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
-import static com.hazelcast.internal.nio.IOUtil.close;
-import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class})
 public class RestClientTest {
     private static final String API_ENDPOINT = "/some/endpoint";
     private static final String BODY_REQUEST = "some body request";
@@ -70,7 +78,7 @@ public class RestClientTest {
     public void getSuccess() {
         // given
         stubFor(get(urlEqualTo(API_ENDPOINT))
-                .willReturn(aResponse().withStatus(200).withBody(BODY_RESPONSE)));
+            .willReturn(aResponse().withStatus(200).withBody(BODY_RESPONSE)));
 
         // when
         String result = RestClient.create(String.format("%s%s", address, API_ENDPOINT)).get().getBody();
@@ -85,14 +93,14 @@ public class RestClientTest {
         String headerKey = "Metadata-Flavor";
         String headerValue = "Google";
         stubFor(get(urlEqualTo(API_ENDPOINT))
-                .withHeader(headerKey, equalTo(headerValue))
-                .willReturn(aResponse().withStatus(200).withBody(BODY_RESPONSE)));
+            .withHeader(headerKey, equalTo(headerValue))
+            .willReturn(aResponse().withStatus(200).withBody(BODY_RESPONSE)));
 
         // when
         String result = RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                                  .withHeaders(singletonMap(headerKey, headerValue))
-                                  .get()
-                                  .getBody();
+            .withHeaders(singletonMap(headerKey, headerValue))
+            .get()
+            .getBody();
 
         // then
         assertEquals(BODY_RESPONSE, result);
@@ -102,22 +110,22 @@ public class RestClientTest {
     public void getWithRetries() {
         // given
         stubFor(get(urlEqualTo(API_ENDPOINT))
-                .inScenario("Retry Scenario")
-                .whenScenarioStateIs(STARTED)
-                .willReturn(aResponse().withStatus(500).withBody("Internal error"))
-                .willSetStateTo("Second Try"));
+            .inScenario("Retry Scenario")
+            .whenScenarioStateIs(STARTED)
+            .willReturn(aResponse().withStatus(500).withBody("Internal error"))
+            .willSetStateTo("Second Try"));
         stubFor(get(urlEqualTo(API_ENDPOINT))
-                .inScenario("Retry Scenario")
-                .whenScenarioStateIs("Second Try")
-                .willReturn(aResponse().withStatus(200).withBody(BODY_RESPONSE)));
+            .inScenario("Retry Scenario")
+            .whenScenarioStateIs("Second Try")
+            .willReturn(aResponse().withStatus(200).withBody(BODY_RESPONSE)));
 
         // when
         String result = RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                                  .withReadTimeoutSeconds(1200)
-                                  .withConnectTimeoutSeconds(1200)
-                                  .withRetries(1)
-                                  .get()
-                                  .getBody();
+            .withReadTimeoutSeconds(1200)
+            .withConnectTimeoutSeconds(1200)
+            .withRetries(1)
+            .get()
+            .getBody();
 
         // then
         assertEquals(BODY_RESPONSE, result);
@@ -127,7 +135,7 @@ public class RestClientTest {
     public void getFailure() {
         // given
         stubFor(get(urlEqualTo(API_ENDPOINT))
-                .willReturn(aResponse().withStatus(500).withBody("Internal error")));
+            .willReturn(aResponse().withStatus(500).withBody("Internal error")));
 
         // when
         RestClient.create(String.format("%s%s", address, API_ENDPOINT)).get();
@@ -140,14 +148,14 @@ public class RestClientTest {
     public void postSuccess() {
         // given
         stubFor(post(urlEqualTo(API_ENDPOINT))
-                .withRequestBody(equalTo(BODY_REQUEST))
-                .willReturn(aResponse().withStatus(200).withBody(BODY_RESPONSE)));
+            .withRequestBody(equalTo(BODY_REQUEST))
+            .willReturn(aResponse().withStatus(200).withBody(BODY_RESPONSE)));
 
         // when
         String result = RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                                  .withBody(BODY_REQUEST)
-                                  .post()
-                                  .getBody();
+            .withBody(BODY_REQUEST)
+            .post()
+            .getBody();
 
         // then
         assertEquals(BODY_RESPONSE, result);
@@ -164,10 +172,10 @@ public class RestClientTest {
 
         // when
         String result = RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                                  .withBody(BODY_REQUEST)
-                                  .expectResponseCodes(expectedCode1, expectedCode2)
-                                  .post()
-                                  .getBody();
+                .withBody(BODY_REQUEST)
+                .expectResponseCodes(expectedCode1, expectedCode2)
+                .post()
+                .getBody();
 
         // then
         assertEquals(BODY_RESPONSE, result);
@@ -184,8 +192,8 @@ public class RestClientTest {
         // when
         RestClientException exception = assertThrows(RestClientException.class, () ->
                 RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                          .withBody(BODY_REQUEST)
-                          .get());
+                        .withBody(BODY_REQUEST)
+                        .get());
 
         // then
         assertEquals(responseCode, exception.getHttpErrorCode());
@@ -203,9 +211,9 @@ public class RestClientTest {
         // when
         RestClientException exception = assertThrows(RestClientException.class, () ->
                 RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                          .withBody(BODY_REQUEST)
-                          .expectResponseCodes(expectedCode)
-                          .post());
+                        .withBody(BODY_REQUEST)
+                        .expectResponseCodes(expectedCode)
+                        .post());
 
         // then
         assertEquals(unexpectedCode, exception.getHttpErrorCode());
@@ -222,9 +230,9 @@ public class RestClientTest {
 
         // when
         RestClient.Response response = RestClient.create(String.format("%s%s", address, API_ENDPOINT))
-                                                 .withBody(BODY_REQUEST)
-                                                 .expectResponseCodes(responseCode)
-                                                 .get();
+                .withBody(BODY_REQUEST)
+                .expectResponseCodes(responseCode)
+                .get();
 
         // then
         assertEquals(responseCode, response.getCode());
@@ -233,62 +241,43 @@ public class RestClientTest {
 
     @Test
     public void tls13SupportDefaultCacert() throws IOException {
-        Tls13CipherCheckingServer server = new Tls13CipherCheckingServer(new ServerSocket(0), "DefaultCa");
-        try {
-            new Thread(server).start();
-            RestClient.create("https://127.0.0.1:" + server.serverSocket.getLocalPort()).get();
-        } catch (Exception e) {
-            // whatever
-        } finally {
-            server.stop();
-        }
-        // Ensure our checking thread is finished before asserting cipher found
-        try {
-            server.shutdownLatch.await(5, TimeUnit.SECONDS);
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-        }
-        assertTrue("No TLS 1.3 cipher used", server.tls13CipherFound);
+        assertTls13SupportInternal(null);
     }
 
     @Test
     public void tls13SupportCustomCacert() throws IOException {
-        Tls13CipherCheckingServer server = new Tls13CipherCheckingServer(new ServerSocket(0), "CustomCa");
-        try {
+        assertTls13SupportInternal("src/test/resources/kubernetes/ca.crt");
+    }
+
+    private void assertTls13SupportInternal(String caFileName) throws IOException {
+        try (Tls13CipherCheckingServer server = new Tls13CipherCheckingServer()) {
             new Thread(server).start();
-            RestClient.create("https://127.0.0.1:" + server.serverSocket.getLocalPort())
-                      .withCaCertificates(readFile("src/test/resources/kubernetes/ca.crt")).get();
-        } catch (Exception e) {
-            // whatever
-        } finally {
-            server.stop();
+            RestClient restClient = RestClient.create("https://127.0.0.1:" + server.getPort());
+            if (caFileName != null) {
+                restClient.withCaCertificates(readFile(caFileName));
+            }
+            try {
+                restClient.get();
+            } catch (Exception e) {
+                Logger.getLogger(getClass()).info("REST call failed (expected)", e);
+            }
+            assertTrueEventually(() -> assertTrue("No TLS 1.3 cipher used", server.tls13CipherFound.get()), 8);
         }
-        // Ensure our checking thread is finished before asserting cipher found
-        try {
-            server.shutdownLatch.await(5, TimeUnit.SECONDS);
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-        }
-        assertTrue("No TLS 1.3 cipher used", server.tls13CipherFound);
     }
 
     private String readFile(String fileName) throws IOException {
         return StringUtil.bytesToString(Files.readAllBytes(Paths.get(fileName)));
     }
 
-    static final class Tls13CipherCheckingServer implements Runnable {
+    static final class Tls13CipherCheckingServer implements Runnable, AutoCloseable {
         private static final ILogger LOGGER = Logger.getLogger(Tls13CipherCheckingServer.class);
 
-        final ServerSocket serverSocket;
-        // For better logging, so we can trace it back to specific tests
-        final String providerName;
-        volatile boolean shutdownRequested;
-        volatile boolean tls13CipherFound = false;
-        final CountDownLatch shutdownLatch = new CountDownLatch(1);
+        private final AtomicBoolean tls13CipherFound = new AtomicBoolean();
+        private final ServerSocket serverSocket;
+        private volatile boolean shutdownRequested;
 
-        Tls13CipherCheckingServer(ServerSocket serverSocket, String providerName) {
-            this.serverSocket = serverSocket;
-            this.providerName = providerName + ": ";
+        Tls13CipherCheckingServer() throws IOException {
+            this.serverSocket = new ServerSocket(0);
             try {
                 this.serverSocket.setSoTimeout(500);
             } catch (SocketException e) {
@@ -297,40 +286,44 @@ public class RestClientTest {
             LOGGER.info("The server will be listening on port " + serverSocket.getLocalPort());
         }
 
+        public int getPort() {
+            return serverSocket.getLocalPort();
+        }
+
         public void run() {
-            try {
-                while (!(shutdownRequested || tls13CipherFound)) {
-                    try {
-                        Socket socket = serverSocket.accept();
-                        new Thread(() -> {
-                            LOGGER.info(providerName + "Socket accepted " + socket);
-                            try {
-                                socket.setSoTimeout(5000);
-                                tls13CipherFound = assertTls13Cipher(socket.getInputStream());
-                                LOGGER.info(providerName + "TLS 1.3 found? " + tls13CipherFound);
-                            } catch (IOException e) {
-                                LOGGER.warning(providerName + "Reading from the socket failed", e);
-                            } finally {
-                                close(socket);
-                            }
-                        }).start();
-                    } catch (SocketTimeoutException e) {
-                        // it's fine
-                    }
+            while (!(shutdownRequested || tls13CipherFound.get())) {
+                try {
+                    Socket socket = serverSocket.accept();
+                    new Thread(() -> {
+                        LOGGER.info("Socket accepted " + socket);
+                        try {
+                            socket.setSoTimeout(5000);
+                            tls13CipherFound.compareAndSet(false, hasTls13Cipher(socket.getInputStream()));
+                        } catch (IOException e) {
+                            LOGGER.warning("Reading from the socket (serverPort=" + getPort() + ") failed", e);
+                        } finally {
+                            LOGGER.info("Closing " + socket);
+                            IOUtil.close(socket);
+                        }
+                    }).start();
+                } catch (SocketTimeoutException e) {
+                    // it's fine
+                } catch (Exception e) {
+                    LOGGER.warning("The ServerSocket (" + getPort() + ") has thrown an exception", e);
                 }
-            } catch (IOException e) {
-                LOGGER.warning(providerName + "The test server thrown an exception", e);
-            } finally {
-                close(serverSocket);
             }
-            shutdownLatch.countDown();
         }
 
-        void stop() {
+        public void close() {
             shutdownRequested = true;
+            try {
+                serverSocket.close();
+            } catch (Exception e) {
+                LOGGER.warning("ServerSocket.close() has failed", e);
+            }
         }
 
-        static boolean assertTls13Cipher(InputStream is) throws IOException {
+        static boolean hasTls13Cipher(InputStream is) throws IOException {
             try (DataInputStream dis = new DataInputStream(is)) {
                 int type = dis.readUnsignedByte();
                 // HANDSHAKE record
@@ -365,9 +358,7 @@ public class RestClientTest {
                     }
                 }
             }
-            // Throw an exception instead of returning false, so we have more detailed
-            // information to work with in the event of a failure
-            throw new IOException("TLS 1.3 cipher not found!");
+            return false;
         }
 
         private static void skip(DataInputStream dis, int toSkip) throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/spi/utils/RestClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/utils/RestClientTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.exception.RestClientException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 
 import org.junit.Before;

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/ProgressMonitor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/ProgressMonitor.java
@@ -81,7 +81,7 @@ public class ProgressMonitor {
             if (lastProgressLoggedNanos > 0) {
                 sb.append("Maximum latency: ")
                         .append(TimeUnit.NANOSECONDS.toMillis(maxLatencyNanos))
-                        .append(" ms.");
+                        .append(" ms. ");
 
                 long timeInNanos = now - lastProgressLoggedNanos;
                 double timeInSeconds = (double) timeInNanos / 1000000000;


### PR DESCRIPTION
Fixes #24676

There are two tests within the `RestClientTest` class which have been
shown to non-deterministically fail occasionally during Jenkins job;
those tests are `tls13SupportDefaultCacert` and `tls13SupportCustomCacert`.

This PR improves error handling, synchronization and logging in the tests.

Notes:
> During my debugging I was able to reproduce the failures only as part of a long-running test suite, never as an isolated test. I was only able to reproduce the issue once with additional logging, which came in the form of a single `"TLS 1.3 found? <boolean>"` logger call after the cipher had been checked - the logging output showed this being called twice with `true` values both times, which should indicate the test was successful. However, the test had still failed due to the assertion check at the end of the test.
>
> Any attempts to debug further resulted in being unable to reproduce the failure, even during long-running tests, leading me to believe this is the result of a niche race condition, most likely around the socket closure, as we know at least this stage is reached before there is divergence.
