### PR TITLE
CP subsystem diagnostics fix [5.3.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/AtomicLongService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/AtomicLongService.java
@@ -24,7 +24,6 @@ import com.hazelcast.cp.internal.datastructures.spi.atomic.RaftAtomicValueServic
 import com.hazelcast.internal.metrics.DynamicMetricsProvider;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
-import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
@@ -33,6 +32,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CP_TAG_NAME;
+import static com.hazelcast.spi.properties.ClusterProperty.METRICS_DATASTRUCTURES;
 
 /**
  * Contains Raft-based atomic long instances, implements snapshotting,
@@ -53,8 +53,10 @@ public class AtomicLongService extends RaftAtomicValueService<Long, AtomicLong, 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
         super.init(nodeEngine, properties);
-        MetricsRegistry metricsRegistry = this.nodeEngine.getMetricsRegistry();
-        metricsRegistry.registerDynamicMetricsProvider(this);
+
+        if (nodeEngine.getProperties().getBoolean(METRICS_DATASTRUCTURES)) {
+            ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     @Override
@@ -69,7 +71,7 @@ public class AtomicLongService extends RaftAtomicValueService<Long, AtomicLong, 
 
     @Override
     protected IAtomicLong newRaftAtomicProxy(NodeEngineImpl nodeEngine, RaftGroupId groupId, String proxyName,
-            String objectNameForProxy) {
+                                             String objectNameForProxy) {
         return new AtomicLongProxy(nodeEngine, groupId, proxyName, objectNameForProxy);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/AtomicRefService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/AtomicRefService.java
@@ -24,7 +24,6 @@ import com.hazelcast.cp.internal.datastructures.spi.atomic.RaftAtomicValueServic
 import com.hazelcast.internal.metrics.DynamicMetricsProvider;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
-import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -34,6 +33,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CP_TAG_NAME;
+import static com.hazelcast.spi.properties.ClusterProperty.METRICS_DATASTRUCTURES;
 
 /**
  * Contains Raft-based atomic reference instances, implements snapshotting,
@@ -54,8 +54,10 @@ public class AtomicRefService extends RaftAtomicValueService<Data, AtomicRef, At
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
         super.init(nodeEngine, properties);
-        MetricsRegistry metricsRegistry = this.nodeEngine.getMetricsRegistry();
-        metricsRegistry.registerDynamicMetricsProvider(this);
+
+        if (nodeEngine.getProperties().getBoolean(METRICS_DATASTRUCTURES)) {
+            ((NodeEngineImpl) nodeEngine).getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     @Override
@@ -70,7 +72,7 @@ public class AtomicRefService extends RaftAtomicValueService<Data, AtomicRef, At
 
     @Override
     protected IAtomicReference newRaftAtomicProxy(NodeEngineImpl nodeEngine, RaftGroupId groupId, String proxyName,
-            String objectNameForProxy) {
+                                                  String objectNameForProxy) {
         return new AtomicRefProxy(nodeEngine, groupId, proxyName, objectNameForProxy);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/CountDownLatchService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/CountDownLatchService.java
@@ -36,6 +36,7 @@ import static com.hazelcast.cp.internal.RaftService.getObjectNameForProxy;
 import static com.hazelcast.cp.internal.RaftService.withoutDefaultGroupName;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CP_TAG_NAME;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.spi.properties.ClusterProperty.METRICS_DATASTRUCTURES;
 
 /**
  * Contains Raft-based count down latch instances
@@ -55,7 +56,10 @@ public class CountDownLatchService extends AbstractBlockingService<AwaitInvocati
     @Override
     protected void initImpl() {
         super.initImpl();
-        nodeEngine.getMetricsRegistry().registerDynamicMetricsProvider(this);
+
+        if (nodeEngine.getProperties().getBoolean(METRICS_DATASTRUCTURES)) {
+            nodeEngine.getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     public boolean trySetCount(CPGroupId groupId, String name, int count) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/LockService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/LockService.java
@@ -41,6 +41,7 @@ import static com.hazelcast.cp.internal.datastructures.lock.AcquireResult.Acquir
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CP_TAG_NAME;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.spi.properties.ClusterProperty.METRICS_DATASTRUCTURES;
 
 /**
  * Contains Raft-based lock instances
@@ -62,7 +63,10 @@ public class LockService extends AbstractBlockingService<LockInvocationKey, Lock
     @Override
     protected void initImpl() {
         super.initImpl();
-        nodeEngine.getMetricsRegistry().registerDynamicMetricsProvider(this);
+
+        if (nodeEngine.getProperties().getBoolean(METRICS_DATASTRUCTURES)) {
+            nodeEngine.getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     public AcquireResult acquire(CPGroupId groupId, String name, LockInvocationKey key, long timeoutMs) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreService.java
@@ -40,6 +40,7 @@ import static com.hazelcast.cp.internal.datastructures.semaphore.AcquireResult.A
 import static com.hazelcast.cp.internal.datastructures.semaphore.AcquireResult.AcquireStatus.WAIT_KEY_ADDED;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.CP_TAG_NAME;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
+import static com.hazelcast.spi.properties.ClusterProperty.METRICS_DATASTRUCTURES;
 
 /**
  * Contains Raft-based semaphore instances
@@ -59,7 +60,10 @@ public class SemaphoreService extends AbstractBlockingService<AcquireInvocationK
     @Override
     protected void initImpl() {
         super.initImpl();
-        nodeEngine.getMetricsRegistry().registerDynamicMetricsProvider(this);
+
+        if (nodeEngine.getProperties().getBoolean(METRICS_DATASTRUCTURES)) {
+            nodeEngine.getMetricsRegistry().registerDynamicMetricsProvider(this);
+        }
     }
 
     public boolean initSemaphore(CPGroupId groupId, String name, int permits) {


### PR DESCRIPTION
Unlike all other data-structures the CP-subsystem is always collecting all metrics for the data-structures. This causes all kinds of problems like huge number of metrics being send to MC (potential perf problems) and storing huge quantities of useless metrics on disk (whereby you loose relevant history since the amount of log info is limited, so the good stuff gets flushed out).

This has been modified so it is done conditionally; just as the rest of the system.

Fixes https://hazelcast.atlassian.net/browse/HZ-2387

Backport of: https://github.com/hazelcast/hazelcast/pull/24795
