### PR TITLE
Fix test by setting driver count to 1

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
@@ -86,7 +86,7 @@ public class EntryProcessorBouncingNodesTest extends HazelcastTestSupport {
     public BounceMemberRule bounceMemberRule = BounceMemberRule
             .with(this::getConfig)
             .clusterSize(2)
-            .driverCount(2)
+            .driverCount(1)
             .driverType(BounceTestConfiguration.DriverType.ALWAYS_UP_MEMBER)
             .build();
 


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/24811

https://github.com/hazelcast/hazelcast/pull/24799 caused this issue.
Due to the merge timing pr builder could not catch it.