### PR TITLE
Introduce ClusterState check in ClearExpiredRecordsTask [HZ-2262]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.eviction;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.util.Clock;
@@ -108,6 +109,9 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable {
     @Override
     public void run() {
         if (!nodeEngine.isStartCompleted()) {
+            return;
+        }
+        if (nodeEngine.getClusterService().getClusterState() == ClusterState.PASSIVE) {
             return;
         }
         if (!singleRunPermit.compareAndSet(false, true)) {


### PR DESCRIPTION
The `ClearExpiredRecordsTask` is a task that is scheduled to run periodically (default of 5s interval), and triggers the cleanup of expired data entries in objects like Maps (`MapClearExpiredOperation`) and Caches (`CacheClearExpiredOperation`). Currently, before this task is executed it has the prerequisites of the current Node's startup phase being completed (`NodeEngine#isStartCompleted`) and another task not already run (via `AtomicBoolean#compareAndSet`).

Due to the underlying Operations produced by this task not being instances of `AllowedDuringPassiveState` Operations, this means they will fail to be executed while `ClusterState` is set to `PASSIVE`. There are currently some cases where this task can execute (and have Operations executed) while the `ClusterState` is `PASSIVE` which, while not harmful to the application, results in confusing warnings and error messages shown to users (`IllegalStateException` from checking methods such as `OperationRunnerImpl#checkNodeState`). One of the more prominent examples of these cases is when Hot Restart (HR) / Persistence is enabled and loading data from disk on startup; if the loading of this data from disk takes 5s or longer (the task interval period), then the task is triggered while the `ClusterState` is still `PASSIVE` for HR.

This commit resolves the issue by introducing a simple `ClusterState` check within `ClearExpiredRecordsTask#run` alongside the existing checks, which means the task does not try to execute expiry Operations while the current `ClusterState` is `PASSIVE`. These operations will be executed in subsequent `ClearExpiredRecordsTask` cycles after `ClusterState` changes.

Closes HZ-2262
