### PR TITLE
DefaultRecordStore.getStateMessage() rewrite for OpenJ9

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/FutureUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/FutureUtil.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.transaction.TransactionTimedOutException;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -448,11 +449,12 @@ public final class FutureUtil {
     /**
      * Get all futures that are done
      *
-     * @param futures
+     * @param futures collection of futures which we will check for done futures.
      * @return list of completed futures
      */
+    @Nonnull
     public static List<Future<?>> getAllDone(Collection<Future<?>> futures) {
-        List<Future<?>> doneFutures = new ArrayList<Future<?>>();
+        List<Future<?>> doneFutures = new ArrayList<>();
         for (Future<?> f : futures) {
             if (f.isDone()) {
                 doneFutures.add(f);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -88,6 +88,7 @@ import static com.hazelcast.map.impl.mapstore.MapDataStores.EMPTY_MAP_DATA_STORE
 import static com.hazelcast.map.impl.record.Record.UNSET;
 import static com.hazelcast.map.impl.recordstore.StaticParams.PUT_BACKUP_PARAMS;
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
+import static java.util.Collections.emptyList;
 
 /**
  * Default implementation of a record store.
@@ -1294,7 +1295,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }
 
         if (FutureUtil.allDone(loadingFutures)) {
-            List<Future<?>> doneFutures = null;
+            List<Future<?>> doneFutures = emptyList();
             try {
                 doneFutures = FutureUtil.getAllDone(loadingFutures);
                 // check all finished loading futures for exceptions
@@ -1406,9 +1407,20 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     private String getStateMessage() {
-        return "on partitionId=" + partitionId + " on " + mapServiceContext.getNodeEngine().getThisAddress()
-                + " loadedOnCreate=" + loadedOnCreate + " loadedOnPreMigration=" + loadedOnPreMigration
-                + " isLoaded=" + isLoaded();
+        // due to weird issue with OpenJ9 implementation of string concatenation:
+        //noinspection StringBufferReplaceableByString
+        StringBuilder sb = new StringBuilder();
+        sb.append("on partitionId=");
+        sb.append(partitionId);
+        sb.append(" on ");
+        sb.append(mapServiceContext.getNodeEngine().getThisAddress());
+        sb.append(" loadedOnCreate=");
+        sb.append(loadedOnCreate);
+        sb.append(" loadedOnPreMigration=");
+        sb.append(loadedOnPreMigration);
+        sb.append(" isLoaded=");
+        sb.append(isLoaded());
+        return sb.toString();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -93,7 +93,7 @@ import static java.util.Collections.emptyList;
 /**
  * Default implementation of a record store.
  */
-@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity", "rawtypes"})
 public class DefaultRecordStore extends AbstractEvictableRecordStore {
     protected final ILogger logger;
     protected final RecordStoreLoader recordStoreLoader;
@@ -729,7 +729,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
         // then try to load missing keys from map-store
         if (mapDataStore != EMPTY_MAP_DATA_STORE && !keys.isEmpty()) {
-            Map loadedEntries = loadEntries(keys, callerAddress);
+            Map<Data, Object> loadedEntries = loadEntries(keys, callerAddress);
             addToMapEntrySet(mapEntries, loadedEntries);
         }
 
@@ -812,8 +812,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         mapEntries.add(dataKey, dataValue);
     }
 
-    public void addToMapEntrySet(MapEntries mapEntries, Map<Object, Object> entries) {
-        for (Map.Entry<Object, Object> entry : entries.entrySet()) {
+    public void addToMapEntrySet(MapEntries mapEntries, Map<?, ?> entries) {
+        for (Map.Entry<?, ?> entry : entries.entrySet()) {
             addToMapEntrySet(entry.getKey(), entry.getValue(), mapEntries);
         }
     }
@@ -1059,6 +1059,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public boolean merge(MapMergeTypes<Object, Object> mergingEntry,
                          SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy,
                          CallerProvenance provenance) {
@@ -1108,7 +1109,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                     now, null, persist, true, false);
         }
 
-        return newValue != null;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Due to some weird issue on OpenJ9, which method failed - looked like an issue with OpenJ9's String.concat implementation. 

To overcome this I've changed the code to use StringBuilder. Even if the issue with partially stay, we will have more precise place where it fails.

Fixes #24718

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
