### PR TITLE
Enable FetchEntriesOperation as a Step operation [HZ-2574]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
@@ -78,20 +78,8 @@ public class MapFetchEntriesOperation extends MapOperation implements ReadonlyOp
 
     @Override
     public Step getStartingStep() {
-        return new IMapOpStep() {
-            @Override
-            public void runStep(State state) {
-                runInternalDirect();
-            }
-
-            @Nullable
-            @Override
-            public Step nextStep(State state) {
-                return UtilSteps.FINAL_STEP;
-            }
-        };
+        return UtilSteps.DIRECT_RUN_STEP;
     }
-
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
@@ -19,10 +19,15 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.internal.iteration.IterationPointer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
+import com.hazelcast.map.impl.operation.steps.IMapOpStep;
+import com.hazelcast.map.impl.operation.steps.UtilSteps;
+import com.hazelcast.map.impl.operation.steps.engine.State;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 
@@ -70,6 +75,23 @@ public class MapFetchEntriesOperation extends MapOperation implements ReadonlyOp
             pointers[i] = new IterationPointer(in.readInt(), in.readInt());
         }
     }
+
+    @Override
+    public Step getStartingStep() {
+        return new IMapOpStep() {
+            @Override
+            public void runStep(State state) {
+                runInternalDirect();
+            }
+
+            @Nullable
+            @Override
+            public Step nextStep(State state) {
+                return UtilSteps.FINAL_STEP;
+            }
+        };
+    }
+
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
@@ -19,15 +19,12 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.internal.iteration.IterationPointer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
-import com.hazelcast.map.impl.operation.steps.IMapOpStep;
 import com.hazelcast.map.impl.operation.steps.UtilSteps;
-import com.hazelcast.map.impl.operation.steps.engine.State;
 import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import javax.annotation.Nullable;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/UtilSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/UtilSteps.java
@@ -23,6 +23,8 @@ import com.hazelcast.map.impl.operation.steps.engine.StepResponseUtil;
 import com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
+import javax.annotation.Nullable;
+
 public enum UtilSteps implements IMapOpStep {
 
     /**
@@ -77,7 +79,23 @@ public enum UtilSteps implements IMapOpStep {
         public Step nextStep(State state) {
             return null;
         }
+    },
+
+    DIRECT_RUN_STEP {
+
+        @Override
+        public void runStep(State state) {
+            MapOperation op = state.getOperation();
+            op.runInternalDirect();
+        }
+
+        @Nullable
+        @Override
+        public Step nextStep(State state) {
+            return UtilSteps.FINAL_STEP;
+        }
     };
+
 
     public static OperationRunnerImpl getPartitionOperationRunner(State state) {
         MapOperation operation = state.getOperation();


### PR DESCRIPTION
This prohibits concurrency between sql that is using fetchEntries operation, and partition-based compactor.

Closes https://hazelcast.atlassian.net/browse/HZ-2574