### PR TITLE
Consider AbstractJoiner's permanent blacklist in split-brain handling [HZ-2065]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
@@ -465,7 +465,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             Boolean previousBlacklistStatus = blacklistedAddresses.remove(member.getAddress());
             if (previousBlacklistStatus != null) {
                 logger.info(member.getAddress() + " is removed from the " + (previousBlacklistStatus ? "permanent " : " ")
-                        + "blacklist due to successfully joining the cluster ");
+                        + "blacklist due to successfully joining the cluster");
             }
         }
     }
@@ -480,14 +480,13 @@ public class TcpIpJoiner extends AbstractJoiner {
         knownMemberAddresses.put(memberAddress, Clock.currentTimeMillis());
     }
 
-    @Override
-    public void searchForOtherClusters() {
+    public Collection<Address> getFilteredPossibleAddresses() {
         final Collection<Address> possibleAddresses;
         try {
             possibleAddresses = getPossibleAddresses();
         } catch (Throwable e) {
             logger.severe(e);
-            return;
+            return Collections.emptyList();
         }
 
         // Remove known addresses from possibleAddresses
@@ -513,6 +512,12 @@ public class TcpIpJoiner extends AbstractJoiner {
                             .map(Map.Entry::getKey)
                             .forEach(possibleAddresses::remove);
 
+        return possibleAddresses;
+    }
+
+    @Override
+    public void searchForOtherClusters() {
+        final Collection<Address> possibleAddresses = getFilteredPossibleAddresses();
         if (possibleAddresses.isEmpty()) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -457,6 +458,15 @@ public class TcpIpJoiner extends AbstractJoiner {
     public void onMemberAdded(Member member) {
         if (!member.localMember()) {
             knownMemberAddresses.put(member.getAddress(), Long.MAX_VALUE);
+
+            // If we previously blacklisted this member's address (i.e. the address/port was
+            // previously used in an incompatible node), we should remove the blacklist now
+            // that it has joined our node - otherwise it's ignored in split-brain!
+            Boolean previousBlacklistStatus = blacklistedAddresses.remove(member.getAddress());
+            if (previousBlacklistStatus != null) {
+                logger.info(member.getAddress() + " is removed from the " + (previousBlacklistStatus ? "permanent " : " ")
+                        + "blacklist due to successfully joining the cluster ");
+            }
         }
     }
 
@@ -479,6 +489,8 @@ public class TcpIpJoiner extends AbstractJoiner {
             logger.severe(e);
             return;
         }
+
+        // Remove known addresses from possibleAddresses
         LocalAddressRegistry addressRegistry = node.getLocalAddressRegistry();
         possibleAddresses.removeAll(addressRegistry.getLocalAddresses());
         node.getClusterService().getMembers().forEach(
@@ -495,9 +507,16 @@ public class TcpIpJoiner extends AbstractJoiner {
                 }
         );
 
+        // Remove permanently blacklisted addresses from possibleAddresses
+        blacklistedAddresses.entrySet().stream()
+                            .filter(Map.Entry::getValue)
+                            .map(Map.Entry::getKey)
+                            .forEach(possibleAddresses::remove);
+
         if (possibleAddresses.isEmpty()) {
             return;
         }
+
         SplitBrainJoinMessage request = node.createSplitBrainJoinMessage();
         for (Address address : possibleAddresses) {
             SplitBrainMergeCheckResult result = sendSplitBrainJoinMessageAndCheckResponse(address, request);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -99,7 +99,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
 
     @Test
     public void testClusterShouldNotMergeDifferentClusterName() {
-        Config config1 = new Config();
+        Config config1 = smallInstanceConfigWithoutJetAndMetrics();
         config1.setProperty(ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5");
         config1.setProperty(ClusterProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "3");
         String firstClusterName = generateRandomString(10);
@@ -110,7 +110,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         join1.getMulticastConfig().setEnabled(true);
         join1.getTcpIpConfig().addMember("127.0.0.1");
 
-        Config config2 = new Config();
+        Config config2 = smallInstanceConfigWithoutJetAndMetrics();
         config2.setProperty(ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5");
         config2.setProperty(ClusterProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "3");
         String secondClusterName = generateRandomString(10);
@@ -197,7 +197,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
 
     private void testMergeAfterSplitBrain(boolean multicast) throws InterruptedException {
         String clusterName = generateRandomString(10);
-        Config config = new Config();
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
         config.setProperty(ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5");
         config.setProperty(ClusterProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "3");
         config.setClusterName(clusterName);
@@ -339,7 +339,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     }
 
     private static Config buildConfig(boolean multicastEnabled, int port) {
-        Config c = new Config();
+        Config c = smallInstanceConfigWithoutJetAndMetrics();
         c.setProperty(ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5");
         c.setProperty(ClusterProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "3");
 
@@ -367,7 +367,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
             }
         });
 
-        Config config1 = new Config();
+        Config config1 = smallInstanceConfigWithoutJetAndMetrics();
         // bigger port to make sure address.hashCode() check pass during merge!
         config1.getNetworkConfig().setPort(5901);
         config1.setClusterName(clusterName);
@@ -379,7 +379,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
 
         sleepSeconds(1);
 
-        Config config2 = new Config();
+        Config config2 = smallInstanceConfigWithoutJetAndMetrics();
         config2.setClusterName(clusterName);
         config2.getNetworkConfig().setPort(5701);
         config2.setProperty(ClusterProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "5");
@@ -404,7 +404,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     }
 
     private void testClusterMerge_when_split_not_detected_by_master(boolean multicastEnabled) {
-        Config config = new Config();
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
         String clusterName = generateRandomString(10);
         config.setClusterName(clusterName);
         config.setProperty(ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "10");
@@ -599,7 +599,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     }
 
     private Config buildConfig(final String clusterName, final boolean liteMember) {
-        Config config = new Config();
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
         config.setProperty(ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5");
         config.setProperty(ClusterProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "3");
         config.setClusterName(clusterName);
@@ -619,7 +619,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     @Test
     // https://github.com/hazelcast/hazelcast/issues/8137
     public void testClusterMerge_when_split_not_detected_by_slave() {
-        Config config = new Config();
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
         String clusterName = generateRandomString(10);
         config.setClusterName(clusterName);
         config.setProperty(ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "10");
@@ -678,7 +678,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     @Test
     // https://github.com/hazelcast/hazelcast/issues/8137
     public void testClusterMerge_when_split_not_detected_by_slave_and_restart_during_merge() {
-        Config config = new Config();
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
         String clusterName = generateRandomString(10);
         config.setClusterName(clusterName);
         config.setProperty(ClusterProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "10");
@@ -793,7 +793,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     }
 
     private Config createSimpleTcpIpConfig(String clusterName) {
-        Config config = new Config();
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
         config.setClusterName(clusterName);
         TcpIpConfig tcpIpConfig = config.getNetworkConfig().getJoin().getTcpIpConfig();
         tcpIpConfig.setEnabled(true);


### PR DESCRIPTION
For context: Hazelcast uses a `Joiner` implementation that handles the joining of Nodes to Clusters; all current Joiners extend `AbstractJoiner` which features a map of blacklisted addresses, `blacklistedAddresses`. The key of the map is the address, and the value is a boolean, which shows whether the blacklist is "permanent" (true) or not. A blacklist is applied in 2 situations: after failing a connection while not joined to a cluster (non-permanent), or during a `ClusterMismatchOp` (permanent). The latter is only fired when a Node tries to join a cluster, but is not compatible with the cluster, and so is rejected.

The `TcpIpJoiner` joiner employs the blacklist quite heavily, however it currently does not use it in the `searchForOtherClusters` method. This method is only called by the `SplitBrainHandler` task, which runs on loop (default of 5m delay, 2m interval). Due to this, when running multiple clusters sharing the same member list, it is possible to encounter a situation such as this:
```
Member list is defined as "127.0.0.1" for all Nodes.

Node A1 starts and forms cluster "cluster_A" as master
Node B1 starts and forms cluster "cluster_B" as master
Node A2 starts and joins cluster "cluster_A"

Node B1, as master, runs `SplitBrainHandler` every 2 minutes.
This finds A2's address; B1 sends a merge validation op
A2 is not master, so offloads to ClusterJoinManager#answerWhoisMasterQuestion
This calls #ensureValidConfiguration, results in ClusterMismatchOp
ClusterMismatchOp blacklists A2's address on the first encounter
```
In this scenario, even though the first attempt from B1's split brain handler blacklists A2's address, because there are no blacklist checks within `TcpIpJoiner#searchForOtherClusters`, the attempts continue with every execution of the `SplitBrainHandler` - this results in numerous unnecessary warnings in the logs for members B1 and A2.

This commit resolves scenarios like this by removing permanently blacklisted addresses from the collection of `possibleAddresses` output by `TcpIpJoiner#searchForOtherClusters`. Now master nodes will not attempt to send `SplitBrainJoinMessage`s to other cluster nodes after blacklisting its address on the first encounter.

However, introducing this blacklist check for `SplitBrainHandler` adds some further considerations, such as what would happen in this scenario:
```
Member list is defined as "127.0.0.1" for all Nodes.

Node A1 starts on port 5701 and forms cluster "cluster_A" as master
Node A2 starts on port 5702 and joins cluster "cluster_A"

Node B1 starts on port 5703 and forms cluster "cluster_B" as master
Node B2 starts on port 5704 and joins cluster "cluster_B"

*Some time elapses, both A1/B2 have run SplitBrainHandler tasks*

Node A2 is shutdown.
Node B3 starts on port 5702 and joins cluster "cluster_B"

B1 (master) has B3's address blacklisted from when A2 was on port 5702
B1 will now never send SplitBrainJoinMessages to B3 due to this
```
In this scenario, B3 is able to join "cluster_B" successfully as it seeks the master itself and so the blacklist is not applied. This commit resolves the situation by removing Node addresses from the permanent blacklist within the `TcpIpJoiner#onMemberAdded` method.

As stated above, addresses are only permanently blacklisted in a `ClusterMismatchOp`, so if a Node has successfully triggered `onMemberAdded`, there has clearly been a topology change meaning this address is no longer incompatible. Therefore it should be safe to add this permanent blacklist removal functionality.

Fixes https://hazelcast.atlassian.net/browse/HZ-2065
