### PR TITLE
Create new overload to allow passing parameters to Source.jdbc that takes the query string 

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -83,7 +83,7 @@
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="FileLength">
-        <property name="max" value="1500"/>
+        <property name="max" value="1600"/>
     </module>
 
     <!-- Checks for whitespace                               -->
@@ -196,7 +196,7 @@
             <property name="max" value="2"/>
         </module>
         <module name="MethodCount">
-            <property name="maxTotal" value="30"/>
+            <property name="maxTotal" value="40"/>
         </module>
 
         <!-- Checks for whitespace                               -->

--- a/checkstyle/checkstyle_jet.xml
+++ b/checkstyle/checkstyle_jet.xml
@@ -78,7 +78,7 @@
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="FileLength">
-        <property name="max" value="1500"/>
+        <property name="max" value="1600"/>
     </module>
 
     <!-- Checks for whitespace                               -->

--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
@@ -49,6 +49,7 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
+import static com.hazelcast.internal.util.StringUtil.isBoolean;
 import static com.hazelcast.mapstore.ExistingMappingValidator.validateColumn;
 import static com.hazelcast.mapstore.ExistingMappingValidator.validateColumnsExist;
 import static com.hazelcast.mapstore.FromSqlRowConverter.toGenericRecord;
@@ -193,11 +194,7 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
         }
     }
 
-    private boolean isBoolean(String value) {
-        return value.equalsIgnoreCase("false") || value.equalsIgnoreCase("true");
-    }
-
-    private ManagedExecutorService getMapStoreExecutor() {
+   private ManagedExecutorService getMapStoreExecutor() {
         return nodeEngine()
                 .getExecutionService()
                 .getExecutor(ExecutionService.MAP_STORE_OFFLOADABLE_EXECUTOR);

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -549,4 +549,8 @@ public final class StringUtil {
         }
         return new String(chars, 0, pos);
     }
+
+    public static boolean isBoolean(String value) {
+        return value.equalsIgnoreCase("false") || value.equalsIgnoreCase("true");
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -67,6 +67,7 @@ import java.security.Permission;
 import java.sql.ResultSet;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Properties;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
@@ -463,9 +464,18 @@ public final class SourceProcessors {
             @Nonnull String query,
             @Nonnull FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
-        return ReadJdbcP.supplier(connectionURL, query, mapOutputFn);
+        Properties properties = new Properties();
+        return ReadJdbcP.supplier(connectionURL, query, properties, mapOutputFn);
     }
 
+    public static <T> ProcessorMetaSupplier readJdbcP(
+            @Nonnull String connectionURL,
+            @Nonnull String query,
+            @Nonnull Properties properties,
+            @Nonnull FunctionEx<? super ResultSet, ? extends T> mapOutputFn
+    ) {
+        return ReadJdbcP.supplier(connectionURL, query, properties, mapOutputFn);
+    }
     /**
      * Returns a supplier of processors for a source that the user can create
      * using the {@link SourceBuilder}. This variant creates a source that

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
@@ -126,8 +126,8 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
                         (connection, parallelism, index) -> {
                             setAutoCommitIfNecessary(connection, properties);
                             PreparedStatement preparedStatement = connection.prepareStatement(query);
-                            setFetchSizeIfNecessary(preparedStatement, properties);
                             try {
+                                setFetchSizeIfNecessary(preparedStatement, properties);
                                 return preparedStatement.executeQuery();
                             } catch (SQLException e) {
                                 preparedStatement.close();
@@ -221,7 +221,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
         }
     }
 
-    private static void setFetchSizeIfNecessary(PreparedStatement statement, Properties properties) {
+    private static void setFetchSizeIfNecessary(PreparedStatement statement, Properties properties) throws SQLException {
         try {
             String key = JdbcPropertyKeys.FETCH_SIZE;
             if (properties.containsKey(key)) {
@@ -230,8 +230,10 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
             }
         } catch (SQLException exception) {
             LOGGER.severe("Error setting setFetchSize to PreparedStatement", exception);
+            throw exception;
         } catch (NumberFormatException exception) {
             LOGGER.severe("Invalid integer value set for fetchSize", exception);
+            throw exception;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
@@ -213,7 +213,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
                 boolean autoCommit = Boolean.parseBoolean(value);
                 connection.setAutoCommit(autoCommit);
             } else {
-                throw new IllegalArgumentException("Invalid boolean value specified for autoCommit");
+                throw new IllegalArgumentException("Invalid boolean value specified for autoCommit: " + value);
             }
         }
     }
@@ -226,7 +226,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
                 int fetchSize = Integer.parseInt(value);
                 statement.setFetchSize(fetchSize);
             } catch (NumberFormatException exception) {
-                LOGGER.severe("Invalid integer value specified for fetchSize", exception);
+                LOGGER.severe("Invalid integer value specified for fetchSize: " + value, exception);
                 throw exception;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
@@ -214,6 +214,8 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
                 if (isBoolean(value)) {
                     boolean autoCommit = Boolean.parseBoolean(value);
                     connection.setAutoCommit(autoCommit);
+                } else {
+                    throw new IllegalArgumentException("Invalid boolean value set for autoCommit");
                 }
             }
         } catch (SQLException exception) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
@@ -205,37 +205,30 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
         return null;
     }
 
-    private static void setAutoCommitIfNecessary(Connection connection, Properties properties) {
-        try {
-            String key = JdbcPropertyKeys.AUTO_COMMIT;
-            if (properties.containsKey(key)) {
-                String value = properties.getProperty(key);
-
-                if (isBoolean(value)) {
-                    boolean autoCommit = Boolean.parseBoolean(value);
-                    connection.setAutoCommit(autoCommit);
-                } else {
-                    throw new IllegalArgumentException("Invalid boolean value set for autoCommit");
-                }
+    private static void setAutoCommitIfNecessary(Connection connection, Properties properties) throws SQLException {
+        String key = JdbcPropertyKeys.AUTO_COMMIT;
+        if (properties.containsKey(key)) {
+            String value = properties.getProperty(key);
+            if (isBoolean(value)) {
+                boolean autoCommit = Boolean.parseBoolean(value);
+                connection.setAutoCommit(autoCommit);
+            } else {
+                throw new IllegalArgumentException("Invalid boolean value specified for autoCommit");
             }
-        } catch (SQLException exception) {
-            LOGGER.severe("Error setting setAutoCommit to PreparedStatement", exception);
         }
     }
 
     private static void setFetchSizeIfNecessary(PreparedStatement statement, Properties properties) throws SQLException {
-        try {
-            String key = JdbcPropertyKeys.FETCH_SIZE;
-            if (properties.containsKey(key)) {
-                int fetchSize = Integer.parseInt(properties.getProperty(key));
+        String key = JdbcPropertyKeys.FETCH_SIZE;
+        if (properties.containsKey(key)) {
+            String value = properties.getProperty(key);
+            try {
+                int fetchSize = Integer.parseInt(value);
                 statement.setFetchSize(fetchSize);
+            } catch (NumberFormatException exception) {
+                LOGGER.severe("Invalid integer value specified for fetchSize", exception);
+                throw exception;
             }
-        } catch (SQLException exception) {
-            LOGGER.severe("Error setting setFetchSize to PreparedStatement", exception);
-            throw exception;
-        } catch (NumberFormatException exception) {
-            LOGGER.severe("Invalid integer value set for fetchSize", exception);
-            throw exception;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/JdbcPropertyKeys.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/JdbcPropertyKeys.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.pipeline;
+
+import com.hazelcast.function.FunctionEx;
+
+import java.util.Properties;
+
+public final class JdbcPropertyKeys {
+
+    /**
+     * Property key to be passed to {@link Sources#jdbc(String, String, Properties, FunctionEx)}
+     */
+    public static final String FETCH_SIZE = "fetchSize";
+
+    /**
+     * Property key to be passed to {@link Sources#jdbc(String, String, Properties, FunctionEx)}
+     */
+    public static final String AUTO_COMMIT = "autoCommit";
+
+    private JdbcPropertyKeys() {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/JdbcPropertyKeys.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/JdbcPropertyKeys.java
@@ -20,15 +20,21 @@ import com.hazelcast.function.FunctionEx;
 
 import java.util.Properties;
 
+/**
+ * This class defines property keys that can be passed to JDBC connector. In turn the JDBC connector
+ * uses these properties to change the JDBC connection's behavior
+ */
 public final class JdbcPropertyKeys {
 
     /**
-     * Property key to be passed to {@link Sources#jdbc(String, String, Properties, FunctionEx)}
+     * Property key to be passed to specify fetch size of the JDBC connection
+     * For usage  example see {@link Sources#jdbc(String, String, Properties, FunctionEx)} method
      */
     public static final String FETCH_SIZE = "fetchSize";
 
     /**
-     * Property key to be passed to {@link Sources#jdbc(String, String, Properties, FunctionEx)}
+     * Property key to be passed to specify auto commit mode of the JDBC connection
+     * For usage example see {@link Sources#jdbc(String, String, Properties, FunctionEx)} method
      */
     public static final String AUTO_COMMIT = "autoCommit";
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -1503,7 +1503,7 @@ public final class Sources {
      * It is not always possible to use the default properties. This overload allows passing some properties to the
      * JDBC driver
      * <p>
-     * Example for PostgreSQL fetchSize:  PostgreSQL requires that the autocommit should be <b>disabled</b>.
+     * Example for PostgreSQL to specify fetchSize:  PostgreSQL requires that the autocommit should be <b>disabled</b>.
      * Because the backend closes cursors at the end of transactions, so in autocommit enabled mode
      * the backend will have closed the cursor before anything can be fetched from it.
      * <pre>{@code
@@ -1517,8 +1517,8 @@ public final class Sources {
      *            resultSet -> new Person(resultSet.getInt(1), resultSet.getString(2))))
      *    }</pre>
      *    <p>
-     * Example for MySQL fetchSize: The database connection URL should have <b>"&useCursorFetch=true"</b> parameter to enable
-     * cursor-based fetching. This means that the JDBC driver will fetch a set of rows from the database at a time,
+     * Example for MySQL to specify fetchSize: The database connection URL should have <b>"&useCursorFetch=true"</b> parameter
+     * to enable cursor-based fetching. This means that the JDBC driver will fetch a set of rows from the database at a time,
      * rather than fetching all the rows in the result set at once
      * <pre>{@code
      *        Properties properties = new Properties();

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -1500,25 +1500,31 @@ public final class Sources {
     /**
      * Same as @{link {@link Sources#jdbc(String, String, FunctionEx)}}
      * <p>
-     * This overload allows passing some properties for JDBC
+     * It is not always possible to use the default properties. This overload allows passing some properties to the
+     * JDBC driver
      * <p>
-     * Example for PostgreSQL fetchSize: <pre>{@code
+     * Example for PostgreSQL fetchSize:  PostgreSQL requires that the autocommit should be <b>disabled</b>.
+     * Because the backend closes cursors at the end of transactions, so in autocommit enabled mode
+     * the backend will have closed the cursor before anything can be fetched from it.
+     * <pre>{@code
      *        Properties properties = new Properties();
      *        properties.put(JdbcPropertyKeys.FETCH_SIZE, "5");
      *        properties.put(JdbcPropertyKeys.AUTO_COMMIT, "false");
      *        p.readFrom(Sources.jdbc(
-     *            DB_CONNECTION_URL,
+     *            "jdbc:postgresql://localhost:5432/mydatabase",
      *            "select ID, NAME from PERSON",
      *            properties
      *            resultSet -> new Person(resultSet.getInt(1), resultSet.getString(2))))
      *    }</pre>
      *    <p>
-     * Example for MySQL fetchSize: The DB_CONNECTION_URL should have "&useCursorFetch=true" parameter
+     * Example for MySQL fetchSize: The database connection URL should have <b>"&useCursorFetch=true"</b> parameter to enable
+     * cursor-based fetching. This means that the JDBC driver will fetch a set of rows from the database at a time,
+     * rather than fetching all the rows in the result set at once
      * <pre>{@code
      *        Properties properties = new Properties();
      *        properties.put(JdbcPropertyKeys.FETCH_SIZE, "5");
      *        p.readFrom(Sources.jdbc(
-     *            DB_CONNECTION_URL,
+     *            "jdbc:mysql://localhost:3306/mydatabase?useCursorFetch=true,"
      *            "select ID, NAME from PERSON",
      *            properties
      *            resultSet -> new Person(resultSet.getInt(1), resultSet.getString(2))))

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -58,6 +58,7 @@ import java.sql.ResultSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Properties;
 
 import static com.hazelcast.jet.Util.cacheEventToEntry;
 import static com.hazelcast.jet.Util.cachePutEvents;
@@ -1494,5 +1495,31 @@ public final class Sources {
     ) {
         return batchFromProcessor("jdbcSource",
                 SourceProcessors.readJdbcP(connectionURL, query, createOutputFn));
+    }
+
+    /**
+     * Same as @{link {@link Sources#jdbc(String, String, FunctionEx)}}
+     * <p>
+     * This overload allows passing some properties for JDBC
+     * <p>
+     * Example: <pre>{@code
+     *        Properties properties = new Properties();
+     *        properties.put(JdbcPropertyKeys.FETCH_SIZE, "5");
+     *        properties.put(JdbcPropertyKeys.AUTO_COMMIT, "false");
+     *        p.readFrom(Sources.jdbc(
+     *            DB_CONNECTION_URL,
+     *            "select ID, NAME from PERSON",
+     *            properties
+     *            resultSet -> new Person(resultSet.getInt(1), resultSet.getString(2))))
+     *    }</pre>
+     */
+    public static <T> BatchSource<T> jdbc(
+            @Nonnull String connectionURL,
+            @Nonnull String query,
+            @Nonnull Properties properties,
+            @Nonnull FunctionEx<? super ResultSet, ? extends T> createOutputFn
+    ) {
+        return batchFromProcessor("jdbcSource",
+                SourceProcessors.readJdbcP(connectionURL, query, properties, createOutputFn));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -1502,7 +1502,7 @@ public final class Sources {
      * <p>
      * This overload allows passing some properties for JDBC
      * <p>
-     * Example: <pre>{@code
+     * Example for PostgreSQL fetchSize: <pre>{@code
      *        Properties properties = new Properties();
      *        properties.put(JdbcPropertyKeys.FETCH_SIZE, "5");
      *        properties.put(JdbcPropertyKeys.AUTO_COMMIT, "false");
@@ -1512,6 +1512,18 @@ public final class Sources {
      *            properties
      *            resultSet -> new Person(resultSet.getInt(1), resultSet.getString(2))))
      *    }</pre>
+     *    <p>
+     * Example for MySQL fetchSize: The DB_CONNECTION_URL should have "&useCursorFetch=true" parameter
+     * <pre>{@code
+     *        Properties properties = new Properties();
+     *        properties.put(JdbcPropertyKeys.FETCH_SIZE, "5");
+     *        p.readFrom(Sources.jdbc(
+     *            DB_CONNECTION_URL,
+     *            "select ID, NAME from PERSON",
+     *            properties
+     *            resultSet -> new Person(resultSet.getInt(1), resultSet.getString(2))))
+     *    }</pre>
+     *
      */
     public static <T> BatchSource<T> jdbc(
             @Nonnull String connectionURL,

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/MySQLReadJdbcPPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/MySQLReadJdbcPPropertiesTest.java
@@ -23,6 +23,9 @@ import org.junit.Test;
 
 import java.sql.SQLException;
 import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class MySQLReadJdbcPPropertiesTest extends ReadJdbcPPropertiesTest {
 
     @BeforeClass
@@ -37,5 +40,13 @@ public class MySQLReadJdbcPPropertiesTest extends ReadJdbcPPropertiesTest {
         Properties properties = new Properties();
         properties.put(JdbcPropertyKeys.FETCH_SIZE, String.valueOf(fetchSize));
         runTestFetchSize(properties, fetchSize);
+    }
+
+    @Test
+    public void testInvalidFetchSize() {
+        Properties properties = new Properties();
+        properties.put(JdbcPropertyKeys.FETCH_SIZE, "aa");
+        assertThatThrownBy(() -> runTest(properties))
+                .hasRootCauseInstanceOf(NumberFormatException.class);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/MySQLReadJdbcPPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/MySQLReadJdbcPPropertiesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector;
+
+import com.hazelcast.jet.pipeline.JdbcPropertyKeys;
+import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.Properties;
+public class MySQLReadJdbcPPropertiesTest extends ReadJdbcPPropertiesTest {
+
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        initializeBeforeClass(new MySQLDatabaseProvider(), "&useCursorFetch=true");
+    }
+
+
+    @Test
+    public void testFetchSize() {
+        int fetchSize = 2;
+        Properties properties = new Properties();
+        properties.put(JdbcPropertyKeys.FETCH_SIZE, String.valueOf(fetchSize));
+        runTestFetchSize(properties, fetchSize);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/PostgreReadJdbcPPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/PostgreReadJdbcPPropertiesTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class PostgreReadJdbcPPropertiesTest extends ReadJdbcPPropertiesTest {
 
     @BeforeClass
@@ -38,5 +40,13 @@ public class PostgreReadJdbcPPropertiesTest extends ReadJdbcPPropertiesTest {
         properties.put(JdbcPropertyKeys.FETCH_SIZE, String.valueOf(fetchSize));
         properties.put(JdbcPropertyKeys.AUTO_COMMIT, "false");
         runTestFetchSize(properties, fetchSize);
+    }
+
+    @Test
+    public void testInvalidFetchSize() {
+        Properties properties = new Properties();
+        properties.put(JdbcPropertyKeys.FETCH_SIZE, "aa");
+        assertThatThrownBy(() -> runTest(properties))
+                .hasRootCauseInstanceOf(NumberFormatException.class);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/PostgreReadJdbcPPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/PostgreReadJdbcPPropertiesTest.java
@@ -45,8 +45,18 @@ public class PostgreReadJdbcPPropertiesTest extends ReadJdbcPPropertiesTest {
     @Test
     public void testInvalidFetchSize() {
         Properties properties = new Properties();
+        // FETCH_SIZE should be a number in string format
         properties.put(JdbcPropertyKeys.FETCH_SIZE, "aa");
         assertThatThrownBy(() -> runTest(properties))
                 .hasRootCauseInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    public void testInvalidAutoCommit() {
+        Properties properties = new Properties();
+        // AUTO_COMMIT should be a boolean in string format
+        properties.put(JdbcPropertyKeys.AUTO_COMMIT, "1");
+        assertThatThrownBy(() -> runTest(properties))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/PostgreReadJdbcPPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/PostgreReadJdbcPPropertiesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector;
+
+import com.hazelcast.jet.pipeline.JdbcPropertyKeys;
+import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class PostgreReadJdbcPPropertiesTest extends ReadJdbcPPropertiesTest {
+
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        initializeBeforeClass(new PostgresDatabaseProvider());
+    }
+
+    @Test
+    public void testFetchSize() {
+        int fetchSize = 2;
+        Properties properties = new Properties();
+        properties.put(JdbcPropertyKeys.FETCH_SIZE, String.valueOf(fetchSize));
+        properties.put(JdbcPropertyKeys.AUTO_COMMIT, "false");
+        runTestFetchSize(properties, fetchSize);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPPropertiesTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sources;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.jdbc.TestDatabaseProvider;
+import org.junit.AfterClass;
+import org.junit.experimental.categories.Category;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.stream.IntStream;
+
+import static com.hazelcast.dataconnection.impl.DataConnectionTestUtil.configureJdbcDataConnection;
+import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.pipeline.test.AssertionSinks.assertOrdered;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category({QuickTest.class})
+public abstract class ReadJdbcPPropertiesTest extends SimpleTestInClusterSupport {
+
+    protected static TestDatabaseProvider databaseProvider;
+
+    private static final int ITEM_COUNT = 100;
+    private static final String JDBC_DATA_CONNECTION = "jdbc-data-connection";
+
+    private static String dbConnectionUrl;
+    private static List<Entry<Integer, String>> tableContents;
+
+
+    protected static void initializeBeforeClass(TestDatabaseProvider testDatabaseProvider, String... args) throws SQLException {
+        databaseProvider = testDatabaseProvider;
+        dbConnectionUrl = databaseProvider.createDatabase(ReadJdbcPPropertiesTest.class.getName());
+        dbConnectionUrl = dbConnectionUrl + String.join("", args);
+
+
+        Config config = smallInstanceConfig();
+        configureJdbcDataConnection(JDBC_DATA_CONNECTION, dbConnectionUrl, config);
+        initialize(2, config);
+        // create and fill a table
+        try (Connection conn = DriverManager.getConnection(dbConnectionUrl);
+             Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute("CREATE TABLE items(id INT PRIMARY KEY, name VARCHAR(10))");
+            for (int i = 0; i < ITEM_COUNT; i++) {
+                stmt.execute(String.format("INSERT INTO items VALUES(%d, 'name-%d')", i, i));
+            }
+        }
+        tableContents = IntStream.range(0, ITEM_COUNT).mapToObj(i -> entry(i, "name-" + i)).collect(toList());
+    }
+
+    @AfterClass
+    public static void afterClass() throws SQLException {
+        if (databaseProvider != null) {
+            databaseProvider.shutdown();
+            databaseProvider = null;
+            dbConnectionUrl = null;
+        }
+    }
+
+
+    protected void runTestFetchSize(Properties properties, int fetchSize) {
+        Pipeline p = Pipeline.create();
+        p.readFrom(Sources.jdbc(dbConnectionUrl, "select * from items",
+                        properties,
+                        resultSet -> {
+                            assertThat(resultSet.getFetchSize()).isEqualTo(fetchSize);
+                            return entry(resultSet.getInt(1), resultSet.getString(2));
+                        }
+                ))
+                .writeTo(assertOrdered(tableContents));
+
+        instance().getJet().newJob(p).join();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPPropertiesTest.java
@@ -97,4 +97,14 @@ public abstract class ReadJdbcPPropertiesTest extends SimpleTestInClusterSupport
         instance().getJet().newJob(p).join();
     }
 
+    protected void runTest(Properties properties) {
+        Pipeline p = Pipeline.create();
+        p.readFrom(Sources.jdbc(dbConnectionUrl, "select * from items",
+                        properties,
+                        resultSet -> entry(resultSet.getInt(1), resultSet.getString(2))
+                ))
+                .writeTo(assertOrdered(tableContents));
+
+        instance().getJet().newJob(p).join();
+    }
 }


### PR DESCRIPTION
The Source.jdbc overload that takes the query string does not allow passing JDBC parameters. Create a new overload that can do this. This overload may be used to specify the fetchSize etc. for JDBC. So that large tables can be ingested with the given fetchSize

Jira : https://hazelcast.atlassian.net/browse/HZ-2432



Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible