### PR TITLE
Update persistence metric naming convention to use discriminators

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -450,6 +450,7 @@ public final class MetricDescriptorConstants {
     public static final String PERSISTENCE_METRIC_TOMB_GARBAGE = "tombGarbage";
     public static final String PERSISTENCE_METRIC_GC_LIVE_VALUES = "liveValues";
     public static final String PERSISTENCE_METRIC_GC_LIVE_TOMBSTONES = "liveTombstones";
+    public static final String PERSISTENCE_DISCRIMINATOR_STORE_NAME = "storeName";
     // ===[/PERSISTENCE]================================================
 
     // ===[PN COUNTER]==================================================


### PR DESCRIPTION
Currently, persistence related metrics are recorded in the format `persistence.<store_name>.<metric>` - the inclusion of `<store_name>` here is not good practice and also not consistent with other metrics (such as operation related metrics). The `store_name` component is not static and should be included as a tag/label as opposed to being integrated into the metric name itself. This allows the metric to play nicely with Prometheus and adheres to [standard naming practices](https://prometheus.io/docs/practices/naming/).

This commit resolves this by changing the `store_name` aspect to be a metric discriminator with the tag `storeName`. The `store_name` itself is compromised of the instance name and chunk sequence ID - I considered splitting this up further into separate tags, but I decided against it as the chosen approach seems to follow convention used in other metrics such as the `thread` discriminator in operation metrics.

Fixes https://hazelcast.atlassian.net/browse/HZ-1299
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6160

Breaking changes (list specific methods/types/messages):
* Metrics - naming convention for `persistence` metrics have changed, see above.
