### PR TITLE
Update metrics for CPSession and Lock in CP Subsystem [HZ-2081]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/LockService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/LockService.java
@@ -227,9 +227,16 @@ public class LockService extends AbstractBlockingService<LockInvocationKey, Lock
                 // We are reading two separate volatile fields but not atomically.
                 // We may observe a partial update.
                 if (owner != null && lockCount > 0) {
-                    context.collect(desc.copy().withUnit(ProbeUnit.COUNT).withMetric("lockCount"), lockCount);
-                    context.collect(desc.copy().withMetric("ownerSessionId"), owner.sessionId());
-                    context.collect(desc.copy().withTag("owner", owner.callerAddress().toString()).withMetric("owner"), 0);
+                    MetricDescriptor copy = desc.copy()
+                                                .withTag("sessionId", String.valueOf(owner.sessionId()))
+                                                .withTag("qualifiedSessionId", owner.sessionId() + "@" + groupId.getName());
+
+                    // Continue to provide `owner.sessionId()` as the value of this metric; although we now include this data in
+                    // tags for this metric, this provides backwards compatibility, and there is no significant meaningful data
+                    // to provide in its place related to the `owner`
+                    context.collect(copy.withMetric("ownerSessionId"), owner.sessionId());
+                    context.collect(copy.withTag("owner", owner.callerAddress().toString()).withMetric("owner"), 0);
+                    context.collect(copy.withUnit(ProbeUnit.COUNT).withMetric("lockCount"), lockCount);
                 } else {
                     context.collect(desc.copy().withUnit(ProbeUnit.COUNT).withMetric("lockCount"), 0);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
@@ -520,8 +520,12 @@ public class RaftSessionService extends AbstractCPMigrationAwareService
         for (RaftSessionRegistry registry : registries.values()) {
             CPGroupId groupId = registry.groupId();
             for (CPSession session : registry.getSessions()) {
+                // We want to provide a dedicated `qualifiedSessionId` tag for use in cross-referencing with Lock metrics, but
+                // also want to keep the `id` tag consistent with other CP related metrics (just happens to be the same here)
+                String qualifiedSessionId = session.id() + "@" + groupId.getName();
                 MetricDescriptor desc = root.copy()
-                        .withDiscriminator("id", session.id() + "@" + groupId.getName())
+                        .withDiscriminator("id", qualifiedSessionId)
+                        .withTag("qualifiedSessionId", qualifiedSessionId)
                         .withTag("sessionId", String.valueOf(session.id()))
                         .withTag("group", groupId.getName());
 


### PR DESCRIPTION
Currently there is some inconsistency in the way metrics are handled for `hz_cp_session_*` and `hz_cp_lock_ownerSessionId` - the CPSession follows the CP subsystem `id` naming convention of using its own ID (session ID) combined with its group name (using the format `id@group`). However this makes it difficult to join the metrics of CPSessions with those of owned Lock metrics, as there is no common tag to join with.

This commit aims to resolve this issue by including 2 new tags in the metrics for both CP Sessions and Locks: `sessionId`, which is the session's ID for Sessions and the owning session's ID for Locks; and `qualifiedSessionId` which is the same as `sessionId`, with the group qualifier applied in the standard format (`sessionId@groupName`). These new tags allow for Session and owned Lock metrics to be joined easily.

I decided to have Lock metrics continue to provide `owner.sessionId()` as the value of the `hz_cp_lock_ownerSessionId` metric; although we now include this data in tags, continuing to provide this metric this way provides backwards compatibility, and there is no significant meaningful data to provide in its place related to the `owner` - alternatively we simply drop this metric as it no longer provides much value for us.

Fixes https://hazelcast.atlassian.net/browse/HZ-2081
