### PR TITLE
Allow for dumb terminal when using 'hz-cli sql' with non-terminal input/output

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/console/SqlConsole.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/console/SqlConsole.java
@@ -38,11 +38,13 @@ import org.jline.reader.SyntaxError;
 import org.jline.reader.UserInterruptException;
 import org.jline.reader.impl.DefaultParser;
 import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
 import org.jline.utils.InfoCmp;
 
 import java.io.IOError;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,6 +81,7 @@ public final class SqlConsole {
                         .style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR)).append("%M%P > ").toAnsi())
                 .variable(LineReader.INDENTATION, 2)
                 .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
+                .terminal(systemOrDumbTerminal())
                 .appName("hazelcast-sql")
                 .build();
 
@@ -163,6 +166,14 @@ public final class SqlConsole {
                 break;
             }
             executeSqlCmd(hzClient, command, reader.getTerminal(), activeSqlResult);
+        }
+    }
+
+    private static Terminal systemOrDumbTerminal() {
+        try {
+            return TerminalBuilder.builder().dumb(true).build();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Allow for a dumb terminal as a fallback if no system terminal detected in the hz-cli input or output. 

Fixes: https://hazelcast.atlassian.net/browse/HZ-2610

Also see:
- https://github.com/jline/jline3/issues/291#issuecomment-402229383
- https://github.com/jline/jline3/issues/299

Testing:
- build local docker image using script (https://hazelcast.slack.com/archives/C01MH9KF1QT/p1657111661829299): `DOCKER_TAG=test ./build-docker-image.sh`
- run the container: `docker run -it --rm --name hz-test hazelcast:test`
- start container shell: `docker exec -it hz-test sh`
- exec hz-cli with piped input: `echo exit\n | hz-cli sql`

Before:
```
$ docker exec -it hz-test sh
/opt/hazelcast $ echo exit\n | hz-cli sql
10:45:18.310 [ WARN] [o.jline] Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)
Connected to Hazelcast 5.3.0 at [172.17.0.2]:5701 (+0 more)
Type 'help' for instructions
sql> Exiting from SQL console
```


After: no jline warning
```
$ docker exec -it hz-test sh
/opt/hazelcast $ echo exit\n | hz-cli sql
Connected to Hazelcast 5.4.0 at [172.17.0.3]:5701 (+0 more)
Type 'help' for instructions
sql> Exiting from SQL console
```


Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
