### PR TITLE
Update snappy to 1.1.10.1 [HZ-2614] [5.3.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1778,7 +1778,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.8.4</version>
+                <version>1.1.10.1</version>
             </dependency>
             <dependency>
                 <groupId>com.google.api.grpc</groupId>


### PR DESCRIPTION
Fixes #24845


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
