### PR TITLE
Provide LocalMapStats data for invocations from Lite members [HZ-2072]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -176,6 +176,16 @@ public class LocalMapStatsProvider {
             String mapName = mapProxy.getName();
 
             if (mapConfig.isStatisticsEnabled() && !statsPerMap.containsKey(mapName)) {
+                // Lite members can invoke MapOperations, and their statistics are of importance for monitoring
+                // when Lite members are in use - so we should include them from our statsMap field in this case
+                if (nodeEngine.getLocalMember().isLiteMember()) {
+                    LocalMapStatsImpl localMapStats = statsMap.get(mapName);
+                    if (localMapStats != null && localMapStats.total() > 0) {
+                        statsPerMap.put(mapName, localMapStats);
+                        continue;
+                    }
+                }
+
                 statsPerMap.put(mapName, EMPTY_LOCAL_MAP_STATS);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -181,12 +181,9 @@ public class LocalMapStatsProvider {
 
             if (mapConfig.isStatisticsEnabled() && !statsPerMap.containsKey(mapName)) {
                 // Lite members can invoke MapOperations, and their statistics are of importance for monitoring
-                // when Lite members are in use - so we should include proxy stats if they are non-zero
-                if (mapProxy.getLocalMapStats().total() > 0) {
-                    statsPerMap.put(mapName, mapProxy.getLocalMapStats());
-                } else {
-                    statsPerMap.put(mapName, EMPTY_LOCAL_MAP_STATS);
-                }
+                // when Lite members are in use - so we should include these stats as well if they exist
+                LocalMapStatsImpl localMapStats = statsMap.get(mapName);
+                statsPerMap.put(mapName, localMapStats != null ? localMapStats : EMPTY_LOCAL_MAP_STATS);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -443,6 +443,10 @@ class MapServiceContextImpl implements MapServiceContext {
 
         MapContainer mapContainer = mapContainers.get(mapName);
         if (mapContainer == null) {
+            // Lite members create their own LocalMapStatsImpl whenever a new IMap is created,
+            // which can happen without a MapContainer, so we need to clean them up - since cleanup
+            // is just a simple map entry removal, we can call it without any Lite member checks
+            localMapStatsProvider.destroyLocalMapStatsImpl(mapName);
             return;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
@@ -23,6 +23,8 @@ import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.collectors.MetricsCollector;
+import com.hazelcast.map.impl.LocalMapStatsProvider;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -37,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.test.Accessors.getNode;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -95,6 +98,12 @@ public class LocalMapStatsProviderTest extends HazelcastTestSupport {
 
         // Confirm 1 putCount metric was collected for the Lite member
         assertEquals(1, metricsCollector.totalCollected.get());
+
+        // Destroy the map and ensure metrics are cleaned up
+        map1.destroy();
+        MapService mapService = getNode(hzLite).getNodeEngine().getService(MapService.SERVICE_NAME);
+        LocalMapStatsProvider statsProvider = mapService.getMapServiceContext().getLocalMapStatsProvider();
+        assertFalse(statsProvider.hasLocalMapStatsImpl(MAP_NAME));
     }
 
     private Config createMetricsBasedConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
@@ -53,7 +53,7 @@ public class LocalMapStatsProviderTest extends HazelcastTestSupport {
     //https://github.com/hazelcast/hazelcast/issues/11598
     @Test
     public void testRedundantPartitionMigrationWhenManagementCenterConfigured() {
-        Config config = new Config();
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
 
         //don't need start management center, just configure it
         final HazelcastInstance instance = factory.newHazelcastInstance(config);
@@ -98,7 +98,7 @@ public class LocalMapStatsProviderTest extends HazelcastTestSupport {
     }
 
     private Config createMetricsBasedConfig() {
-        Config config = new Config();
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
         config.setClusterName("dev");
         config.getMetricsConfig().setEnabled(true);
         MapConfig map = config.getMapConfig(MAP_NAME);

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
@@ -17,15 +17,23 @@
 package com.hazelcast.map;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.management.ManagementCenterService;
+import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.collectors.MetricsCollector;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.test.Accessors.getNode;
 import static org.junit.Assert.assertEquals;
@@ -34,6 +42,13 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class LocalMapStatsProviderTest extends HazelcastTestSupport {
+    private static final String MAP_NAME = "test_map_1";
+    private final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+    @After
+    public void tearDown() {
+        factory.shutdownAll();
+    }
 
     //https://github.com/hazelcast/hazelcast/issues/11598
     @Test
@@ -41,7 +56,7 @@ public class LocalMapStatsProviderTest extends HazelcastTestSupport {
         Config config = new Config();
 
         //don't need start management center, just configure it
-        final HazelcastInstance instance = createHazelcastInstance(config);
+        final HazelcastInstance instance = factory.newHazelcastInstance(config);
 
         assertTrueEventually(() -> {
             ManagementCenterService mcs = getNode(instance).getManagementCenterService();
@@ -56,5 +71,66 @@ public class LocalMapStatsProviderTest extends HazelcastTestSupport {
             long partitionStateStamp = getNode(instance).getPartitionService().getPartitionStateStamp();
             assertEquals(0, partitionStateStamp);
         }, 5);
+    }
+
+    @Test
+    public void testLiteMembersProvideLocalMapStatsForInvocations() {
+        // Create a regular member which will own partitions and execute MapOperations
+        Config nonLiteConfig = createMetricsBasedConfig();
+        HazelcastInstance hzFull = factory.newHazelcastInstance(nonLiteConfig);
+        // Create a Lite member which will only invoke MapOperations
+        Config liteConfig = createMetricsBasedConfig().setLiteMember(true);
+        HazelcastInstance hzLite = factory.newHazelcastInstance(liteConfig);
+
+        waitAllForSafeState(hzFull, hzLite);
+
+        // From the Lite member, access and put data into a map
+        IMap<Object, Object> map1 = hzLite.getMap(MAP_NAME);
+        map1.put("myKey", "myValue");
+
+        // Collect metrics from the Lite member
+        MetricsRegistry metricsRegistry = getNode(hzLite).getNodeEngine().getMetricsRegistry();
+        MapPutCountMetricsCollector metricsCollector = new MapPutCountMetricsCollector();
+        metricsRegistry.collect(metricsCollector);
+
+        // Confirm 1 putCount metric was collected for the Lite member
+        assertEquals(1, metricsCollector.totalCollected.get());
+    }
+
+    private Config createMetricsBasedConfig() {
+        Config config = new Config();
+        config.setClusterName("dev");
+        config.getMetricsConfig().setEnabled(true);
+        MapConfig map = config.getMapConfig(MAP_NAME);
+        map.setStatisticsEnabled(true);
+        map.setPerEntryStatsEnabled(true);
+        return config;
+    }
+
+    private static class MapPutCountMetricsCollector implements MetricsCollector {
+        final AtomicInteger totalCollected = new AtomicInteger(0);
+
+        @Override
+        public void collectLong(MetricDescriptor descriptor, long value) {
+            if (descriptor.metric().equals("putCount")) {
+                String discriminator = descriptor.discriminatorValue();
+                String prefix = descriptor.prefix();
+                if (prefix != null && prefix.equals("map") && discriminator != null && discriminator.equals(MAP_NAME)) {
+                    totalCollected.addAndGet((int) value);
+                }
+            }
+        }
+
+        @Override
+        public void collectDouble(MetricDescriptor descriptor, double value) {
+        }
+
+        @Override
+        public void collectException(MetricDescriptor descriptor, Exception e) {
+        }
+
+        @Override
+        public void collectNoValue(MetricDescriptor descriptor) {
+        }
     }
 }


### PR DESCRIPTION
**Context:** Metrics for IMaps are stored in `LocalMapStats` objects, which are provided by `LocalMapStatsProvider`. Certain MapOperation metrics (get, set, put, & remove) are logged when `MapProxySupport#invokeOperation` is called, which uses `MapOperationStatsUpdater.incrementOperationStats`. This happens for operations not executed on the local member as well, which means that a Lite member invoking `IMap#put` will cause a `PutOperation` being executed on another (non-Lite) member, but it will increment stats on its own member.

**Problem:** Due to Lite members not owning any data themselves, they do not report any metrics for MapOperations. This means that metrics on these operations are lost with the current metric collection mechanics.

**Solution:** Tweaking `LocalMapStatsProvider#addStatsOfNoDataIncludedMaps` to include a `isLiteMember` check which, if passed, will include metrics from the provider's `statsMap` field (which is already correctly updated). This is only done if an empty `LocalMapStats` object would've been passed otherwise, and the `statsMap` entry contains non-zero statistics.

I have also added a very simple regression test which ensures Lite members produce metrics after `IMap#put` is called.

**Note:** It may be worth reworking our map statistic capturing mechanic, shifting the responsibility to the executing member rather than the invoker. I chose my approach with the mindset of changing the least amount of existing functionality/behaviour, while also stopping these metrics being lost entirely as they currently are.

Closes https://hazelcast.atlassian.net/browse/HZ-2072
