### PR TITLE
Update Mockito version to 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <http.client.version>4.5.14</http.client.version>
         <jsr107.tck.version>1.1.1</jsr107.tck.version>
         <junit.version>4.13.2</junit.version>
-        <mockito.version>5.3.1</mockito.version>
+        <mockito.version>5.4.0</mockito.version>
         <reflections.version>0.9.10</reflections.version>
         <testcontainers.version>1.18.3</testcontainers.version>
         <jna.version>5.13.0</jna.version>


### PR DESCRIPTION
There are a number of fixes included in 5.4.0 which might help resolve some of our inconsistent Mockito-related failures.

Changelog: https://github.com/mockito/mockito/releases/tag/v5.4.0

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6179
