### PR TITLE
Add logging and state check to PartitionMigrationComputeIntensiveTest [HZ-2623]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationComputeIntensiveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationComputeIntensiveTest.java
@@ -19,11 +19,12 @@ package com.hazelcast.partition;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -34,28 +35,40 @@ import static com.hazelcast.partition.PartitionMigrationListenerTest.MigrationEv
 import static com.hazelcast.partition.PartitionMigrationListenerTest.assertMigrationEventsConsistentWithResult;
 import static com.hazelcast.partition.PartitionMigrationListenerTest.assertMigrationProcessCompleted;
 import static com.hazelcast.partition.PartitionMigrationListenerTest.assertMigrationProcessEventsConsistent;
+import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_COUNT;
+import static com.hazelcast.spi.properties.ClusterProperty.SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class})
+@Category({SlowTest.class})
 public class PartitionMigrationComputeIntensiveTest extends HazelcastTestSupport {
+
+    private static final ILogger LOGGER = Logger.getLogger(PartitionMigrationComputeIntensiveTest.class);
 
     @Test
     public void testMigrationStats_afterPartitionsLost_when_NO_MIGRATION() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
-        Config config = new Config().setProperty(ClusterProperty.PARTITION_COUNT.getName(), "2000");
+        Config config = new Config().setProperty(PARTITION_COUNT.getName(), "2000")
+                                    .setProperty(SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED.getName(), "true");
         HazelcastInstance[] instances = factory.newInstances(config, 10);
+
         assertClusterSizeEventually(instances.length, instances);
+        waitAllForSafeState(instances);
+
+        LOGGER.info("Cluster formed and in safe state, warming up partitions...");
         warmUpPartitions(instances);
 
+        LOGGER.info("Adding migration listener");
         EventCollectingMigrationListener listener = new EventCollectingMigrationListener();
         instances[0].getPartitionService().addMigrationListener(listener);
 
+        LOGGER.info("Changing cluster state to PASSIVE");
         changeClusterStateEventually(instances[0], ClusterState.PASSIVE);
 
         for (int i = 3; i < instances.length; i++) {
             instances[i].getLifecycleService().terminate();
         }
 
+        LOGGER.info("Changing cluster state to NO_MIGRATION");
         changeClusterStateEventually(instances[0], ClusterState.NO_MIGRATION);
 
         // 3 promotions on each remaining node + 1 to assign owners for lost partitions


### PR DESCRIPTION
Currently, the `PartitionMigrationComputeIntensiveTest` can occasionally fail, particularly on Sonar builds. Analysis of the logged output shows that the cluster size is formed to 10 nodes as expected, but once the `PartitionStateManager` starts initializing cluster partition tables, we start encountering slow `PartitionStateOperation` executions. This leads to high machine load (`load.system=100.0%` in health monitor) and eventually heartbeat timeouts between nodes - connections then start bouncing and mastership of the cluster becomes clouded as nodes compete. This eventually leads to partitions being lost, and the failure seen. This scenario is consistent across all Sonar failures of this test.

This commit largely aims to insert additional logging that can help us identify the root cause of this locking up. By introducing the property `hazelcast.slow.operation.detector.stacktrace.logging.enabled` we will see more details about the slow operations being encountered. I've also introduced some `Logger` output to show the test flow more clearly, although I'm fairly confident the test is failing in `warmUpPartitions`.

As a shot in the dark solution, I've introduced a `waitAllForSafeState` check for all nodes, so we can be sure they're stable (not just cluster size matched) before we warm up partitions. This is unlikely to be a true solution, but provide extra assurance for circumstances. I believe the most likely cause of these non-deterministic failures are machine load related more than test-specific.

I also changed this test from `QuickTest` to `SlowTest` as it runs for 25-35 seconds locally on my end.

Closes: https://github.com/hazelcast/hazelcast/issues/24791
Closes: https://hazelcast.atlassian.net/browse/HZ-2623