### PR TITLE
Improvements to RestClientTest TLS 1.3 support tests  (#24794) [5.3.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/utils/RestClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/utils/RestClientTest.java
@@ -18,13 +18,19 @@ package com.hazelcast.spi.utils;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.hazelcast.internal.util.JavaVersion;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.exception.RestClientException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -34,7 +40,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
-import static com.hazelcast.internal.nio.IOUtil.close;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -52,6 +58,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class})
 public class RestClientTest {
     private static final String API_ENDPOINT = "/some/endpoint";
     private static final String BODY_REQUEST = "some body request";
@@ -234,48 +242,44 @@ public class RestClientTest {
 
     @Test
     public void tls13SupportDefaultCacert() throws IOException {
-        assumeTrue(JavaVersion.isAtLeast(JavaVersion.JAVA_11));
-        Tls13CipherCheckingServer server = new Tls13CipherCheckingServer(new ServerSocket(0));
-        try {
-            new Thread(server).start();
-            RestClient.create("https://127.0.0.1:" + server.serverSocket.getLocalPort()).get();
-        } catch (Exception e) {
-            // whatever
-        } finally {
-            server.shutdownRequested = true;
-        }
-        assertTrue("No TLS 1.3 cipher used", server.tls13CipherFound.get());
+        assertTls13SupportInternal(null);
     }
 
     @Test
     public void tls13SupportCustomCacert() throws IOException {
+        assertTls13SupportInternal("src/test/resources/kubernetes/ca.crt");
+    }
+
+    private void assertTls13SupportInternal(String caFileName) throws IOException {
         assumeTrue(JavaVersion.isAtLeast(JavaVersion.JAVA_11));
-        Tls13CipherCheckingServer server = new Tls13CipherCheckingServer(new ServerSocket(0));
-        try {
+        try (Tls13CipherCheckingServer server = new Tls13CipherCheckingServer()) {
             new Thread(server).start();
-            RestClient.create("https://127.0.0.1:" + server.serverSocket.getLocalPort())
-                    .withCaCertificates(readFile("src/test/resources/kubernetes/ca.crt")).get();
-        } catch (Exception e) {
-            // whatever
-        } finally {
-            server.shutdownRequested = true;
+            RestClient restClient = RestClient.create("https://127.0.0.1:" + server.getPort());
+            if (caFileName != null) {
+                restClient.withCaCertificates(readFile(caFileName));
+            }
+            try {
+                restClient.get();
+            } catch (Exception e) {
+                Logger.getLogger(getClass()).info("REST call failed (expected)", e);
+            }
+            assertTrueEventually(() -> assertTrue("No TLS 1.3 cipher used", server.tls13CipherFound.get()), 8);
         }
-        assertTrue("No TLS 1.3 cipher used", server.tls13CipherFound.get());
     }
 
     private String readFile(String fileName) throws IOException {
         return StringUtil.bytesToString(Files.readAllBytes(Paths.get(fileName)));
     }
 
-    static final class Tls13CipherCheckingServer implements Runnable {
+    static final class Tls13CipherCheckingServer implements Runnable, AutoCloseable {
         private static final ILogger LOGGER = Logger.getLogger(Tls13CipherCheckingServer.class);
 
-        final ServerSocket serverSocket;
-        volatile boolean shutdownRequested;
-        final AtomicBoolean tls13CipherFound = new AtomicBoolean();
+        private final AtomicBoolean tls13CipherFound = new AtomicBoolean();
+        private final ServerSocket serverSocket;
+        private volatile boolean shutdownRequested;
 
-        Tls13CipherCheckingServer(ServerSocket serverSocket) {
-            this.serverSocket = serverSocket;
+        Tls13CipherCheckingServer() throws IOException {
+            this.serverSocket = new ServerSocket(0);
             try {
                 this.serverSocket.setSoTimeout(500);
             } catch (SocketException e) {
@@ -284,35 +288,41 @@ public class RestClientTest {
             LOGGER.info("The server will be listening on port " + serverSocket.getLocalPort());
         }
 
+        public int getPort() {
+            return serverSocket.getLocalPort();
+        }
+
         public void run() {
-            try {
-                while (!(shutdownRequested || tls13CipherFound.get())) {
-                    try {
-                        Socket socket = serverSocket.accept();
-                        new Thread(() -> {
-                            LOGGER.info("Socket accepted " + socket);
-                            try {
-                                socket.setSoTimeout(5000);
-                                tls13CipherFound.compareAndSet(false, hasTls13Cipher(socket.getInputStream()));
-                            } catch (IOException e) {
-                                LOGGER.warning("Reading from the socket failed", e);
-                            } finally {
-                                close(socket);
-                            }
-                        }).start();
-                    } catch (SocketTimeoutException e) {
-                        // it's fine
-                    }
+            while (!(shutdownRequested || tls13CipherFound.get())) {
+                try {
+                    Socket socket = serverSocket.accept();
+                    new Thread(() -> {
+                        LOGGER.info("Socket accepted " + socket);
+                        try {
+                            socket.setSoTimeout(5000);
+                            tls13CipherFound.compareAndSet(false, hasTls13Cipher(socket.getInputStream()));
+                        } catch (IOException e) {
+                            LOGGER.warning("Reading from the socket (serverPort=" + getPort() + ") failed", e);
+                        } finally {
+                            LOGGER.info("Closing " + socket);
+                            IOUtil.close(socket);
+                        }
+                    }).start();
+                } catch (SocketTimeoutException e) {
+                    // it's fine
+                } catch (Exception e) {
+                    LOGGER.warning("The ServerSocket (" + getPort() + ") has thrown an exception", e);
                 }
-            } catch (IOException e) {
-                LOGGER.warning("The test server thrown an exception", e);
-            } finally {
-                close(serverSocket);
             }
         }
 
-        void stop() {
+        public void close() {
             shutdownRequested = true;
+            try {
+                serverSocket.close();
+            } catch (Exception e) {
+                LOGGER.warning("ServerSocket.close() has failed", e);
+            }
         }
 
         static boolean hasTls13Cipher(InputStream is) throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/ProgressMonitor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/ProgressMonitor.java
@@ -81,7 +81,7 @@ public class ProgressMonitor {
             if (lastProgressLoggedNanos > 0) {
                 sb.append("Maximum latency: ")
                         .append(TimeUnit.NANOSECONDS.toMillis(maxLatencyNanos))
-                        .append(" ms.");
+                        .append(" ms. ");
 
                 long timeInNanos = now - lastProgressLoggedNanos;
                 double timeInSeconds = (double) timeInNanos / 1000000000;


### PR DESCRIPTION
Backport of: https://github.com/hazelcast/hazelcast/pull/24794
Closes https://github.com/hazelcast/hazelcast/issues/24676

Fixes #24676

There are two tests within the `RestClientTest` class which have been
shown to non-deterministically fail occasionally during Jenkins job;
those tests are `tls13SupportDefaultCacert` and `tls13SupportCustomCacert`.

This PR improves error handling, synchronization and logging in the tests.

Notes:
> During my debugging I was able to reproduce the failures only as part of a long-running test suite, never as an isolated test. I was only able to reproduce the issue once with additional logging, which came in the form of a single `"TLS 1.3 found? <boolean>"` logger call after the cipher had been checked - the logging output showed this being called twice with `true` values both times, which should indicate the test was successful. However, the test had still failed due to the assertion check at the end of the test.
>
> Any attempts to debug further resulted in being unable to reproduce the failure, even during long-running tests, leading me to believe this is the result of a niche race condition, most likely around the socket closure, as we know at least this stage is reached before there is divergence.