### PR TITLE
Remove redundant broadcastAppendRequest during Raft heartbeat [HZ-2600]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
@@ -607,7 +607,6 @@ public final class RaftNodeImpl implements RaftNode {
      * Schedules periodic heartbeat task when a new leader is elected.
      */
     private void scheduleHeartbeat() {
-        broadcastAppendRequest();
         schedule(new HeartbeatTask(), heartbeatPeriodInMillis);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
@@ -1238,6 +1238,7 @@ public final class RaftNodeImpl implements RaftNode {
         state.toLeader();
         appendEntryAfterLeaderElection();
         printMemberState();
+        broadcastAppendRequest();
         scheduleHeartbeat();
     }
 


### PR DESCRIPTION
The deleted `broadcastAppendRequest()` is redundant because this method is also called inside the `HeartbeatTask`. Otherwise, we have two sequential  `broadcastAppendRequest()` calls that create additional pressure on the network and Followers.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
