### PR TITLE
Bump Guava version from 32.0.0-jre to 32.0.1-jre  [5.2.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <classgraph.version>4.8.149</classgraph.version>
         <debezium.version>1.9.5.Final</debezium.version>
         <grpc.version>1.48.0</grpc.version>
-        <guava.version>30.1.1-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
         <hadoop.version>3.3.5</hadoop.version>
         <h2.version>2.1.214</h2.version>
         <!-- The Jackson version must match the version in EE, if you change this you must send EE PR as well -->


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/24788

Version 32.0.0-jre accidentally introduced a breaking change for Windows machines when using `Files.createTempDir` related to POSIX file permissions. Version 32.0.1-jre resolves this issue, as [detailed in the changelog here](https://github.com/google/guava/releases/tag/v32.0.1).

Fixes https://github.com/hazelcast/hazelcast/issues/24777