### PR TITLE
Bump Guava version from 32.0.0-jre to 32.0.1-jre  [4.2.z]

### DIFF
--- a/hazelcast-sql-core/pom.xml
+++ b/hazelcast-sql-core/pom.xml
@@ -37,7 +37,7 @@
         <main.basedir>${project.parent.basedir}</main.basedir>
 
         <calcite.version>1.23.0</calcite.version>
-        <guava.version>30.1-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
         <slf4j.version>1.7.25</slf4j.version>
         <avatica-core.version>1.22.0</avatica-core.version>
     </properties>


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/24788

Version 32.0.0-jre accidentally introduced a breaking change for Windows machines when using `Files.createTempDir` related to POSIX file permissions. Version 32.0.1-jre resolves this issue, as [detailed in the changelog here](https://github.com/google/guava/releases/tag/v32.0.1).

Fixes https://github.com/hazelcast/hazelcast/issues/24777