### PR TITLE
Honor local parallelism of fused vertices [HZ-2493] [5.3.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
@@ -124,7 +124,7 @@ public class HashJoinTransform<T0, R> extends AbstractTransform {
     @SuppressWarnings("unchecked")
     public void addToDag(Planner p, Context context) {
         determineLocalParallelism(LOCAL_PARALLELISM_USE_DEFAULT, context, p.isPreserveOrder());
-        PlannerVertex primary = p.xform2vertex.get(this.upstream().get(0));
+        PlannerVertex primary = p.transform2vertex.get(this.upstream().get(0));
         List keyFns = toList(this.clauses, JoinClause::leftKeyFn);
 
         List<Tag> tags = this.tags;
@@ -147,7 +147,7 @@ public class HashJoinTransform<T0, R> extends AbstractTransform {
         String collectorName = name() + "-collector";
         int collectorOrdinal = 1;
         for (Transform fromTransform : tailList(this.upstream())) {
-            PlannerVertex fromPv = p.xform2vertex.get(fromTransform);
+            PlannerVertex fromPv = p.transform2vertex.get(fromTransform);
             JoinClause<?, ?, ?, ?> clause = this.clauses.get(collectorOrdinal - 1);
             FunctionEx<Object, Object> getKeyFn = (FunctionEx<Object, Object>) clause.rightKeyFn();
             FunctionEx<Object, Object> projectFn = (FunctionEx<Object, Object>) clause.rightProjectFn();

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PeekTransform.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PeekTransform.java
@@ -49,10 +49,10 @@ public class PeekTransform<T> extends AbstractTransform {
     @Override
     public void addToDag(Planner p, Context context) {
         determineLocalParallelism(LOCAL_PARALLELISM_USE_DEFAULT, context, p.isPreserveOrder());
-        PlannerVertex peekedPv = p.xform2vertex.get(this.upstream().get(0));
+        PlannerVertex peekedPv = p.transform2vertex.get(this.upstream().get(0));
         // Peeking transform doesn't add a vertex, so point to the upstream
         // transform's vertex:
-        p.xform2vertex.put(this, peekedPv);
+        p.transform2vertex.put(this, peekedPv);
         peekedPv.v.updateMetaSupplier(sup -> peekOutputP(toStringFn, shouldLogFn, sup));
     }
 }


### PR DESCRIPTION
Backports #24859
Fixes #24683

In addition, the following members are renamed:
1. **xform2vertex → transform2vertex:** We should avoid using "x" for "trans" for the sake of readability.
2. **findFusableChain() → findFusibleChain():** Fusible is the correct spelling of fusable.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases