### PR TITLE
Bump maven-dependency-plugin from 6.1.5 to 8.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <maven.cobertura.plugin.version>2.7</maven.cobertura.plugin.version>
         <maven.enforcer.plugin.version>3.0.0-M3</maven.enforcer.plugin.version>
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
-        <owasp.dependency-check.version>6.1.5</owasp.dependency-check.version>
+        <owasp.dependency-check.version>8.3.1</owasp.dependency-check.version>
         <codehause.license.plugin.version>2.0.0</codehause.license.plugin.version>
         <reload4j.version>1.2.24</reload4j.version>
         <log4j2.version>2.17.0</log4j2.version>


### PR DESCRIPTION
It fixes problem with security build due to too old version:
https://jenkins.hazelcast.com/view/Security%20and%20Compliance/job/hazelcast-owasp-report-4.2.z/


Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible
