### PR TITLE
Perform resource existence checks only once in Mongo connector

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/DbCheckingPMetaSupplier.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/DbCheckingPMetaSupplier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hazelcast.jet.mongodb;
 
 import com.hazelcast.cluster.Address;
@@ -49,6 +64,9 @@ public class DbCheckingPMetaSupplier implements ProcessorMetaSupplier {
 
     private transient Address ownerAddress;
 
+    /**
+     * Creates a new instance of this meta supplier.
+     */
     public DbCheckingPMetaSupplier(@Nullable Permission requiredPermission,
                                    boolean shouldCheck,
                                    boolean forceTotalParallelismOne,
@@ -115,7 +133,8 @@ public class DbCheckingPMetaSupplier implements ProcessorMetaSupplier {
                                   .filter(en -> arrayIndexOf(partitionId, en.getValue()) >= 0)
                                   .findAny()
                                   .map(Entry::getKey)
-                                  .orElseThrow(() -> new RuntimeException("Owner partition not assigned to any participating member"));
+                                  .orElseThrow(() -> new RuntimeException("Owner partition not assigned to any " +
+                                          "participating member"));
         }
 
         if (shouldCheck) {
@@ -145,11 +164,12 @@ public class DbCheckingPMetaSupplier implements ProcessorMetaSupplier {
             } else if (dataConnectionRef != null) {
                 NodeEngineImpl nodeEngine = Util.getNodeEngine(context.hazelcastInstance());
                 InternalDataConnectionService dataConnectionService = nodeEngine.getDataConnectionService();
-                var dataConnection = dataConnectionService.getAndRetainDataConnection(dataConnectionRef.getName(), MongoDataConnection.class);
+                var dataConnection = dataConnectionService.getAndRetainDataConnection(dataConnectionRef.getName(),
+                        MongoDataConnection.class);
                 return tuple2(dataConnection.getClient(), dataConnection);
             } else {
-                throw new IllegalArgumentException("Either connectionSupplier or dataConnectionRef must be provided if database" +
-                        "and collection existence checks are requested");
+                throw new IllegalArgumentException("Either connectionSupplier or dataConnectionRef must be provided " +
+                        "if database and collection existence checks are requested");
             }
         } catch (Exception e) {
             throw new JetException("Cannot connect to MongoDB", e);

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/DbCheckingPMetaSupplier.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/DbCheckingPMetaSupplier.java
@@ -1,0 +1,172 @@
+package com.hazelcast.jet.mongodb;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.dataconnection.DataConnection;
+import com.hazelcast.dataconnection.impl.InternalDataConnectionService;
+import com.hazelcast.function.SupplierEx;
+import com.hazelcast.jet.JetException;
+import com.hazelcast.jet.core.ProcessorMetaSupplier;
+import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.datamodel.Tuple2;
+import com.hazelcast.jet.impl.processor.ExpectNothingP;
+import com.hazelcast.jet.impl.util.Util;
+import com.hazelcast.jet.mongodb.dataconnection.MongoDataConnection;
+import com.hazelcast.jet.pipeline.DataConnectionRef;
+import com.hazelcast.security.PermissionsUtil;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.connection.ClusterDescription;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.security.Permission;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.function.Function;
+
+import static com.hazelcast.internal.util.UuidUtil.newUnsecureUuidString;
+import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
+import static com.hazelcast.jet.impl.util.Util.arrayIndexOf;
+import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getPartitionKey;
+import static java.util.Collections.singletonList;
+
+/**
+ * A {@link ProcessorMetaSupplier} that will check if requested database and collection exist before creating
+ * the processors.
+ */
+public class DbCheckingPMetaSupplier implements ProcessorMetaSupplier {
+
+    private final Permission requiredPermission;
+    private final boolean shouldCheck;
+    private final boolean forceTotalParallelismOne;
+    private final String databaseName;
+    private final String collectionName;
+    private final ProcessorSupplier processorSupplier;
+    private final SupplierEx<? extends MongoClient> clientSupplier;
+    private final DataConnectionRef dataConnectionRef;
+    private int preferredLocalParallelism = Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
+
+    private transient Address ownerAddress;
+
+    public DbCheckingPMetaSupplier(@Nullable Permission requiredPermission,
+                                   boolean shouldCheck,
+                                   boolean forceTotalParallelismOne,
+                                   @Nullable String databaseName,
+                                   @Nullable String collectionName,
+                                   @Nullable SupplierEx<? extends MongoClient> clientSupplier,
+                                   @Nullable DataConnectionRef dataConnectionRef,
+                                   @Nonnull ProcessorSupplier processorSupplier) {
+        this.requiredPermission = requiredPermission;
+        this.shouldCheck = shouldCheck;
+        this.forceTotalParallelismOne = forceTotalParallelismOne;
+        this.databaseName = databaseName;
+        this.collectionName = collectionName;
+        this.processorSupplier = processorSupplier;
+        this.clientSupplier = clientSupplier;
+        this.dataConnectionRef = dataConnectionRef;
+    }
+
+    public DbCheckingPMetaSupplier withPreferredLocalParallelism(int preferredLocalParallelism) {
+        this.preferredLocalParallelism = preferredLocalParallelism;
+        return this;
+    }
+
+    @Override
+    public int preferredLocalParallelism() {
+        return preferredLocalParallelism;
+    }
+
+    @Nullable
+    @Override
+    public Permission getRequiredPermission() {
+        return requiredPermission;
+    }
+
+    @Override
+    public void init(@Nonnull Context context) throws Exception {
+        PermissionsUtil.checkPermission(processorSupplier, context);
+
+        if (forceTotalParallelismOne) {
+            if (context.localParallelism() != 1) {
+                throw new IllegalArgumentException(
+                        "Local parallelism of " + context.localParallelism() + " was requested for a vertex that "
+                                + "supports only total parallelism of 1. Local parallelism must be 1.");
+            }
+            String key = getPartitionKey(newUnsecureUuidString());
+            int partitionId = context.hazelcastInstance().getPartitionService().getPartition(key).getPartitionId();
+            ownerAddress = context.partitionAssignment().entrySet().stream()
+                                  .filter(en -> arrayIndexOf(partitionId, en.getValue()) >= 0)
+                                  .findAny()
+                                  .map(Entry::getKey)
+                                  .orElseThrow(() -> new RuntimeException("Owner partition not assigned to any participating member"));
+        }
+
+        if (shouldCheck) {
+            Tuple2<MongoClient, DataConnection> clientAndRef = connect(context);
+            MongoClient client = clientAndRef.requiredF0();
+            try {
+                if (databaseName != null) {
+                    checkDatabaseExists(client, databaseName);
+                    MongoDatabase database = client.getDatabase(databaseName);
+                    if (collectionName != null) {
+                        checkCollectionExists(database, collectionName);
+                    }
+                }
+            } finally {
+                DataConnection connection = clientAndRef.f1();
+                if (connection != null) {
+                    connection.release();
+                }
+            }
+        }
+    }
+
+    private Tuple2<MongoClient, DataConnection> connect(Context context) {
+        try {
+            if (clientSupplier != null) {
+                return tuple2(clientSupplier.get(), null);
+            } else if (dataConnectionRef != null) {
+                NodeEngineImpl nodeEngine = Util.getNodeEngine(context.hazelcastInstance());
+                InternalDataConnectionService dataConnectionService = nodeEngine.getDataConnectionService();
+                var dataConnection = dataConnectionService.getAndRetainDataConnection(dataConnectionRef.getName(), MongoDataConnection.class);
+                return tuple2(dataConnection.getClient(), dataConnection);
+            } else {
+                throw new IllegalArgumentException("Either connectionSupplier or dataConnectionRef must be provided if database" +
+                        "and collection existence checks are requested");
+            }
+        } catch (Exception e) {
+            throw new JetException("Cannot connect to MongoDB", e);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public Function<? super Address, ? extends ProcessorSupplier> get(@Nonnull List<Address> addresses) {
+        if (forceTotalParallelismOne) {
+            return addr -> addr.equals(ownerAddress) ? processorSupplier : count -> singletonList(new ExpectNothingP());
+        } else {
+            return addr -> processorSupplier;
+        }
+    }
+
+    static void checkCollectionExists(MongoDatabase database, String collectionName) {
+        for (String name : database.listCollectionNames()) {
+            if (name.equals(collectionName)) {
+                return;
+            }
+        }
+        throw new JetException("Collection " + collectionName + " in database " + database.getName() + " does not exist");
+    }
+
+    static void checkDatabaseExists(MongoClient client, String databaseName) {
+        for (String name : client.listDatabaseNames()) {
+            if (name.equalsIgnoreCase(databaseName)) {
+                return;
+            }
+        }
+        ClusterDescription clusterDescription = client.getClusterDescription();
+        throw new JetException("Database " + databaseName + " does not exist in cluster " + clusterDescription);
+    }
+}

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSinkBuilder.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSinkBuilder.java
@@ -21,6 +21,7 @@ import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.mongodb.impl.DbCheckingPMetaSupplier;
 import com.hazelcast.jet.mongodb.impl.WriteMongoP;
 import com.hazelcast.jet.mongodb.impl.WriteMongoParams;
 import com.hazelcast.jet.pipeline.DataConnectionRef;

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSinkBuilder.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSinkBuilder.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.mongodb;
 import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
-import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.mongodb.impl.WriteMongoP;
@@ -258,8 +257,11 @@ public final class MongoSinkBuilder<T> {
         final WriteMongoParams<T> localParams = this.params;
 
         ConnectorPermission permission = params.buildPermission();
-        return Sinks.fromProcessor(name, ProcessorMetaSupplier.of(preferredLocalParallelism, permission,
-                ProcessorSupplier.of(() -> new WriteMongoP<>(localParams))));
+        return Sinks.fromProcessor(name, new DbCheckingPMetaSupplier(permission, localParams.isThrowOnNonExisting(), false,
+                localParams.getDatabaseName(), localParams.getCollectionName(),
+                localParams.getClientSupplier(), localParams.getDataConnectionRef(),
+                ProcessorSupplier.of(() -> new WriteMongoP<>(localParams)))
+                .withPreferredLocalParallelism(preferredLocalParallelism));
     }
 
 }

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSourceBuilder.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSourceBuilder.java
@@ -20,6 +20,7 @@ import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.mongodb.impl.DbCheckingPMetaSupplier;
 import com.hazelcast.jet.mongodb.impl.ReadMongoP;
 import com.hazelcast.jet.mongodb.impl.ReadMongoParams;
 import com.hazelcast.jet.pipeline.BatchSource;

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSourceBuilder.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/MongoSourceBuilder.java
@@ -413,7 +413,8 @@ public final class MongoSourceBuilder {
             final ReadMongoParams<T> localParams = params;
 
             ConnectorPermission permission = params.buildPermissions();
-            return Sources.batchFromProcessor(name, new DbCheckingPMetaSupplier(permission, localParams.isThrowOnNonExisting(), false,
+            return Sources.batchFromProcessor(name, new DbCheckingPMetaSupplier(permission,
+                    localParams.isThrowOnNonExisting(), false,
                     localParams.getDatabaseName(), localParams.getCollectionName(),
                     localParams.getClientSupplier(), localParams.getDataConnectionRef(),
                     ProcessorSupplier.of(() -> new ReadMongoP<>(localParams))));
@@ -615,7 +616,8 @@ public final class MongoSourceBuilder {
                     eventTimePolicy -> new DbCheckingPMetaSupplier(permission, localParams.isThrowOnNonExisting(), false,
                             localParams.getDatabaseName(), localParams.getCollectionName(),
                             localParams.getClientSupplier(), localParams.getDataConnectionRef(),
-                            ProcessorSupplier.of(() -> new ReadMongoP<>(localParams.setEventTimePolicy(eventTimePolicy)))));
+                            ProcessorSupplier.of(() -> new ReadMongoP<>(localParams.setEventTimePolicy(eventTimePolicy))))
+            );
         }
     }
 

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/DbCheckingPMetaSupplier.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/DbCheckingPMetaSupplier.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hazelcast.jet.mongodb;
+package com.hazelcast.jet.mongodb.impl;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.dataconnection.DataConnection;
@@ -31,7 +31,6 @@ import com.hazelcast.jet.pipeline.DataConnectionRef;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.connection.ClusterDescription;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,6 +42,8 @@ import java.util.function.Function;
 import static com.hazelcast.internal.util.UuidUtil.newUnsecureUuidString;
 import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 import static com.hazelcast.jet.impl.util.Util.arrayIndexOf;
+import static com.hazelcast.jet.mongodb.impl.MongoUtilities.checkCollectionExists;
+import static com.hazelcast.jet.mongodb.impl.MongoUtilities.checkDatabaseExists;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getPartitionKey;
 import static java.util.Collections.singletonList;
 
@@ -191,22 +192,4 @@ public class DbCheckingPMetaSupplier implements ProcessorMetaSupplier {
         return true;
     }
 
-    static void checkCollectionExists(MongoDatabase database, String collectionName) {
-        for (String name : database.listCollectionNames()) {
-            if (name.equals(collectionName)) {
-                return;
-            }
-        }
-        throw new JetException("Collection " + collectionName + " in database " + database.getName() + " does not exist");
-    }
-
-    static void checkDatabaseExists(MongoClient client, String databaseName) {
-        for (String name : client.listDatabaseNames()) {
-            if (name.equalsIgnoreCase(databaseName)) {
-                return;
-            }
-        }
-        ClusterDescription clusterDescription = client.getClusterDescription();
-        throw new JetException("Database " + databaseName + " does not exist in cluster " + clusterDescription);
-    }
 }

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
@@ -148,23 +148,4 @@ public final class MongoUtilities {
                             .withZoneSameInstant(systemDefault())
                             .toLocalDateTime();
     }
-
-    static void checkCollectionExists(MongoDatabase database, String collectionName) {
-        for (String name : database.listCollectionNames()) {
-            if (name.equals(collectionName)) {
-                return;
-            }
-        }
-        throw new JetException("Collection " + collectionName + " in database " + database.getName() + " does not exist");
-    }
-
-    static void checkDatabaseExists(MongoClient client, String databaseName) {
-        for (String name : client.listDatabaseNames()) {
-            if (name.equalsIgnoreCase(databaseName)) {
-                return;
-            }
-        }
-        ClusterDescription clusterDescription = client.getClusterDescription();
-        throw new JetException("Database " + databaseName + " does not exist in cluster " + clusterDescription);
-    }
 }

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoUtilities.java
@@ -15,12 +15,8 @@
  */
 package com.hazelcast.jet.mongodb.impl;
 
-import com.hazelcast.jet.JetException;
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Field;
 import com.mongodb.client.model.Filters;
-import com.mongodb.connection.ClusterDescription;
 import org.bson.BsonArray;
 import org.bson.BsonDateTime;
 import org.bson.BsonString;

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
@@ -349,7 +349,7 @@ public class ReadMongoP<I> extends AbstractProcessor {
 
         private Traverser<Document> delegateForCollection(MongoCollection<Document> collection,
                                                           List<Bson> aggregateList) {
-            return traverseIterable(collection.aggregate(aggregateList));
+            return traverseIterable(collection.aggregate(aggregateList).batchSize(BATCH_SIZE));
         }
 
         private Traverser<Document> delegateForDb(MongoDatabase database, List<Bson> aggregateList) {

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/ReadMongoP.java
@@ -57,8 +57,6 @@ import static com.hazelcast.jet.Traversers.singleton;
 import static com.hazelcast.jet.Traversers.traverseIterable;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.core.BroadcastKey.broadcastKey;
-import static com.hazelcast.jet.mongodb.impl.MongoUtilities.checkCollectionExists;
-import static com.hazelcast.jet.mongodb.impl.MongoUtilities.checkDatabaseExists;
 import static com.hazelcast.jet.mongodb.impl.MongoUtilities.partitionAggregate;
 import static com.mongodb.client.model.Aggregates.match;
 import static com.mongodb.client.model.Aggregates.sort;
@@ -84,7 +82,6 @@ import static com.mongodb.client.model.changestream.FullDocument.UPDATE_LOOKUP;
 public class ReadMongoP<I> extends AbstractProcessor {
 
     private static final int BATCH_SIZE = 1000;
-    private final boolean throwOnNonExisting;
     private ILogger logger;
 
     private int totalParallelism;
@@ -126,7 +123,6 @@ public class ReadMongoP<I> extends AbstractProcessor {
                 params.clientSupplier, params.dataConnectionRef, client -> reader.connect(client, snapshotsEnabled)
         );
         this.nonDistributed = params.isNonDistributed();
-        this.throwOnNonExisting = params.isThrowOnNonExisting();
     }
 
     @Override
@@ -258,9 +254,6 @@ public class ReadMongoP<I> extends AbstractProcessor {
             try {
                 logger.fine("(Re)connecting to MongoDB");
                 if (databaseName != null) {
-                    if (throwOnNonExisting) {
-                        checkDatabaseExists(newClient, databaseName);
-                    }
                     this.database = newClient.getDatabase(databaseName);
                 }
                 if (collectionName != null) {
@@ -268,10 +261,6 @@ public class ReadMongoP<I> extends AbstractProcessor {
                             " is specified");
                     //noinspection ConstantValue false warn by intellij
                     checkState(database != null, "database " + databaseName + " does not exists");
-
-                    if (throwOnNonExisting) {
-                        checkCollectionExists(database, collectionName);
-                    }
                     this.collection = database.getCollection(collectionName);
                 }
 

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/WriteMongoP.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/WriteMongoP.java
@@ -70,8 +70,6 @@ import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
 import static com.hazelcast.jet.mongodb.impl.Mappers.defaultCodecRegistry;
-import static com.hazelcast.jet.mongodb.impl.MongoUtilities.checkCollectionExists;
-import static com.hazelcast.jet.mongodb.impl.MongoUtilities.checkDatabaseExists;
 import static com.hazelcast.jet.retry.IntervalFunction.exponentialBackoffWithCap;
 import static com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL;
 import static com.mongodb.client.model.Filters.eq;
@@ -641,13 +639,7 @@ public class WriteMongoP<IN, I> extends AbstractProcessor {
 
         @Nonnull
         public <I> MongoCollection<I> get(MongoClient mongoClient, Class<I> documentType) {
-            if (throwOnNonExisting) {
-                checkDatabaseExists(mongoClient, databaseName);
-            }
             MongoDatabase database = mongoClient.getDatabase(databaseName);
-            if (throwOnNonExisting) {
-                checkCollectionExists(database, collectionName);
-            }
             return database.getCollection(collectionName, documentType)
                            .withCodecRegistry(defaultCodecRegistry());
         }

--- a/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceResourceExistenceTest.java
+++ b/extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSourceResourceExistenceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.mongodb;
+
+import com.hazelcast.jet.JetException;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.mongodb.client.MongoClients;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import static com.hazelcast.jet.mongodb.MongoSources.batch;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(HazelcastParametrizedRunner.class)
+@Category({QuickTest.class})
+public class MongoSourceResourceExistenceTest extends AbstractMongoTest {
+
+    @Parameter(0)
+    public boolean dbExists;
+    @Parameter(1)
+    public boolean collectionExists;
+    @Parameter(2)
+    public boolean checkRequested;
+    @Parameter(3)
+    public boolean shouldFail;
+
+    @Parameters(name = "dbExists: {0} | collectionExists: {1} | checkRequested: {2} | shouldFail:{3}")
+    public static Object[] filterProjectionSortMatrix() {
+        return new Object[][] {
+                new Object[] { true, true, true, false },
+                new Object[] { true, true, false, false },
+                new Object[] { false, true, false, false },
+                new Object[] { true, false, false, false },
+                new Object[] { false, true, true, true },
+                new Object[] { true, false, true, true },
+                new Object[] { false, false, true, true },
+        };
+    }
+
+    @Test
+    public void test_errors_dbNotExistAndCheckRequested() {
+        final String connectionString = mongoContainer.getConnectionString();
+        Pipeline pipeline = Pipeline.create();
+        String dbName = dbExists ? defaultDatabase() : "nonExisting";
+        String colName = collectionExists ? testName.getMethodName() : "nonExisting";
+
+        pipeline.readFrom(batch(() -> MongoClients.create(connectionString))
+                        .database(dbName)
+                        .collection(colName)
+                        .throwOnNonExisting(checkRequested)
+                        .build()
+                )
+                .setLocalParallelism(2)
+                .writeTo(Sinks.logger());
+
+        if (shouldFail) {
+            assertThatThrownBy(() -> instance().getJet().newJob(pipeline).join())
+                    .hasCauseInstanceOf(JetException.class)
+                    .hasMessageContaining("does not exist");
+        } else {
+            instance().getJet().newJob(pipeline).join();
+        }
+    }
+
+}

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolver.java
@@ -17,6 +17,7 @@ package com.hazelcast.jet.sql.impl.connector.mongodb;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hazelcast.jet.mongodb.dataconnection.MongoDataConnection;
+import com.hazelcast.jet.sql.impl.connector.mongodb.Options.ResourceChecks;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.schema.MappingField;
@@ -36,9 +37,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Predicate;
 
+import static com.hazelcast.jet.mongodb.impl.MongoUtilities.checkDatabaseAndCollectionExists;
 import static com.hazelcast.jet.sql.impl.connector.mongodb.BsonTypes.getBsonType;
 import static com.hazelcast.jet.sql.impl.connector.mongodb.BsonTypes.resolveTypeFromJava;
 import static com.hazelcast.jet.sql.impl.connector.mongodb.Options.CONNECTION_STRING_OPTION;
+import static com.hazelcast.jet.sql.impl.connector.mongodb.Options.readExistenceChecksFlag;
 import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
 import static com.mongodb.client.model.Filters.eq;
 import static java.util.Objects.requireNonNull;
@@ -168,6 +171,11 @@ class FieldResolver {
         Map<String, DocumentField> fields = new HashMap<>();
         try (MongoClient client = connect(dataConnectionName, options)) {
             requireNonNull(client);
+
+            ResourceChecks resourceChecks = readExistenceChecksFlag(options);
+            if (resourceChecks == ResourceChecks.ALWAYS || resourceChecks == ResourceChecks.ONLY_INITIAL) {
+                checkDatabaseAndCollectionExists(client, databaseName, collectionName);
+            }
 
             MongoDatabase database = client.getDatabase(databaseName);
             List<Document> collections = database.listCollections()

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnector.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.List;
 
-import static com.hazelcast.jet.core.ProcessorMetaSupplier.forceTotalParallelismOne;
 import static com.hazelcast.jet.mongodb.impl.MongoUtilities.UPDATE_ALL_PREDICATE;
 import static java.util.stream.Collectors.toList;
 
@@ -79,7 +78,7 @@ public class MongoSqlConnector extends MongoSqlConnectorBase {
         if (hasInput) {
             return context.getDag().newUniqueVertex(
                     "Update(" + table.getSqlName() + ")",
-                    new UpdateProcessorSupplier(table, fieldNames, updates, null, hasInput)
+                    wrap(context, new UpdateProcessorSupplier(table, fieldNames, updates, null, hasInput))
             );
         } else {
             Object predicateRaw = predicate == null
@@ -91,9 +90,9 @@ public class MongoSqlConnector extends MongoSqlConnectorBase {
 
             return context.getDag().newUniqueVertex(
                     "Update(" + table.getSqlName() + ")",
-                    forceTotalParallelismOne(
+                    wrap(context,
                         new UpdateProcessorSupplier(table, fieldNames, updates, translated, hasInput)
-                    )
+                    ).forceTotalParallelismOne(true)
             );
         }
     }
@@ -105,7 +104,7 @@ public class MongoSqlConnector extends MongoSqlConnectorBase {
 
         return context.getDag().newUniqueVertex(
                 "Sink(" + table.getSqlName() + ")",
-                new InsertProcessorSupplier(table, WriteMode.UPSERT)
+                wrap(context, new InsertProcessorSupplier(table, WriteMode.UPSERT))
         );
     }
 
@@ -121,7 +120,7 @@ public class MongoSqlConnector extends MongoSqlConnectorBase {
         if (hasInput) {
             return context.getDag().newUniqueVertex(
                     "Delete(" + table.getSqlName() + ")",
-                    new DeleteProcessorSupplier(table, null, hasInput)
+                    wrap(context, new DeleteProcessorSupplier(table, null, hasInput))
             );
         } else {
             Object predicateTranslated = predicate == null
@@ -137,7 +136,8 @@ public class MongoSqlConnector extends MongoSqlConnectorBase {
 
             return context.getDag().newUniqueVertex(
                     "Delete(" + table.getSqlName() + ")",
-                    forceTotalParallelismOne(new DeleteProcessorSupplier(table, predicateToSend, hasInput))
+                    wrap(context, new DeleteProcessorSupplier(table, predicateToSend, hasInput))
+                            .forceTotalParallelismOne(true)
             );
         }
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
@@ -22,7 +22,7 @@ import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Vertex;
-import com.hazelcast.jet.mongodb.DbCheckingPMetaSupplier;
+import com.hazelcast.jet.mongodb.impl.DbCheckingPMetaSupplier;
 import com.hazelcast.jet.sql.impl.connector.HazelcastRexNode;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.spi.impl.NodeEngine;
@@ -204,7 +204,7 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
         SupplierEx<MongoClient> clientSupplier = connectionString == null
                 ? null
                 : () -> MongoClients.create(connectionString);
-        return new DbCheckingPMetaSupplier(null, table.checkExistence(), table.isForceMongoParallelismOne(),
+        return new DbCheckingPMetaSupplier(null, table.checkExistenceAfterCreation(), table.isForceMongoParallelismOne(),
                 table.databaseName, table.collectionName,
                 clientSupplier, dataConnectionRef(table.dataConnectionName),
                 supplier);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoTable.java
@@ -50,6 +50,7 @@ class MongoTable extends JetTable {
     private final QueryDataType[] fieldTypes;
     private final BsonType[] fieldExternalTypes;
     private final boolean forceMongoParallelismOne;
+    private final boolean checkDbExistence;
 
     MongoTable(
             @Nonnull String schemaName,
@@ -69,6 +70,7 @@ class MongoTable extends JetTable {
         this.connectionString = options.get(Options.CONNECTION_STRING_OPTION);
         this.dataConnectionName = dataConnectionName;
         this.streaming = isStreaming(objectType);
+        this.checkDbExistence = Boolean.parseBoolean(options.getOrDefault(Options.CHECK_EXISTENCE, "true"));
 
         this.externalNames = getFields().stream()
                                         .map(field -> ((MongoTableField) field).externalName)
@@ -102,6 +104,10 @@ class MongoTable extends JetTable {
 
     QueryDataType[] fieldTypes() {
         return fieldTypes;
+    }
+
+    boolean checkExistence() {
+        return checkDbExistence;
     }
 
     QueryDataType fieldType(String externalName) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
@@ -22,6 +22,7 @@ import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.sql.impl.schema.MappingField;
 import org.bson.BsonTimestamp;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
@@ -132,6 +133,29 @@ final class Options {
             return mf -> mf.name().equalsIgnoreCase(value);
         } else {
             return mf -> mf.externalName().equalsIgnoreCase(value);
+        }
+    }
+
+    static ResourceChecks readExistenceChecksFlag(Map<String, String> options) {
+        return ResourceChecks.fromString(options.getOrDefault(CHECK_EXISTENCE, "only-initial"));
+    }
+
+    enum ResourceChecks implements Serializable {
+        ALWAYS,
+        ONLY_INITIAL,
+        NEVER;
+
+        static ResourceChecks fromString(String code) {
+            if (ALWAYS.name().equalsIgnoreCase(code)) {
+                return ALWAYS;
+            }
+            if (ONLY_INITIAL.name().equalsIgnoreCase(code) || "only-initial".equalsIgnoreCase(code)) {
+                return ONLY_INITIAL;
+            }
+            if (NEVER.name().equalsIgnoreCase(code)) {
+                return NEVER;
+            }
+            throw new IllegalArgumentException("Unknown value for " + CHECK_EXISTENCE + " flag:" + code);
         }
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/Options.java
@@ -62,7 +62,7 @@ final class Options {
     static final String PK_COLUMN = "idColumn";
 
     /**
-     * If set to true, the reading from MongoDB will be done in one processor instance.
+     * If set to true, the reading and/or writing from/to MongoDB will be done in one processor instance.
      * <p>
      * Normally user wants to distribute the work, however the {@code $function} aggregate is not present on
      * e.g. Atlas Serverless instances. In such cases setting this property to {@code true} allows user
@@ -70,6 +70,11 @@ final class Options {
      * change that restriction.
      */
     static final String FORCE_PARALLELISM_ONE = "forceMongoReadParallelismOne";
+
+    /**
+     * If set to true, the reading will be preceded with checking the existence of database and collection.
+     */
+    static final String CHECK_EXISTENCE = "checkExistence";
 
     private static final String POSSIBLE_VALUES = "This property should " +
             " have value of: a) 'now' b) time in epoch milliseconds or c) " +

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/SelectProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/SelectProcessorSupplier.java
@@ -157,6 +157,7 @@ public class SelectProcessorSupplier implements ProcessorSupplier {
                             .setStartAtTimestamp(startAt == null ? null : new BsonTimestamp(startAt))
                             .setEventTimePolicy(eventTimePolicy)
                             .setNonDistributed(forceMongoParallelismOne)
+                            .setThrowOnNonExisting(false)
             );
 
             processors.add(processor);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/UpdateProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/UpdateProcessorSupplier.java
@@ -122,7 +122,8 @@ public class UpdateProcessorSupplier implements ProcessorSupplier {
                                 .setDataConnectionRef(dataConnectionName)
                                 .setDatabaseName(databaseName)
                                 .setCollectionName(collectionName)
-                                .setDocumentType(Document.class),
+                                .setDocumentType(Document.class)
+                                .setThrowOnNonExisting(false),
                         writeModelNoScan(predicateWithReplacements)
                 );
 
@@ -143,6 +144,7 @@ public class UpdateProcessorSupplier implements ProcessorSupplier {
                             .setTransactionOptionsSup(() -> DEFAULT_TRANSACTION_OPTION)
                             .setIntermediateMappingFn(this::rowToUpdateDoc)
                             .setWriteModelFn(this::writeModelAfterScan)
+                            .setThrowOnNonExisting(false)
             );
 
             processors[i] = processor;


### PR DESCRIPTION
Instead of performing check on every processor, do it once.

Additionally, make it possible to disable the checks in SQL connector.

Fixes performance issue found during benchmarking, where checks were 1/3 of execution time.

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
