### PR TITLE
Ignore ReadJdbcPPropertiesTest tests on windows [HZ-2672]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPPropertiesTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sources;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.jdbc.TestDatabaseProvider;
 import org.junit.AfterClass;
@@ -40,7 +41,7 @@ import static com.hazelcast.jet.pipeline.test.AssertionSinks.assertOrdered;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Category({QuickTest.class})
+@Category({QuickTest.class, IgnoreInJenkinsOnWindows.class})
 public abstract class ReadJdbcPPropertiesTest extends SimpleTestInClusterSupport {
 
     protected static TestDatabaseProvider databaseProvider;


### PR DESCRIPTION
Ignore tests that require testcontainers on windows

Jira : https://hazelcast.atlassian.net/browse/HZ-2672

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible