### PR TITLE
Fix backup op offloading for tstore maps

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -186,16 +186,16 @@ public class EntryOperation extends LockAwareOperation
         // to enter map-store-api-offloading procedure.
         if (readOnly && existInMemory(dataKey)) {
             mapStoreOffloadEnabled = false;
-            tieredStoreAndPartitionCompactorEnabled = false;
+            tieredStoreOffloadEnabled = false;
         } else {
             mapStoreOffloadEnabled = isMapStoreOffloadEnabled();
-            tieredStoreAndPartitionCompactorEnabled = isTieredStoreAndPartitionCompactorEnabled();
+            tieredStoreOffloadEnabled = isTieredStoreOffloadEnabled();
         }
     }
 
     private boolean existInMemory(Data dataKey) {
         // When tieredStoreAndPartitionCompactorEnabled is false.
-        if (!tieredStoreAndPartitionCompactorEnabled) {
+        if (!tieredStoreOffloadEnabled) {
             return recordStore.existInMemory(dataKey);
         }
 
@@ -245,8 +245,7 @@ public class EntryOperation extends LockAwareOperation
     }
 
     private boolean steppedOperationOffloadEnabled() {
-        return mapStoreOffloadEnabled
-                || tieredStoreAndPartitionCompactorEnabled;
+        return mapStoreOffloadEnabled || tieredStoreOffloadEnabled;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/IMapStepAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/IMapStepAwareOperation.java
@@ -37,11 +37,11 @@ public interface IMapStepAwareOperation extends StepAwareOperation<State> {
         // tieredStoreAndPartitionCompactorEnabled field is set true
         // are created as a Step automatically, otherwise you have
         // to make your MapOperation as a Step operation yourself.
-        if (!(this instanceof BackupOperation
-                && ((MapOperation) this).isTieredStoreAndPartitionCompactorEnabled())) {
-            return StepAwareOperation.super.getStartingStep();
+        if (((MapOperation) this).isTieredStoreAndPartitionCompactorEnabled()
+                && this instanceof BackupOperation) {
+            return UtilSteps.DIRECT_RUN_STEP;
         }
 
-        return UtilSteps.DIRECT_RUN_STEP;
+        return StepAwareOperation.super.getStartingStep();
     }
 }


### PR DESCRIPTION
**Issue:**
Otherwise backup operations will not do compaction. This is because when `IMapStepAwareOperation` checks to see if tstore is enabled, due to the wrong dependency between checks it sees tstore not enabled at the time of the check. This PR fixes this issue.

Tests for this change is here: https://github.com/hazelcast/hazelcast-enterprise/pull/6218