### PR TITLE
Disable the `RepairingTask` reconciliation in the test [API-2028]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheCacheOnUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheCacheOnUpdateTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE;
 import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.INVALIDATE;
+import static com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask.RECONCILIATION_INTERVAL_SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -103,14 +104,14 @@ public class ClientCacheNearCacheCacheOnUpdateTest extends ClientNearCacheTestSu
         Runnable getter = () -> {
             int i = 0;
             while (!stop.get()) {
-                icacheOnClient.get(i++ % NUM_OF_KEYS);
+                icacheOnClient.get(++i % NUM_OF_KEYS);
             }
         };
 
         Runnable putter = () -> {
             int i = 0;
             while (!stop.get()) {
-                i = i++ % NUM_OF_KEYS;
+                i = ++i % NUM_OF_KEYS;
                 icacheOnClient.put(i, i);
             }
         };
@@ -140,7 +141,9 @@ public class ClientCacheNearCacheCacheOnUpdateTest extends ClientNearCacheTestSu
     private ICache<Integer, Integer> newNearCachedCache(NearCacheConfig.LocalUpdatePolicy localUpdatePolicy) {
         NearCacheConfig nearCacheConfig = getNearCacheConfig(localUpdatePolicy);
         ClientConfig clientConfig = getClientConfig()
-                .addNearCacheConfig(nearCacheConfig);
+                .addNearCacheConfig(nearCacheConfig)
+                // Disable the repairing task invalidations to prevent any interference with the test
+                .setProperty(RECONCILIATION_INTERVAL_SECONDS.getName(), "0");
 
         HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
         CachingProvider provider = new HazelcastClientCachingProvider(client);


### PR DESCRIPTION
We disable the `RepairingTask` reconciliation of the partition sequence counts so that the test only has the writer thread to cause any invalidations if needed.

The invalidations can be caused by both the invalidations during IMap modify operations(such as `IMap.put`) or via the `RepairingTask` if there were stale records detected due to the missed partition sequence events. The event misses is not easy to generate, the events should be dropped due to some reason e.g. event queue becoming full, network delivery failures, etc. Hence, we suspected that the reported failure at the [issue](https://github.com/hazelcast/hazelcast/issues/24275) may be caused by this reason. see [comment](https://github.com/hazelcast/hazelcast/pull/24432#issuecomment-1534965810).

I also updated the writer thread to actually write different items (it was mistakenly writing item `0` all the time).

fixes #24275 
