### PR TITLE
Update docker images and ignore not supported tests for arm64 architecture [HZ-1641]

### DIFF
--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -62,9 +62,9 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 @RunWith(HazelcastSerialClassRunner.class)
 public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
     private static final DockerImageName MYSQL_IMAGE =
-            DockerImageName.parse("debezium/example-mysql:1.9.3.Final").asCompatibleSubstituteFor("mysql");
+            DockerImageName.parse("debezium/example-mysql:2.3.0.Final").asCompatibleSubstituteFor("mysql");
     private static final DockerImageName POSTGRES_IMAGE =
-            DockerImageName.parse("debezium/example-postgres:1.7").asCompatibleSubstituteFor("postgres");
+            DockerImageName.parse("debezium/example-postgres:2.3.0.Final").asCompatibleSubstituteFor("postgres");
     private static final DockerImageName MONGODB_IMAGE =
             DockerImageName.parse("mongo:6.0.3").asCompatibleSubstituteFor("mongodb");
 

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 @RunWith(HazelcastSerialClassRunner.class)
 public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
-    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-mysql:1.9.6.Final")
+    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-mysql:2.3.0.Final")
             .asCompatibleSubstituteFor("mysql");
 
     @Rule

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -72,6 +72,7 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     private static final long RECONNECT_INTERVAL_MS = SECONDS.toMillis(1);
+    private static final String TOXI_PROXY_IMAGE = "ghcr.io/shopify/toxiproxy:2.5.0";
 
     @Parameter(value = 0)
     public RetryStrategy reconnectBehavior;
@@ -346,7 +347,7 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
     }
 
     private ToxiproxyContainer initToxiproxy(Network network) {
-        ToxiproxyContainer toxiproxy = namedTestContainer(new ToxiproxyContainer().withNetwork(network));
+        ToxiproxyContainer toxiproxy = namedTestContainer(new ToxiproxyContainer(TOXI_PROXY_IMAGE).withNetwork(network));
         toxiproxy.start();
         return toxiproxy;
     }

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.retry.RetryStrategies;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 @RunWith(HazelcastSerialClassRunner.class)
 public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
-    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-postgres:1.7")
+    public static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("debezium/example-postgres:2.3.0.Final")
             .asCompatibleSubstituteFor("postgres");
 
     protected static final String DATABASE_NAME = "postgres";
@@ -60,12 +60,6 @@ public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcInte
                     .withConnectTimeoutSeconds(300)
                     .withStartupTimeoutSeconds(300)
     );
-
-    @BeforeClass
-    public static void ignoreOnArm64() {
-        //There is no working arm64 version of example-postgres image
-        assumeNoArm64Architecture();
-    }
 
     protected PostgresCdcSources.Builder sourceBuilder(String name) {
         return PostgresCdcSources.postgres(name)

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectJdbcIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectJdbcIntegrationTest.java
@@ -71,7 +71,7 @@ public class KafkaConnectJdbcIntegrationTest extends JetTestSupport {
     public static final String PASSWORD = "mysql";
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConnectJdbcIntegrationTest.class);
 
-    private static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:5.7.34")
+    private static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.33")
             .withUsername(USERNAME).withPassword(PASSWORD)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER).withPrefix("Docker"));
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSchemaJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSchemaJdbcSqlConnectorTest.java
@@ -27,6 +27,8 @@ public class MSSQLSchemaJdbcSqlConnectorTest extends SchemaJdbcConnectorTest {
 
     @BeforeClass
     public static void beforeClass() {
+        //There is no arm64 image for mssql server
+        assumeNoArm64Architecture();
         initialize(new MSSQLDatabaseProvider());
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSinkIntoJdbcSqlConnectorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLSinkIntoJdbcSqlConnectorTest.java
@@ -27,6 +27,8 @@ public class MSSQLSinkIntoJdbcSqlConnectorTest extends SinkJdbcSqlConnectorTest 
 
     @BeforeClass
     public static void beforeClass() {
+        //There is no arm64 image for mssql server
+        assumeNoArm64Architecture();
         initialize(new MSSQLDatabaseProvider());
     }
     //Disable this test by overriding it until official MSSQL support


### PR DESCRIPTION
Update docker images to version which supports arm64
Ignore tests with MSSQL server for arm64

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible