### PR TITLE
Run on partitioned index only if tstore is not enabled and map is HD [HZ-2624]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PartitionWideEntryOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PartitionWideEntryOpSteps.java
@@ -44,20 +44,16 @@ public enum PartitionWideEntryOpSteps implements IMapOpStep {
     PROCESS() {
         @Override
         public void runStep(State state) {
-            if (canRunWithPartitionedIndex(state)
+            /**
+             * Tiered storage only supports global
+             * indexes no partitioned index is supported.
+             */
+            if (isHDMap(state.getRecordStore())
+                    && !isTieredStoreMap(state.getRecordStore())
                     && runWithPartitionedIndex(state)) {
                 return;
             }
             runWithPartitionScan(state);
-        }
-
-        /**
-         * Tiered storage only supports global
-         * indexes no partitioned index is supported.
-         */
-        private boolean canRunWithPartitionedIndex(State state) {
-            return isHDMap(state.getRecordStore())
-                    || !isTieredStoreMap(state.getRecordStore());
         }
 
         private boolean isHDMap(RecordStore<Record> recordStore) {


### PR DESCRIPTION
used `&&` instead of `||` to eliminate ts-enabled maps from partitioned-index usage.

closes https://github.com/hazelcast/hazelcast-enterprise/issues/6178