### PR TITLE
Drop ifSupported methods in AsyncSocketOptions [5.3.z]

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocketBuilder.java
@@ -24,7 +24,7 @@ import com.hazelcast.internal.tpcengine.Reactor;
  * <p/>
  * This builder assumes TCP/IPv4. For different types of sockets
  * new configuration options on this builder need to be added or
- * a the {@link Reactor#newAsyncSocketBuilder()} needs to be modified.
+ * {@link Reactor#newAsyncSocketBuilder()} needs to be modified.
  * <p/>
  * Cast to specific builder for specialized options when available.
  */

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocketOptions.java
@@ -86,59 +86,25 @@ public interface AsyncSocketOptions {
     boolean isSupported(Option option);
 
     /**
-     * Sets an option value.
-     *
-     * @param option the option
-     * @param value  the value
-     * @param <T>    the type of the value
-     * @throws NullPointerException          if option or value is null.
-     * @throws UnsupportedOperationException if the option isn't supported.
-     * @throws java.io.UncheckedIOException  if the value could not be set.
-     */
-    default <T> void set(Option<T> option, T value) {
-        if (!setIfSupported(option, value)) {
-            throw new UnsupportedOperationException("'" + option.name() + "' not supported");
-        }
-    }
-
-    /**
      * Sets an option value if that option is supported.
      *
      * @param option the option
      * @param value  the value
      * @param <T>    the type of the value
-     * @return true if the option was supported, false otherwise.
-     * @throws NullPointerException         if option or value is null.
-     * @throws java.io.UncheckedIOException if the value could not be set.
+     * @return <code>true</code> if the option was supported, <code>false</code> otherwise.
+     * @throws NullPointerException          if option or value is null.
+     * @throws java.io.UncheckedIOException  if the value could not be set.
      */
-    <T> boolean setIfSupported(Option<T> option, T value);
+
+    <T> boolean set(Option<T> option, T value);
 
     /**
-     * Gets an option value if that option is supported. If option not supported,
-     * <code>null</code> is returned.
+     * Gets an option value. If option was not set or is not supported, <code>null</code> is returned.
      *
      * @param option the option
      * @param <T>    the type of the value
-     * @return null if value is null.
-     * @throws java.io.UncheckedIOException if the value could not be get.
+     * @return the value for the option, <code>null</code> if the option was not set or is not supported.
+     * @throws java.io.UncheckedIOException  if the value could not be gotten.
      */
-    <T> T getIfSupported(Option<T> option);
-
-    /**
-     * Gets an option value.
-     *
-     * @param option the option
-     * @param <T>    the type of the value
-     * @return the value for the option
-     * @throws UnsupportedOperationException if the option isn't supported.
-     * @throws java.io.UncheckedIOException  if the value could not be get.
-     */
-    default <T> T get(Option<T> option) {
-        T value = getIfSupported(option);
-        if (value == null) {
-            throw new UnsupportedOperationException("'" + option.name() + "' not supported");
-        } else {
-            return value;
-        }
-    }
+    <T> T get(Option<T> option);
 }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketBuilder.java
@@ -39,7 +39,7 @@ public class NioAsyncServerSocketBuilder implements AsyncServerSocketBuilder {
     final ServerSocketChannel serverSocketChannel;
     final NioAsyncServerSocketOptions options;
     Consumer<AcceptRequest> acceptConsumer;
-    private boolean build;
+    private boolean built;
 
     NioAsyncServerSocketBuilder(NioReactor reactor) {
         this.reactor = reactor;
@@ -54,7 +54,7 @@ public class NioAsyncServerSocketBuilder implements AsyncServerSocketBuilder {
 
     @Override
     public NioAsyncServerSocketBuilder setAcceptConsumer(Consumer<AcceptRequest> acceptConsumer) {
-        verifyNotBuild();
+        verifyNotBuilt();
 
         this.acceptConsumer = checkNotNull(acceptConsumer, "acceptConsumer");
         return this;
@@ -62,21 +62,21 @@ public class NioAsyncServerSocketBuilder implements AsyncServerSocketBuilder {
 
     @Override
     public <T> boolean setIfSupported(Option<T> option, T value) {
-        verifyNotBuild();
+        verifyNotBuilt();
 
-        return options.setIfSupported(option, value);
+        return options.set(option, value);
     }
 
     @SuppressWarnings("java:S1181")
     @Override
     public AsyncServerSocket build() {
-        verifyNotBuild();
+        verifyNotBuilt();
 
         if (acceptConsumer == null) {
             throw new IllegalStateException("acceptConsumer not configured.");
         }
 
-        build = true;
+        built = true;
 
         if (Thread.currentThread() == reactor.eventloopThread()) {
             return new NioAsyncServerSocket(this);
@@ -96,8 +96,8 @@ public class NioAsyncServerSocketBuilder implements AsyncServerSocketBuilder {
         }
     }
 
-    private void verifyNotBuild() {
-        if (build) {
+    private void verifyNotBuilt() {
+        if (built) {
             throw new IllegalStateException("Can't call build twice on the same AsyncServerSocketBuilder");
         }
     }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptions.java
@@ -68,7 +68,7 @@ public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
     }
 
     @Override
-    public <T> boolean setIfSupported(Option<T> option, T value) {
+    public <T> boolean set(Option<T> option, T value) {
         checkNotNull(option, "option");
         checkNotNull(value, "value");
 
@@ -86,7 +86,7 @@ public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
     }
 
     @Override
-    public <T> T getIfSupported(Option<T> option) {
+    public <T> T get(Option<T> option) {
         checkNotNull(option, "option");
 
         try {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketBuilder.java
@@ -46,7 +46,7 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
     int writeQueueCapacity = DEFAULT_WRITE_QUEUE_CAPACITY;
     AsyncSocketReader reader;
     NioAsyncSocketOptions options;
-    private boolean build;
+    private boolean built;
 
     NioAsyncSocketBuilder(NioReactor reactor, NioAcceptRequest acceptRequest) {
         try {
@@ -68,34 +68,34 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
 
     @Override
     public <T> boolean setIfSupported(Option<T> option, T value) {
-        verifyNotBuild();
+        verifyNotBuilt();
 
-        return options.setIfSupported(option, value);
+        return options.set(option, value);
     }
 
     public NioAsyncSocketBuilder setReceiveBufferIsDirect(boolean receiveBufferIsDirect) {
-        verifyNotBuild();
+        verifyNotBuilt();
 
         this.receiveBufferIsDirect = receiveBufferIsDirect;
         return this;
     }
 
     public NioAsyncSocketBuilder setWriteQueueCapacity(int writeQueueCapacity) {
-        verifyNotBuild();
+        verifyNotBuilt();
 
         this.writeQueueCapacity = checkPositive(writeQueueCapacity, "writeQueueCapacity");
         return this;
     }
 
     public NioAsyncSocketBuilder setRegularSchedule(boolean regularSchedule) {
-        verifyNotBuild();
+        verifyNotBuilt();
 
         this.regularSchedule = regularSchedule;
         return this;
     }
 
     public NioAsyncSocketBuilder setWriteThrough(boolean writeThrough) {
-        verifyNotBuild();
+        verifyNotBuilt();
 
         this.writeThrough = writeThrough;
         return this;
@@ -109,7 +109,7 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
      * @throws NullPointerException if readHandler is null.
      */
     public final NioAsyncSocketBuilder setReader(AsyncSocketReader reader) {
-        verifyNotBuild();
+        verifyNotBuilt();
 
         this.reader = checkNotNull(reader);
         return this;
@@ -118,9 +118,9 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
     @SuppressWarnings("java:S1181")
     @Override
     public AsyncSocket build() {
-        verifyNotBuild();
+        verifyNotBuilt();
 
-        build = true;
+        built = true;
 
         if (reader == null) {
             throw new IllegalStateException("reader is not configured.");
@@ -144,8 +144,8 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
         }
     }
 
-    private void verifyNotBuild() {
-        if (build) {
+    private void verifyNotBuilt() {
+        if (built) {
             throw new IllegalStateException("Can't call build twice on the same AsyncSocketBuilder");
         }
     }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketOptions.java
@@ -85,7 +85,7 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
     }
 
     @Override
-    public <T> T getIfSupported(Option<T> option) {
+    public <T> T get(Option<T> option) {
         checkNotNull(option, "option");
 
         try {
@@ -105,7 +105,7 @@ public class NioAsyncSocketOptions implements AsyncSocketOptions {
     }
 
     @Override
-    public <T> boolean setIfSupported(Option<T> option, T value) {
+    public <T> boolean set(Option<T> option, T value) {
         checkNotNull(option, "option");
         checkNotNull(value, "value");
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketOptionsTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.tpcengine.net;
 
+import com.hazelcast.internal.tpcengine.Option;
 import com.hazelcast.internal.tpcengine.Reactor;
 import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import org.junit.After;
@@ -35,9 +36,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AsyncServerSocketOptionsTest {
 
+    private static final Option<Boolean> SUPPORTED_OPTION = SO_REUSEADDR;
     private final List<Reactor> reactors = new ArrayList<>();
 
     public abstract ReactorBuilder newReactorBuilder();
@@ -67,7 +70,14 @@ public abstract class AsyncServerSocketOptionsTest {
     }
 
     @Test
-    public void set_nullOption() {
+    public void test_set() {
+        AsyncServerSocket serverSocket = newServerSocket();
+        AsyncSocketOptions options = serverSocket.options();
+        assertTrue(options.set(SUPPORTED_OPTION, true));
+    }
+
+    @Test
+    public void test_set_nullOption() {
         AsyncServerSocket serverSocket = newServerSocket();
         AsyncSocketOptions options = serverSocket.options();
         assertThrows(NullPointerException.class, () -> options.set(null, 1));
@@ -85,15 +95,7 @@ public abstract class AsyncServerSocketOptionsTest {
         AsyncServerSocket serverSocket = newServerSocket();
         AsyncSocketOptions options = serverSocket.options();
         // SO_SNDBUF is not supported for server sockets.
-        assertThrows(UnsupportedOperationException.class, () -> options.set(SO_SNDBUF, 64 * 1024));
-    }
-
-    @Test
-    public void test_setIfUnsupported_unsupportedOption() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        // SO_SNDBUF is not supported for server sockets.
-        assertFalse(options.setIfSupported(SO_SNDBUF, 64 * 1024));
+        assertFalse(options.set(SO_SNDBUF, 64 * 1024));
     }
 
     @Test
@@ -101,15 +103,7 @@ public abstract class AsyncServerSocketOptionsTest {
         AsyncServerSocket serverSocket = newServerSocket();
         AsyncSocketOptions options = serverSocket.options();
         // SO_SNDBUF is not supported for server sockets.
-        assertThrows(UnsupportedOperationException.class, () -> options.get(SO_SNDBUF));
-    }
-
-    @Test
-    public void test_getIfUnsupported_unsupportedOption() {
-        AsyncServerSocket serverSocket = newServerSocket();
-        AsyncSocketOptions options = serverSocket.options();
-        // SO_SNDBUF is not supported for server sockets.
-        assertNull(options.getIfSupported(SO_SNDBUF));
+        assertNull(options.get(SO_SNDBUF));
     }
 
     @Test
@@ -142,14 +136,13 @@ public abstract class AsyncServerSocketOptionsTest {
         AsyncServerSocket serverSocket = newServerSocket();
         AsyncSocketOptions options = serverSocket.options();
         if (options.isSupported(SO_REUSEPORT)) {
-
             options.set(SO_REUSEPORT, true);
             assertEquals(Boolean.TRUE, options.get(SO_REUSEPORT));
             options.set(SO_REUSEPORT, false);
             assertEquals(Boolean.FALSE, options.get(SO_REUSEPORT));
         } else {
-            assertFalse(options.setIfSupported(SO_REUSEPORT, true));
-            assertNull(options.getIfSupported(SO_REUSEPORT));
+            assertFalse(options.set(SO_REUSEPORT, true));
+            assertNull(options.get(SO_REUSEPORT));
         }
     }
 }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocketOptionsTest.java
@@ -41,10 +41,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AsyncSocketOptionsTest {
 
     private static final Option<String> UNKNOwN_OPTION = new Option<>("banana", String.class);
+    private static final Option<Boolean> SUPPORTED_OPTION = SO_KEEPALIVE;
 
     private final List<Reactor> reactors = new ArrayList<>();
 
@@ -72,6 +74,13 @@ public abstract class AsyncSocketOptionsTest {
     }
 
     @Test
+    public void test_set() {
+        AsyncSocket socket = newSocket();
+        AsyncSocketOptions options = socket.options();
+        assertTrue(options.set(SUPPORTED_OPTION, true));
+    }
+
+    @Test
     public void test_set_nullOption() {
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
@@ -89,28 +98,14 @@ public abstract class AsyncSocketOptionsTest {
     public void test_set_unsupportedOption() {
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
-        assertThrows(UnsupportedOperationException.class, () -> options.set(UNKNOwN_OPTION, ""));
-    }
-
-    @Test
-    public void test_setIfUnsupported_unsupportedOption() {
-        AsyncSocket socket = newSocket();
-        AsyncSocketOptions options = socket.options();
-        assertFalse(options.setIfSupported(UNKNOwN_OPTION, ""));
+        assertFalse(options.set(UNKNOwN_OPTION, ""));
     }
 
     @Test
     public void test_get_unsupportedOption() {
         AsyncSocket socket = newSocket();
         AsyncSocketOptions options = socket.options();
-        assertThrows(UnsupportedOperationException.class, () -> options.get(UNKNOwN_OPTION));
-    }
-
-    @Test
-    public void test_getIfUnsupported_unsupportedOption() {
-        AsyncSocket socket = newSocket();
-        AsyncSocketOptions options = socket.options();
-        assertNull(options.getIfSupported(UNKNOwN_OPTION));
+        assertNull(options.get(UNKNOwN_OPTION));
     }
 
     @Test
@@ -182,8 +177,8 @@ public abstract class AsyncSocketOptionsTest {
             options.set(TCP_KEEPCOUNT, 100);
             assertEquals(Integer.valueOf(100), options.get(TCP_KEEPCOUNT));
         } else {
-            assertFalse(options.setIfSupported(TCP_KEEPCOUNT, 100));
-            assertNull(options.getIfSupported(TCP_KEEPCOUNT));
+            assertFalse(options.set(TCP_KEEPCOUNT, 100));
+            assertNull(options.get(TCP_KEEPCOUNT));
         }
     }
 
@@ -195,8 +190,8 @@ public abstract class AsyncSocketOptionsTest {
             options.set(TCP_KEEPIDLE, 100);
             assertEquals(Integer.valueOf(100), options.get(TCP_KEEPIDLE));
         } else {
-            assertFalse(options.setIfSupported(TCP_KEEPIDLE, 100));
-            assertNull(options.getIfSupported(TCP_KEEPIDLE));
+            assertFalse(options.set(TCP_KEEPIDLE, 100));
+            assertNull(options.get(TCP_KEEPIDLE));
         }
     }
 
@@ -208,8 +203,8 @@ public abstract class AsyncSocketOptionsTest {
             options.set(TCP_KEEPINTERVAL, 100);
             assertEquals(Integer.valueOf(100), options.get(TCP_KEEPINTERVAL));
         } else {
-            assertFalse(options.setIfSupported(TCP_KEEPINTERVAL, 100));
-            assertNull(options.getIfSupported(TCP_KEEPINTERVAL));
+            assertFalse(options.set(TCP_KEEPINTERVAL, 100));
+            assertNull(options.get(TCP_KEEPINTERVAL));
         }
     }
 }


### PR DESCRIPTION
The new AsyncSocketOptions API offers three methods: isSupported, get and set.
isSupported allows to check whether the option is supported. Set allows to
assign a value to an option and get allows to retrieve the value that was
assigned earlier. If the option is not supported, the method call causes
no side effects and no exception is thrown. Furthermore, the set operation
returns a boolean to acknowledge whether the option is supported and the value
was assigned.

Backport of: https://github.com/hazelcast/hazelcast/pull/24615