### PR TITLE
Add try-catch block to shutdown loop in the TestAwareInstanceFactory

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
@@ -158,8 +158,13 @@ public class TestAwareInstanceFactory {
     protected void shutdownInstances(List<HazelcastInstance> listToRemove) {
         if (listToRemove != null) {
             for (HazelcastInstance hz : listToRemove) {
-                ManagementService.shutdown(hz.getName());
-                hz.getLifecycleService().terminate();
+                try {
+                    ManagementService.shutdown(hz.getName());
+                    hz.getLifecycleService().terminate();
+                } catch (Exception e) {
+                    // just log it - it can be already down for instance
+                    e.printStackTrace();
+                }
             }
         }
     }


### PR DESCRIPTION
This PR fixes the behavior of the `TestAwareInstanceFactory.shutdownInstances(...)` method.