### PR TITLE
Fix typo in DurationConfig.toString()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -1272,7 +1272,7 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable, NamedConfi
             public String toString() {
                 return "DurationConfig{"
                         + "durationAmount=" + durationAmount
-                        + ", timeUnit" + timeUnit
+                        + ", timeUnit=" + timeUnit
                         + '}';
             }
         }


### PR DESCRIPTION
Fixes a simple typo in toString() method (missing '=' char)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
