### PR TITLE
Retry in KinesisSinkP#saveToSnapshot [HZ-2545] [5.2.z]

### DIFF
--- a/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/sink/KinesisSinkP.java
+++ b/extensions/kinesis/src/main/java/com/hazelcast/jet/kinesis/impl/sink/KinesisSinkP.java
@@ -165,10 +165,7 @@ public class KinesisSinkP<T> implements Processor {
 
     @Override
     public boolean saveToSnapshot() {
-        if (sendResult != null) {
-            checkIfSendingFinished();
-        }
-        return sendResult == null;
+        return complete();
     }
 
     private void updateThroughputLimitations() {

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/AbstractKinesisTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/AbstractKinesisTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.retry.RetryStrategies;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -57,12 +56,14 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@Category(QuickTest.class)
 public abstract class AbstractKinesisTest extends JetTestSupport {
+
+    public static final String LOCALSTACK_VERSION = "2.1.0";
 
     protected static final int KEYS = 250;
     protected static final int MEMBER_COUNT = 2;
-    protected static final int MESSAGES = 25_000;
+    protected static final int MESSAGES = 2_500;
     protected static final String STREAM = "TestStream";
     protected static final String RESULTS = "Results";
 

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisFailureTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.jet.kinesis;
 
-import com.amazonaws.SDKGlobalConfiguration;
 import com.amazonaws.services.kinesis.AmazonKinesisAsync;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.Job;
@@ -77,7 +76,7 @@ public class KinesisFailureTest extends AbstractKinesisTest {
         assumeDockerEnabled();
 
         localStack = new LocalStackContainer(parse("localstack/localstack")
-                .withTag("0.12.3"))
+                .withTag(LOCALSTACK_VERSION))
                 .withNetwork(NETWORK)
                 .withServices(Service.KINESIS);
         localStack.start();
@@ -86,10 +85,6 @@ public class KinesisFailureTest extends AbstractKinesisTest {
                 .withNetwork(NETWORK)
                 .withNetworkAliases("toxiproxy");
         toxiProxy.start();
-
-        System.setProperty(SDKGlobalConfiguration.AWS_CBOR_DISABLE_SYSTEM_PROPERTY, "true");
-        // with the jackson versions we use (2.11.x) Localstack doesn't without disabling CBOR
-        // https://github.com/localstack/localstack/issues/3208
 
         PROXY = toxiProxy.getProxy(localStack, 4566);
 

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisLimitExceededIntegrationTest.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisLimitExceededIntegrationTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2021 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kinesis;
+
+import com.amazonaws.services.kinesis.AmazonKinesisAsync;
+import com.hazelcast.collection.IList;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.config.ProcessingGuarantee;
+import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.jet.kinesis.impl.AwsConfig;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import com.hazelcast.jet.pipeline.SourceBuilder;
+import com.hazelcast.jet.pipeline.StreamSource;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
+
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.utility.DockerImageName.parse;
+
+@Category(SlowTest.class)
+public class KinesisLimitExceededIntegrationTest extends AbstractKinesisTest {
+
+    public static LocalStackContainer localStack;
+
+    private static AwsConfig AWS_CONFIG;
+    private static AmazonKinesisAsync KINESIS;
+    private static KinesisTestHelper HELPER;
+
+    public KinesisLimitExceededIntegrationTest() {
+        super(AWS_CONFIG, KINESIS, HELPER);
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        // To run with real kinesis AWS credentials need be available
+        // to be loaded by DefaultAWSCredentialsProviderChain.
+        // Keep in mind the real Kinesis is paid service and once you
+        // run it you should ensure that cleanup happened correctly.
+        boolean useRealKinesis = Boolean.parseBoolean(System.getProperty("run.with.real.kinesis", "false"));
+
+        if (useRealKinesis) {
+            AWS_CONFIG = new AwsConfig()
+                    .withEndpoint("https://kinesis.us-east-1.amazonaws.com")
+                    .withRegion("us-east-1");
+        } else {
+            assumeDockerEnabled();
+
+            localStack = new LocalStackContainer(parse("localstack/localstack")
+                    .withTag(LOCALSTACK_VERSION))
+                    // Introduce errors so some items fail to be written and need to be retried
+                    .withEnv("KINESIS_ERROR_PROBABILITY", "0.25")
+                    .withServices(Service.KINESIS);
+            localStack.start();
+
+            AWS_CONFIG = new AwsConfig()
+                    .withEndpoint("http://" + localStack.getHost() + ":" + localStack.getMappedPort(4566))
+                    .withRegion(localStack.getRegion())
+                    .withCredentials(localStack.getAccessKey(), localStack.getSecretKey());
+        }
+        KINESIS = AWS_CONFIG.buildClient();
+        HELPER = new KinesisTestHelper(KINESIS, STREAM, Logger.getLogger(KinesisLimitExceededIntegrationTest.class));
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if (KINESIS != null) {
+            KINESIS.shutdown();
+        }
+
+        if (localStack != null) {
+            localStack.stop();
+        }
+    }
+
+    /**
+     * Regression test for https://github.com/hazelcast/hazelcast/issues/24774
+     */
+    @Test
+    public void limitExceededForTerminalSnapshot() throws Exception {
+        HELPER.createStream(1);
+
+        StreamSource<Entry<String, byte[]>> generatorSource = SourceBuilder
+                .stream("KinesisDataSource", procCtx -> new long[1])
+                .<Entry<String, byte[]>>fillBufferFn((ctx, buf) -> {
+                    long messageId = ctx[0];
+                    byte[] data = Long.toString(messageId).getBytes(StandardCharsets.UTF_8);
+                    buf.add(entry(String.valueOf(messageId), data));
+                    ctx[0] += 1;
+                    sleepMillis(10);
+                })
+                .createSnapshotFn(ctx -> ctx[0])
+                .restoreSnapshotFn((ctx, state) -> ctx[0] = state.get(0))
+                .build();
+
+        Pipeline write = Pipeline.create();
+        write.readFrom(generatorSource)
+             .withoutTimestamps()
+             .writeTo(kinesisSink().build());
+
+        Job writeJob = hz().getJet().newJob(write,
+                new JobConfig().setProcessingGuarantee(ProcessingGuarantee.AT_LEAST_ONCE));
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(kinesisSource().build())
+         .withNativeTimestamps(0)
+         .map(Entry::getKey)
+         .peek()
+         .writeTo(Sinks.list("result"));
+        Job readJob = hz().getJet().newJob(p,
+                new JobConfig().setProcessingGuarantee(ProcessingGuarantee.AT_LEAST_ONCE));
+
+        for (int i = 0; i < 10; i++) {
+            // Make sure job is running before we suspend it
+            assertJobStatusEventually(writeJob, JobStatus.RUNNING);
+
+            logger.info("Suspend #" + i);
+
+            writeJob.suspend();
+            assertJobSuspendedEventually(writeJob);
+            writeJob.resume();
+            Thread.sleep(1000);
+        }
+
+        // Because of the limit exceeded the items are out of order,
+        // if we canceled the job some items at the end would be missing
+        writeJob.suspend();
+
+        assertTrueEventually(() -> {
+            IList<String> list = hz().getList("result");
+            List<Integer> cleanList = list.stream().distinct().map(Integer::valueOf).sorted().collect(toList());
+            Integer max = cleanList.stream().max(Integer::compareTo).orElseThrow(NoSuchElementException::new);
+
+            List<Integer> expected = IntStream.range(0, max + 1).boxed().collect(toList());
+
+            assertThat(cleanList).containsAll(expected);
+        }, 10);
+    }
+
+    public static <K, V> Entry<K, V> entry(K key, V value) {
+        return new AbstractMap.SimpleImmutableEntry<>(key, value);
+    }
+
+}

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisTestHelper.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisTestHelper.java
@@ -58,7 +58,7 @@ class KinesisTestHelper {
 
     static final RetryStrategy RETRY_STRATEGY = RetryStrategies.custom()
             .maxAttempts(30)
-            .intervalFunction(IntervalFunction.exponentialBackoffWithCap(250L, 2.0, 1000L))
+            .intervalFunction(IntervalFunction.exponentialBackoffWithCap(250L, 2.0, 2000L))
             .build();
 
     private final AmazonKinesisAsync kinesis;

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -46,6 +46,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.Accessors;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.OverridePropertyRule;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.rules.Timeout;
@@ -70,6 +71,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
+import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
 import static com.hazelcast.jet.impl.JetServiceBackend.SERVICE_NAME;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -299,6 +301,21 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
         } while (executionId == null || executionId.equals(ignoredExecutionId));
         return executionId;
     }
+
+    /**
+     * Asserts that the {@code job} is eventually SUSPENDED and waits until the suspension cause is set.
+     */
+    public static void assertJobSuspendedEventually(Job job) {
+        assertJobStatusEventually(job, SUSPENDED);
+        assertTrueEventually(() -> {
+            try {
+                assertNotNull(job.getSuspensionCause());
+            } catch (IllegalStateException notSuspended) {
+                Assertions.fail("Suspension cause is not set yet", notSuspended);
+            }
+        });
+    }
+
 
     public static void assertJobStatusEventually(Job job, JobStatus expected, int timeoutSeconds) {
         assertNotNull(job);


### PR DESCRIPTION
When `saveToSnapshot()` is called while `sendResult` is non-null then the result might contain failed records which are retained in the buffer.

However, the buffer is not checked if it is empty, which leads to losing the items in the buffer.

The behaviour of `saveToSnapshot` should be the same as `complete()` - it needs to flush all records and retry on any failures. The change simply delegates to `complete()`.

Fixes #24774
Fixes #23692

Backport of https://github.com/hazelcast/hazelcast/pull/24779
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
