### PR TITLE
Test SQL/Avro schema evolution [HZ-2507] [HZ-2508]

### DIFF
--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -110,6 +110,17 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry</artifactId>
+            <version>6.2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry</artifactId>
-            <version>6.2.2</version>
+            <version>${confluent.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -605,7 +605,6 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         assertEquals(entry(0, "0"), consumeEventually(processor, outbox));
 
         kafkaTestSupport.setPartitionCount(topic1Name, INITIAL_PARTITION_COUNT + 2);
-        kafkaTestSupport.resetProducer(); // this allows production to the added partition
 
         boolean somethingInPartition1 = false;
         for (int i = 1; i < 11; i++) {
@@ -654,7 +653,6 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         assertEquals(entry(1, "1"), consumeEventually(processor, outbox));
 
         kafkaTestSupport.setPartitionCount(topic1Name, INITIAL_PARTITION_COUNT + 2);
-        kafkaTestSupport.resetProducer(); // this allows production to the added partition
 
         boolean somethingInPartition1 = false;
         for (int i = 2; i < 12; i++) {
@@ -923,8 +921,6 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
     private Entry<Integer, String> produceEventToNewPartition(int partitionId) throws Exception {
         String value;
         while (true) {
-            // reset the producer for each attempt as it might not see the new partition yet
-            kafkaTestSupport.resetProducer();
             value = UuidUtil.newUnsecureUuidString();
             Future<RecordMetadata> future = kafkaTestSupport.produce(topic1Name, partitionId, null, 0, value);
             RecordMetadata recordMetadata = future.get();

--- a/extensions/mongodb/pom.xml
+++ b/extensions/mongodb/pom.xml
@@ -72,19 +72,11 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>toxiproxy</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -38,7 +38,6 @@
 
         <checkstyle.headerLocation>${project.parent.basedir}/checkstyle/ClassHeaderHazelcastCommunity.txt</checkstyle.headerLocation>
 
-        <confluent.version>7.4.0</confluent.version>
         <immutables.version>2.9.3</immutables.version>
     </properties>
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -134,6 +134,20 @@ public interface SqlConnector {
     String OPTION_VALUE_COMPACT_TYPE_NAME = "valueCompactTypeName";
 
     /**
+     * Key record name for in generated Avro schema if {@value
+     * #OPTION_KEY_FORMAT} is {@value AVRO_FORMAT}. If not specified, defaults
+     * to {@code "jet.sql"}.
+     */
+    String OPTION_KEY_AVRO_RECORD_NAME = "keyAvroRecordName";
+
+    /**
+     * Value record name for in generated Avro schema if {@value
+     * #OPTION_KEY_FORMAT} is {@value AVRO_FORMAT}. If not specified, defaults
+     * to {@code "jet.sql"}.
+     */
+    String OPTION_VALUE_AVRO_RECORD_NAME = "valueAvroRecordName";
+
+    /**
      * The class name of the Custom Type's underlying Java Class
      */
     String OPTION_TYPE_JAVA_CLASS = "javaClass";

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolver.java
@@ -36,6 +36,8 @@ import java.util.Map.Entry;
 import java.util.stream.Stream;
 
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.AVRO_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_AVRO_RECORD_NAME;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_AVRO_RECORD_NAME;
 import static com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolver.extractFields;
 import static com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolver.maybeAddDefaultField;
 
@@ -91,7 +93,8 @@ public final class KvMetadataAvroResolver implements KvMetadataResolver {
         }
         maybeAddDefaultField(isKey, resolvedFields, fields, QueryDataType.OBJECT);
 
-        String recordName = options.getOrDefault((isKey ? "key" : "value") + ".record.name", "jet.sql");
+        String recordName = options.getOrDefault(isKey ? OPTION_KEY_AVRO_RECORD_NAME : OPTION_VALUE_AVRO_RECORD_NAME,
+                "jet.sql");
         return new KvMetadata(
                 fields,
                 AvroQueryTargetDescriptor.INSTANCE,

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolver.java
@@ -91,18 +91,19 @@ public final class KvMetadataAvroResolver implements KvMetadataResolver {
         }
         maybeAddDefaultField(isKey, resolvedFields, fields, QueryDataType.OBJECT);
 
+        String recordName = options.getOrDefault((isKey ? "key" : "value") + ".record.name", "jet.sql");
         return new KvMetadata(
                 fields,
                 AvroQueryTargetDescriptor.INSTANCE,
-                new AvroUpsertTargetDescriptor(schema(fields))
+                new AvroUpsertTargetDescriptor(schema(recordName, fields))
         );
     }
 
-    private Schema schema(List<TableField> fields) {
+    private Schema schema(String recordName, List<TableField> fields) {
         QueryPath[] paths = paths(fields);
         QueryDataType[] types = types(fields);
 
-        FieldAssembler<Schema> schema = SchemaBuilder.record("jet.sql").fields();
+        FieldAssembler<Schema> schema = SchemaBuilder.record(recordName).fields();
         for (int i = 0; i < fields.size(); i++) {
             String path = paths[i].getPath();
             if (path == null) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolver.java
@@ -94,7 +94,7 @@ public final class KvMetadataAvroResolver implements KvMetadataResolver {
         return new KvMetadata(
                 fields,
                 AvroQueryTargetDescriptor.INSTANCE,
-                new AvroUpsertTargetDescriptor(schema(fields).toString())
+                new AvroUpsertTargetDescriptor(schema(fields))
         );
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTarget.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTarget.java
@@ -35,8 +35,8 @@ class AvroUpsertTarget implements UpsertTarget {
 
     private GenericRecordBuilder record;
 
-    AvroUpsertTarget(String schema) {
-        this.schema = new Schema.Parser().parse(schema);
+    AvroUpsertTarget(Schema schema) {
+        this.schema = schema;
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTargetDescriptor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTargetDescriptor.java
@@ -19,19 +19,20 @@ package com.hazelcast.jet.sql.impl.inject;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import org.apache.avro.Schema;
 
 import java.io.IOException;
 import java.util.Objects;
 
 public final class AvroUpsertTargetDescriptor implements UpsertTargetDescriptor {
-
-    private String schema;
+    private Schema schema;
+    private transient String serializedSchema;
 
     @SuppressWarnings("unused")
     private AvroUpsertTargetDescriptor() {
     }
 
-    public AvroUpsertTargetDescriptor(String schema) {
+    public AvroUpsertTargetDescriptor(Schema schema) {
         this.schema = schema;
     }
 
@@ -42,12 +43,16 @@ public final class AvroUpsertTargetDescriptor implements UpsertTargetDescriptor 
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeObject(schema);
+        if (serializedSchema == null) {
+            serializedSchema = schema.toString();
+        }
+        out.writeObject(serializedSchema);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        schema = in.readObject();
+        serializedSchema = in.readObject();
+        schema = new Schema.Parser().parse(serializedSchema);
     }
 
     @Override

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlTestSupport.java
@@ -168,6 +168,10 @@ public abstract class KafkaSqlTestSupport extends SqlTestSupport {
             return this;
         }
 
+        public KafkaMapping optionsIf(boolean condition, Object... options) {
+            return condition ? options(options) : this;
+        }
+
         public void create() {
             create(false);
         }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroSchemaEvolutionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroSchemaEvolutionTest.java
@@ -127,7 +127,7 @@ public class SqlAvroSchemaEvolutionTest extends KafkaSqlTestSupport {
                         "name VARCHAR",
                         "ssn BIGINT")
                 .optionsIf(!topicNameStrategy,
-                           "value.record.name", "jet.sql2")
+                           "valueAvroRecordName", "jet.sql2")
                 .createOrReplace();
         }
 
@@ -157,7 +157,7 @@ public class SqlAvroSchemaEvolutionTest extends KafkaSqlTestSupport {
                 .options("auto.register.schemas", false,
                          "use.latest.version", true)
                 .optionsIf(!topicNameStrategy,
-                           "value.record.name", "jet.sql2")
+                           "valueAvroRecordName", "jet.sql2")
                 .createOrReplace();
         }
 
@@ -195,7 +195,7 @@ public class SqlAvroSchemaEvolutionTest extends KafkaSqlTestSupport {
                          "key.schema.id", keySchemaId,
                          "value.schema.id", valueSchemaId2)
                 .optionsIf(!topicNameStrategy,
-                           "value.record.name", "jet.sql2")
+                           "valueAvroRecordName", "jet.sql2")
                 .createOrReplace();
         }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroSchemaEvolutionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroSchemaEvolutionTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.kafka;
+
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Arrays;
+
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.AVRO_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.kafka.SqlAvroTest.ID_SCHEMA;
+import static com.hazelcast.jet.sql.impl.connector.kafka.SqlAvroTest.NAME_SCHEMA;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParametrizedRunner.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+public class SqlAvroSchemaEvolutionTest extends KafkaSqlTestSupport {
+    private static final Schema NAME_SSN_SCHEMA = SchemaBuilder.record("jet.sql")
+            .fields()
+            .name("name").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+            .name("ssn").type().unionOf().nullType().and().longType().endUnion().nullDefault()
+            .endRecord();
+    private static final Schema NAME_SSN_SCHEMA2 = SchemaBuilder.record("jet.sql2")
+            .fields()
+            .name("name").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+            .name("ssn").type().unionOf().nullType().and().longType().endUnion().nullDefault()
+            .endRecord();
+
+    @Parameters(name = "{0}")
+    public static Iterable<String> parameters() {
+        return asList("TopicNameStrategy", "TopicRecordNameStrategy", "RecordNameStrategy");
+    }
+
+    @Parameter
+    public String subjectNameStrategy;
+
+    /**
+     * Indicates whether {@link #subjectNameStrategy} is {@code TopicNameStrategy}.
+     */
+    private boolean topicNameStrategy;
+    /**
+     * In format {@code <topic>-value}, {@code <topic>-<record>} or {@code <record>}
+     * depending on {@link #subjectNameStrategy}.
+     */
+    private String valueSubjectName;
+    /**
+     * Name of the current Kafka topic and corresponding mapping.
+     */
+    private String name;
+
+    @BeforeClass
+    public static void initialize() throws Exception {
+        createSchemaRegistry();
+    }
+
+    @Before
+    public void before() throws Exception {
+        name = createRandomTopic(1);
+        kafkaTestSupport.setSubjectNameStrategy(name, false, subjectNameStrategy);
+        topicNameStrategy = subjectNameStrategy.equals("TopicNameStrategy");
+        switch (subjectNameStrategy) {
+            case "TopicNameStrategy":       valueSubjectName = name + "-value"; break;
+            case "TopicRecordNameStrategy": valueSubjectName = name + "-jet.sql"; break;
+            case "RecordNameStrategy":      valueSubjectName = "jet.sql";
+        }
+    }
+
+    private KafkaMapping kafkaMapping() {
+        return new KafkaMapping(name).options(
+                OPTION_KEY_FORMAT, AVRO_FORMAT,
+                OPTION_VALUE_FORMAT, AVRO_FORMAT,
+                "bootstrap.servers", kafkaTestSupport.getBrokerConnectionString(),
+                "schema.registry.url", kafkaTestSupport.getSchemaRegistryURI(),
+                "auto.offset.reset", "earliest",
+                "value.subject.name.strategy", "io.confluent.kafka.serializers.subject." + subjectNameStrategy
+        );
+    }
+
+    @Test
+    public void test_autoRegisterSchema() throws SchemaRegistryException {
+        kafkaMapping()
+            .fields("id INT EXTERNAL NAME \"__key.id\"",
+                    "name VARCHAR")
+            .create();
+
+        insertInitialRecordAndAlterSchema();
+
+        insertAndAssertRecords(false);
+    }
+
+    @Test
+    public void test_autoRegisterSchema_recreateMapping() throws SchemaRegistryException {
+        kafkaMapping()
+            .fields("id INT EXTERNAL NAME \"__key.id\"",
+                    "name VARCHAR")
+            .create();
+
+        insertInitialRecordAndAlterSchema();
+
+        // recreate mapping to match new schema
+        kafkaMapping()
+            .fields("id INT EXTERNAL NAME \"__key.id\"",
+                    "name VARCHAR",
+                    "ssn BIGINT")
+            .optionsIf(!topicNameStrategy,
+                       "value.record.name", "jet.sql2")
+            .createOrReplace();
+
+        insertAndAssertRecords(true);
+    }
+
+    @Test
+    public void test_useLatestSchema() throws SchemaRegistryException {
+        // create initial schema
+        kafkaTestSupport.registerSchema(name + "-key", ID_SCHEMA);
+        kafkaTestSupport.registerSchema(valueSubjectName, NAME_SCHEMA);
+
+        kafkaMapping()
+            .fields("id INT EXTERNAL NAME \"__key.id\"",
+                    "name VARCHAR")
+            .options("auto.register.schemas", false,
+                     "use.latest.version", true)
+            .create();
+
+        insertInitialRecordAndAlterSchema();
+
+        if (topicNameStrategy) {
+            // insert record against mapping's schema
+            assertThatThrownBy(() -> sqlService.execute("INSERT INTO " + name + " VALUES (29, 'Bob')"))
+                    .hasMessageContaining("Error serializing Avro message");
+        } else {
+            insertAndAssertRecords(false);
+        }
+    }
+
+    @Test
+    public void test_useLatestSchema_recreateMapping() throws SchemaRegistryException {
+        // create initial schema
+        kafkaTestSupport.registerSchema(name + "-key", ID_SCHEMA);
+        kafkaTestSupport.registerSchema(valueSubjectName, NAME_SCHEMA);
+
+        kafkaMapping()
+            .fields("id INT EXTERNAL NAME \"__key.id\"",
+                    "name VARCHAR")
+            .options("auto.register.schemas", false,
+                     "use.latest.version", true)
+            .create();
+
+        insertInitialRecordAndAlterSchema();
+
+        // recreate mapping to match new schema
+        kafkaMapping()
+            .fields("id INT EXTERNAL NAME \"__key.id\"",
+                    "name VARCHAR",
+                    "ssn BIGINT")
+            .options("auto.register.schemas", false,
+                     "use.latest.version", true)
+            .optionsIf(!topicNameStrategy,
+                       "value.record.name", "jet.sql2")
+            .createOrReplace();
+
+        insertAndAssertRecords(true);
+    }
+
+    @Test
+    public void test_useSpecificSchema() throws SchemaRegistryException {
+        // create initial schema
+        int keySchemaId = kafkaTestSupport.registerSchema(name + "-key", ID_SCHEMA);
+        int valueSchemaId = kafkaTestSupport.registerSchema(valueSubjectName, NAME_SCHEMA);
+
+        kafkaMapping()
+            .fields("id INT EXTERNAL NAME \"__key.id\"",
+                    "name VARCHAR")
+            .options("auto.register.schemas", false,
+                     "key.schema.id", keySchemaId,
+                     "value.schema.id", valueSchemaId)
+            .create();
+
+        insertInitialRecordAndAlterSchema();
+
+        insertAndAssertRecords(false);
+    }
+
+    @Test
+    public void test_useSpecificSchema_recreateMapping() throws SchemaRegistryException {
+        // create initial schema
+        int keySchemaId = kafkaTestSupport.registerSchema(name + "-key", ID_SCHEMA);
+        int valueSchemaId = kafkaTestSupport.registerSchema(valueSubjectName, NAME_SCHEMA);
+
+        kafkaMapping()
+            .fields("id INT EXTERNAL NAME \"__key.id\"",
+                    "name VARCHAR")
+            .options("auto.register.schemas", false,
+                     "key.schema.id", keySchemaId,
+                     "value.schema.id", valueSchemaId)
+            .create();
+
+        int valueSchemaId2 = insertInitialRecordAndAlterSchema();
+
+        // recreate mapping to match new schema
+        kafkaMapping()
+            .fields("id INT EXTERNAL NAME \"__key.id\"",
+                    "name VARCHAR",
+                    "ssn BIGINT")
+            .options("auto.register.schemas", false,
+                     "key.schema.id", keySchemaId,
+                     "value.schema.id", valueSchemaId2)
+            .optionsIf(!topicNameStrategy,
+                       "value.record.name", "jet.sql2")
+            .createOrReplace();
+
+        insertAndAssertRecords(true);
+    }
+
+    private int insertInitialRecordAndAlterSchema() throws SchemaRegistryException {
+        // insert initial record
+        sqlService.execute("INSERT INTO " + name + " VALUES (13, 'Alice')");
+        assertEquals(1, kafkaTestSupport.getLatestSchemaVersion(valueSubjectName));
+
+        // alter schema externally
+        int valueSchemaId;
+        if (topicNameStrategy) {
+            valueSchemaId = kafkaTestSupport.registerSchema(valueSubjectName, NAME_SSN_SCHEMA);
+            assertEquals(2, kafkaTestSupport.getLatestSchemaVersion(valueSubjectName));
+        } else {
+            valueSchemaId = kafkaTestSupport.registerSchema(valueSubjectName + "2", NAME_SSN_SCHEMA2);
+            assertEquals(1, kafkaTestSupport.getLatestSchemaVersion(valueSubjectName));
+            assertEquals(1, kafkaTestSupport.getLatestSchemaVersion(valueSubjectName + "2"));
+        }
+        return valueSchemaId;
+    }
+
+    private void insertAndAssertRecords(boolean mappingUpdated) throws SchemaRegistryException {
+        int fields = mappingUpdated ? 3 : 2;
+
+        // insert record against mapping's schema
+        sqlService.execute("INSERT INTO " + name + " VALUES (29, 'Bob'" + (fields == 3 ? ", 123456789)" : ")"));
+
+        // insert record against old schema externally
+        kafkaTestSupport.produce(name,
+                new GenericRecordBuilder(ID_SCHEMA).set("id", 31).build(),
+                new GenericRecordBuilder(NAME_SCHEMA).set("name", "Carol").build());
+
+        // insert record against new schema externally
+        kafkaTestSupport.produce(name,
+                new GenericRecordBuilder(ID_SCHEMA).set("id", 47).build(),
+                new GenericRecordBuilder(topicNameStrategy ? NAME_SSN_SCHEMA : NAME_SSN_SCHEMA2)
+                        .set("name", "Dave").set("ssn", 123456789L).build());
+
+        // insert record against mapping's schema again
+        sqlService.execute("INSERT INTO " + name + " VALUES (53, 'Erin'" + (fields == 3 ? ", 987654321)" : ")"));
+
+        if (topicNameStrategy) {
+            assertEquals(2, kafkaTestSupport.getLatestSchemaVersion(valueSubjectName));
+        } else {
+            assertEquals(1, kafkaTestSupport.getLatestSchemaVersion(valueSubjectName));
+            assertEquals(1, kafkaTestSupport.getLatestSchemaVersion(valueSubjectName + "2"));
+        }
+
+        // assert both initial & evolved records are correctly read
+        Object[][] records = {
+                { 13, "Alice", null },
+                { 29, "Bob", 123456789L },
+                { 31, "Carol", null },
+                { 47, "Dave", 123456789L },
+                { 53, "Erin", 987654321L }
+        };
+        assertRowsEventuallyInAnyOrder(
+                "SELECT * FROM " + name,
+                Arrays.stream(records).map(record -> new Row(Arrays.copyOf(record, fields))).collect(toList())
+        );
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
@@ -18,13 +18,8 @@ package com.hazelcast.jet.sql.impl.connector.kafka;
 
 import com.google.common.collect.ImmutableMap;
 import com.hazelcast.internal.nio.Bits;
-import com.hazelcast.jet.kafka.impl.KafkaTestSupport;
-import com.hazelcast.jet.sql.SqlTestSupport;
 import com.hazelcast.jet.sql.impl.connector.test.TestAllTypesSqlConnector;
 import com.hazelcast.sql.HazelcastSqlException;
-import com.hazelcast.sql.SqlService;
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import org.apache.avro.Schema;
@@ -35,8 +30,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
-import org.eclipse.jetty.server.Server;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,10 +43,11 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import static com.hazelcast.jet.core.TestUtil.createMap;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.AVRO_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JAVA_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
 import static java.time.ZoneOffset.UTC;
@@ -64,68 +58,47 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
-public class SqlAvroTest extends SqlTestSupport {
-
+public class SqlAvroTest extends KafkaSqlTestSupport {
     private static final int INITIAL_PARTITION_COUNT = 4;
 
-    private static KafkaTestSupport kafkaTestSupport;
-    private static Server schemaRegistry;
-
-    private static SqlService sqlService;
+    private static final Schema ID_SCHEMA = SchemaBuilder.record("jet.sql")
+            .fields()
+            .name("id").type().unionOf().nullType().and().intType().endUnion().nullDefault()
+            .endRecord();
+    private static final Schema NAME_SCHEMA = SchemaBuilder.record("jet.sql")
+            .fields()
+            .name("name").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+            .endRecord();
 
     @BeforeClass
-    public static void setUpClass() throws Exception {
-        initialize(1, null);
-        sqlService = instance().getSql();
-
-        kafkaTestSupport = KafkaTestSupport.create();
-        kafkaTestSupport.createKafkaCluster();
-
-        Properties properties = new Properties();
-        properties.put("listeners", "http://0.0.0.0:0");
-        properties.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, kafkaTestSupport.getBrokerConnectionString());
-        //When Kafka is under load the schema registry may give
-        //io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException: Register operation timed out; error code: 50002
-        //Because the default timeout is 500 ms. Use a bigger timeout value to avoid it
-        properties.put(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG, "5000");
-        SchemaRegistryConfig config = new SchemaRegistryConfig(properties);
-        SchemaRegistryRestApplication schemaRegistryApplication = new SchemaRegistryRestApplication(config);
-        schemaRegistry = schemaRegistryApplication.createServer();
-        schemaRegistry.start();
+    public static void initialize() throws Exception {
+        createSchemaRegistry();
     }
 
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-        if (schemaRegistry != null) {
-            schemaRegistry.stop();
-        }
-        if (kafkaTestSupport != null) {
-            kafkaTestSupport.shutdownKafkaCluster();
-        }
+    private static KafkaMapping kafkaMapping(String name) {
+        return new KafkaMapping(name).options(
+                OPTION_KEY_FORMAT, AVRO_FORMAT,
+                OPTION_VALUE_FORMAT, AVRO_FORMAT,
+                "bootstrap.servers", kafkaTestSupport.getBrokerConnectionString(),
+                "schema.registry.url", kafkaTestSupport.getSchemaRegistryURI(),
+                "auto.offset.reset", "earliest"
+        );
     }
 
     @Test
     public void test_nulls() {
         String name = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + name + " ("
-                + "id INT EXTERNAL NAME \"__key.id\""
-                + ", name VARCHAR"
-                + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + '\'' + OPTION_KEY_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", '" + OPTION_VALUE_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", 'schema.registry.url'='" + schemaRegistry.getURI() + '\''
-                + ", 'auto.offset.reset'='earliest'"
-                + ")"
-        );
+        kafkaMapping(name)
+                .fields("id INT EXTERNAL NAME \"__key.id\"",
+                        "name VARCHAR")
+                .create();
 
         assertTopicEventually(
                 name,
                 "INSERT INTO " + name + " VALUES (null, null)",
                 createMap(
-                        new GenericRecordBuilder(intSchema("id")).build(),
-                        new GenericRecordBuilder(stringSchema("name")).set("name", null).build()
+                        new GenericRecordBuilder(ID_SCHEMA).build(),
+                        new GenericRecordBuilder(NAME_SCHEMA).set("name", null).build()
                 )
         );
         assertRowsEventuallyInAnyOrder(
@@ -137,25 +110,17 @@ public class SqlAvroTest extends SqlTestSupport {
     @Test
     public void test_fieldsMapping() {
         String name = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + name + " ("
-                + "key_name VARCHAR EXTERNAL NAME \"__key.name\""
-                + ", value_name VARCHAR EXTERNAL NAME \"this.name\""
-                + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + '\'' + OPTION_KEY_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", '" + OPTION_VALUE_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", 'schema.registry.url'='" + schemaRegistry.getURI() + '\''
-                + ", 'auto.offset.reset'='earliest'"
-                + ")"
-        );
+        kafkaMapping(name)
+                .fields("key_name VARCHAR EXTERNAL NAME \"__key.name\"",
+                        "value_name VARCHAR EXTERNAL NAME \"this.name\"")
+                .create();
 
         assertTopicEventually(
                 name,
                 "INSERT INTO " + name + " (value_name, key_name) VALUES ('Bob', 'Alice')",
                 createMap(
-                        new GenericRecordBuilder(stringSchema("name")).set("name", "Alice").build(),
-                        new GenericRecordBuilder(stringSchema("name")).set("name", "Bob").build()
+                        new GenericRecordBuilder(NAME_SCHEMA).set("name", "Alice").build(),
+                        new GenericRecordBuilder(NAME_SCHEMA).set("name", "Bob").build()
                 )
         );
         assertRowsEventuallyInAnyOrder(
@@ -167,36 +132,20 @@ public class SqlAvroTest extends SqlTestSupport {
     @Test
     public void test_schemaEvolution() {
         String name = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + name + " ("
-                + "id INT EXTERNAL NAME \"__key.id\""
-                + ", name VARCHAR"
-                + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + '\'' + OPTION_KEY_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", '" + OPTION_VALUE_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", 'schema.registry.url'='" + schemaRegistry.getURI() + '\''
-                + ", 'auto.offset.reset'='earliest'"
-                + ")"
-        );
+        kafkaMapping(name)
+                .fields("id INT EXTERNAL NAME \"__key.id\"",
+                        "name VARCHAR")
+                .create();
 
         // insert initial record
         sqlService.execute("INSERT INTO " + name + " VALUES (13, 'Alice')");
 
         // alter schema
-        sqlService.execute("CREATE OR REPLACE MAPPING " + name + " ("
-                + "id INT EXTERNAL NAME \"__key.id\""
-                + ", name VARCHAR"
-                + ", ssn BIGINT"
-                + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + '\'' + OPTION_KEY_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", '" + OPTION_VALUE_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", 'schema.registry.url'='" + schemaRegistry.getURI() + '\''
-                + ", 'auto.offset.reset'='earliest'"
-                + ")"
-        );
+        kafkaMapping(name)
+                .fields("id INT EXTERNAL NAME \"__key.id\"",
+                        "name VARCHAR",
+                        "ssn BIGINT")
+                .createOrReplace();
 
         // insert record against new schema
         sqlService.execute("INSERT INTO " + name + " VALUES (69, 'Bob', 123456789)");
@@ -217,32 +166,24 @@ public class SqlAvroTest extends SqlTestSupport {
         TestAllTypesSqlConnector.create(sqlService, from);
 
         String to = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + to + " ("
-                + "id VARCHAR EXTERNAL NAME \"__key.id\""
-                + ", string VARCHAR"
-                + ", \"boolean\" BOOLEAN"
-                + ", byte TINYINT"
-                + ", short SMALLINT"
-                + ", \"int\" INT"
-                + ", long BIGINT"
-                + ", \"float\" REAL"
-                + ", \"double\" DOUBLE"
-                + ", \"decimal\" DECIMAL"
-                + ", \"time\" TIME"
-                + ", \"date\" DATE"
-                + ", \"timestamp\" TIMESTAMP"
-                + ", timestampTz TIMESTAMP WITH TIME ZONE"
-                + ", map OBJECT"
-                + ", object OBJECT"
-                + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + '\'' + OPTION_KEY_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", '" + OPTION_VALUE_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", 'schema.registry.url'='" + schemaRegistry.getURI() + '\''
-                + ", 'auto.offset.reset'='earliest'"
-                + ")"
-        );
+        kafkaMapping(to)
+                .fields("id VARCHAR EXTERNAL NAME \"__key.id\"",
+                        "string VARCHAR",
+                        "\"boolean\" BOOLEAN",
+                        "byte TINYINT",
+                        "short SMALLINT",
+                        "\"int\" INT",
+                        "long BIGINT",
+                        "\"float\" REAL",
+                        "\"double\" DOUBLE",
+                        "\"decimal\" DECIMAL",
+                        "\"time\" TIME",
+                        "\"date\" DATE",
+                        "\"timestamp\" TIMESTAMP",
+                        "timestampTz TIMESTAMP WITH TIME ZONE",
+                        "map OBJECT",
+                        "object OBJECT")
+                .create();
 
         sqlService.execute("INSERT INTO " + to + " SELECT '1', f.* FROM " + from + " f");
 
@@ -289,16 +230,10 @@ public class SqlAvroTest extends SqlTestSupport {
 
     private void when_explicitTopLevelField_then_fail(String field, String otherField) {
         assertThatThrownBy(() ->
-                sqlService.execute("CREATE MAPPING kafka ("
-                        + field + " VARCHAR"
-                        + ", f VARCHAR EXTERNAL NAME \"" + otherField + ".f\""
-                        + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
-                        + "OPTIONS ("
-                        + '\'' + OPTION_KEY_FORMAT + "'='" + AVRO_FORMAT + '\''
-                        + ", '" + OPTION_VALUE_FORMAT + "'='" + AVRO_FORMAT + '\''
-                        + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                        + ", 'auto.offset.reset'='earliest'"
-                        + ")"))
+                    kafkaMapping("kafka")
+                            .fields(field + " VARCHAR",
+                                    "f VARCHAR EXTERNAL NAME \"" + otherField + ".f\"")
+                            .create())
                 .isInstanceOf(HazelcastSqlException.class)
                 .hasMessage("Cannot use the '" + field + "' field with Avro serialization");
     }
@@ -306,17 +241,10 @@ public class SqlAvroTest extends SqlTestSupport {
     @Test
     public void test_writingToTopLevel() {
         String mapName = randomName();
-        sqlService.execute("CREATE MAPPING " + mapName + "("
-                + "id INT EXTERNAL NAME \"__key.id\""
-                + ", name VARCHAR"
-                + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ("
-                + '\'' + OPTION_KEY_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", '" + OPTION_VALUE_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", 'auto.offset.reset'='earliest'"
-                + ")"
-        );
+        kafkaMapping(mapName)
+                .fields("id INT EXTERNAL NAME \"__key.id\"",
+                        "name VARCHAR")
+                .create();
 
         assertThatThrownBy(() ->
                 sqlService.execute("INSERT INTO " + mapName + "(__key, name) VALUES('{\"id\":1}', null)"))
@@ -332,25 +260,17 @@ public class SqlAvroTest extends SqlTestSupport {
     @Test
     public void test_topLevelFieldExtraction() {
         String name = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + name + " ("
-                + "id INT EXTERNAL NAME \"__key.id\""
-                + ", name VARCHAR"
-                + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + '\'' + OPTION_KEY_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", '" + OPTION_VALUE_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", 'schema.registry.url'='" + schemaRegistry.getURI() + '\''
-                + ", 'auto.offset.reset'='earliest'"
-                + ")"
-        );
+        kafkaMapping(name)
+                .fields("id INT EXTERNAL NAME \"__key.id\"",
+                        "name VARCHAR")
+                .create();
         sqlService.execute("INSERT INTO " + name + " VALUES (1, 'Alice')");
 
         assertRowsEventuallyInAnyOrder(
                 "SELECT __key, this FROM " + name,
                 singletonList(new Row(
-                        new GenericRecordBuilder(intSchema("id")).set("id", 1).build(),
-                        new GenericRecordBuilder(stringSchema("name")).set("name", "Alice").build()
+                        new GenericRecordBuilder(ID_SCHEMA).set("id", 1).build(),
+                        new GenericRecordBuilder(NAME_SCHEMA).set("name", "Alice").build()
                 ))
         );
     }
@@ -358,29 +278,21 @@ public class SqlAvroTest extends SqlTestSupport {
     @Test
     public void test_explicitKeyAndValueSerializers() {
         String name = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + name + " ("
-                + "key_name VARCHAR EXTERNAL NAME \"__key.name\""
-                + ", value_name VARCHAR EXTERNAL NAME \"this.name\""
-                + ") TYPE " + KafkaSqlConnector.TYPE_NAME + ' '
-                + "OPTIONS ( "
-                + '\'' + OPTION_KEY_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", '" + OPTION_VALUE_FORMAT + "'='" + AVRO_FORMAT + '\''
-                + ", 'key.serializer'='" + KafkaAvroSerializer.class.getCanonicalName() + '\''
-                + ", 'key.deserializer'='" + KafkaAvroDeserializer.class.getCanonicalName() + '\''
-                + ", 'value.serializer'='" + KafkaAvroSerializer.class.getCanonicalName() + '\''
-                + ", 'value.deserializer'='" + KafkaAvroDeserializer.class.getCanonicalName() + '\''
-                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", 'schema.registry.url'='" + schemaRegistry.getURI() + '\''
-                + ", 'auto.offset.reset'='earliest'"
-                + ")"
-        );
+        kafkaMapping(name)
+                .fields("key_name VARCHAR EXTERNAL NAME \"__key.name\"",
+                        "value_name VARCHAR EXTERNAL NAME \"this.name\"")
+                .options("key.serializer", KafkaAvroSerializer.class.getCanonicalName(),
+                         "key.deserializer", KafkaAvroDeserializer.class.getCanonicalName(),
+                         "value.serializer", KafkaAvroSerializer.class.getCanonicalName(),
+                         "value.deserializer", KafkaAvroDeserializer.class.getCanonicalName())
+                .create();
 
         assertTopicEventually(
                 name,
                 "INSERT INTO " + name + " (value_name, key_name) VALUES ('Bob', 'Alice')",
                 createMap(
-                        new GenericRecordBuilder(stringSchema("name")).set("name", "Alice").build(),
-                        new GenericRecordBuilder(stringSchema("name")).set("name", "Bob").build()
+                        new GenericRecordBuilder(NAME_SCHEMA).set("name", "Alice").build(),
+                        new GenericRecordBuilder(NAME_SCHEMA).set("name", "Bob").build()
                 )
         );
         assertRowsEventuallyInAnyOrder(
@@ -392,16 +304,12 @@ public class SqlAvroTest extends SqlTestSupport {
     @Test
     public void test_schemaIdForTwoQueriesIsEqual() {
         String topicName = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + topicName + " (__key INT, field1 VARCHAR) "
-                + "TYPE Kafka "
-                + "OPTIONS ("
-                + "'keyFormat'='java'"
-                + ", 'keyJavaClass'='java.lang.Integer'"
-                + ", 'valueFormat'='avro'"
-                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", 'schema.registry.url'='" + schemaRegistry.getURI() + '\''
-                + ", 'auto.offset.reset'='earliest')"
-        );
+        kafkaMapping(topicName)
+                .fields("__key INT",
+                        "field1 VARCHAR")
+                .options(OPTION_KEY_FORMAT, JAVA_FORMAT,
+                         OPTION_KEY_CLASS, Integer.class.getCanonicalName())
+                .create();
 
         sqlService.execute("INSERT INTO " + topicName + " VALUES(42, 'foo')");
         sqlService.execute("INSERT INTO " + topicName + " VALUES(43, 'bar')");
@@ -426,9 +334,7 @@ public class SqlAvroTest extends SqlTestSupport {
     }
 
     private static String createRandomTopic() {
-        String topicName = "t_" + randomString().replace('-', '_');
-        kafkaTestSupport.createTopic(topicName, INITIAL_PARTITION_COUNT);
-        return topicName;
+        return createRandomTopic(INITIAL_PARTITION_COUNT);
     }
 
     private static void assertTopicEventually(String name, String sql, Map<Object, Object> expected) {
@@ -439,21 +345,7 @@ public class SqlAvroTest extends SqlTestSupport {
                 expected,
                 KafkaAvroDeserializer.class,
                 KafkaAvroDeserializer.class,
-                ImmutableMap.of("schema.registry.url", schemaRegistry.getURI().toString())
+                ImmutableMap.of("schema.registry.url", kafkaTestSupport.getSchemaRegistryURI().toString())
         );
-    }
-
-    private static Schema intSchema(String fieldName) {
-        return SchemaBuilder.record("jet.sql")
-                            .fields()
-                            .name(fieldName).type().unionOf().nullType().and().intType().endUnion().nullDefault()
-                            .endRecord();
-    }
-
-    private static Schema stringSchema(String fieldName) {
-        return SchemaBuilder.record("jet.sql")
-                            .fields()
-                            .name(fieldName).type().unionOf().nullType().and().stringType().endUnion().nullDefault()
-                            .endRecord();
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolverTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolverTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.sql.impl.schema.map.MapTableField;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.apache.avro.SchemaBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -145,31 +146,32 @@ public class KvMetadataAvroResolverTest {
                 new MapTableField(prefix, QueryDataType.OBJECT, true, QueryPath.create(prefix))
         );
         assertThat(metadata.getQueryTargetDescriptor()).isEqualTo(AvroQueryTargetDescriptor.INSTANCE);
-        assertThat(metadata.getUpsertTargetDescriptor())
-                .isEqualToComparingFieldByField(new AvroUpsertTargetDescriptor(
-                                "{"
-                                        + "\"type\":\"record\""
-                                        + ",\"name\":\"sql\""
-                                        + ",\"namespace\":\"jet\""
-                                        + ",\"fields\":["
-                                        + "{\"name\":\"string\",\"type\":[\"null\",\"string\"],\"default\":null}"
-                                        + ",{\"name\":\"boolean\",\"type\":[\"null\",\"boolean\"],\"default\":null}"
-                                        + ",{\"name\":\"byte\",\"type\":[\"null\",\"int\"],\"default\":null}"
-                                        + ",{\"name\":\"short\",\"type\":[\"null\",\"int\"],\"default\":null}"
-                                        + ",{\"name\":\"int\",\"type\":[\"null\",\"int\"],\"default\":null}"
-                                        + ",{\"name\":\"long\",\"type\":[\"null\",\"long\"],\"default\":null}"
-                                        + ",{\"name\":\"float\",\"type\":[\"null\",\"float\"],\"default\":null}"
-                                        + ",{\"name\":\"double\",\"type\":[\"null\",\"double\"],\"default\":null}"
-                                        + ",{\"name\":\"decimal\",\"type\":[\"null\",\"string\"],\"default\":null}"
-                                        + ",{\"name\":\"time\",\"type\":[\"null\",\"string\"],\"default\":null}"
-                                        + ",{\"name\":\"date\",\"type\":[\"null\",\"string\"],\"default\":null}"
-                                        + ",{\"name\":\"timestamp\",\"type\":[\"null\",\"string\"],\"default\":null}"
-                                        + ",{\"name\":\"timestampTz\",\"type\":[\"null\",\"string\"],\"default\":null}"
-                                        + ",{\"name\":\"object\",\"type\":[\"null\",\"boolean\",\"int\",\"long\",\"float\",\"double\",\"string\"],\"default\":null}"
-                                        + "]"
-                                        + "}"
-                        )
-                );
+        assertThat(metadata.getUpsertTargetDescriptor()).isEqualToComparingFieldByField(
+                new AvroUpsertTargetDescriptor(SchemaBuilder.record("jet.sql")
+                        .fields()
+                        .name("string").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+                        .name("boolean").type().unionOf().nullType().and().booleanType().endUnion().nullDefault()
+                        .name("byte").type().unionOf().nullType().and().intType().endUnion().nullDefault()
+                        .name("short").type().unionOf().nullType().and().intType().endUnion().nullDefault()
+                        .name("int").type().unionOf().nullType().and().intType().endUnion().nullDefault()
+                        .name("long").type().unionOf().nullType().and().longType().endUnion().nullDefault()
+                        .name("float").type().unionOf().nullType().and().floatType().endUnion().nullDefault()
+                        .name("double").type().unionOf().nullType().and().doubleType().endUnion().nullDefault()
+                        .name("decimal").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+                        .name("time").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+                        .name("date").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+                        .name("timestamp").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+                        .name("timestampTz").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+                        .name("object").type()
+                                .unionOf().nullType()
+                                .and().booleanType()
+                                .and().intType()
+                                .and().longType()
+                                .and().floatType()
+                                .and().doubleType()
+                                .and().stringType()
+                                .endUnion().nullDefault()
+                        .endRecord()));
     }
 
     private static MappingField field(String name, QueryDataType type, String externalName) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTargetDescriptorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTargetDescriptorTest.java
@@ -21,6 +21,8 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -30,17 +32,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class AvroUpsertTargetDescriptorTest {
-
     private static final InternalSerializationService SERIALIZATION_SERVICE =
             new DefaultSerializationServiceBuilder().build();
 
-    private static final String SCHEMA = "{"
-            + "\"type\": \"record\""
-            + ", \"name\": \"name\""
-            + ", \"fields\": ["
-            + " {\"name\": \"name\", \"type\": \"string\"}"
-            + "]"
-            + "} ";
+    private static final Schema SCHEMA = SchemaBuilder.record("name")
+            .fields()
+            .name("name").type().stringType().noDefault()
+            .endRecord();
 
     @Test
     public void test_create() {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTargetTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTargetTest.java
@@ -66,7 +66,7 @@ public class AvroUpsertTargetTest {
                         .endUnion().nullDefault()
                 .endRecord();
 
-        UpsertTarget target = new AvroUpsertTarget(schema.toString());
+        UpsertTarget target = new AvroUpsertTarget(schema);
         UpsertInjector nullInjector = target.createInjector("null", QueryDataType.OBJECT);
         UpsertInjector stringInjector = target.createInjector("string", QueryDataType.VARCHAR);
         UpsertInjector booleanInjector = target.createInjector("boolean", QueryDataType.BOOLEAN);
@@ -156,7 +156,7 @@ public class AvroUpsertTargetTest {
                                      .endUnion().nullDefault()
                                      .endRecord();
 
-        UpsertTarget target = new AvroUpsertTarget(schema.toString());
+        UpsertTarget target = new AvroUpsertTarget(schema);
         UpsertInjector injector = target.createInjector("object", QueryDataType.OBJECT);
 
         target.init();

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTargetTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/AvroUpsertTargetTest.java
@@ -54,16 +54,7 @@ public class AvroUpsertTargetTest {
                 .name("time").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
                 .name("date").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
                 .name("timestamp").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
-                .name("timestampTz").type()
-                        .unionOf()
-                        .nullType()
-                        .and().booleanType()
-                        .and().intType()
-                        .and().longType()
-                        .and().floatType()
-                        .and().doubleType()
-                        .and().stringType()
-                        .endUnion().nullDefault()
+                .name("timestampTz").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
                 .endRecord();
 
         UpsertTarget target = new AvroUpsertTarget(schema);

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
         <commons-codec.version>1.16.0</commons-codec.version>
         <commons-io.version>2.13.0</commons-io.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
+        <confluent.version>7.4.0</confluent.version>
         <felix.utils.version>1.11.6</felix.utils.version>
         <findbugs.annotations.version>3.0.1u2</findbugs.annotations.version>
         <http.core.version>4.4.16</http.core.version>


### PR DESCRIPTION
This PR
1. serializes schema in `AvroUpsertTargetDescriptor` lazily in order to speed up the submission of light jobs with reusable DAGs (8c61e70),
2. fixes `timestampTz` schema in `AvroUpsertTargetTest` (9addac3),
3. refactors Kafka test support (57bf012, hazelcast/hazelcast-enterprise@59f74d9), and
4. tests SQL/Avro schema evolution for combinations of internal/external data/schema changes, different subject name strategies and reusing/updating the Kafka mapping.

EE PR: hazelcast/hazelcast-enterprise#6238

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases