### PR TITLE
Add remoteMapKeys source [data migration tool] [HZ-2582]

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -211,6 +211,9 @@
     <!-- SQL -->
     <suppress checks="FileLength" files="com[\\/]hazelcast[\\/]jet[\\/]sql[\\/]impl[\\/]SqlPlanImpl"/>
 
+    <!-- Jet -->
+    <suppress checks="FileLength" files="[\\/]src[\\/]main[\\/]java[\\/]com[\\/]hazelcast[\\/]jet[\\/]pipeline[\\/]Sources.java"/>
+
     <!-- Security -->
     <suppress checks="Javadoc(Method|Type|Variable)" files="com[\\/]hazelcast[\\/]security[\\/]"/>
     <suppress checks="ClassDataAbstractionCoupling" files="com[\\/]hazelcast[\\/]security[\\/]permission[\\/]ActionConstants"/>

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/JetDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/JetDataSerializerHook.java
@@ -63,6 +63,7 @@ public final class JetDataSerializerHook implements DataSerializerHook {
     public static final int EXPECT_NOTHING_PROCESSOR_SUPPLIER = 19;
     public static final int SPECIFIC_MEMBER_PROCESSOR_META_SUPPLIER = 20;
     public static final int RANDOM_MEMBER_PROCESSOR_META_SUPPLIER = 21;
+    public static final int REMOTE_MAP_KEYS_READER_FUNCTION = 22;
 
     /**
      * Factory ID

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -177,6 +177,15 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
+     * {@link Sources#remoteMapKeys(String, String)}.
+     */
+    @Nonnull
+    public static ProcessorSupplier readRemoteMapKeysP(@Nonnull String mapName, @Nonnull String dataConnectionName) {
+        return HazelcastReaders.readRemoteMapKeysSupplier(mapName, dataConnectionName);
+    }
+
+    /**
+     * Returns a supplier of processors for
      * {@link Sources#remoteMapJournal(String, ClientConfig, JournalInitialPosition)}.
      */
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -168,6 +168,15 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
+     * {@link Sources#remoteMapKeys(String, ClientConfig)}.
+     */
+    @Nonnull
+    public static ProcessorSupplier readRemoteMapKeysP(@Nonnull String mapName, @Nonnull ClientConfig clientConfig) {
+        return HazelcastReaders.readRemoteMapKeysSupplier(mapName, clientConfig);
+    }
+
+    /**
+     * Returns a supplier of processors for
      * {@link Sources#remoteMapJournal(String, ClientConfig, JournalInitialPosition)}.
      */
     @Nonnull

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/HazelcastReaders.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/HazelcastReaders.java
@@ -130,7 +130,7 @@ public final class HazelcastReaders {
             @Nonnull ClientConfig clientConfig
     ) {
         String clientXml = ImdgUtil.asXmlString(clientConfig);
-        return new RemoteProcessorSupplier<>(clientXml, new RemoteCacheReaderFunction(cacheName));
+        return new RemoteProcessorSupplier<>(clientXml, null, new RemoteCacheReaderFunction(cacheName));
     }
 
     public static class RemoteCacheReaderFunction implements FunctionEx<HazelcastInstance,
@@ -298,7 +298,7 @@ public final class HazelcastReaders {
             @Nonnull ClientConfig clientConfig
     ) {
         String clientXml = ImdgUtil.asXmlString(clientConfig);
-        return new RemoteProcessorSupplier<>(clientXml, new RemoteMapReaderFunction(mapName));
+        return new RemoteProcessorSupplier<>(clientXml, null, new RemoteMapReaderFunction(mapName));
     }
 
     @Nonnull
@@ -307,7 +307,15 @@ public final class HazelcastReaders {
             @Nonnull ClientConfig clientConfig
     ) {
         String clientXml = ImdgUtil.asXmlString(clientConfig);
-        return new RemoteProcessorSupplier<>(clientXml, new RemoteMapKeysReaderFunction(mapName));
+        return new RemoteProcessorSupplier<>(clientXml, null, new RemoteMapKeysReaderFunction(mapName));
+    }
+
+    @Nonnull
+    public static ProcessorSupplier readRemoteMapKeysSupplier(
+            @Nonnull String mapName,
+            @Nonnull String dataConnectionName
+    ) {
+        return new RemoteProcessorSupplier<>(null, dataConnectionName, new RemoteMapKeysReaderFunction(mapName));
     }
 
     public static class RemoteMapReaderFunction implements FunctionEx<HazelcastInstance,
@@ -362,7 +370,8 @@ public final class HazelcastReaders {
         }
 
         @Override
-        public ReadMapOrCacheP.Reader<ClientInvocationFuture, MapFetchKeysCodec.ResponseParameters, Data> applyEx(HazelcastInstance hzInstance) throws Exception {
+        public ReadMapOrCacheP.Reader<ClientInvocationFuture, MapFetchKeysCodec.ResponseParameters, Data>
+        applyEx(HazelcastInstance hzInstance) throws Exception {
             return new ReadMapOrCacheP.RemoteMapKeysReader(hzInstance, mapName);
         }
 
@@ -398,7 +407,7 @@ public final class HazelcastReaders {
         checkSerializable(Objects.requireNonNull(projection), "projection");
 
         String clientXml = ImdgUtil.asXmlString(clientConfig);
-        return new RemoteProcessorSupplier<>(clientXml, new RemoteMapQueryReaderFunction<>(mapName, predicate,
+        return new RemoteProcessorSupplier<>(clientXml, null, new RemoteMapQueryReaderFunction<>(mapName, predicate,
                 projection));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
@@ -25,6 +25,7 @@ import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheIterateEntriesCodec;
 import com.hazelcast.client.impl.protocol.codec.MapFetchEntriesCodec;
+import com.hazelcast.client.impl.protocol.codec.MapFetchKeysCodec;
 import com.hazelcast.client.impl.protocol.codec.MapFetchWithQueryCodec;
 import com.hazelcast.client.impl.proxy.ClientMapProxy;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
@@ -635,6 +636,45 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
         @Nullable @Override
         public Entry<Data, Data> toObject(@Nonnull Entry<Data, Data> entry) {
             return new LazyMapEntry<>(entry.getKey(), entry.getValue(), serializationService);
+        }
+    }
+
+    static class RemoteMapKeysReader
+            extends Reader<ClientInvocationFuture, MapFetchKeysCodec.ResponseParameters, Data> {
+
+        private final ClientMapProxy clientMapProxy;
+
+        RemoteMapKeysReader(@Nonnull HazelcastInstance hzInstance,
+                        @Nonnull String mapName) {
+            super(mapName, parameters -> decodePointers(parameters.iterationPointers), parameters -> parameters.keys);
+
+            this.clientMapProxy = (ClientMapProxy) hzInstance.getMap(mapName);
+            this.serializationService = clientMapProxy.getContext().getSerializationService();
+        }
+
+        @Nonnull @Override
+        public ClientInvocationFuture readBatch(int partitionId, IterationPointer[] pointers) {
+            ClientMessage request = MapFetchKeysCodec.encodeRequest(
+                    objectName, encodePointers(pointers), MAX_FETCH_SIZE
+            );
+            ClientInvocation clientInvocation = new ClientInvocation(
+                    (HazelcastClientInstanceImpl) clientMapProxy.getContext().getHazelcastInstance(),
+                    request,
+                    objectName,
+                    partitionId
+            );
+            return clientInvocation.invoke();
+        }
+
+        @Nonnull @Override
+        public MapFetchKeysCodec.ResponseParameters toBatchResult(@Nonnull ClientInvocationFuture future)
+                throws ExecutionException, InterruptedException {
+            return MapFetchKeysCodec.decodeResponse(future.get());
+        }
+
+        @Nullable @Override
+        public Object toObject(@Nonnull Data keyData) {
+            return serializationService.toObject(keyData);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -68,6 +68,7 @@ import static com.hazelcast.jet.core.processor.SourceProcessors.readListP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readMapP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readRemoteCacheP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readRemoteListP;
+import static com.hazelcast.jet.core.processor.SourceProcessors.readRemoteMapKeysP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readRemoteMapP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamCacheP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamMapP;
@@ -596,6 +597,32 @@ public final class Sources {
     ) {
         return batchFromProcessor("remoteMapSource(" + mapName + ')',
                 ProcessorMetaSupplier.of(readRemoteMapP(mapName, clientConfig, predicate, projection)));
+    }
+
+    /**
+     * Returns a source that fetches keys from the Hazelcast {@code IMap}
+     * with the specified name in a remote cluster identified by the supplied
+     * {@code ClientConfig} and emits them.
+     * <p>
+     * The source does not save any state to snapshot. If the job is restarted,
+     * it will re-emit all keys.
+     * <p>
+     * If the {@code IMap} is modified while being read, or if there is a
+     * cluster topology change (triggering data migration), the source may miss
+     * and/or duplicate some keys. If we detect a topology change, the job
+     * will fail, but the detection is only on a best-effort basis - we might
+     * still give incorrect results without reporting a failure. Concurrent
+     * mutation is not detected at all.
+     * <p>
+     * The default local parallelism for this processor is 1.
+     */
+    @Nonnull
+    public static <K> BatchSource<K> remoteMapKeys(
+            @Nonnull String mapName,
+            @Nonnull ClientConfig clientConfig
+    ) {
+        return batchFromProcessor("remoteMapKeysSource(" + mapName + ')',
+                ProcessorMetaSupplier.of(readRemoteMapKeysP(mapName, clientConfig)));
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -626,6 +626,34 @@ public final class Sources {
     }
 
     /**
+     * Returns a source that fetches keys from the Hazelcast {@code IMap}
+     * with the specified name in a remote cluster connected via the data connection identified by the supplied
+     * data connection name and emits them as keys. You can add a data connection config by
+     * {@link com.hazelcast.config.DataConnectionConfig}. If the data connection is not found, this method
+     * will throw a {@link com.hazelcast.core.HazelcastException}.
+     * <p>
+     * The source does not save any state to snapshot. If the job is restarted,
+     * it will re-emit all entries.
+     * <p>
+     * If the {@code IMap} is modified while being read, or if there is a
+     * cluster topology change (triggering data migration), the source may miss
+     * and/or duplicate some entries. If we detect a topology change, the job
+     * will fail, but the detection is only on a best-effort basis - we might
+     * still give incorrect results without reporting a failure. Concurrent
+     * mutation is not detected at all.
+     * <p>
+     * The default local parallelism for this processor is 1.
+     */
+    @Nonnull
+    public static <K> BatchSource<K> remoteMapKeys(
+            @Nonnull String mapName,
+            @Nonnull String dataConnectionName
+    ) {
+        return batchFromProcessor("remoteMapKeysSource(" + mapName + ')',
+                ProcessorMetaSupplier.of(readRemoteMapKeysP(mapName, dataConnectionName)));
+    }
+
+    /**
      * Returns a source that will stream the {@link EventJournalMapEvent}
      * events of the Hazelcast {@code IMap} with the specified name from a
      * remote cluster. By supplying a {@code predicate} and {@code projection}

--- a/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
@@ -227,6 +227,24 @@ public class SourcesTest extends PipelineTestSupport {
     }
 
     @Test
+    public void remoteMapKeys() {
+        // Given
+        List<Integer> input = sequence(itemCount);
+        putToMap(remoteHz.getMap(srcName), input);
+
+        // When
+        BatchSource<Object> source = Sources.remoteMapKeys(srcName, clientConfig);
+
+        // Then
+        p.readFrom(source).writeTo(sink);
+        execute();
+        List<String> expected = input.stream()
+                .map(String::valueOf)
+                .collect(toList());
+        assertEquals(toBag(expected), sinkToBag());
+    }
+
+    @Test
     public void remoteMap() {
         // Given
         List<Integer> input = sequence(itemCount);


### PR DESCRIPTION
[HZ-2582]

adds Sources.remoteMapKeys to iterate over keys instead of entries



[HZ-2582]: https://hazelcast.atlassian.net/browse/HZ-2582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ