### PR TITLE
added assumeDockerEnabled() for ReadJdbcPPropertiesTests (#24946)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPPropertiesTest.java
@@ -108,4 +108,8 @@ public abstract class ReadJdbcPPropertiesTest extends SimpleTestInClusterSupport
 
         instance().getJet().newJob(p).join();
     }
+    @BeforeClass
+    public static void beforeClassCheckDocker() {
+        assumeDockerEnabled();
+    }
 }


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

INSERT_PR_DESCRIPTION_HERE

Fixes INSERT_LINK_TO_THE_ISSUE_HERE

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
