### PR TITLE
Give the possibility to control pool size of Mongo Data Connection

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/dataconnection/MongoDataConnection.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/dataconnection/MongoDataConnection.java
@@ -51,10 +51,12 @@ import static java.util.Collections.singletonList;
  */
 @Beta
 public class MongoDataConnection extends DataConnectionBase {
+
     /**
      * Name of a property which holds connection string to the mongodb instance.
      */
     public static final String CONNECTION_STRING_PROPERTY = "connectionString";
+
     /**
      * Name of a property with a database name hint.
      * This is used as a <strong>hint</strong> only; {@link #listResources} will return only collection from db with this
@@ -67,27 +69,34 @@ public class MongoDataConnection extends DataConnectionBase {
      * Name of the property holding username.
      */
     public static final String USERNAME_PROPERTY = "username";
+
     /**
      * Name of the property holding user password.
      */
     public static final String PASSWORD_PROPERTY = "password";
+
     /**
      * Name of a property which holds host:port address of the mongodb instance.
      */
     public static final String HOST_PROPERTY = "host";
+
     /**
      * Name of the property holding the name of the database in which user is created.
      * Default value is {@code admin}.
      */
     public static final String AUTH_DB_PROPERTY = "authDb";
+
     /**
      * Name of the property holding the minimum size of Mongo Client connection pool.
      * Default is 10.
+     * @since 5.4
      */
     public static final String CONNECTION_POOL_MIN = "connectionPoolMinSize";
+
     /**
      * Name of the property holding the maximum size of Mongo Client connection pool.
      * Default is 0, which means unlimited.
+     * @since 5.4
      */
     public static final String CONNECTION_POOL_MAX = "connectionPoolMaxSize";
 

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/dataconnection/MongoDataConnection.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/dataconnection/MongoDataConnection.java
@@ -95,7 +95,7 @@ public class MongoDataConnection extends DataConnectionBase {
 
     /**
      * Name of the property holding the maximum size of Mongo Client connection pool.
-     * Default is 0, which means unlimited.
+     * Default is 10.
      * @since 5.4
      */
     public static final String CONNECTION_POOL_MAX = "connectionPoolMaxSize";
@@ -125,7 +125,10 @@ public class MongoDataConnection extends DataConnectionBase {
         this.host = config.getProperty(HOST_PROPERTY);
         this.authDb = config.getProperty(AUTH_DB_PROPERTY, "admin");
         this.connectionPoolMinSize = Integer.parseInt(config.getProperty(CONNECTION_POOL_MIN, "10"));
-        this.connectionPoolMaxSize = Integer.parseInt(config.getProperty(CONNECTION_POOL_MAX, "0"));
+        this.connectionPoolMaxSize = Integer.parseInt(config.getProperty(CONNECTION_POOL_MAX, "10"));
+
+        checkState(connectionPoolMinSize <= connectionPoolMaxSize, "connection pool max size" +
+                " cannot be lower than min size");
 
         checkState(allSame((username == null), (password == null), (host == null)),
         "You have to provide connectionString property or combination of username, password and host");
@@ -149,7 +152,6 @@ public class MongoDataConnection extends DataConnectionBase {
         return true;
     }
 
-    @SuppressWarnings("checkstyle:MagicNumber")
     private MongoClient createClient() {
         try {
             if (connectionString != null) {
@@ -168,8 +170,8 @@ public class MongoDataConnection extends DataConnectionBase {
                                                  .credential(credential);
             return MongoClients.create(builder.build());
         } catch (Exception e) {
-            throw new HazelcastException("Unable to create Mongo client for data connection '" + name + "'",
-                    e);
+            throw new HazelcastException("Unable to create Mongo client for data connection '" + name + "'"
+                    + e.getMessage(), e);
         }
     }
 
@@ -263,7 +265,7 @@ public class MongoDataConnection extends DataConnectionBase {
         dataConnectionConfig.setName(name);
         dataConnectionConfig.setShared(true);
         dataConnectionConfig.setProperty(CONNECTION_STRING_PROPERTY, connectionString);
-        dataConnectionConfig.setType("MongoDB");
+        dataConnectionConfig.setType("Mongo");
         return dataConnectionConfig;
     }
 }


### PR DESCRIPTION
By default it's min=zero, which is suboptimal for point-like queries (e.g. select by key). It takes more time to set up a connection than to perform actual query.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
