### PR TITLE
Make MigrationListener timers use wall-clock not CPU time [HZ-2651]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationStats.java
@@ -45,89 +45,40 @@ import static com.hazelcast.internal.metrics.ProbeUnit.NS;
  */
 public class MigrationStats {
 
-    /**
-     * In {@link TimeUnit#MILLISECONDS}
-     *
-     * @see #getLastRepartitionTime()
-     */
     @Probe(name = MIGRATION_METRIC_LAST_REPARTITION_TIME, unit = MS)
     private final AtomicLong lastRepartitionTime = new AtomicLong();
 
-    /**
-     * In {@link TimeUnit#NANOSECONDS}
-     *
-     * @see #getPlannedMigrations()
-     */
     @Probe(name = MIGRATION_METRIC_PLANNED_MIGRATIONS)
     private volatile int plannedMigrations;
 
-    /**
-     * In {@link TimeUnit#NANOSECONDS}
-     *
-     * @see #getCompletedMigrations()
-     */
     @Probe(name = MIGRATION_METRIC_COMPLETED_MIGRATIONS)
     private final AtomicInteger completedMigrations = new AtomicInteger();
 
-    /**
-     * In {@link TimeUnit#NANOSECONDS}
-     *
-     * @see #getTotalCompletedMigrations()
-     */
     @Probe(name = MIGRATION_METRIC_TOTAL_COMPLETED_MIGRATIONS)
     private final AtomicInteger totalCompletedMigrations = new AtomicInteger();
 
-    /**
-     * In {@link TimeUnit#NANOSECONDS}
-     *
-     * @see #getElapsedMigrationOperationTime()
-     */
     @Probe(name = MIGRATION_METRIC_ELAPSED_MIGRATION_OPERATION_TIME, unit = NS)
     private final AtomicLong elapsedMigrationOperationTime = new AtomicLong();
 
-    /**
-     * In {@link TimeUnit#NANOSECONDS}
-     *
-     * @see #getElapsedDestinationCommitTime()
-     */
     @Probe(name = MIGRATION_METRIC_ELAPSED_DESTINATION_COMMIT_TIME, unit = NS)
     private final AtomicLong elapsedDestinationCommitTime = new AtomicLong();
 
-    /**
-     * In {@link TimeUnit#NANOSECONDS}
-     *
-     * @see #getElapsedMigrationTime()
-     */
     @Probe(name = MIGRATION_METRIC_ELAPSED_MIGRATION_TIME, unit = NS)
     private final AtomicLong elapsedMigrationTime = new AtomicLong();
 
-    /**
-     * In {@link TimeUnit#NANOSECONDS}
-     *
-     * @see #getTotalElapsedMigrationOperationTime()
-     */
     @Probe(name = MIGRATION_METRIC_TOTAL_ELAPSED_MIGRATION_OPERATION_TIME, unit = NS)
     private final AtomicLong totalElapsedMigrationOperationTime = new AtomicLong();
 
-    /**
-     * In {@link TimeUnit#NANOSECONDS}
-     *
-     * @see #getTotalElapsedDestinationCommitTime()
-     */
     @Probe(name = MIGRATION_METRIC_TOTAL_ELAPSED_DESTINATION_COMMIT_TIME, unit = NS)
     private final AtomicLong totalElapsedDestinationCommitTime = new AtomicLong();
 
-    /**
-     * In {@link TimeUnit#NANOSECONDS}
-     *
-     * @see #getTotalElapsedMigrationTime()
-     */
     @Probe(name = MIGRATION_METRIC_TOTAL_ELAPSED_MIGRATION_TIME, unit = NS)
     private final AtomicLong totalElapsedMigrationTime = new AtomicLong();
 
     /**
      * Marks start of new repartitioning.
      * Resets stats from previous repartitioning round.
+     *
      * @param migrations number of planned migration tasks
      */
     void markNewRepartition(int migrations) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationStats.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.partition.MigrationStateImpl;
 import com.hazelcast.internal.util.Clock;
 import com.hazelcast.partition.MigrationState;
 
-import java.time.Duration;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -98,8 +97,7 @@ public class MigrationStats {
     private void calculateElapsed(final AtomicLong elapsedTime, final AtomicLong totalElapsedTime) {
         // This is called from each migration thread, so calculate the wall-clock time, rather than summing each
         // individual threads execution time
-        final long newElapsed =
-                Duration.ofMillis(Clock.currentTimeMillis()).minusMillis(lastRepartitionTime.get()).toNanos();
+        final long newElapsed = TimeUnit.MILLISECONDS.toNanos(Clock.currentTimeMillis() - lastRepartitionTime.get());
 
         final long oldElapsed = elapsedTime.getAndSet(newElapsed);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationStats.java
@@ -105,7 +105,7 @@ public class MigrationStats {
     private void calculateElapsed(final AtomicLong elapsedTime, final AtomicLong totalElapsedTime) {
         // This is called from each migration thread, so calculate the wall-clock time, rather than summing each
         // individual threads execution time
-        final long newElapsed = TimeUnit.MILLISECONDS.toNanos(Clock.currentTimeMillis()) - lastRepartitionNanos.get();
+        final long newElapsed = System.nanoTime() - lastRepartitionNanos.get();
 
         final long oldElapsed = elapsedTime.getAndSet(newElapsed);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationStats.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.partition.impl;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.partition.MigrationStateImpl;
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.internal.util.Timer;
 import com.hazelcast.partition.MigrationState;
 
 import java.util.Date;
@@ -89,7 +90,7 @@ public class MigrationStats {
      */
     void markNewRepartition(int migrations) {
         lastRepartitionTime.set(Clock.currentTimeMillis());
-        lastRepartitionNanos.set(System.nanoTime());
+        lastRepartitionNanos.set(Timer.nanos());
         plannedMigrations = migrations;
         elapsedMigrationOperationTime.set(0);
         elapsedDestinationCommitTime.set(0);
@@ -105,7 +106,7 @@ public class MigrationStats {
     private void calculateElapsed(final AtomicLong elapsedTime, final AtomicLong totalElapsedTime) {
         // This is called from each migration thread, so calculate the wall-clock time, rather than summing each
         // individual threads execution time
-        final long newElapsed = System.nanoTime() - lastRepartitionNanos.get();
+        final long newElapsed = Timer.nanosElapsed(lastRepartitionNanos.get());
 
         final long oldElapsed = elapsedTime.getAndSet(newElapsed);
 

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -387,8 +387,9 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
         LOGGER.fine(message);
         assertTrue(message, migrationTimer.elapsed().compareTo(reportedMigrationTime) >= 0);
     }
-    
-    private HazelcastInstance createPausedMigrationCluster(final TestHazelcastInstanceFactory factory, final Optional<Config> config) {
+
+    private HazelcastInstance createPausedMigrationCluster(final TestHazelcastInstanceFactory factory,
+            final Optional<Config> config) {
         LOGGER.fine("Starting paused migration instance...");
         final HazelcastInstance hazelcastInstance = factory.newHazelcastInstance(config.orElse(null));
         warmUpPartitions(hazelcastInstance);
@@ -396,7 +397,7 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
         // Change to NO_MIGRATION to prevent repartitioning
         // before 2nd member started and ready.
         hazelcastInstance.getCluster().changeClusterState(ClusterState.NO_MIGRATION);
-        
+
         return hazelcastInstance;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -382,13 +382,19 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
         assertFalse(reportedMigrationDuration.isZero());
 
         final String message = MessageFormat.format("migrationState.getTotalElapsedTime={1}, migrationTimer={0}",
-                migrationTimer.elapsed().toMillis(),
-                reportedMigrationDuration.toMillis());
+                formatDuration(migrationTimer.elapsed()), formatDuration(reportedMigrationDuration));
 
         LOGGER.fine(message);
         assertTrue(MessageFormat.format("Reported migrationState.getTotalElapsedTime() was greater than the migration"
                         + " execution time recorded - {0}", message),
                 migrationTimer.elapsed().compareTo(reportedMigrationDuration) >= 0);
+    }
+
+    /**
+     * @see <a href="https://github.com/hazelcast/hazelcast/pull/25028#discussion_r1266692838">Discussion</a>
+     */
+    private static String formatDuration(final Duration duration) {
+        return MessageFormat.format("{0} {1}", duration.toMillis(), TimeUnit.MILLISECONDS.name().toLowerCase());
     }
 
     private HazelcastInstance createPausedMigrationCluster(final TestHazelcastInstanceFactory factory,

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nullable;
 import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -454,7 +455,7 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
     }
 
     private HazelcastInstance createPausedMigrationCluster(final TestHazelcastInstanceFactory factory,
-                                                           final Config config) {
+                                                           @Nullable final Config config) {
         LOGGER.fine("Starting paused migration instance...");
         final HazelcastInstance hazelcastInstance = factory.newHazelcastInstance(config);
         warmUpPartitions(hazelcastInstance);

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -16,39 +16,6 @@
 
 package com.hazelcast.partition;
 
-import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
-import static com.hazelcast.test.Accessors.getPartitionService;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
-import java.text.MessageFormat;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
 import com.google.common.base.Stopwatch;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
@@ -67,6 +34,38 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.text.MessageFormat;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
+import static com.hazelcast.test.Accessors.getPartitionService;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})


### PR DESCRIPTION
The Javadoc on `MigrationStats` implied that the times recorded were wall-clock execution time, but the implementation was recording the execution time of each migration thread.

Resolved by deriving the migration times from the difference between the start of the migration (`lastRepartitionTime`) and completion time, rather than explicitly timing the operation in each thread.

Fixes [HZ-2651](https://hazelcast.atlassian.net/browse/HZ-2651)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc

[HZ-2651]: https://hazelcast.atlassian.net/browse/HZ-2651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ