### PR TITLE
Improve assertion in SplitBrainTest [HZ-1826] [5.2.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -179,8 +179,16 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
 
         Consumer<HazelcastInstance[]> afterMerge = instances -> {
             assertTrueEventually(() -> {
-                assertEquals(clusterSize * 2, MockPS.initCount.get());
-                assertEquals(clusterSize * 2, MockPS.closeCount.get());
+                // Members may be slow when joining and the job may start when the cluster reaches quorum size,
+                // but not all members have joined.
+                // The expected initCount is between
+                // clusterSize (first start of the job) + quorumSize (size of the cluster when quorum is met)
+                // and clusterSize * 2 (start of the job on all members before split and after healing split
+                int quorumSize = clusterSize / 2 + 1;
+                assertThat(MockPS.initCount.get()).isBetween(clusterSize + quorumSize, clusterSize * 2);
+
+                // Close count must match init count
+                assertThat(MockPS.closeCount.get()).isEqualTo(MockPS.initCount.get());
             });
 
             assertEquals(clusterSize, MockPS.receivedCloseErrors.size());

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -47,6 +47,7 @@ import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.NOT_RUNNING;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.JobStatus.STARTING;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
Members may be slow when joining and the job may start when the cluster reaches quorum size, but not all members have joined.

Fixes #19326

Backport of #25034

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
