### PR TITLE
Sets connection and read timeout values of RestClient used in Kubernetes Discovery [CN-908] [5.3.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -67,6 +67,9 @@ class KubernetesClient {
     private static final int HTTP_UNAUTHORIZED = 401;
     private static final int HTTP_FORBIDDEN = 403;
 
+    private static final int CONNECTION_TIMEOUT_SECONDS = 10;
+    private static final int READ_TIMEOUT_SECONDS = 10;
+
     private static final List<String> NON_RETRYABLE_KEYWORDS = asList(
             "\"reason\":\"Forbidden\"",
             "\"reason\":\"NotFound\"",
@@ -592,6 +595,8 @@ class KubernetesClient {
                 .parse(RestClient.create(urlString)
                         .withHeader("Authorization", String.format("Bearer %s", tokenProvider.getToken()))
                         .withCaCertificates(caCertificate)
+                        .withConnectTimeoutSeconds(CONNECTION_TIMEOUT_SECONDS)
+                        .withReadTimeoutSeconds(READ_TIMEOUT_SECONDS)
                         .get()
                         .getBody())
                 .asObject(), retries, NON_RETRYABLE_KEYWORDS);


### PR DESCRIPTION
Set connection and read timeouts configuration of RestClient in order to avoid infinite timeout in calls to Kubernetes API.

Fixes #24163

Backport of #25025

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases