### PR TITLE
Avoid re-creating MapContainer when collecting statistics [HZ-2745]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -350,7 +350,10 @@ public class LocalMapStatsProvider {
     }
 
     private void addIndexStats(String mapName, LocalMapStatsImpl localMapStats) {
-        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+        MapContainer mapContainer = mapServiceContext.getExistingMapContainer(mapName);
+        if (mapContainer == null) {
+            return;
+        }
         Indexes globalIndexes = mapContainer.getIndexes();
 
         Map<String, OnDemandIndexStats> freshStats = null;


### PR DESCRIPTION
In `GenericMapStoreIntegrationTest.testDestroy` we destroy a map. The map gets re-created when the destroy happens in the middle of statistics collection. The re-creation causes a MapStore to be initialized again and it causes failure reported in #24428 and #24935. See stacktrace [here](https://github.com/hazelcast/hazelcast/issues/24428#issuecomment-1643951555).

Fixes #24428
Fixes #24935

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
