### PR TITLE
Stop partition compactor before migrating compactor [HZ-2697]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -80,6 +80,7 @@ import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.eventservice.EventFilter;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
+import com.hazelcast.spi.impl.operationservice.Operation;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -477,7 +478,11 @@ class MapServiceContextImpl implements MapServiceContext {
         final List<LocalRetryableExecution> executions = new ArrayList<>();
 
         for (PartitionContainer container : partitionContainers) {
-            final MapPartitionDestroyOperation op = new MapPartitionDestroyOperation(container, mapContainer);
+            Operation op = new MapPartitionDestroyOperation(container, mapContainer)
+                    .setNodeEngine(nodeEngine)
+                    .setCallerUuid(nodeEngine.getLocalMember().getUuid())
+                    .setServiceName(SERVICE_NAME);
+
             executions.add(InvocationUtil.executeLocallyWithRetry(nodeEngine, op));
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -478,7 +478,8 @@ class MapServiceContextImpl implements MapServiceContext {
         final List<LocalRetryableExecution> executions = new ArrayList<>();
 
         for (PartitionContainer container : partitionContainers) {
-            Operation op = new MapPartitionDestroyOperation(container, mapContainer)
+            Operation op = new MapPartitionDestroyOperation(mapContainer.getName())
+                    .setPartitionId(container.getPartitionId())
                     .setNodeEngine(nodeEngine)
                     .setCallerUuid(nodeEngine.getLocalMember().getUuid())
                     .setServiceName(SERVICE_NAME);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapLocalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapLocalOperation.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 
 abstract class AbstractMapLocalOperation extends MapOperation {
 
+    AbstractMapLocalOperation() {
+    }
+
     AbstractMapLocalOperation(String name) {
         super(name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapLocalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapLocalOperation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+
+abstract class AbstractMapLocalOperation extends MapOperation {
+
+    AbstractMapLocalOperation(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+
+    @Override
+    public int getFactoryId() {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+
+    @Override
+    public int getClassId() {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapLocalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapLocalOperation.java
@@ -21,6 +21,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 
+/**
+ * Used when no serialization of {@link MapOperation} is desired.
+ *
+ * @see com.hazelcast.spi.impl.operationservice.AbstractLocalOperation
+ */
 abstract class AbstractMapLocalOperation extends MapOperation {
 
     AbstractMapLocalOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -422,7 +422,7 @@ public abstract class MapOperation extends AbstractNamedOperation
     public ObjectNamespace getServiceNamespace() {
         MapContainer container = mapContainer;
         if (container == null) {
-            throw new IllegalStateException("There is no such map with name " + name + " exists ");
+            return MapService.getObjectNamespace(name);
         }
         return container.getObjectNamespace();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -121,14 +121,10 @@ public abstract class MapOperation extends AbstractNamedOperation
         MapConfig mapConfig = mapContainer.getMapConfig();
         MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();
 
-        boolean hasUserConfiguredOffload = mapServiceContext.isForceOffloadEnabled()
-                || (mapStoreConfig.isOffload()
-                && recordStore != null
-                && recordStore.getMapDataStore() != MapDataStores.EMPTY_MAP_DATA_STORE);
-
         // check if mapStoreOffloadEnabled is true for this operation
         mapStoreOffloadEnabled = recordStore != null
-                && hasUserConfiguredOffload
+                && (mapServiceContext.isForceOffloadEnabled()
+                || (mapStoreConfig.isOffload() && hasMapStoreImplementation()))
                 && getStartingStep() != null;
 
         // check if tieredStoreOffloadEnabled for this operation
@@ -139,6 +135,10 @@ public abstract class MapOperation extends AbstractNamedOperation
         assertNativeMapOnPartitionThread();
 
         innerBeforeRun();
+    }
+
+    private boolean hasMapStoreImplementation() {
+        return recordStore.getMapDataStore() != MapDataStores.EMPTY_MAP_DATA_STORE;
     }
 
     public boolean isTieredStoreAndPartitionCompactorEnabled() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -107,6 +107,9 @@ public abstract class MapOperation extends AbstractNamedOperation
         try {
             recordStore = getRecordStoreOrNull();
             if (recordStore == null) {
+                if (!createRecordStoreOnDemand) {
+                    return;
+                }
                 mapContainer = mapServiceContext.getMapContainer(name);
             } else {
                 mapContainer = recordStore.getMapContainer();
@@ -419,8 +422,7 @@ public abstract class MapOperation extends AbstractNamedOperation
     public ObjectNamespace getServiceNamespace() {
         MapContainer container = mapContainer;
         if (container == null) {
-            MapService service = getService();
-            container = service.getMapServiceContext().getMapContainer(name);
+            throw new IllegalStateException("There is no such map with name " + name + " exists ");
         }
         return container.getObjectNamespace();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -67,6 +67,7 @@ import static com.hazelcast.map.impl.operation.steps.engine.StepRunner.isStepRun
 import static com.hazelcast.spi.impl.operationservice.CallStatus.RESPONSE;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.VOID;
 import static com.hazelcast.spi.impl.operationservice.CallStatus.WAIT;
+import static java.lang.String.format;
 
 @SuppressWarnings("checkstyle:methodcount")
 public abstract class MapOperation extends AbstractNamedOperation
@@ -108,7 +109,7 @@ public abstract class MapOperation extends AbstractNamedOperation
             recordStore = getRecordStoreOrNull();
             mapContainer = getMapContainerOrNull();
             if (mapContainer == null) {
-                // no map exists
+                logNoSuchMapExists();
                 return;
             }
         } catch (Throwable t) {
@@ -135,6 +136,14 @@ public abstract class MapOperation extends AbstractNamedOperation
         assertNativeMapOnPartitionThread();
 
         innerBeforeRun();
+    }
+
+    private void logNoSuchMapExists() {
+        ILogger logger = logger();
+        if (logger.isFinestEnabled()) {
+            logger.finest(format("No such map exists [mapName=%s, operation=%s]",
+                    name, getClass().getName()));
+        }
     }
 
     private MapContainer getMapContainerOrNull() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl.operation;
 
 
-import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.operation.steps.UtilSteps;
 import com.hazelcast.map.impl.operation.steps.engine.Step;
@@ -30,19 +29,17 @@ import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 public class MapPartitionDestroyOperation extends AbstractMapLocalOperation
         implements PartitionAwareOperation, AllowedDuringPassiveState {
 
-    private final PartitionContainer partitionContainer;
-    private final MapContainer mapContainer;
+    public MapPartitionDestroyOperation() {
+    }
 
-    public MapPartitionDestroyOperation(PartitionContainer container, MapContainer mapContainer) {
-        super(mapContainer.getName());
-
-        this.partitionContainer = container;
-        this.mapContainer = mapContainer;
-        setPartitionId(partitionContainer.getPartitionId());
+    public MapPartitionDestroyOperation(String mapName) {
+        super(mapName);
     }
 
     @Override
     protected void runInternal() {
+        PartitionContainer partitionContainer = getMapContainer().getMapServiceContext()
+                .getPartitionContainer(getPartitionId());
         partitionContainer.destroyMap(mapContainer);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
@@ -39,11 +39,7 @@ public class MapPartitionDestroyOperation extends AbstractMapLocalOperation
 
     @Override
     protected void runInternal() {
-        if (recordStore == null || mapContainer == null) {
-            return;
-        }
-
-        PartitionContainer partitionContainer = getMapContainer().getMapServiceContext()
+        PartitionContainer partitionContainer = mapContainer.getMapServiceContext()
                 .getPartitionContainer(getPartitionId());
         partitionContainer.destroyMap(mapContainer);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
@@ -34,10 +34,15 @@ public class MapPartitionDestroyOperation extends AbstractMapLocalOperation
 
     public MapPartitionDestroyOperation(String mapName) {
         super(mapName);
+        this.createRecordStoreOnDemand = false;
     }
 
     @Override
     protected void runInternal() {
+        if (recordStore == null || mapContainer == null) {
+            return;
+        }
+
         PartitionContainer partitionContainer = getMapContainer().getMapServiceContext()
                 .getPartitionContainer(getPartitionId());
         partitionContainer.destroyMap(mapContainer);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
@@ -39,6 +39,10 @@ public class MapPartitionDestroyOperation extends AbstractMapLocalOperation
 
     @Override
     protected void runInternal() {
+        if (mapContainer == null) {
+            // if we are here, this means no such map exists
+            return;
+        }
         PartitionContainer partitionContainer = mapContainer.getMapServiceContext()
                 .getPartitionContainer(getPartitionId());
         partitionContainer.destroyMap(mapContainer);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
@@ -19,27 +19,36 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.PartitionContainer;
-import com.hazelcast.spi.impl.operationservice.AbstractLocalOperation;
-import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
+import com.hazelcast.map.impl.operation.steps.UtilSteps;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 
 /**
  * Operation to destroy the map data on the partition thread
  */
-public class MapPartitionDestroyOperation extends AbstractLocalOperation
+public class MapPartitionDestroyOperation extends AbstractMapLocalOperation
         implements PartitionAwareOperation, AllowedDuringPassiveState {
+
     private final PartitionContainer partitionContainer;
     private final MapContainer mapContainer;
 
     public MapPartitionDestroyOperation(PartitionContainer container, MapContainer mapContainer) {
+        super(mapContainer.getName());
+
         this.partitionContainer = container;
         this.mapContainer = mapContainer;
         setPartitionId(partitionContainer.getPartitionId());
     }
 
     @Override
-    public void run() {
+    protected void runInternal() {
         partitionContainer.destroyMap(mapContainer);
+    }
+
+    @Override
+    public Step getStartingStep() {
+        return UtilSteps.DIRECT_RUN_STEP;
     }
 
     @Override


### PR DESCRIPTION
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/6248

**Modification:**
Added Step support for MapPartitionDestroyOperation. So destroy will be in order with other map operations. Means if there is ongoing compaction it will wait.