### PR TITLE
Make MigrationListener timers use wall-clock not CPU time [5.1.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -1453,7 +1453,7 @@ public class MigrationManager {
             }
 
             return future.handleAsync((done, t) -> {
-                stats.recordMigrationOperationTime(Timer.nanosElapsed(start));
+                stats.recordMigrationOperationTime();
                 logger.fine("Migration operation response received -> " + migration + ", success: " + done + ", failure: " + t);
 
                 if (t != null) {
@@ -1482,12 +1482,10 @@ public class MigrationManager {
                     return CompletableFuture.completedFuture(false);
                 }
             }, asyncExecutor).handleAsync((result, t) -> {
-                long elapsed = Timer.nanosElapsed(start);
-                stats.recordMigrationTaskTime(elapsed);
+                stats.recordMigrationTaskTime();
 
-                PartitionEventManager partitionEventManager = partitionService.getPartitionEventManager();
-                partitionEventManager.sendMigrationEvent(stats.toMigrationState(), migration,
-                        TimeUnit.NANOSECONDS.toMillis(elapsed));
+                partitionService.getPartitionEventManager().sendMigrationEvent(stats.toMigrationState(), migration,
+                        TimeUnit.NANOSECONDS.toMillis(Timer.nanosElapsed(start)));
 
                 if (t != null) {
                     Level level = nodeEngine.isRunning() ? Level.WARNING : Level.FINE;
@@ -1577,11 +1575,10 @@ public class MigrationManager {
          */
         private CompletionStage<Boolean> migrationOperationSucceeded() {
             migrationInterceptor.onMigrationComplete(MigrationParticipant.MASTER, migration, true);
-            long start = System.nanoTime();
 
             CompletionStage<Boolean> f = commitMigrationToDestinationAsync(migration);
             f = f.thenApplyAsync(commitSuccessful -> {
-                stats.recordDestinationCommitTime(System.nanoTime() - start);
+                stats.recordDestinationCommitTime();
 
                 partitionServiceLock.lock();
                 try {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationTimer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationTimer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.impl;
+
+import com.hazelcast.internal.util.Timer;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAccumulator;
+
+/**
+ * the total elapsed time of executions from source to destination endpoints
+ */
+public class MigrationTimer {
+    /**
+     * on the latest repartitioning round.
+     */
+    private final LongAccumulator elapsedNanoseconds = new LongAccumulator(Long::max, 0);
+
+    /**
+     * the sum of all previous rounds, except the latest, since the beginning.
+     */
+    private volatile long lastTotalElapsedNanoseconds;
+
+    protected void markNewRepartition() {
+        lastTotalElapsedNanoseconds = getTotalElapsedNanoseconds();
+        elapsedNanoseconds.reset();
+    }
+
+    protected void calculateElapsed(final long lastRepartitionNanos) {
+        elapsedNanoseconds.accumulate(Timer.nanosElapsed(lastRepartitionNanos));
+    }
+
+    /**
+     * @return nanoseconds
+     * @see #elapsedNanoseconds
+     */
+    public long getElapsedNanoseconds() {
+        return elapsedNanoseconds.get();
+    }
+
+    /**
+     * @return milliseconds
+     * @see #elapsedNanoseconds
+     */
+    public long getElapsedMilliseconds() {
+        return TimeUnit.NANOSECONDS.toMillis(getElapsedNanoseconds());
+    }
+
+    /**
+     * @return the sum of all previous rounds, since the beginning - nanoseconds
+     */
+    public long getTotalElapsedNanoseconds() {
+        return lastTotalElapsedNanoseconds + getElapsedNanoseconds();
+    }
+
+    /**
+     * @return the sum of all previous rounds, since the beginning - milliseconds
+     */
+    public long getTotalElapsedMilliseconds() {
+        return TimeUnit.NANOSECONDS.toMillis(getTotalElapsedNanoseconds());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationTimer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
 
 import static com.hazelcast.internal.metrics.impl.FieldProbe.createFieldProbe;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
@@ -66,6 +68,8 @@ public class FieldProbeTest extends HazelcastTestSupport {
         getLong("intField", 10);
         getLong("longField", 10);
         getLong("atomicLongField", 10);
+        getLong("longAccumulatorField", 10);
+        getLong("longAdderField", 10);
         getLong("atomicIntegerField", 10);
         getLong("counterField", 10);
         getLong("collectionField", 10);
@@ -78,6 +82,8 @@ public class FieldProbeTest extends HazelcastTestSupport {
         getLong("LongField", 10);
 
         getLong("nullAtomicLongField", 0);
+        getLong("nullLongAccumulatorField", 0);
+        getLong("nullLongAdderField", 0);
         getLong("nullAtomicIntegerField", 0);
         getLong("nullCounterField", 0);
         getLong("nullCollectionField", 0);
@@ -129,56 +135,64 @@ public class FieldProbeTest extends HazelcastTestSupport {
 
     private class SomeSource {
         @Probe(name = "byteField")
-        private byte byteField = 10;
+        private final byte byteField = 10;
         @Probe(name = "shortField")
-        private short shortField = 10;
+        private final short shortField = 10;
         @Probe(name = "intField")
-        private int intField = 10;
+        private final int intField = 10;
         @Probe(name = "longField")
-        private long longField = 10;
+        private final long longField = 10;
 
         @Probe(name = "floatField")
-        private float floatField = 10;
+        private final float floatField = 10;
         @Probe(name = "doubleField")
-        private double doubleField = 10;
+        private final double doubleField = 10;
 
         @Probe(name = "atomicLongField")
-        private AtomicLong atomicLongField = new AtomicLong(10);
+        private final AtomicLong atomicLongField = new AtomicLong(10);
         @Probe(name = "nullAtomicLongField")
         private AtomicLong nullAtomicLongField;
+        @Probe(name = "longAdderField")
+        private final LongAdder longAdderField = new LongAdder();
+        @Probe(name = "nullLongAdderField")
+        private LongAdder nullLongAdderField;
+        @Probe(name = "longAccumulatorField")
+        private final LongAccumulator longAccumulatorField = new LongAccumulator(Long::sum, 10);
+        @Probe(name = "nullLongAccumulatorField")
+        private LongAccumulator nullLongAccumulatorField;
         @Probe(name = "atomicIntegerField")
-        private AtomicInteger atomicIntegerField = new AtomicInteger(10);
+        private final AtomicInteger atomicIntegerField = new AtomicInteger(10);
         @Probe(name = "nullAtomicIntegerField")
         private AtomicInteger nullAtomicIntegerField;
         @Probe(name = "counterField")
-        private Counter counterField = newSwCounter(10);
+        private final Counter counterField = newSwCounter(10);
         @Probe(name = "nullCounterField")
         private Counter nullCounterField;
         @Probe(name = "collectionField")
-        private Collection collectionField = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        private final Collection collectionField = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         @Probe(name = "nullCollectionField")
         private Collection nullCollectionField;
         @Probe(name = "mapField")
-        private Map mapField = MetricsUtils.createMap(10);
+        private final Map mapField = MetricsUtils.createMap(10);
         @Probe(name = "nullMapField")
         private Map nullMapField;
         @Probe(name = "semaphoreField")
-        private Semaphore semaphoreField = new Semaphore(10);
+        private final Semaphore semaphoreField = new Semaphore(10);
         @Probe(name = "nullSemaphoreField")
         private Semaphore nullSemaphoreField;
 
         @Probe(name = "ByteField")
-        private Byte ByteField = (byte) 10;
+        private final Byte ByteField = (byte) 10;
         @Probe(name = "ShortField")
-        private Short ShortField = (short) 10;
+        private final Short ShortField = (short) 10;
         @Probe(name = "IntegerField")
-        private Integer IntegerField = 10;
+        private final Integer IntegerField = 10;
         @Probe(name = "LongField")
-        private Long LongField = (long) 10;
+        private final Long LongField = (long) 10;
         @Probe(name = "FloatField")
-        private Float FloatField = (float) 10;
+        private final Float FloatField = (float) 10;
         @Probe(name = "DoubleField")
-        private Double DoubleField = (double) 10;
+        private final Double DoubleField = (double) 10;
 
         @Probe(name = "nullByteField")
         private Byte nullByteField;
@@ -193,5 +207,8 @@ public class FieldProbeTest extends HazelcastTestSupport {
         @Probe(name = "nullDoubleField")
         private Double nullDoubleField;
 
+        private SomeSource() {
+            longAdderField.add(10);
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -16,15 +16,20 @@
 
 package com.hazelcast.partition;
 
+import com.google.common.base.Stopwatch;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.metrics.MetricDescriptorConstants;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.partition.MigrationStateImpl;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.MigrationInterceptor;
 import com.hazelcast.internal.partition.impl.MigrationStats;
 import com.hazelcast.internal.util.UuidUtil;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -36,15 +41,23 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nullable;
+import java.text.MessageFormat;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
+import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.test.Accessors.getPartitionService;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -65,16 +78,12 @@ import static org.mockito.Mockito.verify;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class PartitionMigrationListenerTest extends HazelcastTestSupport {
+    private static final ILogger LOGGER = Logger.getLogger(PartitionMigrationListenerTest.class);
 
     @Test
     public void testMigrationStats_whenMigrationProcessCompletes() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
-        HazelcastInstance hz1 = factory.newHazelcastInstance();
-        warmUpPartitions(hz1);
-
-        // Change to NO_MIGRATION to prevent repartitioning
-        // before 2nd member started and ready.
-        hz1.getCluster().changeClusterState(ClusterState.NO_MIGRATION);
+        HazelcastInstance hz1 = createPausedMigrationCluster(factory, null);
 
         EventCollectingMigrationListener listener = new EventCollectingMigrationListener();
         hz1.getPartitionService().addMigrationListener(listener);
@@ -97,14 +106,14 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
         config.setProperty(ClusterProperty.PARTITION_COUNT.getName(), String.valueOf(partitionCount));
         config.setProperty(ClusterProperty.PARTITION_MAX_PARALLEL_MIGRATIONS.getName(), String.valueOf(1));
 
-        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
-        warmUpPartitions(hz1);
+        HazelcastInstance hz1 = createPausedMigrationCluster(factory, config);
 
         InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) getPartitionService(hz1);
         AtomicReference<HazelcastInstance> newInstanceRef = new AtomicReference<>();
         partitionService.setMigrationInterceptor(new MigrationInterceptor() {
             @Override
-            public void onMigrationComplete(MigrationParticipant participant, MigrationInfo migration, boolean success) {
+            public void onMigrationComplete(MigrationParticipant participant, MigrationInfo migration,
+                                            boolean success) {
                 MigrationStats stats = partitionService.getMigrationManager().getStats();
                 if (stats.getRemainingMigrations() < 50) {
                     // start a new member to restart migrations
@@ -118,10 +127,6 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
 
         EventCollectingMigrationListener listener = new EventCollectingMigrationListener();
         hz1.getPartitionService().addMigrationListener(listener);
-
-        // Change to NO_MIGRATION to prevent repartitioning
-        // before 2nd member started and ready.
-        hz1.getCluster().changeClusterState(ClusterState.NO_MIGRATION);
 
         // trigger migrations
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);
@@ -360,6 +365,138 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
         // and verify that the listener isn't called.
         verify(listener, never()).migrationStarted(any(MigrationStateImpl.class));
         verify(listener, never()).replicaMigrationCompleted(any(ReplicaMigrationEvent.class));
+    }
+
+    /**
+     * @see <a href="https://hazelcast.atlassian.net/browse/HZ-2651">HZ-2651 - MigrationListener: Difference between
+     * "wall clock elapsed time" and the totalElasedTime API</a>
+     */
+    @Test
+    public void testMigrationListenerElapsedTime() throws InterruptedException, ExecutionException, TimeoutException {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        // Use an arbitrarily high number of partitions to exacerbate the issue
+        final Config config = new Config().setProperty(ClusterProperty.PARTITION_COUNT.getName(), String.valueOf(1000));
+
+        final HazelcastInstance hz1 = createPausedMigrationCluster(factory, config);
+
+        final Stopwatch migrationTimer = Stopwatch.createUnstarted();
+        final CompletableFuture<Duration> migrationDurationReference = new CompletableFuture<>();
+
+        hz1.getPartitionService().addMigrationListener(new MigrationListener() {
+            @Override
+            public void migrationStarted(final MigrationState migrationState) {
+                // Don't trust the listener start time because no guarantees as to when its executed
+            }
+
+            @Override
+            public void migrationFinished(final MigrationState migrationState) {
+                migrationTimer.stop();
+                migrationDurationReference.complete(Duration.ofMillis(migrationState.getTotalElapsedTime()));
+            }
+
+            @Override
+            public void replicaMigrationCompleted(final ReplicaMigrationEvent replicaMigrationEvent) {
+            }
+
+            @Override
+            public void replicaMigrationFailed(final ReplicaMigrationEvent replicaMigrationEvent) {
+            }
+        });
+
+        LOGGER.fine("Starting second instance...");
+        final HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+
+        // Back to ACTIVE
+        migrationTimer.start();
+        changeClusterStateEventually(hz2, ClusterState.ACTIVE);
+
+        LOGGER.fine("Awaiting migration completion...");
+        final Duration reportedMigrationDuration = migrationDurationReference.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT,
+                TimeUnit.SECONDS);
+
+        assertFalse(reportedMigrationDuration.isZero());
+
+        final String message = MessageFormat.format("migrationState.getTotalElapsedTime={1}, migrationTimer={0}",
+                formatDuration(migrationTimer.elapsed()), formatDuration(reportedMigrationDuration));
+
+        LOGGER.fine(message);
+        assertTrue(MessageFormat.format("Reported migrationState.getTotalElapsedTime() was greater than the migration"
+                        + " execution time recorded - {0}", message),
+                migrationTimer.elapsed().compareTo(reportedMigrationDuration) >= 0);
+    }
+
+    /**
+     * @see <a href="https://github.com/hazelcast/hazelcast/pull/25028#discussion_r1266664004">Discussion</a>
+     */
+    @Test
+    public void testMigrationListenerTotalElapsedTime() {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        LOGGER.fine("Setting starting up instances...");
+        final HazelcastInstance hz1 = factory.newHazelcastInstance();
+        warmUpPartitions(hz1);
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        waitAllForSafeState(hz1, hz2);
+
+        final MetricsRegistry metricsRegistry = getNode(hz1).nodeEngine.getMetricsRegistry();
+
+        long totalElapsedMigrationTime = getMetric(metricsRegistry,
+                MetricDescriptorConstants.MIGRATION_METRIC_TOTAL_ELAPSED_MIGRATION_TIME);
+        long elapsedMigrationTime = getMetric(metricsRegistry,
+                MetricDescriptorConstants.MIGRATION_METRIC_ELAPSED_MIGRATION_TIME);
+
+        assertNotEquals(MessageFormat.format("{0} should not be instantaneous",
+                        MetricDescriptorConstants.MIGRATION_METRIC_TOTAL_ELAPSED_MIGRATION_TIME), 0,
+                totalElapsedMigrationTime);
+        assertNotEquals(MessageFormat.format("{0} should not be instantaneous",
+                        MetricDescriptorConstants.MIGRATION_METRIC_ELAPSED_MIGRATION_TIME), 0,
+                elapsedMigrationTime);
+
+        assertEquals(MessageFormat.format("With only one migration, {0} ({2}) and {1} ({3}) times should be equal",
+                        MetricDescriptorConstants.MIGRATION_METRIC_TOTAL_ELAPSED_MIGRATION_TIME,
+                        MetricDescriptorConstants.MIGRATION_METRIC_ELAPSED_MIGRATION_TIME,
+                        totalElapsedMigrationTime, elapsedMigrationTime), totalElapsedMigrationTime,
+                elapsedMigrationTime);
+
+        LOGGER.fine("Triggering another migration...");
+        hz2.shutdown();
+        hz2 = factory.newHazelcastInstance();
+        waitAllForSafeState(hz1, hz2);
+
+        totalElapsedMigrationTime = getMetric(metricsRegistry,
+                MetricDescriptorConstants.MIGRATION_METRIC_TOTAL_ELAPSED_MIGRATION_TIME);
+        elapsedMigrationTime = getMetric(metricsRegistry,
+                MetricDescriptorConstants.MIGRATION_METRIC_ELAPSED_MIGRATION_TIME);
+
+        assertTrue(MessageFormat.format("After multiple migrations, {0} ({2}) should be greater than {1} ({3})",
+                MetricDescriptorConstants.MIGRATION_METRIC_TOTAL_ELAPSED_MIGRATION_TIME,
+                MetricDescriptorConstants.MIGRATION_METRIC_ELAPSED_MIGRATION_TIME, totalElapsedMigrationTime,
+                elapsedMigrationTime), totalElapsedMigrationTime > elapsedMigrationTime);
+    }
+
+    private long getMetric(final MetricsRegistry metricsRegistry, final String metric) {
+        return metricsRegistry.newLongGauge(MetricDescriptorConstants.PARTITIONS_PREFIX + '.' + metric).read();
+    }
+
+    /**
+     * @see <a href="https://github.com/hazelcast/hazelcast/pull/25028#discussion_r1266692838">Discussion</a>
+     */
+    private static String formatDuration(final Duration duration) {
+        return MessageFormat.format("{0} {1}", duration.toMillis(), TimeUnit.MILLISECONDS.name().toLowerCase());
+    }
+
+    private HazelcastInstance createPausedMigrationCluster(final TestHazelcastInstanceFactory factory,
+                                                           @Nullable final Config config) {
+        LOGGER.fine("Starting paused migration instance...");
+        final HazelcastInstance hazelcastInstance = factory.newHazelcastInstance(config);
+        warmUpPartitions(hazelcastInstance);
+
+        // Change to NO_MIGRATION to prevent repartitioning
+        // before 2nd member started and ready.
+        hazelcastInstance.getCluster().changeClusterState(ClusterState.NO_MIGRATION);
+
+        return hazelcastInstance;
     }
 
     @SuppressWarnings("SameParameterValue")


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/25028

The Javadoc on `MigrationStats` implied that the times recorded were wall-clock execution time, but the implementation was recording the execution time of each migration thread.

Resolved by deriving the migration times from the difference between the start of the migration (`lastRepartitionTime`) and completion time, rather than explicitly timing the operation in each thread.

Fixes [HZ-2651](https://hazelcast.atlassian.net/browse/HZ-2651)

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc

[HZ-2651]: https://hazelcast.atlassian.net/browse/HZ-2651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ