### PR TITLE
Fix xsd documentation [HZ-2777]

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-config-5.4.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.4.xsd
@@ -642,8 +642,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         Lets you add listeners (listener classes) for the queue items. You can also set the attribute
-                        include-value to true if you want the item event to contain the item values, and you can set
-                        local to true if you want to listen to the items on the local node.
+                        include-value to true if the updated item should be passed to the item listener. Its default value is true.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
@@ -734,8 +733,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         Lets you add listeners (listener classes) for the list items. You can also set the attribute
-                        include-value to true if you want the item event to contain the item values, and you can set
-                        local to true if you want to listen to the items on the local node.
+                        include-value to true if the updated item should be passed to the item listener. Its default value is true.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
@@ -804,8 +802,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         Lets you add listeners (listener classes) for the set items. You can also set the attribute
-                        include-value to true if you want the item event to contain the item values, and you can set
-                        local to true if you want to listen to the items on the local node.
+                        include-value to true if the updated item should be passed to the item listener. Its default value is true.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>


### PR DESCRIPTION
Remove the sentence that mentions local attribute is the xsd, because there is not such attribute

Fixes https://github.com/hazelcast/hazelcast/issues/18083
Jira : https://hazelcast.atlassian.net/browse/HZ-2777

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible