### PR TITLE
Make MigrationListener timers use wall-clock not CPU time [HZ-2651]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
 
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static java.util.Collections.unmodifiableMap;
@@ -61,6 +63,8 @@ final class ProbeUtils {
         types.put(Long.class, TYPE_LONG_NUMBER);
         types.put(AtomicInteger.class, TYPE_LONG_NUMBER);
         types.put(AtomicLong.class, TYPE_LONG_NUMBER);
+        types.put(LongAdder.class, TYPE_LONG_NUMBER);
+        types.put(LongAccumulator.class, TYPE_LONG_NUMBER);
 
         types.put(double.class, TYPE_DOUBLE_PRIMITIVE);
         types.put(float.class, TYPE_DOUBLE_PRIMITIVE);

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
@@ -98,13 +98,13 @@ final class ProbeUtils {
      * @param classType the class object type.
      * @return the accessible object probe type.
      */
-    static int getType(Class classType) {
+    static int getType(Class<?> classType) {
         Integer type = TYPES.get(classType);
         if (type != null) {
             return type;
         }
 
-        List<Class<?>> flattenedClasses = new ArrayList<Class<?>>();
+        List<Class<?>> flattenedClasses = new ArrayList<>();
 
         flatten(classType, flattenedClasses);
 
@@ -118,7 +118,7 @@ final class ProbeUtils {
         return -1;
     }
 
-    static void flatten(Class clazz, List<Class<?>> result) {
+    static void flatten(Class<?> clazz, List<Class<?>> result) {
         if (!result.contains(clazz)) {
             result.add(clazz);
         }
@@ -127,7 +127,7 @@ final class ProbeUtils {
             flatten(clazz.getSuperclass(), result);
         }
 
-        for (Class interfaze : clazz.getInterfaces()) {
+        for (Class<?> interfaze : clazz.getInterfaces()) {
             if (!result.contains(interfaze)) {
                 result.add(interfaze);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
@@ -56,8 +56,8 @@ final class ProbeUtils {
         Stream.of(byte.class, short.class, int.class, long.class).forEach(clazz -> types.put(clazz,
                 TYPE_PRIMITIVE_LONG));
 
-        Stream.of(Byte.class, Integer.class, Long.class, AtomicInteger.class, AtomicLong.class, LongAdder.class,
-                LongAccumulator.class).forEach(clazz -> types.put(clazz,
+        Stream.of(Byte.class, Integer.class, Short.class, Long.class, AtomicInteger.class, AtomicLong.class,
+                LongAdder.class, LongAccumulator.class).forEach(clazz -> types.put(clazz,
                 TYPE_LONG_NUMBER));
 
         Stream.of(double.class, float.class).forEach(clazz -> types.put(clazz,

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Stream;
 
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 import static java.util.Collections.unmodifiableMap;
@@ -50,30 +51,25 @@ final class ProbeUtils {
     private static final Map<Class<?>, Integer> TYPES;
 
     static {
-        final Map<Class<?>, Integer> types = createHashMap(18);
+        final Map<Class<?>, Integer> types = createHashMap(20);
 
-        types.put(byte.class, TYPE_PRIMITIVE_LONG);
-        types.put(short.class, TYPE_PRIMITIVE_LONG);
-        types.put(int.class, TYPE_PRIMITIVE_LONG);
-        types.put(long.class, TYPE_PRIMITIVE_LONG);
+        Stream.of(byte.class, short.class, int.class, long.class).forEach(clazz -> types.put(clazz,
+                TYPE_PRIMITIVE_LONG));
 
-        types.put(Byte.class, TYPE_LONG_NUMBER);
-        types.put(Short.class, TYPE_LONG_NUMBER);
-        types.put(Integer.class, TYPE_LONG_NUMBER);
-        types.put(Long.class, TYPE_LONG_NUMBER);
-        types.put(AtomicInteger.class, TYPE_LONG_NUMBER);
-        types.put(AtomicLong.class, TYPE_LONG_NUMBER);
-        types.put(LongAdder.class, TYPE_LONG_NUMBER);
-        types.put(LongAccumulator.class, TYPE_LONG_NUMBER);
+        Stream.of(Byte.class, Integer.class, Long.class, AtomicInteger.class, AtomicLong.class, LongAdder.class,
+                LongAccumulator.class).forEach(clazz -> types.put(clazz,
+                TYPE_LONG_NUMBER));
 
-        types.put(double.class, TYPE_DOUBLE_PRIMITIVE);
-        types.put(float.class, TYPE_DOUBLE_PRIMITIVE);
+        Stream.of(double.class, float.class).forEach(clazz -> types.put(clazz,
+                TYPE_DOUBLE_PRIMITIVE));
 
-        types.put(Double.class, TYPE_DOUBLE_NUMBER);
-        types.put(Float.class, TYPE_DOUBLE_NUMBER);
+        Stream.of(Double.class, Float.class).forEach(clazz -> types.put(clazz,
+                TYPE_DOUBLE_NUMBER));
 
         types.put(Collection.class, TYPE_COLLECTION);
+
         types.put(Map.class, TYPE_MAP);
+
         types.put(Counter.class, TYPE_COUNTER);
 
         types.put(Semaphore.class, TYPE_SEMAPHORE);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationTimer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationTimer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.internal.partition.impl;
 
 import com.hazelcast.internal.util.Timer;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationTimer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationTimer.java
@@ -1,0 +1,60 @@
+package com.hazelcast.internal.partition.impl;
+
+import com.hazelcast.internal.util.Timer;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAccumulator;
+
+/**
+ * the total elapsed time of executions from source to destination endpoints
+ */
+public class MigrationTimer {
+    /**
+     * on the latest repartitioning round.
+     */
+    private final LongAccumulator elapsedNanoseconds = new LongAccumulator(Long::max, 0);
+
+    /**
+     * the sum of all previous rounds, except the latest, since the beginning.
+     */
+    private volatile long lastTotalElapsedNanoseconds;
+
+    protected void markNewRepartition() {
+        lastTotalElapsedNanoseconds = getTotalElapsedNanoseconds();
+        elapsedNanoseconds.reset();
+    }
+
+    protected void calculateElapsed(final long lastRepartitionNanos) {
+        elapsedNanoseconds.accumulate(Timer.nanosElapsed(lastRepartitionNanos));
+    }
+
+    /**
+     * @return nanoseconds
+     * @see #elapsedNanoseconds
+     */
+    public long getElapsedNanoseconds() {
+        return elapsedNanoseconds.get();
+    }
+
+    /**
+     * @return milliseconds
+     * @see #elapsedNanoseconds
+     */
+    public long getElapsedMilliseconds() {
+        return TimeUnit.NANOSECONDS.toMillis(getElapsedNanoseconds());
+    }
+
+    /**
+     * @return the sum of all previous rounds, since the beginning - nanoseconds
+     */
+    public long getTotalElapsedNanoseconds() {
+        return lastTotalElapsedNanoseconds + getElapsedNanoseconds();
+    }
+
+    /**
+     * @return the sum of all previous rounds, since the beginning - milliseconds
+     */
+    public long getTotalElapsedMilliseconds() {
+        return TimeUnit.NANOSECONDS.toMillis(getTotalElapsedNanoseconds());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
 
 import static com.hazelcast.internal.metrics.impl.FieldProbe.createFieldProbe;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
@@ -66,6 +68,9 @@ public class FieldProbeTest extends HazelcastTestSupport {
         getLong("intField", 10);
         getLong("longField", 10);
         getLong("atomicLongField", 10);
+        getLong("longAccumulatorField", 10);
+        getLong("longAdderField", 10);
+        getLong("atomicLongField", 10);
         getLong("atomicIntegerField", 10);
         getLong("counterField", 10);
         getLong("collectionField", 10);
@@ -78,6 +83,8 @@ public class FieldProbeTest extends HazelcastTestSupport {
         getLong("LongField", 10);
 
         getLong("nullAtomicLongField", 0);
+        getLong("nullLongAccumulatorField", 0);
+        getLong("nullLongAdderField", 0);
         getLong("nullAtomicIntegerField", 0);
         getLong("nullCounterField", 0);
         getLong("nullCollectionField", 0);
@@ -129,56 +136,64 @@ public class FieldProbeTest extends HazelcastTestSupport {
 
     private class SomeSource {
         @Probe(name = "byteField")
-        private byte byteField = 10;
+        private final byte byteField = 10;
         @Probe(name = "shortField")
-        private short shortField = 10;
+        private final short shortField = 10;
         @Probe(name = "intField")
-        private int intField = 10;
+        private final int intField = 10;
         @Probe(name = "longField")
-        private long longField = 10;
+        private final long longField = 10;
 
         @Probe(name = "floatField")
-        private float floatField = 10;
+        private final float floatField = 10;
         @Probe(name = "doubleField")
-        private double doubleField = 10;
+        private final double doubleField = 10;
 
         @Probe(name = "atomicLongField")
-        private AtomicLong atomicLongField = new AtomicLong(10);
+        private final AtomicLong atomicLongField = new AtomicLong(10);
         @Probe(name = "nullAtomicLongField")
         private AtomicLong nullAtomicLongField;
+        @Probe(name = "longAdderField")
+        private final LongAdder longAdderField = new LongAdder();
+        @Probe(name = "nullLongAdderField")
+        private LongAdder nullLongAdderField;
+        @Probe(name = "longAccumulatorField")
+        private final LongAccumulator longAccumulatorField = new LongAccumulator(Long::sum, 10);
+        @Probe(name = "nullLongAccumulatorField")
+        private LongAccumulator nullLongAccumulatorField;
         @Probe(name = "atomicIntegerField")
-        private AtomicInteger atomicIntegerField = new AtomicInteger(10);
+        private final AtomicInteger atomicIntegerField = new AtomicInteger(10);
         @Probe(name = "nullAtomicIntegerField")
         private AtomicInteger nullAtomicIntegerField;
         @Probe(name = "counterField")
-        private Counter counterField = newSwCounter(10);
+        private final Counter counterField = newSwCounter(10);
         @Probe(name = "nullCounterField")
         private Counter nullCounterField;
         @Probe(name = "collectionField")
-        private Collection collectionField = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        private final Collection collectionField = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         @Probe(name = "nullCollectionField")
         private Collection nullCollectionField;
         @Probe(name = "mapField")
-        private Map mapField = MetricsUtils.createMap(10);
+        private final Map mapField = MetricsUtils.createMap(10);
         @Probe(name = "nullMapField")
         private Map nullMapField;
         @Probe(name = "semaphoreField")
-        private Semaphore semaphoreField = new Semaphore(10);
+        private final Semaphore semaphoreField = new Semaphore(10);
         @Probe(name = "nullSemaphoreField")
         private Semaphore nullSemaphoreField;
 
         @Probe(name = "ByteField")
-        private Byte ByteField = (byte) 10;
+        private final Byte ByteField = (byte) 10;
         @Probe(name = "ShortField")
-        private Short ShortField = (short) 10;
+        private final Short ShortField = (short) 10;
         @Probe(name = "IntegerField")
-        private Integer IntegerField = 10;
+        private final Integer IntegerField = 10;
         @Probe(name = "LongField")
-        private Long LongField = (long) 10;
+        private final Long LongField = (long) 10;
         @Probe(name = "FloatField")
-        private Float FloatField = (float) 10;
+        private final Float FloatField = (float) 10;
         @Probe(name = "DoubleField")
-        private Double DoubleField = (double) 10;
+        private final Double DoubleField = (double) 10;
 
         @Probe(name = "nullByteField")
         private Byte nullByteField;
@@ -193,5 +208,8 @@ public class FieldProbeTest extends HazelcastTestSupport {
         @Probe(name = "nullDoubleField")
         private Double nullDoubleField;
 
+        private SomeSource() {
+            longAdderField.add(10);
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
@@ -70,7 +70,6 @@ public class FieldProbeTest extends HazelcastTestSupport {
         getLong("atomicLongField", 10);
         getLong("longAccumulatorField", 10);
         getLong("longAdderField", 10);
-        getLong("atomicLongField", 10);
         getLong("atomicIntegerField", 10);
         getLong("counterField", 10);
         getLong("collectionField", 10);


### PR DESCRIPTION
Refactored the code to create an object - `com.hazelcast.internal.partition.impl.MigrationTimer` - that represents the time taken for a specific migration operation.

Modified the logic to ensure that the longest elapsed time taken within a migration is retained, and that the total migration time is recorded in a simpler manner.

Refactored use of `AtomicLong` to either `LongAccumulator` or `LongAdder` specialisations, or just plain `volatile long` where atomic operations not required to improve performance.

`com.hazelcast.internal.metrics.impl.ProbeUtils` refactored to keep checkstyle happy due static initialiser size.

Addresses race condition added in https://github.com/hazelcast/hazelcast/pull/25028

Fixes [HZ-2651](https://hazelcast.atlassian.net/browse/HZ-2651)

[HZ-2651]: https://hazelcast.atlassian.net/browse/HZ-2651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ