### PR TITLE
Allow overriding default serializer for compact inner fields [API-2088]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -700,12 +700,18 @@ public abstract class AbstractSerializationService implements InternalSerializat
 
     /**
      * Makes sure that the classes registered as Compact serializable are not
-     * overriding the default serializers.
+     * overriding the default serializers if the user did not explicitly set
+     * {@link com.hazelcast.config.SerializationConfig#setAllowOverrideDefaultSerializers(boolean)} to
+     * true.
      * <p>
      * Must be called in the constructor of the child classes after they
      * complete registering default serializers.
      */
     protected void verifyDefaultSerializersNotOverriddenWithCompact() {
+        if (allowOverrideDefaultSerializers) {
+            return;
+        }
+
         for (Class clazz : compactStreamSerializer.getCompactSerializableClasses()) {
             if (!constantTypesMap.containsKey(clazz)) {
                 continue;

--- a/hazelcast/src/test/java/example/serialization/CompactWithInnerFieldAsUuid.java
+++ b/hazelcast/src/test/java/example/serialization/CompactWithInnerFieldAsUuid.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.serialization;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class CompactWithInnerFieldAsUuid {
+    private final UUID uuid;
+
+    public CompactWithInnerFieldAsUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CompactWithInnerFieldAsUuid that = (CompactWithInnerFieldAsUuid) o;
+
+        return Objects.equals(uuid, that.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return uuid != null ? uuid.hashCode() : 0;
+    }
+}

--- a/hazelcast/src/test/java/example/serialization/CustomUUIDSerializer.java
+++ b/hazelcast/src/test/java/example/serialization/CustomUUIDSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.serialization;
+
+import com.hazelcast.nio.serialization.compact.CompactReader;
+import com.hazelcast.nio.serialization.compact.CompactSerializer;
+import com.hazelcast.nio.serialization.compact.CompactWriter;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.UUID;
+
+public class CustomUUIDSerializer implements CompactSerializer<UUID> {
+
+    @Nonnull
+    @Override
+    public UUID read(@Nonnull CompactReader reader) {
+        return UUID.fromString(Objects.requireNonNull(reader.readString("uuidField")));
+    }
+
+    @Override
+    public void write(@Nonnull CompactWriter writer, @Nonnull UUID object) {
+        writer.writeString("uuidField", object.toString());
+    }
+
+    @Nonnull
+    @Override
+    public String getTypeName() {
+        return "myUUID";
+    }
+
+    @Nonnull
+    @Override
+    public Class<UUID> getCompactClass() {
+        return UUID.class;
+    }
+
+}


### PR DESCRIPTION
Allow overriding default serializer for compact inner fields to work seamlessly with `ReflectiveCompactSerializer` if the user explicitly sets the `com.hazelcast.config.SerializationConfig#setAllowOverrideDefaultSerializer (boolean)` to `true` and user registers a custom compact serializer for the inner field type which already has a default serializer associated.

fixes #23698
