### PR TITLE
Introduce a flow control to fix exponential backoff behaviour for CP subsystem [HZ-2702] [5.3.z] (#25055)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -41,3 +41,10 @@ code derived from the Apache Flink project.
 
 The class com.hazelcast.internal.util.ConcurrentReferenceHashMap contains code written by Doug Lea
 and updated within the WildFly project (https://github.com/wildfly/wildfly).
+
+The classes:
+com.hazelcast.cp.internal.raft.impl.state.FollowerState
+com.hazelcast.cp.internal.raft.impl.state.FollowerStateTest
+com.hazelcast.cp.internal.raft.impl.SlowFollowerBackoffTest
+
+contain code originating from the MicroRaft project (https://github.com/MicroRaft/MicroRaft)

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -35,6 +35,11 @@
     <suppress checks="Header" files="com[\\/]hazelcast[\\/]internal[\\/]cluster[\\/]fd[\\/]PhiAccrualFailureDetector"/>
     <suppress checks="Header" files="com[\\/]hazelcast[\\/]instance[\\/]impl[\\/]MobyNames"/>
 
+    <!--  Suppress checking of copyright notice, adapted from the MicroRaft project  -->
+    <suppress checks="Header" files="com[\\/]hazelcast[\\/]cp[\\/]internal[\\/]raft[\\/]impl[\\/]state[\\/]FollowerState"/>
+    <suppress checks="Header" files="com[\\/]hazelcast[\\/]cp[\\/]internal[\\/]raft[\\/]impl[\\/]state[\\/]FollowerStateTest"/>
+    <suppress checks="Header" files="com[\\/]hazelcast[\\/]cp[\\/]internal[\\/]raft[\\/]impl[\\/]SlowFollowerBackoffTest"/>
+
     <!--  Suppress checking of copyright notice, adapted from Agrona project  -->
     <suppress checks="Header" files="com[\\/]hazelcast[\\/]internal[\\/]util[\\/]HashUtil"/>
     <suppress checks="Header" files="com[\\/]hazelcast[\\/]internal[\\/]util[\\/]QuickMath"/>

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendFailureResponseHandlerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendFailureResponseHandlerTask.java
@@ -77,26 +77,28 @@ public class AppendFailureResponseHandlerTask extends AbstractResponseHandlerTas
     }
 
     private boolean updateNextIndex(RaftState state) {
+        RaftEndpoint follower = resp.follower();
         LeaderState leaderState = state.leaderState();
-        FollowerState followerState = leaderState.getFollowerState(resp.follower());
+        FollowerState followerState = leaderState.getFollowerState(follower);
 
         long nextIndex = followerState.nextIndex();
         long matchIndex = followerState.matchIndex();
 
-        if (resp.expectedNextIndex() == nextIndex) {
-            // Received a response for the last append request. Resetting the flag...
-            followerState.appendRequestAckReceived();
+        // Received a response for the append request.
+        // Check if the backoff state should be reset.
+        followerState.appendRequestAckReceived(resp.flowControlSequenceNumber());
 
+        if (resp.expectedNextIndex() == nextIndex) {
             // this is the response of the request I have sent for this nextIndex
             nextIndex--;
             if (nextIndex <= matchIndex) {
                 logger.severe("Cannot decrement next index: " + nextIndex + " below match index: " + matchIndex
-                        + " for follower: " + resp.follower());
+                        + " for follower: " + follower);
                 return false;
             }
 
             if (logger.isFineEnabled()) {
-                logger.fine("Updating next index: " + nextIndex + " for follower: " + resp.follower());
+                logger.fine("Updating next index: " + nextIndex + " for follower: " + follower);
             }
             followerState.nextIndex(nextIndex);
             return true;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendRequestHandlerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendRequestHandlerTask.java
@@ -204,7 +204,8 @@ public class AppendRequestHandlerTask extends RaftNodeStatusAwareTask implements
         raftNode.updateLastAppendEntriesTimestamp();
 
         try {
-            AppendSuccessResponse resp = new AppendSuccessResponse(localMember(), state.term(), lastLogIndex, req.queryRound());
+            AppendSuccessResponse resp = new AppendSuccessResponse(localMember(), state.term(), lastLogIndex,
+                    req.queryRound(), req.flowControlSequenceNumber());
             raftNode.send(resp, req.leader());
         } finally {
             if (state.commitIndex() > oldCommitIndex) {
@@ -261,6 +262,7 @@ public class AppendRequestHandlerTask extends RaftNodeStatusAwareTask implements
     }
 
     private AppendFailureResponse createFailureResponse(int term) {
-        return new AppendFailureResponse(localMember(), term, req.prevLogIndex() + 1);
+        return new AppendFailureResponse(localMember(), term, req.prevLogIndex() + 1,
+                req.flowControlSequenceNumber());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/InstallSnapshotHandlerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/InstallSnapshotHandlerTask.java
@@ -63,7 +63,8 @@ public class InstallSnapshotHandlerTask extends RaftNodeStatusAwareTask implemen
                 logger.warning("Stale snapshot: " + req + " received in current term: " + state.term());
             }
 
-            raftNode.send(new AppendFailureResponse(localMember(), state.term(), snapshot.index() + 1), req.leader());
+            raftNode.send(new AppendFailureResponse(localMember(), state.term(), snapshot.index() + 1,
+                    req.flowControlSequenceNumber()), req.leader());
             return;
         }
 
@@ -85,7 +86,8 @@ public class InstallSnapshotHandlerTask extends RaftNodeStatusAwareTask implemen
         raftNode.updateLastAppendEntriesTimestamp();
 
         if (raftNode.installSnapshot(snapshot)) {
-            raftNode.send(new AppendSuccessResponse(localMember(), req.term(), snapshot.index(), req.queryRound()), req.leader());
+            raftNode.send(new AppendSuccessResponse(localMember(), req.term(), snapshot.index(), req.queryRound(),
+                            req.flowControlSequenceNumber()), req.leader());
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/task/LeadershipTransferTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/task/LeadershipTransferTask.java
@@ -91,7 +91,7 @@ public class LeadershipTransferTask implements Runnable {
             logger.info("Transferring leadership to " + leadershipTransferState.endpoint());
         }
 
-        leaderState.getFollowerState(targetEndpoint).appendRequestAckReceived();
+        leaderState.getFollowerState(targetEndpoint).resetRequestBackoff();
         raftNode.sendAppendRequest(targetEndpoint);
 
         LogEntry entry = state.log().lastLogOrSnapshotEntry();

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/SlowFollowerBackoffTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/SlowFollowerBackoffTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ * Portions Copyright (c) 2020, MicroRaft.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.raft.impl;
+
+import com.hazelcast.config.cp.RaftAlgorithmConfig;
+import com.hazelcast.cp.exception.CannotReplicateException;
+import com.hazelcast.cp.internal.raft.impl.dataservice.ApplyRaftRunnable;
+import com.hazelcast.cp.internal.raft.impl.dto.AppendFailureResponse;
+import com.hazelcast.cp.internal.raft.impl.dto.AppendRequest;
+import com.hazelcast.cp.internal.raft.impl.dto.AppendSuccessResponse;
+import com.hazelcast.cp.internal.raft.impl.dto.InstallSnapshot;
+import com.hazelcast.cp.internal.raft.impl.state.FollowerState;
+import com.hazelcast.cp.internal.raft.impl.testing.LocalRaftGroup;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.cp.internal.raft.impl.testing.LocalRaftGroup.LocalRaftGroupBuilder.newGroup;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
+public class SlowFollowerBackoffTest {
+    private LocalRaftGroup group;
+
+    @After
+    public void destroy() {
+        if (group != null) {
+            group.destroy();
+        }
+    }
+
+    @Test
+    public void when_majoritySlowFollowers_then_rejectNewAppends() {
+        int uncommittedEntryCount = 10;
+        RaftAlgorithmConfig config = new RaftAlgorithmConfig()
+                .setUncommittedEntryCountToRejectNewAppends(uncommittedEntryCount);
+        group = newGroup(3, config);
+        group.start();
+        RaftNode leader = group.waitUntilLeaderElected();
+
+        // we are slowing down the followers
+        // by making their Raft thread sleep for 3 seconds
+        for (RaftNode follower : group.getNodesExcept(leader.getLocalMember())) {
+            group.slowDownNode(follower.getLocalMember(), 3);
+        }
+
+        while (true) {
+            // we are filling up the request buffer of the leader.
+            // since the followers are slowed down, the leader won't be able to
+            // keep up with the incoming request rate and after some time it
+            // will start to fail new requests with CannotReplicateException
+            CompletableFuture<Object> future = leader.replicate(new ApplyRaftRunnable("val"));
+            sleepMillis(10);
+
+            if (future.isCompletedExceptionally()) {
+                try {
+                    future.join();
+                } catch (CompletionException e) {
+                    assertThat(e).hasCauseInstanceOf(CannotReplicateException.class);
+                    return;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void when_slowFollower_then_checkBackoffAppendRequestsCount() {
+        int appendRequestBackoffTimeout = 50;
+        RaftAlgorithmConfig config = new RaftAlgorithmConfig()
+                .setAppendRequestBackoffTimeoutInMillis(appendRequestBackoffTimeout);
+        group = newGroup(3, config);
+        group.start();
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+
+        RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
+        RaftEndpoint slowFollower = followers[0].getLocalMember();
+        AtomicInteger appendRequestsCounter = new AtomicInteger();
+
+        // we are slowing down the follower
+        // by making their Raft thread sleep for 3 seconds
+        group.slowDownNode(slowFollower, 3);
+
+        // track the AppendRequests count sent to slowFollower
+        group.alterMessagesToMember(leader.getLocalMember(), slowFollower, o -> {
+            if (o instanceof AppendRequest) {
+                appendRequestsCounter.incrementAndGet();
+            }
+            return o;
+        });
+
+        // sent 3 messages
+        leader.replicate(new ApplyRaftRunnable("val1"));
+        leader.replicate(new ApplyRaftRunnable("val2"));
+        leader.replicate(new ApplyRaftRunnable("val3"));
+
+        FollowerState followerState = leader.state().leaderState().getFollowerState(slowFollower);
+        // waiting for slowFollower to acknowledge receiving messages
+        assertTrueEventually(() -> assertEquals(3, followerState.matchIndex()));
+
+        /** With 50ms for appendRequestBackoffTimeout and 3sec for slowFollower delay,
+         * there should be five AppendRequests at 0, 200, 400, 800 and 1000 milliseconds.
+         * The next backoff period calculation logic {@link FollowerState#setAppendRequestBackoff}
+         */
+        assertEquals(5, appendRequestsCounter.get());
+        assertEquals(5, followerState.flowControlSequenceNumber());
+    }
+
+    @Test
+    public void when_slowFollowerAndOutdatedSuccessResponse_then_checkNoBackoffResetHappen() {
+        int appendRequestBackoffTimeout = 50;
+        RaftAlgorithmConfig config = new RaftAlgorithmConfig()
+                .setAppendRequestBackoffTimeoutInMillis(appendRequestBackoffTimeout);
+        group = newGroup(3, config);
+        group.start();
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+
+        RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
+        RaftEndpoint slowFollower = followers[0].getLocalMember();
+        AtomicInteger appendRequestsCounter = new AtomicInteger();
+        CountDownLatch countDownLatch = new CountDownLatch(2);
+
+        // track the AppendRequests count sent to slowFollower
+        group.alterMessagesToMember(leader.getLocalMember(), slowFollower, o -> {
+            if (o instanceof AppendRequest) {
+                appendRequestsCounter.incrementAndGet();
+                countDownLatch.countDown();
+            }
+            return o;
+        });
+
+        // we are slowing down the follower
+        // by making their Raft thread sleep for 3 seconds
+        group.slowDownNode(slowFollower, 3);
+
+        // emulate receiving AppendSuccessResponse with outdated flowControlSequenceNumber
+        new Thread(() -> {
+            try {
+                // wait until the current flowControlSequenceNumber will be equal 2
+                countDownLatch.await();
+                leader.handleAppendResponse(
+                        // send response with outdated flowControlSequenceNumber equal 1
+                        new AppendSuccessResponse(slowFollower, leader.state().term(), 0, 0, 1));
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }).start();
+
+        leader.replicate(new ApplyRaftRunnable("val"));
+
+        FollowerState followerState = leader.state().leaderState().getFollowerState(slowFollower);
+        // waiting for slowFollower to acknowledge receiving messages
+        assertTrueEventually(() -> assertEquals(1, followerState.matchIndex()));
+
+        // verify that outdated response didn't affect the AppendRequest's count
+        assertEquals(5, appendRequestsCounter.get());
+        assertEquals(5, followerState.flowControlSequenceNumber());
+    }
+
+    @Test
+    public void when_slowFollowerAndOutdatedFailureResponse_then_checkNoBackoffResetHappen() {
+        int appendRequestBackoffTimeout = 50;
+        RaftAlgorithmConfig config = new RaftAlgorithmConfig()
+                .setAppendRequestBackoffTimeoutInMillis(appendRequestBackoffTimeout);
+        group = newGroup(3, config);
+        group.start();
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+
+        RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
+        RaftEndpoint slowFollower = followers[0].getLocalMember();
+        AtomicInteger appendRequestsCounter = new AtomicInteger();
+        CountDownLatch countDownLatch = new CountDownLatch(2);
+
+        // track the AppendRequests count sent to slowFollower
+        group.alterMessagesToMember(leader.getLocalMember(), slowFollower, o -> {
+            if (o instanceof AppendRequest) {
+                appendRequestsCounter.incrementAndGet();
+                countDownLatch.countDown();
+            }
+            return o;
+        });
+
+        // we are slowing down the follower
+        // by making their Raft thread sleep for 3 seconds
+        group.slowDownNode(slowFollower, 3);
+
+        // emulate receiving AppendSuccessResponse with outdated flowControlSequenceNumber
+        new Thread(() -> {
+            try {
+                // wait until the current flowControlSequenceNumber will be equal 2
+                countDownLatch.await();
+                leader.handleAppendResponse(
+                        // send response with outdated flowControlSequenceNumber equal 1
+                        new AppendFailureResponse(slowFollower, leader.state().term(), 0, 1));
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }).start();
+
+        leader.replicate(new ApplyRaftRunnable("val"));
+
+        FollowerState followerState = leader.state().leaderState().getFollowerState(slowFollower);
+        // waiting for slowFollower to acknowledge receiving messages
+        assertTrueEventually(() -> assertEquals(1, followerState.matchIndex()));
+
+        // verify that outdated response didn't affect the AppendRequest's count
+        assertEquals(5, appendRequestsCounter.get());
+        assertEquals(5, followerState.flowControlSequenceNumber());
+    }
+
+
+    @Test
+    public void when_slowFollower_then_checkBackoffInstallSnapshotsCount() {
+        int appendRequestBackoffTimeout = 100;
+        int commitIndexAdvanceCountToSnapshot = 5;
+        RaftAlgorithmConfig config = new RaftAlgorithmConfig()
+                .setAppendRequestBackoffTimeoutInMillis(appendRequestBackoffTimeout)
+                .setCommitIndexAdvanceCountToSnapshot(commitIndexAdvanceCountToSnapshot);
+        group = newGroup(3, config);
+        group.start();
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+
+        RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
+        RaftEndpoint slowFollower = followers[0].getLocalMember();
+        AtomicInteger installSnapshotCounter = new AtomicInteger();
+
+        // we are slowing down the follower
+        // by making their Raft thread sleep for 3 seconds
+        group.slowDownNode(slowFollower, 3);
+
+        // track the InstallSnapshots count sent to slowFollower
+        group.alterMessagesToMember(leader.getLocalMember(), slowFollower, o -> {
+            if (o instanceof InstallSnapshot) {
+                installSnapshotCounter.incrementAndGet();
+            }
+            return o;
+        });
+
+        // sent 6 messages to trigger a snapshot
+        leader.replicate(new ApplyRaftRunnable("val1"));
+        leader.replicate(new ApplyRaftRunnable("val2"));
+        leader.replicate(new ApplyRaftRunnable("val3"));
+        leader.replicate(new ApplyRaftRunnable("val4"));
+        leader.replicate(new ApplyRaftRunnable("val5"));
+        leader.replicate(new ApplyRaftRunnable("val6"));
+
+        FollowerState followerState = leader.state().leaderState().getFollowerState(slowFollower);
+        // waiting for slowFollower to acknowledge receiving messages via snapshot
+        assertTrueEventually(() -> assertEquals(6, followerState.matchIndex()));
+
+        /**
+         * With 100ms for appendRequestBackoffTimeout and 3sec for slowFollower delay,
+         * there should be two InstallSnapshots at 0 and 2000 milliseconds.
+         * The next backoff period calculation logic {@link FollowerState#setAppendRequestBackoff}
+         * For InstallSnapshot the MAX_BACKOFF_ROUND is used.
+         */
+        assertEquals(2, installSnapshotCounter.get());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/SnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/SnapshotTest.java
@@ -568,10 +568,12 @@ public class SnapshotTest extends HazelcastTestSupport {
                 if (entries.length > 0) {
                     if (entries[entries.length - 1].operation() instanceof UpdateRaftGroupMembersCmd) {
                         entries = Arrays.copyOf(entries, entries.length - 1);
-                        return new AppendRequest(request.leader(), request.term(), request.prevLogTerm(), request.prevLogIndex(), request.leaderCommitIndex(), entries, request.queryRound());
+                        return new AppendRequest(request.leader(), request.term(), request.prevLogTerm(), request.prevLogIndex(),
+                                request.leaderCommitIndex(), entries, request.queryRound(), request.flowControlSequenceNumber());
                     } else if (entries[0].operation() instanceof UpdateRaftGroupMembersCmd) {
                         entries = new LogEntry[0];
-                        return new AppendRequest(request.leader(), request.term(), request.prevLogTerm(), request.prevLogIndex(), request.leaderCommitIndex(), entries, request.queryRound());
+                        return new AppendRequest(request.leader(), request.term(), request.prevLogTerm(), request.prevLogIndex(),
+                                request.leaderCommitIndex(), entries, request.queryRound(), request.flowControlSequenceNumber());
                     }
                 }
             }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/state/FollowerStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/state/FollowerStateTest.java
@@ -1,0 +1,204 @@
+/*
+ * Original work Copyright (c) 2020, MicroRaft.
+ * Modified work Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.raft.impl.state;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.cp.internal.raft.impl.state.FollowerState.MIN_BACKOFF_ROUNDS;
+import static com.hazelcast.cp.internal.raft.impl.state.FollowerState.MAX_BACKOFF_ROUND;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class FollowerStateTest {
+
+    private final FollowerState followerState = new FollowerState(0, 1);
+
+    @Test
+    public void testFirstBackoffRound() {
+        long flowControlSeqNum = followerState.setAppendRequestBackoff();
+
+        assertThat(flowControlSeqNum).isEqualTo(1);
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum);
+        assertThat(followerState.backoffRound()).isEqualTo(MIN_BACKOFF_ROUNDS);
+    }
+
+    @Test
+    public void testValidFlowControlResponseReceivedOnFirstBackoff() {
+        long flowControlSeqNum = followerState.setAppendRequestBackoff();
+        boolean success = followerState.appendRequestAckReceived(flowControlSeqNum);
+
+        assertThat(success).isTrue();
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum);
+        assertThat(followerState.backoffRound()).isEqualTo(0);
+    }
+
+    // TODO RU_COMPAT_5_3 test Version 5.3 compatibility. Test should be removed at Version 5.5
+    @Test
+    public void compatibilityTestBackoffIsRetestedIfFlowControlIsMinusOne() {
+        long flowControlSeqNum = followerState.setAppendRequestBackoff();
+        boolean success = followerState.appendRequestAckReceived(-1);
+
+        assertThat(success).isTrue();
+        assertThat(flowControlSeqNum).isGreaterThanOrEqualTo(1);
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum);
+        assertThat(followerState.backoffRound()).isEqualTo(0);
+    }
+
+    @Test
+    public void testInvalidFlowControlResponseReceivedOnFirstBackoff() {
+        long flowControlSeqNum = followerState.setAppendRequestBackoff();
+        boolean success = followerState.appendRequestAckReceived(flowControlSeqNum + 1);
+
+        assertThat(success).isFalse();
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum);
+        assertThat(followerState.backoffRound()).isEqualTo(MIN_BACKOFF_ROUNDS);
+    }
+
+    @Test
+    public void testUncompletedFirstBackoff() {
+        long flowControlSeqNum = followerState.setAppendRequestBackoff();
+        boolean backoffCompleted = followerState.completeAppendRequestBackoffRound();
+
+        assertThat(backoffCompleted).isFalse();
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum);
+        assertThat(followerState.backoffRound()).isEqualTo(MIN_BACKOFF_ROUNDS - 1);
+    }
+
+    @Test
+    public void testCompletedFirstBackoff() {
+        long flowControlSeqNum = followerState.setAppendRequestBackoff();
+        boolean backoffCompleted = executeCompleteAppendReqBackoffRound(MIN_BACKOFF_ROUNDS);
+
+        assertThat(backoffCompleted).isTrue();
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum);
+        assertThat(followerState.backoffRound()).isEqualTo(0);
+    }
+
+    @Test
+    public void testFirstResponseReceivedAfterBackoffIsSetForSecondRequest() {
+        long flowControlSeqNum1 = followerState.setAppendRequestBackoff();
+        executeCompleteAppendReqBackoffRound(MIN_BACKOFF_ROUNDS);
+
+        long flowControlSeqNum2 = followerState.setAppendRequestBackoff();
+        assertThat(flowControlSeqNum2).isGreaterThan(flowControlSeqNum1);
+
+        boolean success = followerState.appendRequestAckReceived(flowControlSeqNum1);
+
+        assertThat(success).isFalse();
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum2);
+        assertThat(followerState.backoffRound()).isEqualTo(2 * MIN_BACKOFF_ROUNDS);
+    }
+
+    @Test
+    public void testValidFlowControlResponseReceivedOnSecondBackoff() {
+        followerState.setAppendRequestBackoff();
+        executeCompleteAppendReqBackoffRound(MIN_BACKOFF_ROUNDS);
+
+        long flowControlSeqNum = followerState.setAppendRequestBackoff();
+        boolean success = followerState.appendRequestAckReceived(flowControlSeqNum);
+
+        assertThat(success).isTrue();
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum);
+        assertThat(followerState.backoffRound()).isEqualTo(0);
+    }
+
+    @Test
+    public void testCompletedSecondBackoff() {
+        followerState.setAppendRequestBackoff();
+        executeCompleteAppendReqBackoffRound(MIN_BACKOFF_ROUNDS);
+
+        long flowControlSeqNum = followerState.setAppendRequestBackoff();
+        boolean backoffCompleted1 = followerState.completeAppendRequestBackoffRound();
+
+        assertThat(backoffCompleted1).isFalse();
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum);
+        assertThat(followerState.backoffRound()).isEqualTo((2 * MIN_BACKOFF_ROUNDS) - 1);
+
+        boolean backoffCompleted2 = executeCompleteAppendReqBackoffRound((2 * MIN_BACKOFF_ROUNDS) - 1);
+
+        assertThat(backoffCompleted2).isTrue();
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum);
+        assertThat(followerState.backoffRound()).isEqualTo(0);
+    }
+
+    @Test
+    public void testSecondResponseReceivedAfterBackoffIsSetForSecondRequest() {
+        long flowControlSeqNum1 = followerState.setAppendRequestBackoff();
+        executeCompleteAppendReqBackoffRound(MIN_BACKOFF_ROUNDS);
+
+        long flowControlSeqNum2 = followerState.setAppendRequestBackoff();
+        assertThat(flowControlSeqNum2).isGreaterThan(flowControlSeqNum1);
+
+        boolean success = followerState.appendRequestAckReceived(flowControlSeqNum1);
+        assertThat(success).isFalse();
+        assertThat(followerState.backoffRound()).isEqualTo(2 * MIN_BACKOFF_ROUNDS);
+
+        followerState.completeAppendRequestBackoffRound();
+        success = followerState.appendRequestAckReceived(flowControlSeqNum2);
+
+        assertThat(success).isTrue();
+        assertThat(followerState.backoffRound()).isEqualTo(0);
+    }
+
+    @Test
+    public void testMaxBackoff() {
+        long flowControlSeqNum1 = followerState.setAppendRequestBackoff();
+        executeCompleteAppendReqBackoffRound(MIN_BACKOFF_ROUNDS);
+
+        long flowControlSeqNum2 = followerState.setAppendRequestBackoff();
+        executeCompleteAppendReqBackoffRound(2 * MIN_BACKOFF_ROUNDS);
+
+        long flowControlSeqNum3 = followerState.setAppendRequestBackoff();
+        executeCompleteAppendReqBackoffRound(4 * MIN_BACKOFF_ROUNDS);
+
+        long flowControlSeqNum4 = followerState.setAppendRequestBackoff();
+
+        assertThat(flowControlSeqNum4).isGreaterThan(flowControlSeqNum3);
+        assertThat(flowControlSeqNum3).isGreaterThan(flowControlSeqNum2);
+        assertThat(flowControlSeqNum2).isGreaterThan(flowControlSeqNum1);
+        assertThat(followerState.flowControlSequenceNumber()).isEqualTo(flowControlSeqNum4);
+        assertThat(followerState.backoffRound()).isEqualTo(MAX_BACKOFF_ROUND);
+    }
+
+    @Test
+    public void testNoBackoffOverflow() {
+        for (int i = 0; i < 64; i++) {
+            followerState.setAppendRequestBackoff();
+            while (followerState.isAppendRequestBackoffSet()) {
+                followerState.completeAppendRequestBackoffRound();
+            }
+
+        }
+    }
+
+    private boolean executeCompleteAppendReqBackoffRound(int times) {
+        boolean res = false;
+        for (int i = 0; i < times; i++) {
+            res = followerState.completeAppendRequestBackoffRound();
+        }
+        return res;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftGroup.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftGroup.java
@@ -42,6 +42,7 @@ import static com.hazelcast.cp.internal.raft.impl.RaftUtil.minority;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.newRaftMember;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
@@ -488,6 +489,14 @@ public class LocalRaftGroup {
             node.forceSetTerminatedStatus().joinInternal();
             integration.shutdown();
         }
+    }
+
+    /**
+     * Creates an artificial load on the given Raft node by sleeping its thread for
+     * the given duration.
+     */
+    public void slowDownNode(RaftEndpoint endpoint, int seconds) {
+        getNode(endpoint).execute(() -> sleepSeconds(seconds));
     }
 
     public int size() {


### PR DESCRIPTION
Added `flowControlSequenceNumber` to Append/InstallSnapshot requests and responses to perform matching between them.
This allows reset the backoff only for the corresponding request.

Fixes https://github.com/hazelcast/hazelcast/issues/24958

Breaking changes (list specific methods/types/messages):
* `AppendRequest`, `InstallSnapshot`, `AppendSuccessResponse`,`AppendFailureResponse`

(cherry picked from commit 8e3ffce5c2ee1730bd40569b0b4d7c813d9c490e)

Backport of: https://github.com/hazelcast/hazelcast/pull/25055

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
