### PR TITLE
Fix [TCP/IP join] members configuration override [HZ-2786]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -1656,7 +1656,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 }
                 tcpIpConfig.setRequiredMember(getTextContent(n));
             } else if (memberTags.contains(cleanNodeName(n))) {
-                tcpIpConfig.addMember(getTextContent(n));
+                String textContent = getTextContent(n);
+                tcpIpConfig.setMembers(List.of(textContent));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -264,6 +264,10 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
 
     protected final Config config;
 
+    // Flag that indicates if DOM processor is called for
+    // external configuration (system properties or environment variables)
+    protected boolean forExternalConfiguration;
+
     public MemberDomConfigProcessor(boolean domLevel3, Config config, boolean strict) {
         super(domLevel3, strict);
         this.config = config;
@@ -272,6 +276,11 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
     public MemberDomConfigProcessor(boolean domLevel3, Config config) {
         super(domLevel3);
         this.config = config;
+    }
+
+    public MemberDomConfigProcessor setForExternalConfiguration() {
+        this.forExternalConfiguration = true;
+        return this;
     }
 
     @Override
@@ -1657,7 +1666,14 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 tcpIpConfig.setRequiredMember(getTextContent(n));
             } else if (memberTags.contains(cleanNodeName(n))) {
                 String textContent = getTextContent(n);
-                tcpIpConfig.setMembers(List.of(textContent));
+                // If DOM processor is configured for ExternalConfiguration then replace all members
+                // with external values
+                if (forExternalConfiguration) {
+                    tcpIpConfig.setMembers(List.of(textContent));
+                } else {
+                    // If DOM processor is configured for XML/YAML then append the value
+                    tcpIpConfig.addMember(textContent);
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/override/ExternalConfigurationOverride.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/override/ExternalConfigurationOverride.java
@@ -60,6 +60,7 @@ public class ExternalConfigurationOverride {
         return overwrite(config, (provider, rootNode, target) -> {
                     try {
                         new YamlMemberDomConfigProcessor(true, target, false)
+                                .setForExternalConfiguration()
                                 .buildConfig(new ConfigOverrideElementAdapter(rootNode));
                     } catch (Exception e) {
                         throw new InvalidConfigurationException("failed to overwrite configuration coming from " + provider, e);

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/override/ExternalMemberConfigurationOverrideEnvTest.java
@@ -98,7 +98,7 @@ public class ExternalMemberConfigurationOverrideEnvTest extends HazelcastTestSup
         envVariables.put("HZ_NETWORK_JOIN_TCPIP_MEMBERS", "10.0.0.1,10.0.0.2,10.0.0.2");
         new ExternalConfigurationOverride(envVariables, System::getProperties).overwriteMemberConfig(config);
 
-        assertThat(tcpIpConfig.getMembers()).containsExactlyInAnyOrder("10.0.0.1","10.0.0.2","10.0.0.2");
+        assertThat(tcpIpConfig.getMembers()).containsExactlyInAnyOrder("10.0.0.1", "10.0.0.2", "10.0.0.2");
     }
 
     @Test


### PR DESCRIPTION
This issue is reported by community. 

When HZ_NETWORK_JOIN_TCPIP_MEMBERS env variable is set, the TcpIpConfig members field is appended instead of getting replaced

1. Changed the MemberDomConfigProcessor to replace the given value. Added a new test  method to test it
2. There were a lot of unnecessary "throws Exception" in the test class.  Removed them

Fixes https://github.com/hazelcast/hazelcast/issues/21272
Jira https://hazelcast.atlassian.net/browse/HZ-2786

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

[HZ-2786]: https://hazelcast.atlassian.net/browse/HZ-2786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ