### PR TITLE
Don't fail consistency check when partitions not inited [HZ-2716]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/DataConnectionConsistencyChecker.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/DataConnectionConsistencyChecker.java
@@ -65,7 +65,7 @@ public class DataConnectionConsistencyChecker {
             return;
         }
 
-        if (nodeEngine.getPartitionService().isPartitionAssignmentDone()
+        if (!nodeEngine.getPartitionService().isPartitionAssignmentDone()
             && !hazelcastInstance.getCluster().getClusterState().isMigrationAllowed()) {
             // partitions have not been assigned yet and migrations are not allowed
             // so sql catalog can have no values -> skip check, because we anyway cannot

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/DataConnectionConsistencyChecker.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/DataConnectionConsistencyChecker.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.dataconnection.DataConnection;
 import com.hazelcast.dataconnection.impl.DataConnectionServiceImpl;
 import com.hazelcast.jet.impl.JetServiceBackend;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.IMap;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.sql.impl.schema.dataconnection.DataConnectionCatalogEntry;
@@ -30,7 +31,9 @@ import java.util.List;
 @NotThreadSafe
 public class DataConnectionConsistencyChecker {
     private final HazelcastInstance hazelcastInstance;
+    private final NodeEngine nodeEngine;
     private final DataConnectionServiceImpl dataConnectionService;
+    private final ILogger logger;
     // sqlCatalog supposed to be initialized lazily
     private IMap<Object, Object> sqlCatalog;
 
@@ -38,7 +41,9 @@ public class DataConnectionConsistencyChecker {
 
     public DataConnectionConsistencyChecker(HazelcastInstance instance, NodeEngine nodeEngine) {
         this.hazelcastInstance = instance;
+        this.nodeEngine = nodeEngine;
         this.dataConnectionService = (DataConnectionServiceImpl) nodeEngine.getDataConnectionService();
+        this.logger = nodeEngine.getLogger(DataConnectionConsistencyChecker.class);
     }
 
     /**
@@ -57,6 +62,17 @@ public class DataConnectionConsistencyChecker {
      */
     public void check() {
         if (!initialized) {
+            return;
+        }
+
+        if (nodeEngine.getPartitionService().isPartitionAssignmentDone()
+            && !hazelcastInstance.getCluster().getClusterState().isMigrationAllowed()) {
+            // partitions have not been assigned yet and migrations are not allowed
+            // so sql catalog can have no values -> skip check, because we anyway cannot
+            // iterate over sqlCatalog values (operation will fail with exception, since
+            // partition assignments do not exist and cannot be triggered).
+            logger.info("Skipping data connection consistency check because"
+                    + " initial partition assignment is not done yet.");
             return;
         }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/dataconnection/impl/DataConnectionConsistencyCheckerTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/dataconnection/impl/DataConnectionConsistencyCheckerTest.java
@@ -18,20 +18,20 @@ package com.hazelcast.dataconnection.impl;
 
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.DataConnectionConfig;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.dataconnection.DataConnection;
-import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.impl.JetServiceBackend;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.map.IMap;
 import com.hazelcast.sql.impl.DataConnectionConsistencyChecker;
 import com.hazelcast.sql.impl.QueryUtils;
 import com.hazelcast.sql.impl.schema.dataconnection.DataConnectionCatalogEntry;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,15 +40,16 @@ import java.util.Collections;
 import java.util.Map;
 
 import static com.hazelcast.test.AbstractHazelcastClassRunner.getTestMethodName;
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class DataConnectionConsistencyCheckerTest extends SimpleTestInClusterSupport {
+public class DataConnectionConsistencyCheckerTest extends HazelcastTestSupport {
 
     private DataConnectionServiceImpl linkService;
     private IMap<Object, Object> sqlCatalog;
@@ -57,13 +58,11 @@ public class DataConnectionConsistencyCheckerTest extends SimpleTestInClusterSup
     private String name;
     private final String type = "dummy";
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        initialize(3, null);
-    }
+    private HazelcastInstance[] instances;
 
     @Before
     public void setUp() throws Exception {
+        instances = createHazelcastInstances(3);
         name = randomName();
         linkService = (DataConnectionServiceImpl) getNodeEngineImpl(instance()).getDataConnectionService();
         dataConnectionConsistencyChecker = new DataConnectionConsistencyChecker(instance(), Util.getNodeEngine(instance()));
@@ -169,5 +168,9 @@ public class DataConnectionConsistencyCheckerTest extends SimpleTestInClusterSup
         dataConnectionConsistencyChecker.init();
         // the check should not fail with exception
         dataConnectionConsistencyChecker.check();
+    }
+
+    private HazelcastInstance instance() {
+        return instances[0];
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/IPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/IPartitionService.java
@@ -242,4 +242,10 @@ public interface IPartitionService extends CoreService {
         keysData.forEach(o -> partitionIds.add(getPartitionId(o)));
         return partitionIds;
     }
+
+    /**
+     * @return  {@code true} if initial partition assignment ("first arrangement")
+     *          is done, otherwise {@code false}.
+     */
+    boolean isPartitionAssignmentDone();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -265,6 +265,11 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
         }
     }
 
+    @Override
+    public boolean isPartitionAssignmentDone() {
+        return partitionStateManager.isInitialized();
+    }
+
     /** Sends a {@link AssignPartitions} to the master to assign partitions. */
     private void triggerMasterToAssignPartitions() {
         if (!shouldTriggerMasterToAssignPartitions()) {


### PR DESCRIPTION
The consistency check in `DataConnectionConsistencyChecker` needs to iterate over sqlCatalog's values. When partition assignments are not done and the cluster state does not allow triggering partition assignments (for example in `FROZEN` state), the consistency check should be skipped, because no data can exist in the sqlCatalog anyway. Previously, the check would fail with an `IllegalStateException`.

Fixes HZ-2716

Checklist:
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
