### PR TITLE
Don't fail consistency check when partitions not inited [HZ-2716] [5.3.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/IPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/IPartitionService.java
@@ -242,4 +242,10 @@ public interface IPartitionService extends CoreService {
         keysData.forEach(o -> partitionIds.add(getPartitionId(o)));
         return partitionIds;
     }
+
+    /**
+     * @return  {@code true} if initial partition assignment ("first arrangement")
+     *          is done, otherwise {@code false}.
+     */
+    boolean isPartitionAssignmentDone();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/IPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/IPartitionService.java
@@ -35,6 +35,7 @@ import javax.annotation.Nonnull;
 /**
  * An SPI service for accessing partition related information.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public interface IPartitionService extends CoreService {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -265,6 +265,11 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
         }
     }
 
+    @Override
+    public boolean isPartitionAssignmentDone() {
+        return partitionStateManager.isInitialized();
+    }
+
     /** Sends a {@link AssignPartitions} to the master to assign partitions. */
     private void triggerMasterToAssignPartitions() {
         if (!shouldTriggerMasterToAssignPartitions()) {


### PR DESCRIPTION
The consistency check in DataConnectionConsistencyChecker needs to iterate over sqlCatalog's values. When partition assignments are not done and the cluster state does not allow triggering partition assignments (for example in FROZEN state), the consistency check should be skipped, because no data can exist in the sqlCatalog anyway. Previously, the check would fail with an IllegalStateException.

Fixes HZ-2716

(cherry picked from commit a3ca14e2725b069156642e7c29e12919fe17e54d)
Backport of #25076 to 5.3.z