### PR TITLE
Update janino to 3.1.10 [5.3.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
         <jackson.version>2.15.2</jackson.version>
         <jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
         <jaxb.version>2.3.1</jaxb.version>
+        <janino.version>3.1.10</janino.version>
         <jline.version>3.23.0</jline.version>
         <jms.api.version>2.0.1</jms.api.version>
         <json-surfer.version>0.11</json-surfer.version>
@@ -1921,6 +1922,17 @@
                 <artifactId>proto-google-iam-v1</artifactId>
                 <version>1.9.3</version>
             </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>${janino.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>${janino.version}</version>
+            </dependency>
+
             <!-- Force higher version, compatible with M1 -->
             <!-- Otherwise Docker for Java (used by TestContainers) is not able to load all JNA files for aarch64 -->
             <dependency>


### PR DESCRIPTION
Fixes #24732 (CVE-2023-33546) in 5.3.z branch.

The fix in `master` should be to update calcite when they update their dependency to 3.1.10. If they don't publish such version before 5.4 release then we can forward-port this PR.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
