### PR TITLE
Make StreamKafkaPTest less flaky [HZ-2779]

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -163,6 +163,14 @@ public abstract class KafkaTestSupport {
                 .send(new ProducerRecord<>(topic, key, value));
     }
 
+    public RecordMetadata produceSync(String topic, Object key, Object value) {
+        try {
+            return produce(topic, key, value).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public Future<RecordMetadata> produce(String topic, int partition, Long timestamp, Object key, Object value) {
         return producers.computeIfAbsent(topic, t -> getProducer(topic, key, value))
                 .send(new ProducerRecord<>(topic, partition, timestamp, key, value));

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -325,7 +325,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
     ) {
         String sinkListName = randomName();
         for (int i = 0; i < messageCount; i++) {
-            kafkaTestSupport.produce(topic1Name, i, String.valueOf(i));
+                kafkaTestSupport.produceSync(topic1Name, i, String.valueOf(i));
         }
         Pipeline p = Pipeline.create();
         p.readFrom(KafkaSources.<Integer, String, String>kafka(kafkaProperties, ConsumerRecord::value, topicsConfig))

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -55,7 +55,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -167,7 +166,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
                 String value = i + "-x";
                 assertTrue("missing entry: " + value, list.contains(value));
             }
-        }, 5);
+        });
     }
 
     @Test
@@ -219,7 +218,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
 
         IList<Tuple2<String, String>> list = instance().getList(sinkListName);
         int totalRecordsRead = expectedRecordsReadFromTopic1 + expectedRecordsReadFromTopic2;
-        assertTrueEventually(() -> assertEquals(totalRecordsRead, list.size()), 5);
+        assertTrueEventually(() -> assertEquals(totalRecordsRead, list.size()));
 
         // group retrieved records by topic and check if expected number of records were skipped
         Map<String, List<String>> recordsByTopic = list.stream()
@@ -328,26 +327,22 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         for (int i = 0; i < messageCount; i++) {
             kafkaTestSupport.produce(topic1Name, i, String.valueOf(i));
         }
-        sleepAtLeastSeconds(3);
-
         Pipeline p = Pipeline.create();
         p.readFrom(KafkaSources.<Integer, String, String>kafka(kafkaProperties, ConsumerRecord::value, topicsConfig))
                 .withoutTimestamps()
                 .writeTo(Sinks.list(sinkListName));
 
         Job job = instance().getJet().newJob(p, new JobConfig().setProcessingGuarantee(processingGuarantee));
-        sleepAtLeastSeconds(3);
-
-        assertTrueEventually(() -> assertEquals(expectedCountBeforeRestart, instance().getList(sinkListName).size()), 5);
+        long oldExecutionId = assertJobRunningEventually(instance(), job, null);
+        assertTrueEventually(() -> assertEquals(expectedCountBeforeRestart, instance().getList(sinkListName).size()));
 
         job.restart();
 
         for (int i = messageCount; i < messageCount * 2; i++) {
             kafkaTestSupport.produce(topic1Name, i, String.valueOf(i));
         }
-        sleepAtLeastSeconds(3);
-
-        assertTrueEventually(() -> assertEquals(expectedCountAfterRestart, instance().getList(sinkListName).size()), 5);
+        assertJobRunningEventually(instance(), job, oldExecutionId);
+        assertTrueEventually(() -> assertEquals(expectedCountAfterRestart, instance().getList(sinkListName).size()));
     }
 
     @Test
@@ -390,7 +385,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
                 assertTrue("missing entry: " + entry1, list.contains(entry1));
                 assertTrue("missing entry: " + entry2, list.contains(entry2));
             }
-        }, 15);
+        });
 
         if (guarantee != ProcessingGuarantee.NONE) {
             // wait until a new snapshot appears
@@ -422,7 +417,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
                     assertTrue("missing entry: " + entry1, list.contains(entry1));
                     assertTrue("missing entry: " + entry2, list.contains(entry2));
                 }
-            }, 10);
+            });
         }
 
         assertFalse(job.getFuture().isDone());
@@ -546,7 +541,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         JobConfig config = new JobConfig();
         Job job = instances[0].getJet().newJob(p, config);
 
-        assertJobStatusEventually(job, RUNNING, 10);
+        assertJobStatusEventually(job, RUNNING);
 
         int messageCount = 1000;
         for (int i = 0; i < messageCount; i++) {
@@ -556,7 +551,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         IList<Object> list = instances[0].getList(sinkListName);
         try {
             // Wait for all messages
-            assertTrueEventually(() -> assertThat(list).hasSize(messageCount), 15);
+            assertTrueEventually(() -> assertThat(list).hasSize(messageCount));
             // Check there are no more messages (duplicates..)
             assertTrueAllTheTime(() -> assertThat(list).hasSize(messageCount), 1);
         } finally {
@@ -822,13 +817,12 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         assertTrueEventually(() -> {
             assertFalse(processor.complete());
             assertFalse("no item in outbox", outbox.queue(0).isEmpty());
-        }, 3);
+        });
         assertEquals("1", outbox.queue(0).poll());
         assertNull(outbox.queue(0).poll());
     }
 
     @Test
-    @Ignore("https://github.com/hazelcast/hazelcast-jet/issues/3011")
     public void when_topicDoesNotExist_then_partitionCountGreaterThanZero() {
         KafkaConsumer<Integer, String> c = kafkaTestSupport.createConsumer("non-existing-topic");
         assertGreaterOrEquals("partition count", c.partitionsFor("non-existing-topic", Duration.ofSeconds(2)).size(), 1);
@@ -866,7 +860,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
 
         kafkaTestSupport.produce(topic1Name, 0, "0").get();
         instance().getJet().newJob(p);
-        assertTrueEventually(() -> assertThat(sinkList).contains(entry(0, "0")), 2);
+        assertTrueEventually(() -> assertThat(sinkList).contains(entry(0, "0")));
     }
 
     @SuppressWarnings("unchecked")
@@ -874,7 +868,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         assertTrueEventually(() -> {
             assertFalse(processor.complete());
             assertFalse("no item in outbox", outbox.queue(0).isEmpty());
-        }, 12);
+        });
         return (T) outbox.queue(0).poll();
     }
 


### PR DESCRIPTION
- Use default timeout for assertions instead of small values that can lead to test-failures
- Check job status instead of waiting 3 seconds

Fixes https://github.com/hazelcast/hazelcast/issues/24986
Fixes https://hazelcast.atlassian.net//browse/HZ-2778
Maybe fixes https://github.com/hazelcast/hazelcast/issues/24578
Maybe fixes https://github.com/hazelcast/hazelcast/issues/24852

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
