### PR TITLE
bugfix: Discovery SPI Group partitioning - master now shuts down cleanly

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/SPIAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/SPIAwareMemberGroupFactory.java
@@ -53,34 +53,30 @@ public class SPIAwareMemberGroupFactory extends BackupSafeMemberGroupFactory imp
     protected Set<MemberGroup> createInternalMemberGroups(Collection<? extends Member> allMembers) {
         Set<MemberGroup> memberGroups = createHashSet(allMembers.size());
 
-        for (Member member : allMembers) {
-            try {
-                if (member.localMember()) {
-                    DefaultDiscoveryService defaultDiscoveryService = (DefaultDiscoveryService) discoveryService;
-                    // If no discovery strategy is found fail-fast
-                    if (!defaultDiscoveryService.getDiscoveryStrategies().iterator().hasNext()) {
-                        throw new RuntimeException("Could not load any Discovery Strategy, please "
-                                + "check service definitions under META_INF.services folder. ");
-                    } else {
-                        for (DiscoveryStrategy discoveryStrategy : defaultDiscoveryService.getDiscoveryStrategies()) {
-                            PartitionGroupStrategy groupStrategy = discoveryStrategy.getPartitionGroupStrategy(allMembers);
-                            if (groupStrategy == null) {
-                                groupStrategy = discoveryStrategy.getPartitionGroupStrategy();
-                            }
-                            checkNotNull(groupStrategy);
-                            for (MemberGroup group : groupStrategy.getMemberGroups()) {
-                                memberGroups.add(group);
-                            }
-                            return memberGroups;
-                        }
+        try {
+            DefaultDiscoveryService defaultDiscoveryService = (DefaultDiscoveryService) discoveryService;
+            // If no discovery strategy is found fail-fast
+            if (!defaultDiscoveryService.getDiscoveryStrategies().iterator().hasNext()) {
+                throw new RuntimeException("Could not load any Discovery Strategy, please "
+                        + "check service definitions under META_INF.services folder. ");
+            } else {
+                for (DiscoveryStrategy discoveryStrategy : defaultDiscoveryService.getDiscoveryStrategies()) {
+                    PartitionGroupStrategy groupStrategy = discoveryStrategy.getPartitionGroupStrategy(allMembers);
+                    if (groupStrategy == null) {
+                        groupStrategy = discoveryStrategy.getPartitionGroupStrategy();
                     }
+                    checkNotNull(groupStrategy);
+                    for (MemberGroup group : groupStrategy.getMemberGroups()) {
+                        memberGroups.add(group);
+                    }
+                    return memberGroups;
                 }
-            } catch (Exception e) {
-                if (e instanceof ValidationException) {
-                    throw new InvalidConfigurationException("Invalid configuration", e);
-                } else {
-                    throw new RuntimeException("Failed to configure discovery strategies", e);
-                }
+            }
+        } catch (Exception e) {
+            if (e instanceof ValidationException) {
+                throw new InvalidConfigurationException("Invalid configuration", e);
+            } else {
+                throw new RuntimeException("Failed to configure discovery strategies", e);
             }
         }
 


### PR DESCRIPTION
Removed the loop over the members. This loop no longer has a purpose, and triggered this bug.
The code needed this loop a while ago, but since it was refactored, it no longer needs it.

fixes #25100

<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

Breaking changes (list specific methods/types/messages):
None.

**Please use "Hide whitespace changes" when reviewing**

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
