### PR TITLE
Partition Pruning support for __key filters [HZ-2525]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
@@ -75,6 +75,7 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.partition.Partition;
+import com.hazelcast.partition.PartitionAware;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.partition.strategy.AttributePartitioningStrategy;
 import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
@@ -555,6 +556,10 @@ public class PlanExecutor {
                     }
 
                     partitionKeyComponents[i] = perMapCandidate.get(attribute).eval(null, evalContext);
+                    // handling case of __key = ? where the parameter is an PartitionAware OBJECT.
+                    if (partitionKeyComponents[i] instanceof PartitionAware) {
+                        partitionKeyComponents[i] = ((PartitionAware<?>) partitionKeyComponents[i]).getPartitionKey();
+                    }
                 }
 
                 final Partition partition = hazelcastInstance.getPartitionService().getPartition(

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
@@ -75,7 +75,6 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.partition.Partition;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.partition.strategy.AttributePartitioningStrategy;
 import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
@@ -557,16 +556,16 @@ public class PlanExecutor {
                     partitionKeyComponents[i] = perMapCandidate.get(attribute).eval(null, evalContext);
                 }
 
-                final Partition partition = PartitioningStrategyUtil.getPartitionFromKeyComponents(
-                        hazelcastInstance, strategy, partitionKeyComponents);
+                final Integer partitionId = PartitioningStrategyUtil.getPartitionIdFromKeyComponents(
+                        nodeEngine, strategy, partitionKeyComponents);
 
-                if (partition == null) {
-                    // Can happen if the cluster is mid-repartitioning/migration, in this case we revert to
-                    // non-pruning logic. Alternative scenario is if the produced partitioning key somehow invalid.
+                if (partitionId == null) {
+                    // The produced partitioning key is somehow invalid, most likely null.
+                    // In this case we revert to non-pruning logic.
                     allVariantsValid = false;
                     break;
                 }
-                partitions.add(partition.getPartitionId());
+                partitions.add(partitionId);
             }
         }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
@@ -557,7 +557,8 @@ public class PlanExecutor {
                     partitionKeyComponents[i] = perMapCandidate.get(attribute).eval(null, evalContext);
                 }
 
-                final Partition partition = PartitioningStrategyUtil.getPartitionFromKeyComponents(hazelcastInstance, strategy, partitionKeyComponents);
+                final Partition partition = PartitioningStrategyUtil.getPartitionFromKeyComponents(
+                        hazelcastInstance, strategy, partitionKeyComponents);
 
                 if (partition == null) {
                     // Can happen if the cluster is mid-repartitioning/migration, in this case we revert to

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -456,13 +456,14 @@ public class IMapSqlConnector implements SqlConnector {
         return PRIMARY_KEY_LIST;
     }
 
+    @Nullable
     private List<List<Expression<?>>> computeRequiredPartitionsToScan(
             NodeEngine nodeEngine,
             List<Map<String, Expression<?>>> candidates,
             String mapName
     ) {
         if (candidates == null) {
-            return emptyList();
+            return null;
         }
 
         List<List<Expression<?>>> partitionsExpressions = new ArrayList<>();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/SpecificPartitionsImapReaderPms.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/SpecificPartitionsImapReaderPms.java
@@ -94,8 +94,10 @@ public abstract class SpecificPartitionsImapReaderPms<F extends CompletableFutur
                         : "Partition calculated for PMS not present in the job";
                 partitionsToScanList.add(partition.getPartitionId());
             }
-            partitionsToScan = partitionsToScanList.asArray();
-            Arrays.sort(partitionsToScan);
+
+            // requiredPartitionsExprs may produce the same partition multiple times
+            // partitionsToScan is required to be unique and sorted
+            partitionsToScan = partitionsToScanList.stream().sorted().distinct().toArray();
             partitionAssignment = context.partitionAssignment();
         }
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/metadata/HazelcastRelMdPrunability.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/metadata/HazelcastRelMdPrunability.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.sql.impl.opt.physical.FullScanPhysicalRel;
 import com.hazelcast.jet.sql.impl.opt.physical.IndexScanMapPhysicalRel;
 import com.hazelcast.jet.sql.impl.opt.prunability.PartitionStrategyConditionExtractor;
 import com.hazelcast.jet.sql.impl.schema.HazelcastTable;
+import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.schema.map.PartitionedMapTable;
 import org.apache.calcite.linq4j.tree.Types;
@@ -83,19 +84,22 @@ public final class HazelcastRelMdPrunability
         }
 
         final PartitionedMapTable targetTable = hazelcastTable.getTarget();
-        Set<String> partitioningColumns;
-
-        if (targetTable.partitioningAttributes().isEmpty()) {
+        if (!targetTable.supportsPartitionPruning()) {
             return emptyMap();
         }
 
-        // PartitioningColumns contains field names rather than columns names,
-        // we have to convert it to column names if EXTERNAL NAME is used.
-        final HashSet<String> partitioningFieldNames = new HashSet<>(targetTable.partitioningAttributes());
-        partitioningColumns = targetTable.keyFields()
-                .filter(kf -> partitioningFieldNames.contains(kf.getPath().getPath()))
-                .map(TableField::getName)
-                .collect(Collectors.toSet());
+        final Set<String> partitioningColumns;
+        if (targetTable.partitioningAttributes().isEmpty()) {
+            partitioningColumns = Set.of(QueryPath.KEY);
+        } else {
+            // PartitioningColumns contains field names rather than columns names,
+            // we have to convert it to column names if EXTERNAL NAME is used.
+            final HashSet<String> partitioningFieldNames = new HashSet<>(targetTable.partitioningAttributes());
+            partitioningColumns = targetTable.keyFields()
+                    .filter(kf -> partitioningFieldNames.contains(kf.getPath().getPath()))
+                    .map(TableField::getName)
+                    .collect(Collectors.toSet());
+        }
 
         final RexNode filter = hazelcastTable.getFilter();
         if (!(filter instanceof RexCall)) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/FullScanPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/FullScanPhysicalRel.java
@@ -48,6 +48,7 @@ import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.impl.util.Util.toList;
@@ -170,6 +171,7 @@ public class FullScanPhysicalRel extends FullScan implements HazelcastPhysicalSc
             partitioningKeyValues = candidates.get(target.getSqlName()).stream()
                     .map(candidate -> fieldNames.stream()
                             .map(candidate::get)
+                            .filter(Objects::nonNull)
                             .map(RexNode::toString)
                             .collect(Collectors.joining(", ")))
                     .map(s -> "(" + s + ")")

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/map/PartitionedMapTable.java
@@ -36,6 +36,7 @@ public class PartitionedMapTable extends AbstractMapTable {
     private final List<MapTableIndex> indexes;
     private final boolean hd;
     private final List<String> partitioningAttributes;
+    private final boolean supportsPartitionPruning;
 
     @SuppressWarnings("checkstyle:ParameterNumber")
     public PartitionedMapTable(
@@ -50,7 +51,8 @@ public class PartitionedMapTable extends AbstractMapTable {
             Object valueJetMetadata,
             List<MapTableIndex> indexes,
             boolean hd,
-            List<String> partitioningAttributes
+            List<String> partitioningAttributes,
+            boolean supportsPartitionPruning
     ) {
         super(
             schemaName,
@@ -68,6 +70,7 @@ public class PartitionedMapTable extends AbstractMapTable {
         this.indexes = indexes;
         this.hd = hd;
         this.partitioningAttributes = partitioningAttributes;
+        this.supportsPartitionPruning = supportsPartitionPruning;
     }
 
     @Override
@@ -88,7 +91,8 @@ public class PartitionedMapTable extends AbstractMapTable {
                 getValueJetMetadata(),
                 getIndexes(),
                 isHd(),
-                partitioningAttributes());
+                partitioningAttributes(),
+                supportsPartitionPruning());
     }
 
     public List<MapTableIndex> getIndexes() {
@@ -136,6 +140,15 @@ public class PartitionedMapTable extends AbstractMapTable {
         return partitioningAttributes != null ? partitioningAttributes : emptyList();
     }
 
+    /**
+     * Flag to indicate whether underlying Map/Table uses one of the supported PartitioningStrategies and therefore
+     * can support Partition Pruning.
+     * @return true if table supports Partition Pruning
+     */
+    public boolean supportsPartitionPruning() {
+        return supportsPartitionPruning;
+    }
+
     static class PartitionedMapPlanObjectKey implements PlanObjectKey {
 
         private final String schemaName;
@@ -150,6 +163,7 @@ public class PartitionedMapTable extends AbstractMapTable {
         private final boolean hd;
         private final Set<String> conflictingSchemas;
         private final List<String> partitioningAttributes;
+        private final boolean supportsPartitionPruning;
 
         @SuppressWarnings("checkstyle:ParameterNumber")
         PartitionedMapPlanObjectKey(
@@ -164,7 +178,8 @@ public class PartitionedMapTable extends AbstractMapTable {
                 Object valueJetMetadata,
                 List<MapTableIndex> indexes,
                 boolean hd,
-                final List<String> partitioningAttributes) {
+                final List<String> partitioningAttributes,
+                final boolean supportsPartitionPruning) {
             this.schemaName = schemaName;
             this.tableName = tableName;
             this.mapName = mapName;
@@ -177,6 +192,7 @@ public class PartitionedMapTable extends AbstractMapTable {
             this.hd = hd;
             this.conflictingSchemas = conflictingSchemas;
             this.partitioningAttributes = partitioningAttributes;
+            this.supportsPartitionPruning = supportsPartitionPruning;
         }
 
         @Override
@@ -203,7 +219,8 @@ public class PartitionedMapTable extends AbstractMapTable {
                     && Objects.equals(valueJetMetadata, that.valueJetMetadata)
                     && indexes.equals(that.indexes)
                     && conflictingSchemas.equals(that.conflictingSchemas)
-                    && partitioningAttributes.equals(that.partitioningAttributes);
+                    && partitioningAttributes.equals(that.partitioningAttributes)
+                    && supportsPartitionPruning == that.supportsPartitionPruning;
         }
 
         @Override
@@ -220,6 +237,7 @@ public class PartitionedMapTable extends AbstractMapTable {
             result = 31 * result + (hd ? 1 : 0);
             result = 31 * result + conflictingSchemas.hashCode();
             result = 31 * result + partitioningAttributes.hashCode();
+            result = 31 * result + (supportsPartitionPruning ? 1 : 0);
             return result;
         }
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/ExplainStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/ExplainStatementTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningAttributeConfig;
 import com.hazelcast.jet.sql.SqlTestSupport;
 import com.hazelcast.jet.sql.impl.connector.map.model.Person;
-import com.hazelcast.jet.sql.impl.opt.prunability.PartitionPruningIT;
+import com.hazelcast.jet.sql.impl.opt.prunability.PartitionPruningIntegrationTest.KeyObj;
 import com.hazelcast.map.IMap;
 import com.hazelcast.sql.SqlResult;
 import com.hazelcast.sql.SqlStatement;
@@ -337,7 +337,7 @@ public class ExplainStatementTest extends SqlTestSupport {
                 + ") TYPE IMap OPTIONS ("
                 + "'valueFormat'='varchar', "
                 + "'keyFormat'='java', "
-                + "'keyJavaClass'='" + PartitionPruningIT.KeyObj.class.getName() + "')");
+                + "'keyJavaClass'='" + KeyObj.class.getName() + "')");
 
         // non-prunable
         assertRowsOrdered("EXPLAIN PLAN FOR SELECT this FROM test WHERE c1 = ? AND c2 = ?", rows(1,
@@ -372,7 +372,7 @@ public class ExplainStatementTest extends SqlTestSupport {
                 + ") TYPE IMap OPTIONS ("
                 + "'valueFormat'='varchar', "
                 + "'keyFormat'='java', "
-                + "'keyJavaClass'='" + PartitionPruningIT.KeyObj.class.getName() + "')");
+                + "'keyJavaClass'='" + KeyObj.class.getName() + "')");
 
         // simple query for which member pruning is not possible
         assertRowsAnyOrder("EXPLAIN PLAN FOR SELECT this FROM test WHERE c3 = 1 AND c2 = ?" +
@@ -406,7 +406,7 @@ public class ExplainStatementTest extends SqlTestSupport {
                 + ") TYPE IMap OPTIONS ("
                 + "'valueFormat'='varchar', "
                 + "'keyFormat'='java', "
-                + "'keyJavaClass'='" + PartitionPruningIT.KeyObj.class.getName() + "')");
+                + "'keyJavaClass'='" + KeyObj.class.getName() + "')");
 
         // complicated query that should not be eligible for member pruning
         // but at least one side of the join should execute full scan that is eligible for scan partition pruning

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/ExplainStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/ExplainStatementTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -309,7 +308,6 @@ public class ExplainStatementTest extends SqlTestSupport {
     }
 
     @Test
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/25033")
     public void test_partitioningKeyInfoWithSimpleKey() {
         createMapping("test", Long.class, String.class);
         // non-prunable

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SpecificPartitionsImapReaderPmsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SpecificPartitionsImapReaderPmsTest.java
@@ -100,7 +100,7 @@ public class SpecificPartitionsImapReaderPmsTest extends SimpleTestInClusterSupp
 
         DAG dag = new DAG();
         ProcessorMetaSupplier readPms = mapReader(mapName, new DefaultPartitioningStrategy(), List.of(
-                List.of(ConstantExpression.create(pKey, QueryDataType.INT))));
+                List.of(ConstantExpression.create(0, QueryDataType.INT))));
         Vertex source = dag.newVertex("source", readPms);
         Vertex sink = dag.newVertex("sink", writeMapP(sinkName));
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SpecificPartitionsImapReaderPmsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SpecificPartitionsImapReaderPmsTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.impl.execution.init.ExecutionPlanBuilder;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.map.IMap;
+import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.type.QueryDataType;
@@ -98,7 +99,7 @@ public class SpecificPartitionsImapReaderPmsTest extends SimpleTestInClusterSupp
         map.put(0, 0);
 
         DAG dag = new DAG();
-        ProcessorMetaSupplier readPms = mapReader(mapName, List.of(
+        ProcessorMetaSupplier readPms = mapReader(mapName, new DefaultPartitioningStrategy(), List.of(
                 List.of(ConstantExpression.create(pKey, QueryDataType.INT))));
         Vertex source = dag.newVertex("source", readPms);
         Vertex sink = dag.newVertex("sink", writeMapP(sinkName));
@@ -117,7 +118,7 @@ public class SpecificPartitionsImapReaderPmsTest extends SimpleTestInClusterSupp
         map.put(pKey, pKey);
 
         // Given
-        ProcessorMetaSupplier pms = mapReader(mapName, List.of(
+        ProcessorMetaSupplier pms = mapReader(mapName, new DefaultPartitioningStrategy(), List.of(
                 List.of(ConstantExpression.create(pKey, QueryDataType.INT))
         ));
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SpecificPartitionsImapReaderPmsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SpecificPartitionsImapReaderPmsTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.map.IMap;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -92,7 +91,7 @@ public class SpecificPartitionsImapReaderPmsTest extends SimpleTestInClusterSupp
         map.put(0, 0);
 
         DAG dag = new DAG();
-        ProcessorMetaSupplier readPms = mapReader(mapName, new DefaultPartitioningStrategy(), List.of(
+        ProcessorMetaSupplier readPms = mapReader(mapName, null, List.of(
                 List.of(ConstantExpression.create(0, QueryDataType.INT))));
         Vertex source = dag.newVertex("source", readPms);
         Vertex sink = dag.newVertex("sink", writeMapP(sinkName));
@@ -111,7 +110,7 @@ public class SpecificPartitionsImapReaderPmsTest extends SimpleTestInClusterSupp
         map.put(pKey, pKey);
 
         // Given
-        ProcessorMetaSupplier pms = mapReader(mapName, new DefaultPartitioningStrategy(), List.of(
+        ProcessorMetaSupplier pms = mapReader(mapName, null, List.of(
                 List.of(ConstantExpression.create(pKey, QueryDataType.INT))
         ));
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorTest.java
@@ -124,7 +124,8 @@ public class UpdateProcessorTest extends SqlTestSupport {
                 PrimitiveUpsertTargetDescriptor.INSTANCE,
                 emptyList(),
                 false,
-                Collections.emptyList());
+                Collections.emptyList(),
+                false);
     }
 
     private Object executeUpdate(

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/OptimizerTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/OptimizerTestSupport.java
@@ -149,15 +149,17 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
             List<MapTableIndex> indexes,
             long rowCount
     ) {
-        return partitionedTable(name, fields, indexes, rowCount, emptyList());
+        return partitionedTable(name, fields, indexes, rowCount, emptyList(), false);
     }
 
+    // TODO: migrate this code to builder
     protected static HazelcastTable partitionedTable(
             String name,
             List<TableField> fields,
             List<MapTableIndex> indexes,
             long rowCount,
-            List<String> partitioningAttributes
+            List<String> partitioningAttributes,
+            boolean supportsPartitionPruning
     ) {
         PartitionedMapTable table = new PartitionedMapTable(
                 SCHEMA_NAME_PUBLIC,
@@ -171,7 +173,8 @@ public abstract class OptimizerTestSupport extends SqlTestSupport {
                 null,
                 indexes,
                 false,
-                partitioningAttributes);
+                partitioningAttributes,
+                supportsPartitionPruning);
         return new HazelcastTable(table, new HazelcastTableStatistic(rowCount));
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PSConditionExtractorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PSConditionExtractorTest.java
@@ -27,7 +27,6 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -47,6 +46,7 @@ import static com.hazelcast.sql.impl.type.QueryDataType.INT;
 import static com.hazelcast.sql.impl.type.QueryDataType.OBJECT;
 import static com.hazelcast.sql.impl.type.QueryDataType.VARCHAR;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.calcite.sql.type.SqlTypeName.INTEGER;
 import static org.junit.Assert.assertEquals;
@@ -64,14 +64,14 @@ public class PSConditionExtractorTest extends OptimizerTestSupport {
     }
 
     @Test
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/25033")
     public void test_singleEquals() {
         var table = partitionedTable(
                 "m",
                 asList(
                         mapField(KEY, INT, QueryPath.KEY_PATH),
                         mapField(VALUE, VARCHAR, QueryPath.VALUE_PATH)),
-                10).getTarget();
+                emptyList(),
+                10, emptyList(), true).getTarget();
 
         var b = new RexBuilder(typeFactory);
         var leftInputRef = b.makeInputRef(typeFactory.createSqlType(INTEGER), 0);
@@ -92,7 +92,7 @@ public class PSConditionExtractorTest extends OptimizerTestSupport {
                         mapField("comp2", BIGINT, QueryPath.create(QueryPath.KEY_PREFIX + "comp3")),
                         mapField(KEY, OBJECT, QueryPath.KEY_PATH),
                         mapField(VALUE, VARCHAR, QueryPath.VALUE_PATH)),
-                Collections.emptyList(), 10, Arrays.asList("comp1", "comp2")).getTarget();
+                Collections.emptyList(), 10, Arrays.asList("comp1", "comp2"), true).getTarget();
 
         // comp0 = ?2 AND comp1 = ?1 AND comp2 = ?0
         var b = new RexBuilder(typeFactory);
@@ -126,7 +126,7 @@ public class PSConditionExtractorTest extends OptimizerTestSupport {
                         mapField("comp2", BIGINT, QueryPath.create(QueryPath.KEY_PREFIX + "comp3")),
                         mapField(KEY, OBJECT, QueryPath.KEY_PATH),
                         mapField(VALUE, VARCHAR, QueryPath.VALUE_PATH)),
-                Collections.emptyList(), 10, Arrays.asList("comp1", "comp2")).getTarget();
+                Collections.emptyList(), 10, Arrays.asList("comp1", "comp2"), true).getTarget();
 
         // comp0 = ?2 AND comp1 = ?1 AND comp2 = ?0
         var b = new RexBuilder(typeFactory);
@@ -157,7 +157,7 @@ public class PSConditionExtractorTest extends OptimizerTestSupport {
                         mapField("comp2", BIGINT, QueryPath.create(QueryPath.KEY_PREFIX + "comp3")),
                         mapField(KEY, OBJECT, QueryPath.KEY_PATH),
                         mapField(VALUE, VARCHAR, QueryPath.VALUE_PATH)),
-                Collections.emptyList(), 10, Arrays.asList("comp1", "comp2")).getTarget();
+                Collections.emptyList(), 10, Arrays.asList("comp1", "comp2"), true).getTarget();
 
         // comp0 = ?2 AND comp1 = ?1 AND comp2 = ?0
         var b = new RexBuilder(typeFactory);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PartitionPruningIT.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PartitionPruningIT.java
@@ -22,12 +22,10 @@ import com.hazelcast.jet.sql.SqlTestSupport;
 import com.hazelcast.map.IMap;
 import com.hazelcast.partition.PartitionAware;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.SlowTest;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.Serializable;
@@ -42,7 +40,6 @@ import static java.util.Collections.singletonList;
  * the job execution.
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({SlowTest.class})
 public class PartitionPruningIT extends SqlTestSupport {
     @BeforeClass
     public static void beforeClass() {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PartitionPruningIT.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PartitionPruningIT.java
@@ -163,7 +163,7 @@ public class PartitionPruningIT extends SqlTestSupport {
         instance().getConfig().addMapConfig(new MapConfig(mapName).setPartitioningAttributeConfigs(Arrays.asList(
                 new PartitioningAttributeConfig("nestedKey")
         )));
-        var paKey = new PAKey(1L,"one");
+        var paKey = new PAKey(1L, "one");
         IMap<KeyWithPAField, String> map = instance().getMap(mapName);
         map.put(new KeyWithPAField(paKey), "oneValue");
 
@@ -179,7 +179,7 @@ public class PartitionPruningIT extends SqlTestSupport {
         instance().getConfig().addMapConfig(new MapConfig(mapName).setPartitioningAttributeConfigs(Arrays.asList(
                 new PartitioningAttributeConfig("nestedKey")
         )));
-        var paKey = new PAKey(1L,"one");
+        var paKey = new PAKey(1L, "one");
         IMap<PAKeyWithPAField, String> map = instance().getMap(mapName);
         map.put(new PAKeyWithPAField(paKey), "oneValue");
 
@@ -192,7 +192,7 @@ public class PartitionPruningIT extends SqlTestSupport {
     @Test
     public void test_partitionAwarePartitionAwareKeyShouldBePruned() {
         String mapName = randomName();
-        var paKey = new PAKey(1L,"one");
+        var paKey = new PAKey(1L, "one");
         IMap<PAKeyWithPAField, String> map = instance().getMap(mapName);
         map.put(new PAKeyWithPAField(paKey), "oneValue");
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PartitionPruningIT.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PartitionPruningIT.java
@@ -25,7 +25,6 @@ import com.hazelcast.test.annotation.SlowTest;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -89,7 +88,6 @@ public class PartitionPruningIT extends SqlTestSupport {
     }
 
     @Test
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/25033")
     public void test_simpleKeyAndEmptyMapPruned() {
         createMapping("test4", Integer.class, Integer.class);
         instance().getMap("test4");
@@ -97,13 +95,11 @@ public class PartitionPruningIT extends SqlTestSupport {
     }
 
     @Test
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/25033")
     public void test_simpleKeyPruned() {
         assertRowsAnyOrder("SELECT this FROM test1 WHERE __key = ? AND this = 'v1'", List.of(1), rows(1, "v1"));
     }
 
     @Test
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/25033")
     public void test_simpleKeyNotPruned() {
         assertRowsAnyOrder("SELECT this FROM test1 WHERE __key > 0 AND this = 'v1'", rows(1, "v1"));
     }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PartitionPruningIT.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PartitionPruningIT.java
@@ -130,7 +130,7 @@ public class PartitionPruningIT extends SqlTestSupport {
     }
 
     @Test
-    public void test_partitionAwareKeyNonMappedShouldNotBePruned() {
+    public void test_partitionAwareKeyNonMappedShouldBePruned() {
         instance().getSql().execute("CREATE MAPPING test4 TYPE IMap OPTIONS ("
                 + "'valueFormat'='varchar', "
                 + "'keyFormat'='java', "

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PartitionPruningIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/PartitionPruningIntegrationTest.java
@@ -40,7 +40,7 @@ import static java.util.Collections.singletonList;
  * the job execution.
  */
 @RunWith(HazelcastSerialClassRunner.class)
-public class PartitionPruningIT extends SqlTestSupport {
+public class PartitionPruningIntegrationTest extends SqlTestSupport {
     @BeforeClass
     public static void beforeClass() {
         initialize(6, null);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/RelPrunabilityTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/opt/prunability/RelPrunabilityTest.java
@@ -91,11 +91,10 @@ public class RelPrunabilityTest extends OptimizerTestSupport {
                 mapTableFields,
                 emptyList(),
                 10,
-                singletonList("comp1"));
+                singletonList("comp1"), true);
     }
 
     @Test
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/25033")
     public void test_fullScanWithDefaultKey() {
         this.mapTableFields = asList(
                 mapField(KEY, BIGINT, QueryPath.KEY_PATH),
@@ -106,7 +105,7 @@ public class RelPrunabilityTest extends OptimizerTestSupport {
                 mapTableFields,
                 emptyList(),
                 10,
-                emptyList());
+                emptyList(), true);
 
         PhysicalRel root = optimizePhysical("SELECT * FROM m WHERE __key = 10 AND this IS NOT NULL",
                 asList(BIGINT, BIGINT), table)
@@ -165,8 +164,8 @@ public class RelPrunabilityTest extends OptimizerTestSupport {
                 mapTableFields,
                 getPartitionedMapIndexes(mapContainer(map), mapTableFields),
                 1, // we can place random number, doesn't matter in current case.
-                singletonList("comp1")
-        );
+                singletonList("comp1"),
+                true);
 
         PhysicalRel root = optimizePhysical(
                 "SELECT * FROM " + mapName + " WHERE comp1 = 10",

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/parse/ParserNameResolutionTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/parse/ParserNameResolutionTest.java
@@ -201,7 +201,8 @@ public class ParserNameResolutionTest extends SqlTestSupport {
                 null,
                 null,
                 false,
-                Collections.emptyList());
+                Collections.emptyList(),
+                false);
         PartitionedMapTable table2 = new PartitionedMapTable(
                 SCHEMA_2,
                 TABLE_2,
@@ -214,7 +215,8 @@ public class ParserNameResolutionTest extends SqlTestSupport {
                 null,
                 null,
                 false,
-                Collections.emptyList());
+                Collections.emptyList(),
+                false);
 
         TableResolver resolver1 = TestTableResolver.create(SCHEMA_1, table1);
         TableResolver resolver2 = TestTableResolver.create(SCHEMA_2, table2);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/parse/ParserOperationsTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/parse/ParserOperationsTest.java
@@ -195,7 +195,8 @@ public class ParserOperationsTest extends SqlTestSupport {
                 null,
                 null,
                 false,
-                Collections.emptyList());
+                Collections.emptyList(),
+                false);
 
         TableResolver resolver = TestTableResolver.create(
                 "public",

--- a/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/schema/map/PartitionedMapPlanObjectKeyTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/sql/impl/schema/map/PartitionedMapPlanObjectKeyTest.java
@@ -84,21 +84,24 @@ public class PartitionedMapPlanObjectKeyTest extends CoreSqlTestSupport {
         List<String> partitioningAttributes1 = singletonList("attr1");
         List<String> partitioningAttributes2 = emptyList();
 
-        PartitionedMapPlanObjectKey objectId = new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes1);
+        boolean supportsPartitionPruning1 = true;
+        boolean supportsPartitionPruning2 = false;
 
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes1), true);
+        PartitionedMapPlanObjectKey objectId = new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes1, supportsPartitionPruning1);
 
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema2, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema2, tableName2, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName2, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields2, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas2, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor2, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor2, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor2, keyJetMetadata2, valueJetMetadata1, indexes1, hd1, partitioningAttributes2), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor2, keyJetMetadata1, valueJetMetadata2, indexes1, hd1, partitioningAttributes2), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes2, hd1, partitioningAttributes2), false);
-        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd2, partitioningAttributes2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes1, supportsPartitionPruning1), true);
+
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema2, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2, supportsPartitionPruning2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema2, tableName2, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2, supportsPartitionPruning2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName2, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2, supportsPartitionPruning2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields2, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2, supportsPartitionPruning2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas2, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2, supportsPartitionPruning2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor2, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2, supportsPartitionPruning2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor2, keyJetMetadata1, valueJetMetadata1, indexes1, hd1, partitioningAttributes2, supportsPartitionPruning2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor2, keyJetMetadata2, valueJetMetadata1, indexes1, hd1, partitioningAttributes2, supportsPartitionPruning2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor2, keyJetMetadata1, valueJetMetadata2, indexes1, hd1, partitioningAttributes2, supportsPartitionPruning2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes2, hd1, partitioningAttributes2, supportsPartitionPruning2), false);
+        checkEquals(objectId, new PartitionedMapPlanObjectKey(schema1, tableName1, mapName1, fields1, conflictingSchemas1, keyDescriptor1, valueDescriptor1, keyJetMetadata1, valueJetMetadata1, indexes1, hd2, partitioningAttributes2, supportsPartitionPruning2), false);
     }
 
     private static class TestTargetDescriptor implements QueryTargetDescriptor {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/PartitioningStrategyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/PartitioningStrategyUtil.java
@@ -16,14 +16,12 @@
 
 package com.hazelcast.internal.util;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.jet.impl.util.Util;
-import com.hazelcast.partition.Partition;
 import com.hazelcast.partition.PartitionAware;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.partition.strategy.AttributePartitioningStrategy;
 import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
+import com.hazelcast.spi.impl.NodeEngine;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,11 +52,11 @@ public final class PartitioningStrategyUtil {
      * Gets partition for given key specified as key components. Supports
      * {@link AttributePartitioningStrategy} and {@link
      * DefaultPartitioningStrategy}.
-     * @return Partition to which the key belongs or null if the partition
+     * @return Partition id to which the key belongs or null if the partition
      *         cannot be determined.
      */
     @Nullable
-    public static Partition getPartitionFromKeyComponents(@Nonnull HazelcastInstance hazelcastInstance,
+    public static Integer getPartitionIdFromKeyComponents(@Nonnull NodeEngine nodeEngine,
                                                           @Nullable PartitioningStrategy<?> strategy,
                                                           @Nonnull Object[] partitionKeyComponents) {
         assert strategy == null
@@ -88,12 +86,12 @@ public final class PartitioningStrategyUtil {
             // as AttributePartitioningStrategy would on a full key.
             // We also cannot use the default calculation because finalKey might be PartitionAware, which
             // we must ignore to be in line with partition calculation for IMap.
-            Data keyData = Util.getSerializationService(hazelcastInstance)
+            Data keyData = nodeEngine.getSerializationService()
                     .toData(finalKey, IDENTITY_PARTITIONING_STRATEGY);
-            return hazelcastInstance.getPartitionService().getPartition(keyData);
+            return nodeEngine.getPartitionService().getPartitionId(keyData);
         } else {
             // For other IMap strategies we use default calculation
-            return hazelcastInstance.getPartitionService().getPartition(finalKey);
+            return nodeEngine.getPartitionService().getPartitionId(finalKey);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
@@ -67,7 +67,6 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
-import com.hazelcast.version.Version;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
@@ -317,7 +317,7 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
 
         private transient HazelcastInstance hzInstance;
         private transient InternalSerializationService serializationService;
-        private transient int[] partitionsToScan;
+        private int[] partitionsToScan;
 
         public LocalProcessorSupplier() {
         }
@@ -361,11 +361,13 @@ public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends Ab
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeObject(readerSupplier);
+            out.writeIntArray(partitionsToScan);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             readerSupplier = in.readObject();
+            partitionsToScan = in.readIntArray();
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -41,6 +41,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.security.auth.Subject;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -30,6 +30,7 @@ import com.hazelcast.jet.function.RunnableEx;
 import com.hazelcast.jet.impl.JetServiceBackend;
 import com.hazelcast.jet.impl.JobClassLoaderService;
 import com.hazelcast.jet.impl.execution.init.Contexts.MetaSupplierCtx;
+import com.hazelcast.jet.impl.util.FixedCapacityIntArrayList;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -38,7 +39,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.security.auth.Subject;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -286,22 +286,4 @@ public final class ExecutionPlanBuilder {
         return partitionAssignment;
     }
 
-    static class FixedCapacityIntArrayList {
-        private int[] elements;
-        private int size;
-
-        FixedCapacityIntArrayList(int capacity) {
-            elements = new int[capacity];
-        }
-
-        void add(int element) {
-            elements[size++] = element;
-        }
-
-        int[] asArray() {
-            int[] result = size == elements.length ? elements : Arrays.copyOfRange(elements, 0, size);
-            elements = null;
-            return result;
-        }
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/FixedCapacityIntArrayList.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/FixedCapacityIntArrayList.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl.util;
 
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
 /**
  * Simple list of integers that stores its content in a non-resizeable array.
@@ -39,5 +40,9 @@ public class FixedCapacityIntArrayList {
         int[] result = size == elements.length ? elements : Arrays.copyOfRange(elements, 0, size);
         elements = null;
         return result;
+    }
+
+    public IntStream stream() {
+        return Arrays.stream(elements, 0, size);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/FixedCapacityIntArrayList.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/FixedCapacityIntArrayList.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import java.util.Arrays;
+
+/**
+ * Simple list of integers that stores its content in a non-resizeable array.
+ * Simplified variant of {@link com.hazelcast.internal.util.collection.FixedCapacityArrayList}
+ * for integers.
+ */
+public class FixedCapacityIntArrayList {
+    private int[] elements;
+    private int size;
+
+    public FixedCapacityIntArrayList(int capacity) {
+        elements = new int[capacity];
+    }
+
+    public void add(int element) {
+        elements[size++] = element;
+    }
+
+    public int[] asArray() {
+        int[] result = size == elements.length ? elements : Arrays.copyOfRange(elements, 0, size);
+        elements = null;
+        return result;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/JetJobPrunabilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/JetJobPrunabilityTest.java
@@ -112,8 +112,14 @@ public class JetJobPrunabilityTest extends SimpleTestInClusterSupport {
         // should print 0 and 1.
         assertJobStatusEventually(job, JobStatus.COMPLETED);
         List<List<Object>> lists = consumerPms.getLists();
+        List<List<Object>> nonEmptyRes = lists.stream().filter(l -> !l.isEmpty()).collect(Collectors.toList());
+
         // one of the processors should get all data
-        assertThat(lists).contains(List.of(0, 1));
+        assertThat(nonEmptyRes).isNotEmpty();
+        assertThat(nonEmptyRes.size()).isOne();
+
+        List<Object> results = nonEmptyRes.get(0);
+        assertThat(results).containsExactlyInAnyOrder(0, 1);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/JetJobPrunabilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/execution/init/JetJobPrunabilityTest.java
@@ -140,8 +140,14 @@ public class JetJobPrunabilityTest extends SimpleTestInClusterSupport {
 
         assertJobStatusEventually(job, JobStatus.COMPLETED);
         List<List<Object>> lists = consumerPms.getLists();
+        List<List<Object>> nonEmptyRes = lists.stream().filter(l -> !l.isEmpty()).collect(Collectors.toList());
+
         // one of the processors should get all data
-        assertThat(lists).contains(List.of(0, 1, 0, 1));
+        assertThat(nonEmptyRes).isNotEmpty();
+        assertThat(nonEmptyRes.size()).isOne();
+
+        List<Object> results = nonEmptyRes.get(0);
+        assertThat(results).containsExactlyInAnyOrder(0, 1, 1, 0);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/FixedCapacityIntArrayListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/FixedCapacityIntArrayListTest.java
@@ -53,4 +53,19 @@ public class FixedCapacityIntArrayListTest {
             }
         }
     }
+
+    @Test
+    public void when_elementsAdded_then_properElementsInStream() {
+        for (int i = 0; i < TEST_ARRAY_SIZE; i++) {
+            FixedCapacityIntArrayList fixedCapacityIntArrayList = new FixedCapacityIntArrayList(TEST_ARRAY_SIZE);
+            for (int j = 0; j < i; j++) {
+                fixedCapacityIntArrayList.add(j);
+            }
+
+            int[] filledElements = fixedCapacityIntArrayList.stream().toArray();
+            for (int j = 0; j < i; j++) {
+                assertEquals(j, filledElements[j]);
+            }
+        }
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/FixedCapacityIntArrayListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/FixedCapacityIntArrayListTest.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hazelcast.jet.impl.execution.init;
+package com.hazelcast.jet.impl.util;
 
-import com.hazelcast.jet.impl.execution.init.ExecutionPlanBuilder.FixedCapacityIntArrayList;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;


### PR DESCRIPTION
This also adds `supportsPartitionPruning` property to PartitionMapTable/Key, might be worth moving it up a level in the future however. 
Fixes #25033