### PR TITLE
Update AWS Terraform workflow[CN-954]

### DIFF
--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -1,4 +1,5 @@
 name: aws-tests
+
 on:
   workflow_dispatch:
   pull_request_target:
@@ -11,15 +12,19 @@ on:
       - 'hazelcast/src/main/java/com/hazelcast/aws/**'
       - '.github/terraform/aws/**'
 
+env:
+  GAR_PROJECT_ID: hazelcast-33
+  GAR_REGION: us-east1
+  GAR_REPO: auto-discovery-test-suite
+  AWS_REGION: us-east-1
+
+defaults:
+  run:
+    working-directory: aws-discovery-suite/terraform/test
+
 jobs:
   build:
     name: AWS Tests
-    defaults:
-      run:
-        shell: bash
-    env:
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
     runs-on: ubuntu-latest
     if: >-
       github.repository_owner == 'hazelcast' && 
@@ -29,14 +34,24 @@ jobs:
           github.event.label.name == 'run-discovery-tests' 
         )
       )
+    outputs:
+      HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
+      CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}
     steps:
-      - name: Setup JDK
-        uses: actions/setup-java@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
-          java-version: 11
-          architecture: x64
-          distribution: adopt
-          cache: 'maven'
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Checkout Auto Discovery Test Suite
+        uses: actions/checkout@v3
+        with:
+          repository: hazelcast/auto-discovery-test-suite
+          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+          path: aws-discovery-suite
 
       - name: Decide which ref to checkout
         id: decide-ref
@@ -52,42 +67,138 @@ jobs:
         with:
           ref: ${{steps.decide-ref.outputs.ref}}
 
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          architecture: x64
+          distribution: adopt
+          cache: 'maven'
+
+      - name: Setup Local Maven Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Build hazelcast jar
+        working-directory: master
         run: |
-          ./mvnw -T 4 -B -V -e clean package \
-          -Dfindbugs.skip \
-          -Dcheckstyle.skip \
-          -Dpmd.skip=true \
-          -Dspotbugs.skip \
-          -Denforcer.skip \
-          -Dmaven.javadoc.skip \
-          -DskipTests \
-          -Dlicense.skip=true \
-          -Drat.skip=true \
-          -Dspotless.check.skip=true \
-          -Dattribution.skip \
-          -Dmaven.source.skip=true
-          echo "Hazelcast jar is: " hazelcast/target/hazelcast-*-SNAPSHOT.jar
-          cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ~/hazelcast.jar
+          echo ${GITHUB_WORKSPACE}
+          HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "HAZELCAST_VERSION=${HAZELCAST_VERSION}" >> $GITHUB_ENV
+           ./mvnw -T 4 -B -V -e clean install \
+           -Dfindbugs.skip \
+           -Dcheckstyle.skip \
+           -Dpmd.skip=true \
+           -Dspotbugs.skip \
+           -Denforcer.skip \
+           -Dmaven.javadoc.skip \
+           -DskipTests \
+           -Dlicense.skip=true \
+           -Drat.skip=true \
+           -Dspotless.check.skip=true \
+           -Dattribution.skip \
+           -Danimal.sniffer.skip=true \
+           -Dmaven.source.skip=true
+            cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ${GITHUB_WORKSPACE}/aws-discovery-suite/terraform/tools/hazelcast.jar
+
+      - name: Build client jar
+        working-directory: aws-discovery-suite/terraform/tools/client
+        run: |
+          mvn versions:set-property -Dproperty=hazelcast.version -DnewVersion=$HAZELCAST_VERSION
+          mvn clean package
+          mv target/aws-discovery-client.jar aws-discovery-client.jar
+
+      - name: Upload hazelcast.jar
+        uses: actions/upload-artifact@v3
+        with:
+          name: hazelcast.jar
+          path: aws-discovery-suite/terraform/tools/hazelcast.jar
+
+      - name: Upload aws-discovery-client.jar
+        uses: actions/upload-artifact@v3
+        with:
+          name: aws-discovery-client.jar
+          path: aws-discovery-suite/terraform/tools/client/aws-discovery-client.jar
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Build Hazelcast Image
+        id: get-hz-image-tag
+        working-directory: aws-discovery-suite/terraform/tools
+        run: |
+          HZ_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
+          echo "HZ_IMG=${HZ_IMG}" >> $GITHUB_OUTPUT
+          docker build -f Dockerfile -t ${HZ_IMG} .
+          docker push ${HZ_IMG}
+
+      - name: Build Client Image
+        id: get-cl-image-tag
+        working-directory: aws-discovery-suite/terraform/tools/client
+        run: |
+          CL_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
+          echo "CL_IMG=${CL_IMG}" >> $GITHUB_OUTPUT
+          docker build -f Dockerfile -t ${CL_IMG} .
+          docker push ${CL_IMG}
+
+  test:
+    name: Run Tests
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        suite: ['ec2_cl_to_ec2_m', 'ec2_cl_to_fargate_ecs_m', 'fargate_ecs_cl_to_ec2_m', 'fargate_ecs_cl_to_fargate_ecs_m']
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Checkout Auto Discovery Test Suite
+        uses: actions/checkout@v3
+        with:
+          repository: hazelcast/auto-discovery-test-suite
+          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+          path: aws-discovery-suite
+
+      - name: Download hazelcast.jar
+        uses: actions/download-artifact@v3
+        with:
+          name: hazelcast.jar
+          path: aws-discovery-suite/terraform/tools
+
+      - name: Download aws-discovery-client.jar
+        uses: actions/download-artifact@v3
+        with:
+          name: aws-discovery-client.jar
+          path: aws-discovery-suite/terraform/tools/client
 
       - name : Set-up Terraform
-        uses: hashicorp/setup-terraform@v2.0.0
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
-          terraform_version: 1.1.8
+          terraform_version: 1.5.4
+          terraform_wrapper: false
 
-      - name: Terraform Init
-        working-directory: .github/terraform/aws
-        run: terraform init
+      - name: Cache Golang dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-      - name: Terraform Apply
-        working-directory: .github/terraform/aws
+      - name: Run Tests
         run: |
-          terraform apply \
-            -var="hazelcast_mancenter_version=latest-snapshot" \
-            -var="hazelcast_path=~/hazelcast.jar" \
-            -auto-approve
-
-      - name: Terraform Destroy
-        if: ${{ always() }}
-        working-directory: .github/terraform/aws
-        run: terraform destroy -auto-approve
+          go test -v -timeout 20m -run TestSuite -suite ${{ matrix.suite }} -member-image ${{ needs.build.outputs.HZ_IMG }} -client-image ${{ needs.build.outputs.CL_IMG }}

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -12,20 +12,9 @@ on:
       - 'hazelcast/src/main/java/com/hazelcast/aws/**'
       - '.github/terraform/aws/**'
 
-env:
-  GAR_PROJECT_ID: hazelcast-33
-  GAR_REGION: us-east1
-  GAR_REPO: auto-discovery-test-suite
-  AWS_REGION: us-east-1
-
-defaults:
-  run:
-    working-directory: aws-discovery-suite/terraform/test
-
 jobs:
   build:
-    name: AWS Tests
-    runs-on: ubuntu-latest
+    name: Build Jar's And Docker Images
     if: >-
       github.repository_owner == 'hazelcast' && 
       ( github.event_name == 'workflow_dispatch' || 
@@ -34,132 +23,18 @@ jobs:
           github.event.label.name == 'run-discovery-tests' 
         )
       )
-    outputs:
-      HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
-      CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}
-    steps:
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2.0.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
-        with:
-          secret-ids: |
-            DEVOPS_GITHUB_TOKEN,CN/DEVOPS_GITHUB_TOKEN
-            GCP_SA_KEY,CN/GKE_SA_KEY
-
-      - name: Checkout Auto Discovery Test Suite
-        uses: actions/checkout@v3
-        with:
-          repository: hazelcast/auto-discovery-test-suite
-          token: ${{ env.DEVOPS_GITHUB_TOKEN }}
-          path: aws-discovery-suite
-
-      - name: Decide which ref to checkout
-        id: decide-ref
-        run: |
-          if [[ "${{github.event_name}}" == "pull_request_target" ]]; then
-            echo "ref=refs/pull/${{ github.event.pull_request.number }}/merge" >> $GITHUB_OUTPUT
-          else
-            echo "ref=${{github.ref}}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{steps.decide-ref.outputs.ref}}
-
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          architecture: x64
-          distribution: adopt
-          cache: 'maven'
-
-      - name: Setup Local Maven Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Build hazelcast jar
-        working-directory: master
-        run: |
-          echo ${GITHUB_WORKSPACE}
-          HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "HAZELCAST_VERSION=${HAZELCAST_VERSION}" >> $GITHUB_ENV
-           ./mvnw -T 4 -B -V -e clean install \
-           -Dfindbugs.skip \
-           -Dcheckstyle.skip \
-           -Dpmd.skip=true \
-           -Dspotbugs.skip \
-           -Denforcer.skip \
-           -Dmaven.javadoc.skip \
-           -DskipTests \
-           -Dlicense.skip=true \
-           -Drat.skip=true \
-           -Dspotless.check.skip=true \
-           -Dattribution.skip \
-           -Danimal.sniffer.skip=true \
-           -Dmaven.source.skip=true
-            cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ${GITHUB_WORKSPACE}/aws-discovery-suite/terraform/tools/hazelcast.jar
-
-      - name: Build client jar
-        working-directory: aws-discovery-suite/terraform/tools/client
-        run: |
-          mvn versions:set-property -Dproperty=hazelcast.version -DnewVersion=$HAZELCAST_VERSION
-          mvn clean package
-          mv target/aws-discovery-client.jar aws-discovery-client.jar
-
-      - name: Upload hazelcast.jar
-        uses: actions/upload-artifact@v3
-        with:
-          name: hazelcast.jar
-          path: aws-discovery-suite/terraform/tools/hazelcast.jar
-
-      - name: Upload aws-discovery-client.jar
-        uses: actions/upload-artifact@v3
-        with:
-          name: aws-discovery-client.jar
-          path: aws-discovery-suite/terraform/tools/client/aws-discovery-client.jar
-
-      - name: Authenticate to GAR
-        uses: docker/login-action@v2
-        with:
-          registry: us-east1-docker.pkg.dev
-          username: _json_key
-          password: ${{ env.GCP_SA_KEY }}
-
-      - name: Build Hazelcast Image
-        id: get-hz-image-tag
-        working-directory: aws-discovery-suite/terraform/tools
-        run: |
-          HZ_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
-          echo "HZ_IMG=${HZ_IMG}" >> $GITHUB_OUTPUT
-          docker build -f Dockerfile -t ${HZ_IMG} .
-          docker push ${HZ_IMG}
-
-      - name: Build Client Image
-        id: get-cl-image-tag
-        working-directory: aws-discovery-suite/terraform/tools/client
-        run: |
-          CL_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
-          echo "CL_IMG=${CL_IMG}" >> $GITHUB_OUTPUT
-          docker build -f Dockerfile -t ${CL_IMG} .
-          docker push ${CL_IMG}
+    uses: ./.github/workflows/build-artifact.yml
+    secrets: inherit
 
   test:
     name: Run Tests
     needs: build
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: aws-discovery-suite/terraform/test
+    env:
+      AWS_REGION: us-east-1
     strategy:
       matrix:
         suite: ['ec2_cl_to_ec2_m', 'ec2_cl_to_fargate_ecs_m', 'fargate_ecs_cl_to_ec2_m', 'fargate_ecs_cl_to_fargate_ecs_m']

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -46,11 +46,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Get Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
+            DEVOPS_GITHUB_TOKEN,CN/DEVOPS_GITHUB_TOKEN
+            GCP_SA_KEY,CN/GKE_SA_KEY
+
       - name: Checkout Auto Discovery Test Suite
         uses: actions/checkout@v3
         with:
           repository: hazelcast/auto-discovery-test-suite
-          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+          token: ${{ env.DEVOPS_GITHUB_TOKEN }}
           path: aws-discovery-suite
 
       - name: Decide which ref to checkout
@@ -129,7 +136,7 @@ jobs:
         with:
           registry: us-east1-docker.pkg.dev
           username: _json_key
-          password: ${{ secrets.GCP_SA_KEY }}
+          password: ${{ env.GCP_SA_KEY }}
 
       - name: Build Hazelcast Image
         id: get-hz-image-tag
@@ -164,11 +171,17 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Get Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
+            DEVOPS_GITHUB_TOKEN,CN/DEVOPS_GITHUB_TOKEN
+
       - name: Checkout Auto Discovery Test Suite
         uses: actions/checkout@v3
         with:
           repository: hazelcast/auto-discovery-test-suite
-          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+          token: ${{ env.DEVOPS_GITHUB_TOKEN }}
           path: aws-discovery-suite
 
       - name: Download hazelcast.jar

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,0 +1,144 @@
+name: Build and Dockerize
+
+on:
+  workflow_call:
+    outputs:
+      HZ_IMG:
+        description: "The Hazelcast Docker image"
+        value: ${{ jobs.build.outputs.HZ_IMG }}
+      CL_IMG:
+        description: "The client Docker image"
+        value: ${{ jobs.build.outputs.CL_IMG }}
+
+jobs:
+  build:
+    name: Build Jar's And Docker Images
+    runs-on: ubuntu-latest
+    env:
+      GAR_PROJECT_ID: hazelcast-33
+      GAR_REGION: us-east1
+      GAR_REPO: auto-discovery-test-suite
+      AWS_REGION: us-east-1
+    defaults:
+      run:
+        working-directory: aws-discovery-suite/terraform/test
+    outputs:
+      HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
+      CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
+            DEVOPS_GITHUB_TOKEN,CN/DEVOPS_GITHUB_TOKEN
+            GCP_SA_KEY,CN/GKE_SA_KEY
+
+      - name: Checkout Auto Discovery Test Suite
+        uses: actions/checkout@v3
+        with:
+          repository: hazelcast/auto-discovery-test-suite
+          token: ${{ env.DEVOPS_GITHUB_TOKEN }}
+          path: aws-discovery-suite
+
+      - name: Decide Which 'ref' To Checkout
+        id: decide-ref
+        run: |
+          if [[ "${{github.event_name}}" == "pull_request_target" ]]; then
+            echo "ref=refs/pull/${{ github.event.pull_request.number }}/merge" >> $GITHUB_OUTPUT
+          else
+            echo "ref=${{github.ref}}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{steps.decide-ref.outputs.ref}}
+          path: ${{steps.decide-ref.outputs.ref}}
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          architecture: x64
+          distribution: adopt
+          cache: 'maven'
+
+      - name: Setup Local Maven Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build hazelcast jar
+        working-directory: ${{steps.decide-ref.outputs.ref}}
+        run: |
+          HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "HAZELCAST_VERSION=${HAZELCAST_VERSION}" >> $GITHUB_ENV
+           ./mvnw -T 4 -B -V -e clean install \
+           -Dfindbugs.skip \
+           -Dcheckstyle.skip \
+           -Dpmd.skip=true \
+           -Dspotbugs.skip \
+           -Denforcer.skip \
+           -Dmaven.javadoc.skip \
+           -DskipTests \
+           -Dlicense.skip=true \
+           -Drat.skip=true \
+           -Dspotless.check.skip=true \
+           -Dattribution.skip \
+           -Danimal.sniffer.skip=true \
+           -Dmaven.source.skip=true
+            cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ${GITHUB_WORKSPACE}/aws-discovery-suite/terraform/tools/hazelcast.jar
+
+      - name: Build client jar
+        working-directory: aws-discovery-suite/terraform/tools/client
+        run: |
+          mvn versions:set-property -Dproperty=hazelcast.version -DnewVersion=$HAZELCAST_VERSION
+          mvn clean package
+          mv target/aws-discovery-client.jar aws-discovery-client.jar
+
+      - name: Upload hazelcast.jar
+        uses: actions/upload-artifact@v3
+        with:
+          name: hazelcast.jar
+          path: aws-discovery-suite/terraform/tools/hazelcast.jar
+
+      - name: Upload aws-discovery-client.jar
+        uses: actions/upload-artifact@v3
+        with:
+          name: aws-discovery-client.jar
+          path: aws-discovery-suite/terraform/tools/client/aws-discovery-client.jar
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ env.GCP_SA_KEY }}
+
+      - name: Build Hazelcast Image
+        id: get-hz-image-tag
+        working-directory: aws-discovery-suite/terraform/tools
+        run: |
+          HZ_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
+          echo "HZ_IMG=${HZ_IMG}" >> $GITHUB_OUTPUT
+          docker build -f Dockerfile -t ${HZ_IMG} .
+          docker push ${HZ_IMG}
+
+      - name: Build Client Image
+        id: get-cl-image-tag
+        working-directory: aws-discovery-suite/terraform/tools/client
+        run: |
+          CL_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
+          echo "CL_IMG=${CL_IMG}" >> $GITHUB_OUTPUT
+          docker build -f Dockerfile -t ${CL_IMG} .
+          docker push ${CL_IMG}


### PR DESCRIPTION
Updated AWS Terraform workflow to support ECS, EC2, Fargate runs

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
