### PR TITLE
Fix isEnterprise() by setting isFailoverSupported for initial connection as well HZ-2588

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -885,12 +885,12 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         connectionManager.reset();
     }
 
-    public void onConnectionToNewCluster(boolean isFailoverSupported) {
+    public void onConnectionToNewCluster() {
         ILogger logger = loggingService.getLogger(HazelcastInstance.class);
         logger.info("Clearing local state of the client, because of a cluster restart.");
 
         dispose(onClusterChangeDisposables);
-        clusterService.onClusterConnect(isFailoverSupported);
+        clusterService.onClusterConnect();
     }
 
     public void collectAndSendStatsNow() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -893,10 +893,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         clusterService.onClusterConnect(isFailoverSupported);
     }
 
-    public void onInitialClusterConnection(boolean isFailoverSupported) {
-        clusterService.setFailoverSupported(isFailoverSupported);
-    }
-
     public void collectAndSendStatsNow() {
         clientStatisticsService.collectAndSendStatsNow();
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -885,12 +885,16 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         connectionManager.reset();
     }
 
-    public void onConnectionToNewCluster(boolean isFailoverSupported) {
+    public void onConnectionToNewCluster() {
         ILogger logger = loggingService.getLogger(HazelcastInstance.class);
         logger.info("Clearing local state of the client, because of a cluster restart.");
 
         dispose(onClusterChangeDisposables);
-        clusterService.onClusterConnect(isFailoverSupported);
+        clusterService.onClusterConnect();
+    }
+
+    public void onAuthenticated(boolean isFailoverSupported) {
+        clusterService.setFailoverSupported(isFailoverSupported);
     }
 
     public void collectAndSendStatsNow() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -885,15 +885,15 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         connectionManager.reset();
     }
 
-    public void onConnectionToNewCluster() {
+    public void onConnectionToNewCluster(boolean isFailoverSupported) {
         ILogger logger = loggingService.getLogger(HazelcastInstance.class);
         logger.info("Clearing local state of the client, because of a cluster restart.");
 
         dispose(onClusterChangeDisposables);
-        clusterService.onClusterConnect();
+        clusterService.onClusterConnect(isFailoverSupported);
     }
 
-    public void onAuthenticated(boolean isFailoverSupported) {
+    public void onInitialClusterConnection(boolean isFailoverSupported) {
         clusterService.setFailoverSupported(isFailoverSupported);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -1023,8 +1023,9 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             if (clusterIdChanged) {
                 checkClientStateOnClusterIdChange(connection, switchingToNextCluster);
                 logger.warning("Switching from current cluster: " + this.clusterId + " to new cluster: " + newClusterId);
-                client.onConnectionToNewCluster(isFailoverSupported);
+                client.onConnectionToNewCluster();
             }
+            client.onAuthenticated(isFailoverSupported);
             checkClientState(connection, switchingToNextCluster);
 
             List<Integer> tpcPorts = response.getTpcPorts();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -1023,7 +1023,8 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             if (clusterIdChanged) {
                 checkClientStateOnClusterIdChange(connection, switchingToNextCluster);
                 logger.warning("Switching from current cluster: " + this.clusterId + " to new cluster: " + newClusterId);
-                client.onConnectionToNewCluster(isFailoverSupported);
+                client.onConnectionToNewCluster();
+                client.getClientClusterService().setFailoverSupported(isFailoverSupported);
             }
             checkClientState(connection, switchingToNextCluster);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -1023,9 +1023,8 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             if (clusterIdChanged) {
                 checkClientStateOnClusterIdChange(connection, switchingToNextCluster);
                 logger.warning("Switching from current cluster: " + this.clusterId + " to new cluster: " + newClusterId);
-                client.onConnectionToNewCluster();
+                client.onConnectionToNewCluster(isFailoverSupported);
             }
-            client.onAuthenticated(isFailoverSupported);
             checkClientState(connection, switchingToNextCluster);
 
             List<Integer> tpcPorts = response.getTpcPorts();
@@ -1054,6 +1053,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
                     // state to the cluster after the first cluster connection,
                     // regardless the cluster id is changed or not.
                     clientState = ClientState.CONNECTED_TO_CLUSTER;
+                    client.onInitialClusterConnection(isFailoverSupported);
                     executor.execute(() -> {
                         initializeClientOnCluster(newClusterId);
                         /*

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -1039,6 +1039,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
                 // The first connection that opens a connection to the new cluster should set `clusterId`.
                 // This one will initiate `initializeClientOnCluster` if necessary.
                 clusterId = newClusterId;
+                client.getClientClusterService().setFailoverSupported(isFailoverSupported);
                 if (establishedInitialClusterConnection) {
                     // In split brain, the client might connect to the one half
                     // of the cluster, and then later might reconnect to the
@@ -1053,7 +1054,6 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
                     // state to the cluster after the first cluster connection,
                     // regardless the cluster id is changed or not.
                     clientState = ClientState.CONNECTED_TO_CLUSTER;
-                    client.onInitialClusterConnection(isFailoverSupported);
                     executor.execute(() -> {
                         initializeClientOnCluster(newClusterId);
                         /*

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/ClientClusterService.java
@@ -82,4 +82,10 @@ public interface ClientClusterService {
      * @throws IllegalStateException If called from a Hazelcast client, and it is not in a cluster.
      */
     boolean isEnterprise();
+
+    /**
+     * Sets the failover supported flag. This is used to determine if the client is connected to a EE
+     * cluster or not. See {@link #isEnterprise()}.
+     */
+    void setFailoverSupported(boolean failoverSupported);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -199,8 +199,9 @@ public class ClientClusterServiceImpl implements ClientClusterService {
         }
     }
 
-    public void onClusterConnect() {
+    public void onClusterConnect(boolean isFailoverSupported) {
         synchronized (clusterViewLock) {
+            this.setFailoverSupported(isFailoverSupported);
             this.resetMemberSnapshot();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -199,10 +199,15 @@ public class ClientClusterServiceImpl implements ClientClusterService {
         }
     }
 
-    public void onClusterConnect(boolean isFailoverSupported) {
+    public void onClusterConnect() {
+        synchronized (clusterViewLock) {
+            this.resetMemberSnapshot();
+        }
+    }
+
+    public void setFailoverSupported(boolean isFailoverSupported) {
         synchronized (clusterViewLock) {
             this.isFailoverSupported = isFailoverSupported;
-            this.resetMemberSnapshot();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -201,7 +201,6 @@ public class ClientClusterServiceImpl implements ClientClusterService {
 
     public void onClusterConnect() {
         synchronized (clusterViewLock) {
-            this.setFailoverSupported(isFailoverSupported);
             this.resetMemberSnapshot();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImpl.java
@@ -199,7 +199,7 @@ public class ClientClusterServiceImpl implements ClientClusterService {
         }
     }
 
-    public void onClusterConnect(boolean isFailoverSupported) {
+    public void onClusterConnect() {
         synchronized (clusterViewLock) {
             this.setFailoverSupported(isFailoverSupported);
             this.resetMemberSnapshot();

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientClusterServiceImplTest.java
@@ -177,7 +177,7 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
         });
 
         //called on cluster restart
-        clusterService.onClusterConnect(true);
+        clusterService.onClusterConnect();
 
         MemberInfo addedMemberInfo = member("127.0.0.2");
         clusterService.handleMembersViewEvent(1, asList(addedMemberInfo), UUID.randomUUID());
@@ -250,7 +250,7 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
         });
 
         //called on reconnect to same cluster when registering the listener back
-        clusterService.onClusterConnect(true);
+        clusterService.onClusterConnect();
 
         clusterService.handleMembersViewEvent(1, memberList, clusterUuid);
         assertEquals(1, clusterService.getMemberList().size());
@@ -296,7 +296,7 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
         });
 
         //called on reconnect to same cluster when registering the listener back
-        clusterService.onClusterConnect(true);
+        clusterService.onClusterConnect();
 
         MemberInfo addedMember1 = member("127.0.0.1", member2uuid);
         MemberInfo addedMember2 = member("127.0.0.2", member1uuid);
@@ -342,7 +342,7 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
         });
 
         //called on reconnect to same cluster when registering the listener back
-        clusterService.onClusterConnect(true);
+        clusterService.onClusterConnect();
 
         clusterService.handleMembersViewEvent(1, memberList, UUID.randomUUID());
         assertEquals(2, clusterService.getMemberList().size());
@@ -358,7 +358,7 @@ public class ClientClusterServiceImplTest extends HazelcastTestSupport {
         clusterService.handleMembersViewEvent(1, asList(member("127.0.0.1")), UUID.randomUUID());
         assertEquals(1, clusterService.getMemberList().size());
         //called on cluster restart
-        clusterService.onClusterConnect(true);
+        clusterService.onClusterConnect();
         assertEquals(1, clusterService.getMemberList().size());
         clusterService.handleMembersViewEvent(1, asList(member("127.0.0.2")), UUID.randomUUID());
         assertEquals(1, clusterService.getMemberList().size());


### PR DESCRIPTION
EE tests were failing because we made a mistake. For initial cluster connections we were not setting isFailoverSupported. This PR fixes this. 


Also add a test: isEnterpriseReconnectionToCluster
