### PR TITLE
Fix OnJoinOp handling during batched cluster joining  (#25114) [5.3.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -543,7 +543,7 @@ public final class ClusterProperty {
      * This parameter defines time that the master node will wait since the last
      * received join request (a pre-join window) before it starts processing the
      * join requests and forming a cluster.
-     * Alternatively, if the pre-join phase has laster for over
+     * Alternatively, if the pre-join phase has lasted for over
      * {@link #MAX_WAIT_SECONDS_BEFORE_JOIN} seconds, the master node will proceed
      * with processing the join requests and forming the cluster, regardless of the
      * time elapsed since the last join request.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/EventRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/EventRegistrationTest.java
@@ -18,78 +18,100 @@ package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
+import com.hazelcast.internal.util.Clock;
+import com.hazelcast.internal.util.FutureUtil;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
-import static java.util.Collections.synchronizedList;
+import static com.hazelcast.test.OverridePropertyRule.set;
+import static com.hazelcast.test.TestEnvironment.HAZELCAST_TEST_USE_NETWORK;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class EventRegistrationTest extends HazelcastTestSupport {
 
-    private final ILogger logger = Logger.getLogger(getClass());
+    @Rule
+    public final OverridePropertyRule overridePropertyRule = set(HAZELCAST_TEST_USE_NETWORK, "true");
+    private final HazelcastInstance[] batchedMembers = new HazelcastInstance[6];
 
-    @After
-    public void tearDown() throws InterruptedException {
-        Hazelcast.shutdownAll();
-    }
+    @Before
+    public void prepare() throws InterruptedException {
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
-    @Test
-    public void test_eventRegistrations_OnStartup() {
-        assertEventRegistrations(3, startInstances(3));
-    }
-
-    private HazelcastInstance[] startInstances(int nodeCount) {
-        List<HazelcastInstance> instancesList = synchronizedList(new ArrayList<>());
-        CountDownLatch latch = new CountDownLatch(nodeCount);
-        TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(3);
-
-        for (int i = 0; i < nodeCount; ++i) {
-            new Thread(() -> {
-                try {
-                    Address address = instanceFactory.nextAddress();
-                    HazelcastInstance instance = instanceFactory.newHazelcastInstance(address, new Config());
-                    instancesList.add(instance);
-                } catch (Throwable e) {
-                    logger.severe(e);
-                } finally {
-                    latch.countDown();
-                }
-            }, "Start thread for node " + i).start();
+        // Create a cluster that goes through a batched join, starting with a master instance (always index 0)
+        batchedMembers[0] = factory.newHazelcastInstance(config);
+        // Start 3 members simultaneously (so their join requests are batched)
+        List<Future<?>> futures = new ArrayList<>(3);
+        for (int k = 1; k < 4; k++) {
+            int finalK = k;
+            futures.add(spawn(() -> batchedMembers[finalK] = factory.newHazelcastInstance(config)));
         }
 
-        assertOpenEventually(latch);
+        // Wait for all batched member instances to be created
+        FutureUtil.waitWithDeadline(futures, 30, TimeUnit.SECONDS);
 
-        return instancesList.toArray(new HazelcastInstance[0]);
+        // Ensure the batched join period has elapsed
+        ClusterJoinManager joinManager = ((ClusterServiceImpl) getNodeEngineImpl(batchedMembers[0])
+                .getClusterService()).getClusterJoinManager();
+        assertTrueEventually(() -> assertFalse(joinManager.isBatchingJoins(Clock.currentTimeMillis())));
+
+        // Then start 2 members sequentially (so their join requests are not batched)
+        for (int k = 4; k < 6; k++) {
+            batchedMembers[k] = factory.newHazelcastInstance(config);
+        }
+
+        // Ensure cluster size is 6
+        assertClusterSizeEventually(6, batchedMembers);
     }
 
-    private static void assertEventRegistrations(int expected, HazelcastInstance... instances) {
-        assertTrueEventually(() -> {
-            for (HazelcastInstance instance : instances) {
-                Collection<EventRegistration> regs = getNodeEngineImpl(instance).getEventService().getRegistrations(
-                        ProxyServiceImpl.SERVICE_NAME, ProxyServiceImpl.SERVICE_NAME);
-                assertEquals(instance + ": " + regs, expected, regs.size());
-            }
-        });
+    /**
+     * <a href="https://hazelcast.atlassian.net/browse/HZ-2797">Related to HZ-2797</a>
+     */
+    @Test
+    public void testEventRegistrationsForAllMembers_AfterJoin() {
+        // Gather a set of expected addresses to use in comparisons
+        Set<Address> expectedAddresses = new HashSet<>(batchedMembers.length);
+        for (HazelcastInstance member : batchedMembers) {
+            expectedAddresses.add(getNodeEngineImpl(member).getThisAddress());
+        }
+
+        // Iterate over all members of the cluster and assert that it has listeners registered for
+        //  every member of the cluster (including the local member itself)
+        Set<Address> localAddresses = new HashSet<>(batchedMembers.length);
+        for (HazelcastInstance member : batchedMembers) {
+            Collection<EventRegistration> registrations = getNodeEngineImpl(member).getEventService().getRegistrations(
+                    ProxyServiceImpl.SERVICE_NAME, ProxyServiceImpl.SERVICE_NAME);
+
+            localAddresses.clear();
+            registrations.forEach(registration -> localAddresses.add(registration.getSubscriber()));
+
+            assertEquals(String.format("Expected: %s, Actual: %s", expectedAddresses, localAddresses),
+                    expectedAddresses.size(), localAddresses.size());
+            assertContainsAll(localAddresses, expectedAddresses);
+        }
     }
 }


### PR DESCRIPTION
Backport of: https://github.com/hazelcast/hazelcast/pull/25114

After the introduction of these changes in December 2022 (https://github.com/hazelcast/hazelcast/pull/22942), it became possible for the `OnJoinRegistrationOperation` used in the `EventServiceImpl` to not be executed correctly across the cluster.

This previous commit changed `EventServiceImpl#getPostJoinOperation` to return null permanently, replacing this functionality with an `OnJoinOp` passed for execution on the cluster's master by each joining member. This solution works under ideal circumstances of sequential cluster startup, however when several members try to join the master within `ClusterProperty#WAIT_SECONDS_BEFORE_JOIN` of startup, these joins are batched together - when a batched join occurs like this, currently only the "triggering" (final) member's `OnJoinOp` is executed, while all others are discarded. This results in registrations not being distributed across the cluster as expected, and can lead to inconsistent query results on Hazelcast.

This commit aims to resolve this issue by storing all passed `OnJoinOp`s alongside their `MemberInfo`, mapped in `ClusterJoinManager` - this allows us to then execute _all_ passed `OnJoinOp`s when iterating through the batch within `ClusterJoinManager#startJoin`. This ensures registrations are not missed. I opted to use a `BiTuple` to store this operation rather than creating a `MemberInfo` extension to ensure we're not retaining the `OnJoinOp` object longer than necessary (which could happen if our extension is retained elsewhere), and since this operation only has value during the join process, and is only needed once. I also only broadcast these operations to members not included in the batched join itself, to avoid additional complexity.

This commit also includes a regression test that focuses on the most prevalent method of observing this inconsistency - by examining `ProxyServiceImpl` registrations across a 6 member cluster where some non-master members start simultaneously, and others sequentially.

Fixes https://hazelcast.atlassian.net/browse/HZ-2797