### PR TITLE
Allow permissions subtraction - using deny rules [HZ-2780]

### DIFF
--- a/docs/design/security/04-deny-permissions.adoc
+++ b/docs/design/security/04-deny-permissions.adoc
@@ -123,7 +123,7 @@ public PermissionConfig setDeny(boolean deny);
 
 ==== Permission Priority flag
 
-The deny flag is configured on a security configuration level by attribute named `permissionPriorityGrant` in the `SecurityConfig`.
+The permission priority flag is configured on a security configuration level by attribute named `permissionPriorityGrant` in the `SecurityConfig`.
 
 [source,java]
 ----

--- a/docs/design/security/04-deny-permissions.adoc
+++ b/docs/design/security/04-deny-permissions.adoc
@@ -1,0 +1,195 @@
+= Deny permissions
+:lang: en
+:toc:
+
+== Background
+=== Description
+
+This document introduces the possibility of using the subtraction of client permissions as an extension to the existing additive-only model.
+
+The current model has a limited expression ability and can lead to "fail open" cases due to granted unintended permissions.
+
+Here are a few examples of problematic scenarios of the additive-only approach:
+
+* give a client access to all Maps, but not the protected one;
+* provide a client with all permissions, but not the management ones;
+* give a client's Jet job to access all external databases but not the ones on a specific host.
+
+Permission configurations will be extended by a flag saying if the permission is granted (default) or denied.
+
+Similar architecture limitations are present in the default Java Security Manager implementation (using the `PolicyFile` class).
+
+The permission additive-only approach is also listed as a medium-severity issue in the Kubernetes security review published in 2023.
+
+=== Terminology
+
+[options="header"]
+|=====================================================================================================
+| Term               | Definition
+| Role               | Hazelcast Clients are assigned roles during the authentication. Roles group together sets of permissions that are relevant to those roles.
+| Permission         | Protects access to specific resources. A permission could be something like "everyone can access the Map ABC", "role XYZ can deploy and run jobs", "Role XYZ can run SQL queries".
+| Grant (Permission) | Default permission type. It allows (adds) access to the protected resource.
+| Deny (Permission)  | Access to resource/action described by the permission is forbidden  (subtracted) instead of granted.
+| Priority           | Defines which kind of permissions takes precedence - Grant or Deny.
+|=====================================================================================================
+
+=== Actors and Scenarios
+
+As a _Cluster Administrator_, I want to allow clients _access to all data structures but the Hazelcast internal ones_.
+
+As a _Cluster Administrator_, I want to allow Management Center to fully manage the members, but I don't
+want to _prevent it from reading files on the member's local filesystem_.
+
+[[functional-design]]
+== Functional Design
+
+=== Summary of Functionality
+
+* allow specifying the Deny permissions in client permission configuration;
+* add permission priority to security configuration;
+* extend the `DefaultPermissionPolicy` to support the Deny permissions and the permission priority.
+
+==== Permission evaluation
+
+Let's first review the original behavior without the Deny permissions.
+The business logic is present in the `DefaultPermissionPolicy` class provided
+as our default (out-of-the-box) implementation of `PermissionPolicy` interface.
+And here are the evaluation rules:
+
+[options="header"]
+|=====================================================================================================
+| Is the checked permission implied?   | Evaluation result
+| No Grant implies the permission. | denied
+| A Grant implies the permission. | granted
+|=====================================================================================================
+
+The rules change after allowing the permission subtraction
+(by Deny permissions) and also specifying global priority
+between Grant and Deny permissions. 
+The following table lists new permission evaluation rules for the `DefaultPermissionPolicy`:
+
+[options="header"]
+|=====================================================================================================
+| What implies the checked permission?   | Priority=deny (default) | Priority=grant
+| Neither a Grant nor a Deny implies it. | denied | granted
+| A Grant implies, but no Deny does. | granted | granted
+| A Deny implies, but no Grant does. | denied | denied
+| Both, a Deny and a Grant imply. | denied | granted
+|=====================================================================================================
+
+==== Notes/Questions/Issues
+
+The `DefaultPermissionPolicy` will behave in a backward-compatible way.
+If users don't configure Deny permissions or priority for Grants, then
+there will be no difference in Hazelcast permission evaluation.
+
+An alternative approach would be to introduce the `deny` permission support
+in a new `PermissionPolicy` implementation besides the `DefaultPermissionPolicy`.
+It would have the following consequences:
+
+* `DefaultPermissionPolicy` stays unchanged and it's not able to process (or recognize) the Deny permissions;
+* We have to maintain two implementations and only one of them supports Deny permissions;
+* There has to be an additional logic deciding which policy should be used by default. Or we would need to transfer the decision to users (which goes against simplicity).
+
+Following the simplicity rule, changing the `DefaultPermissionPolicy` to support Deny permissions (in backward-compatible way) seems as the best solution.
+
+== User Interaction
+
+=== API design and/or Prototypes
+
+Two new configuration attributes items will be added:
+
+* _deny_ permission flag
+* _permission priority_ flag
+
+==== Deny flag
+
+The deny flag is configured on a permission level.
+It's represented by a new `deny` attribute in `PermissionConfig` class.
+
+[source,java]
+----
+/**
+ * Returns {@code true} when the permission should be subtracted (denied) instead of added (granted).
+ */
+public boolean isDeny();
+
+/**
+ * Configures if this permission config is for a grant ({@code false}, default) permission or deny ({@code true})
+ * @param deny value to set
+ */
+public PermissionConfig setDeny(boolean deny);
+----
+
+==== Permission Priority flag
+
+The deny flag is configured on a security configuration level by attribute named `permissionPriorityGrant` in the `SecurityConfig`.
+
+[source,java]
+----
+/**
+ * Returns {@code true} when grant permissions should take precedence over deny ones. Default value is {@code false}.
+ */
+public boolean isPermissionPriorityGrant();
+
+/**
+ * Sets if grant permissions should take precedence over deny ones.
+ */
+public SecurityConfig setPermissionPriorityGrant(boolean permissionPriorityGrant);
+----
+
+When stored in XML or YAML the value is listed as a child of the `client-permissions` node.
+
+=== Configuration example
+
+[source,yaml]
+----
+hazelcast:
+  security:
+    enabled: true
+    client-permissions:
+      priority-grant: false
+      map:
+        - name: *
+          actions:
+            - all
+      map:
+        - name: protected
+          deny: true
+          actions:
+            - all
+----
+
+[source,xml]
+----
+<hazelcast>
+    <security enabled="false">
+        <client-permissions priority-grant="false">
+            <map-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </map-permission>
+            <map-permission name="protected" deny="true">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </map-permission>
+        </client-permission>
+    </security>
+</hazelcast>
+----
+
+== Technical Design
+
+The necessary changes are already described in the <<functional-design>> section.
+
+== Testing Criteria
+
+* Existing security permission tests remain unchanged to check the backward compatibility of the new implementation;
+* New tests for Deny permissions and permission priority will be added;
+
+== Other Artifacts
+
+* https://pro-grade.sourceforge.net/pro-grade.html[ProGrade Security Policy] and research in the related https://is.muni.cz/th/324879/fi_m/[Master thesis] solve the same problem on Java Security Manager Level
+* The *Additive Access Controls* issues are described in the https://github.com/kubernetes/sig-security/blob/main/sig-security-external-audit/security-audit-2021-2022/findings/Kubernetes%20v1.24%20Final%20Report.pdf[Kubernetes 1.24 Security Audit] (https://www.cncf.io/blog/2023/04/19/new-kubernetes-security-audit-complete-and-open-sourced/[open-sourced in April 2023])

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -659,11 +659,11 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
                 .setEndpoints(Collections.emptySet());
         assertContains(clientPermissionConfigs, pnCounterPermission);
 
-        PermissionConfig queueuPermission = new PermissionConfig(PermissionType.QUEUE, "*", "*")
+        PermissionConfig queuePermission = new PermissionConfig(PermissionType.QUEUE, "*", "*")
                 .addAction("all");
-        assertNotContains(clientPermissionConfigs, queueuPermission);
-        queueuPermission.setDeny(true);
-        assertContains(clientPermissionConfigs, queueuPermission);
+        assertNotContains(clientPermissionConfigs, queuePermission);
+        queuePermission.setDeny(true);
+        assertContains(clientPermissionConfigs, queuePermission);
 
         Set<PermissionType> permTypes = new HashSet<>(Arrays.asList(PermissionType.values()));
         for (PermissionConfig pc : clientPermissionConfigs) {

--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -649,6 +649,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     public void testSecurity() {
         SecurityConfig securityConfig = config.getSecurityConfig();
         assertEquals(OnJoinPermissionOperationName.SEND, securityConfig.getOnJoinPermissionOperation());
+        assertTrue(securityConfig.isPermissionPriorityGrant());
         final Set<PermissionConfig> clientPermissionConfigs = securityConfig.getClientPermissionConfigs();
         assertFalse(securityConfig.getClientBlockUnmappedActions());
         assertTrue(isNotEmpty(clientPermissionConfigs));
@@ -657,12 +658,18 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
                 .addAction("create")
                 .setEndpoints(Collections.emptySet());
         assertContains(clientPermissionConfigs, pnCounterPermission);
+
+        PermissionConfig queueuPermission = new PermissionConfig(PermissionType.QUEUE, "*", "*")
+                .addAction("all");
+        assertNotContains(clientPermissionConfigs, queueuPermission);
+        queueuPermission.setDeny(true);
+        assertContains(clientPermissionConfigs, queueuPermission);
+
         Set<PermissionType> permTypes = new HashSet<>(Arrays.asList(PermissionType.values()));
         for (PermissionConfig pc : clientPermissionConfigs) {
             permTypes.remove(pc.getType());
         }
         assertTrue("All permission types should be listed in fullConfig. Not found ones: " + permTypes, permTypes.isEmpty());
-
         RealmConfig kerberosRealm = securityConfig.getRealmConfig("kerberosRealm");
         assertNotNull(kerberosRealm);
         KerberosAuthenticationConfig kerbAuthentication = kerberosRealm.getKerberosAuthenticationConfig();

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -21,7 +21,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-5.3.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-5.4.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
@@ -818,7 +818,7 @@
                 </hz:realms>
                 <hz:member-authentication realm="r1"/>
                 <hz:client-authentication realm="r2"/>
-                <hz:client-permissions on-join-operation="SEND">
+                <hz:client-permissions on-join-operation="SEND" priority-grant="true">
                     <hz:pn-counter-permission name="pnCounterPermission">
                         <hz:actions>
                             <hz:action>create</hz:action>
@@ -842,7 +842,7 @@
                             <hz:action>read</hz:action>
                         </hz:actions>
                     </hz:map-permission>
-                    <hz:queue-permission name="*">
+                    <hz:queue-permission name="*" deny="true">
                         <hz:actions>
                             <hz:action>all</hz:action>
                         </hz:actions>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -2093,6 +2093,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             Set<BeanDefinition> permissions = new ManagedSet<>();
             NamedNodeMap attributes = node.getAttributes();
             Node onJoinOpAttribute = attributes.getNamedItem("on-join-operation");
+            securityConfigBuilder.addPropertyValue("permissionPriorityGrant",
+                    getBooleanValue(getAttribute(node, "priority-grant")));
             if (onJoinOpAttribute != null) {
                 String onJoinOp = getTextContent(onJoinOpAttribute);
                 OnJoinPermissionOperationName onJoinPermissionOperation = OnJoinPermissionOperationName
@@ -2119,6 +2121,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             Node nameNode = attributes.getNamedItem("name");
             String name = nameNode != null ? getTextContent(nameNode) : null;
             permissionConfigBuilder.addPropertyValue("name", name);
+            permissionConfigBuilder.addPropertyValue("deny", getBooleanValue(getAttribute(node, "deny")));
             Node principalNode = attributes.getNamedItem("principal");
             String principal = principalNode != null ? getTextContent(principalNode) : null;
             permissionConfigBuilder.addPropertyValue("principal", principal);

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.4.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.4.xsd
@@ -3028,6 +3028,16 @@
                                     maxOccurs="unbounded"/>
                     </xs:choice>
                     <xs:attribute name="on-join-operation" type="permission-on-join-operation" default="RECEIVE"/>
+                    <xs:attribute name="priority-grant" type="xs:boolean" default="false">
+                        <xs:annotation>
+                            <xs:documentation>
+                                When true, the grant permissions take priority
+                                over deny ones. When the value is true and neither grant nor
+                                deny implies explicitly the checked permission, the permission
+                                is implied implicitly.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
                 </xs:complexType>
             </xs:element>
             <xs:element name="security-interceptors" type="interceptors" minOccurs="0"/>
@@ -3101,6 +3111,13 @@
             <xs:annotation>
                 <xs:documentation>
                     Name of the principal. Wildcards(*) can be used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="deny" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    When true, subtract/deny the permission instead of granting.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -275,7 +275,8 @@ public class ConfigXmlGenerator {
         }
 
         appendSecurityPermissions(gen, "client-permissions", c.getClientPermissionConfigs(),
-                "on-join-operation", c.getOnJoinPermissionOperation());
+                "on-join-operation", c.getOnJoinPermissionOperation(),
+                "priority-grant", c.isPermissionPriorityGrant());
         gen.close();
     }
 
@@ -417,34 +418,32 @@ public class ConfigXmlGenerator {
     private static void appendSecurityPermissions(XmlGenerator gen, String tag, Set<PermissionConfig> cpc, Object... attributes) {
         final List<PermissionConfig.PermissionType> clusterPermTypes = asList(ALL, CONFIG, TRANSACTION);
 
-        if (!cpc.isEmpty()) {
-            gen.open(tag, attributes);
-            for (PermissionConfig p : cpc) {
-                if (clusterPermTypes.contains(p.getType())) {
-                    gen.open(p.getType().getNodeName(), "principal", p.getPrincipal());
-                } else {
-                    gen.open(p.getType().getNodeName(), "principal", p.getPrincipal(), "name", p.getName());
-                }
+        gen.open(tag, attributes);
+        for (PermissionConfig p : cpc) {
+            if (clusterPermTypes.contains(p.getType())) {
+                gen.open(p.getType().getNodeName(), "principal", p.getPrincipal(), "deny", p.isDeny());
+            } else {
+                gen.open(p.getType().getNodeName(), "principal", p.getPrincipal(), "name", p.getName(), "deny", p.isDeny());
+            }
 
-                if (!p.getEndpoints().isEmpty()) {
-                    gen.open("endpoints");
-                    for (String endpoint : p.getEndpoints()) {
-                        gen.node("endpoint", endpoint);
-                    }
-                    gen.close();
+            if (!p.getEndpoints().isEmpty()) {
+                gen.open("endpoints");
+                for (String endpoint : p.getEndpoints()) {
+                    gen.node("endpoint", endpoint);
                 }
+                gen.close();
+            }
 
-                if (!p.getActions().isEmpty()) {
-                    gen.open("actions");
-                    for (String action : p.getActions()) {
-                        gen.node("action", action);
-                    }
-                    gen.close();
+            if (!p.getActions().isEmpty()) {
+                gen.open("actions");
+                for (String action : p.getActions()) {
+                    gen.node("action", action);
                 }
                 gen.close();
             }
             gen.close();
         }
+        gen.close();
     }
 
     private static void appendLoginModules(XmlGenerator gen, String tag, List<LoginModuleConfig> loginModuleConfigs) {

--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
@@ -36,6 +36,7 @@ import com.hazelcast.security.ICredentialsFactory;
 public class SecurityConfig {
 
     private static final boolean DEFAULT_CLIENT_BLOCK_UNMAPPED_ACTIONS = true;
+    private static final boolean DEFAULT_PERMISSION_PRIORITY_GRANT = false;
 
     private boolean enabled;
 
@@ -51,6 +52,8 @@ public class SecurityConfig {
     private String clientRealm;
 
     private boolean clientBlockUnmappedActions = DEFAULT_CLIENT_BLOCK_UNMAPPED_ACTIONS;
+
+    private boolean permissionPriorityGrant = DEFAULT_PERMISSION_PRIORITY_GRANT;
 
     private OnJoinPermissionOperationName onJoinPermissionOperation = OnJoinPermissionOperationName.RECEIVE;
 
@@ -210,22 +213,42 @@ public class SecurityConfig {
         return this;
     }
 
+    /**
+     * Returns {@code true} when grant permissions should take precedence over deny ones. Default value is {@code false}.
+     * @since 5.4
+     */
+    public boolean isPermissionPriorityGrant() {
+        return permissionPriorityGrant;
+    }
+
+    /**
+     * Sets if grant permissions should take precedence over deny ones.
+     * @return this instance
+     * @since 5.4
+     */
+    public SecurityConfig setPermissionPriorityGrant(boolean permissionPriorityGrant) {
+        this.permissionPriorityGrant = permissionPriorityGrant;
+        return this;
+    }
+
+
     @Override
     public String toString() {
         return "SecurityConfig [enabled=" + enabled + ", securityInterceptorConfigs=" + securityInterceptorConfigs
                 + ", clientPolicyConfig=" + clientPolicyConfig + ", clientPermissionConfigs=" + clientPermissionConfigs
                 + ", realmConfigs=" + realmConfigs + ", memberRealm=" + memberRealm + ", clientRealm=" + clientRealm
                 + ", clientBlockUnmappedActions=" + clientBlockUnmappedActions + ", onJoinPermissionOperation="
-                + onJoinPermissionOperation + "]";
+                + onJoinPermissionOperation + ", permissionPriorityGrant=" + permissionPriorityGrant + "]";
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(clientBlockUnmappedActions, clientPermissionConfigs, clientPolicyConfig, clientRealm, enabled,
-                memberRealm, onJoinPermissionOperation, realmConfigs, securityInterceptorConfigs);
+                memberRealm, onJoinPermissionOperation, realmConfigs, securityInterceptorConfigs, permissionPriorityGrant);
     }
 
     @Override
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
@@ -243,6 +266,7 @@ public class SecurityConfig {
                 && Objects.equals(clientRealm, other.clientRealm) && enabled == other.enabled
                 && Objects.equals(memberRealm, other.memberRealm)
                 && onJoinPermissionOperation == other.onJoinPermissionOperation
+                && permissionPriorityGrant == other.permissionPriorityGrant
                 && Objects.equals(realmConfigs, other.realmConfigs)
                 && Objects.equals(securityInterceptorConfigs, other.securityInterceptorConfigs);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -2894,6 +2894,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                     .valueOf(upperCaseInternal(onJoinOp));
             config.getSecurityConfig().setOnJoinPermissionOperation(onJoinPermissionOperation);
         }
+        config.getSecurityConfig().setPermissionPriorityGrant(getBooleanValue(getAttribute(node, "priority-grant")));
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             PermissionType type = PermissionConfig.PermissionType.getType(nodeName);
@@ -2911,6 +2912,7 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         Node principalNode = getNamedItemNode(node, "principal");
         String principal = principalNode != null ? getTextContent(principalNode) : null;
         PermissionConfig permConfig = new PermissionConfig(type, name, principal);
+        permConfig.setDeny(getBooleanValue(getAttribute(node, "deny")));
         cfg.addClientPermissionConfig(permConfig);
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/YamlMemberDomConfigProcessor.java
@@ -140,10 +140,11 @@ public class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
                     .valueOf(upperCaseInternal(onJoinOp));
             config.getSecurityConfig().setOnJoinPermissionOperation(onJoinPermissionOperation);
         }
+        config.getSecurityConfig().setPermissionPriorityGrant(getBooleanValue(getAttribute(node, "priority-grant")));
         Iterable<Node> nodes = childElements(node);
         for (Node child : nodes) {
             String nodeName = cleanNodeName(child);
-            if (matches("on-join-operation", nodeName)) {
+            if (matches("on-join-operation", nodeName) || matches("priority-grant", nodeName)) {
                 continue;
             }
             nodeName = matches("all", nodeName) ? nodeName + "-permissions" : nodeName + "-permission";

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
@@ -198,6 +198,17 @@ public class DynamicSecurityConfig extends SecurityConfig {
         return staticSecurityConfig.isRealm(name);
     }
 
+
+    @Override
+    public boolean isPermissionPriorityGrant() {
+        return staticSecurityConfig.isPermissionPriorityGrant();
+    }
+
+    @Override
+    public SecurityConfig setPermissionPriorityGrant(boolean permissionPriorityGrant) {
+        throw new UnsupportedOperationException("Unsupported operation");
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/hazelcast/src/main/resources/hazelcast-config-5.4.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.4.json
@@ -2885,6 +2885,7 @@
           "propertyNames": {
             "enum": [
               "on-join-operation",
+              "priority-grant",
               "all",
               "config",
               "transaction",
@@ -2924,6 +2925,11 @@
                 "NONE"
               ]
             },
+            "priority-grant": {
+              "type": "boolean",
+              "default": false,
+              "description": "When true, the grant permissions take priority over deny ones. When the value is true and neither grant nor deny implies explicitly the checked permission, the permission is implied implicitly."
+            },
             "all": {
               "$ref": "#/definitions/SecurityPermission"
             },
@@ -2956,6 +2962,11 @@
           "type": "array",
           "items": {
             "type": "string"
+          },
+        "deny": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, subtract/deny the permission instead of granting."
           }
         },
         "actions": {

--- a/hazelcast/src/main/resources/hazelcast-config-5.4.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.4.xsd
@@ -2790,6 +2790,16 @@
             <xs:element name="sql-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>
         <xs:attribute name="on-join-operation" type="permission-on-join-operation" default="RECEIVE"/>
+        <xs:attribute name="priority-grant" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    When true, the grant permissions take priority
+                    over deny ones. When the value is true and neither grant nor
+                    deny implies explicitly the checked permission, the permission
+                    is implied implicitly.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="base-permission">
         <xs:sequence>
@@ -2814,6 +2824,13 @@
             <xs:annotation>
                 <xs:documentation>
                     Name of the principal. Wildcards(*) can be used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="deny" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    When true, subtract/deny the permission instead of granting.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2487,8 +2487,8 @@
                 <property name="property">value</property>
             </properties>
         </client-permission-policy>
-        <client-permissions on-join-operation="RECEIVE">
-            <all-permissions principal="admin">
+        <client-permissions on-join-operation="RECEIVE" priority-grant="false">
+            <all-permissions principal="admin" deny="true">
                 <endpoints>
                     <endpoint>127.0.0.1</endpoint>
                 </endpoints>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2451,8 +2451,10 @@ hazelcast:
         property: value
     client-permissions:
       on-join-operation: RECEIVE
+      priority-grant: false
       all:
         principal: admin
+        deny: true
         endpoints:
           - 127.0.0.1
       config:

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -665,6 +665,7 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(expected.getPrincipal(), configured.getPrincipal());
         assertEquals(expected.getName(), configured.getName());
         assertEquals(expected.getActions(), configured.getActions());
+        assertEquals(expected.isDeny(), configured.isDeny());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1692,6 +1692,7 @@ public class ConfigCompatibilityChecker {
         boolean check(SecurityConfig c1, SecurityConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.isEnabled(), c2.isEnabled())
+                    && nullSafeEqual(c1.isPermissionPriorityGrant(), c2.isPermissionPriorityGrant())
                     && (c1.getOnJoinPermissionOperation() == c2.getOnJoinPermissionOperation())
                     && nullSafeEqual(c1.getClientBlockUnmappedActions(), c2.getClientBlockUnmappedActions())
                     && nullSafeEqual(c1.getClientRealm(), c2.getClientRealm())

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -598,6 +598,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         SecurityConfig expectedConfig = new SecurityConfig();
         expectedConfig.setEnabled(true)
                 .setOnJoinPermissionOperation(OnJoinPermissionOperationName.NONE)
+                .setPermissionPriorityGrant(true)
                 .setClientBlockUnmappedActions(false)
                 .setClientRealmConfig("cr", new RealmConfig().setJaasAuthenticationConfig(new JaasAuthenticationConfig().setLoginModuleConfigs(
                                 Arrays.asList(
@@ -621,6 +622,7 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
                                 .setPrincipal("devos"),
                         new PermissionConfig()
                                 .setType(PermissionConfig.PermissionType.MANAGEMENT)
+                                .setDeny(true)
                                 .setPrincipal("mcadmin"),
                         new PermissionConfig()
                                 .setType(PermissionConfig.PermissionType.CONFIG),

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3752,23 +3752,25 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         PermissionConfig expected = new PermissionConfig(CACHE, "/hz/cachemanager1/cache1", "dev");
         expected.addAction("create").addAction("destroy").addAction("add").addAction("remove");
         assertPermissionConfig(expected, config);
+        assertFalse(config.getSecurityConfig().isPermissionPriorityGrant());
     }
 
     @Override
     @Test
     public void testConfigPermission() {
         String xml = HAZELCAST_START_TAG + SECURITY_START_TAG
-                + "  <client-permissions>"
-                + "    <config-permission principal=\"dev\">"
+                + "  <client-permissions priority-grant='true'>"
+                + "    <config-permission principal=\"dev\" deny='true'>"
                 + "       <endpoints><endpoint>127.0.0.1</endpoint></endpoints>"
                 + "    </config-permission>\n"
                 + "  </client-permissions>"
                 + SECURITY_END_TAG + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
-        PermissionConfig expected = new PermissionConfig(CONFIG, null, "dev");
+        PermissionConfig expected = new PermissionConfig(CONFIG, null, "dev").setDeny(true);
         expected.getEndpoints().add("127.0.0.1");
         assertPermissionConfig(expected, config);
+        assertTrue(config.getSecurityConfig().isPermissionPriorityGrant());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3724,15 +3724,18 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "  security:\n"
                 + "    enabled: true\n"
                 + "    client-permissions:\n"
+                + "      priority-grant: true\n"
                 + "      config:\n"
+                + "        deny: true\n"
                 + "        principal: dev\n"
                 + "        endpoints:\n"
                 + "          - 127.0.0.1";
 
         Config config = buildConfig(yaml);
-        PermissionConfig expected = new PermissionConfig(CONFIG, null, "dev");
+        PermissionConfig expected = new PermissionConfig(CONFIG, null, "dev").setDeny(true);
         expected.getEndpoints().add("127.0.0.1");
         assertPermissionConfig(expected, config);
+        assertTrue(config.getSecurityConfig().isPermissionPriorityGrant());
     }
 
     @Override

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -816,14 +816,14 @@
                 <property name="property">value</property>
             </properties>
         </client-permission-policy>
-        <client-permissions on-join-operation="SEND">
+        <client-permissions on-join-operation="SEND" priority-grant="true">
             <all-permissions principal="admin">
                 <endpoints>
                     <endpoint>127.0.0.1</endpoint>
                 </endpoints>
             </all-permissions>
             <config-permission principal="deployer"/>
-            <transaction-permission principal="deployer"/>
+            <transaction-permission principal="deployer" deny="true"/>
             <map-permission name="custom" principal="dev">
                 <endpoints>
                     <endpoint>127.0.0.1</endpoint>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -776,6 +776,7 @@ hazelcast:
         property: value
     client-permissions:
       on-join-operation: SEND
+      priority-grant: true
       all:
         principal: admin
         endpoints:
@@ -809,6 +810,7 @@ hazelcast:
             - all
       transaction:
         principal: deployer
+        deny: true
       pn-counter:
         - name: "*"
           actions:


### PR DESCRIPTION
Adds support for "deny permissions" - which in fact allows permissions subtraction.

EE PR: hazelcast/hazelcast-enterprise#6314

An example configuration that allows access to all maps but one:

```xml
<hazelcast>
    <security enabled="false">
        <client-permissions priority-grant="false">
            <map-permission name="*">
                <actions>
                    <action>all</action>
                </actions>
            </map-permission>
            <map-permission name="protected" deny="true">
                <actions>
                    <action>all</action>
                </actions>
            </map-permission>
        </client-permission>
    </security>
</hazelcast>
```

### New evaluation rules

| What implies the checked permission?   | Priority=deny (default) | Priority=grant |
|----------------------------------------|-------------------------|----------------|
| Neither a Grant nor a Deny permission implies it. | denied                  | granted        |
| A Grant implies, but no Deny does.     | granted                 | granted        |
| A Deny implies, but no Grant does.     | denied                  | denied         |
| Both, a Deny and a Grant imply.        | denied                  | granted        |
