### PR TITLE
Add missing `hazelcast-cloud` to the client xml config generator [API-2098]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -157,6 +157,7 @@ public final class ClientConfigXmlGenerator {
         socketOptions(gen, network.getSocketOptions());
         socketInterceptor(gen, network.getSocketInterceptorConfig());
         ssl(gen, network.getSSLConfig());
+        cloud(gen, network.getCloudConfig());
         aliasedDiscoveryConfigsGenerator(gen, aliasedDiscoveryConfigsFrom(network));
         autoDetection(gen, network.getAutoDetectionConfig());
         discovery(gen, network.getDiscoveryConfig());
@@ -517,6 +518,12 @@ public final class ClientConfigXmlGenerator {
                 .node("class-name", classNameOrImplClass(socketInterceptor.getClassName(),
                         socketInterceptor.getImplementation()))
                 .appendProperties(socketInterceptor.getProperties())
+                .close();
+    }
+
+    private static void cloud(XmlGenerator gen, ClientCloudConfig cloudConfig) {
+        gen.open("hazelcast-cloud", "enabled", cloudConfig.isEnabled())
+                .node("discovery-token", cloudConfig.getDiscoveryToken())
                 .close();
     }
 

--- a/hazelcast/src/main/resources/hazelcast-client-config-5.4.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-5.4.xsd
@@ -151,7 +151,7 @@
 
     <xs:complexType name="hazelcast-cloud">
         <xs:all>
-            <xs:element name="discovery-token" type="xs:string"/>
+            <xs:element name="discovery-token" type="xs:string" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="enabled" type="xs:boolean" use="required"/>
     </xs:complexType>

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -785,6 +785,15 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
         assertEquals(originalConfig, generatedConfig);
     }
 
+    @Test
+    public void testNetworkCloud() {
+        ClientCloudConfig originalConfig = new ClientCloudConfig().setEnabled(true)
+                .setDiscoveryToken("pAB2kwCdHKbGpFBNd9iO9AmnYBiQa7rz8yfGW25iHEHRvoRWSN");
+        clientConfig.getNetworkConfig().setCloudConfig(originalConfig);
+        ClientCloudConfig generatedConfig = newConfigViaGenerator().getNetworkConfig().getCloudConfig();
+        assertEquals(originalConfig, generatedConfig);
+    }
+
     private ClientConfig newConfigViaGenerator() {
         String xml = ClientConfigXmlGenerator.generate(clientConfig, DEBUG ? 5 : -1);
         debug(xml);


### PR DESCRIPTION
Added the missing `hazelcast-cloud` xml config generator to the `ClientConfigXmlGenerator` class. Also added a unit test.

fixes #25052
