### PR TITLE
[CN-930] Add K8s auto discovery test workflow

### DIFF
--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -1,4 +1,5 @@
 name: aws-tests
+
 on:
   workflow_dispatch:
   pull_request_target:
@@ -11,15 +12,19 @@ on:
       - 'hazelcast/src/main/java/com/hazelcast/aws/**'
       - '.github/terraform/aws/**'
 
+env:
+  GAR_PROJECT_ID: hazelcast-33
+  GAR_REGION: us-east1
+  GAR_REPO: auto-discovery-test-suite
+  AWS_REGION: us-east-1
+
+defaults:
+  run:
+    working-directory: aws-discovery-suite/terraform/test
+
 jobs:
   build:
     name: AWS Tests
-    defaults:
-      run:
-        shell: bash
-    env:
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
     runs-on: ubuntu-latest
     if: >-
       github.repository_owner == 'hazelcast' && 
@@ -29,14 +34,24 @@ jobs:
           github.event.label.name == 'run-discovery-tests' 
         )
       )
+    outputs:
+      HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
+      CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}
     steps:
-      - name: Setup JDK
-        uses: actions/setup-java@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
-          java-version: 11
-          architecture: x64
-          distribution: adopt
-          cache: 'maven'
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Checkout Auto Discovery Test Suite
+        uses: actions/checkout@v3
+        with:
+          repository: hazelcast/auto-discovery-test-suite
+          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+          path: aws-discovery-suite
 
       - name: Decide which ref to checkout
         id: decide-ref
@@ -52,42 +67,138 @@ jobs:
         with:
           ref: ${{steps.decide-ref.outputs.ref}}
 
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          architecture: x64
+          distribution: adopt
+          cache: 'maven'
+
+      - name: Setup Local Maven Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Build hazelcast jar
+        working-directory: master
         run: |
-          ./mvnw -T 4 -B -V -e clean package \
-          -Dfindbugs.skip \
-          -Dcheckstyle.skip \
-          -Dpmd.skip=true \
-          -Dspotbugs.skip \
-          -Denforcer.skip \
-          -Dmaven.javadoc.skip \
-          -DskipTests \
-          -Dlicense.skip=true \
-          -Drat.skip=true \
-          -Dspotless.check.skip=true \
-          -Dattribution.skip \
-          -Dmaven.source.skip=true
-          echo "Hazelcast jar is: " hazelcast/target/hazelcast-*-SNAPSHOT.jar
-          cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ~/hazelcast.jar
+          echo ${GITHUB_WORKSPACE}
+          HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "HAZELCAST_VERSION=${HAZELCAST_VERSION}" >> $GITHUB_ENV
+           ./mvnw -T 4 -B -V -e clean install \
+           -Dfindbugs.skip \
+           -Dcheckstyle.skip \
+           -Dpmd.skip=true \
+           -Dspotbugs.skip \
+           -Denforcer.skip \
+           -Dmaven.javadoc.skip \
+           -DskipTests \
+           -Dlicense.skip=true \
+           -Drat.skip=true \
+           -Dspotless.check.skip=true \
+           -Dattribution.skip \
+           -Danimal.sniffer.skip=true \
+           -Dmaven.source.skip=true
+            cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ${GITHUB_WORKSPACE}/aws-discovery-suite/terraform/tools/hazelcast.jar
+
+      - name: Build client jar
+        working-directory: aws-discovery-suite/terraform/tools/client
+        run: |
+          mvn versions:set-property -Dproperty=hazelcast.version -DnewVersion=$HAZELCAST_VERSION
+          mvn clean package
+          mv target/aws-discovery-client.jar aws-discovery-client.jar
+
+      - name: Upload hazelcast.jar
+        uses: actions/upload-artifact@v3
+        with:
+          name: hazelcast.jar
+          path: aws-discovery-suite/terraform/tools/hazelcast.jar
+
+      - name: Upload aws-discovery-client.jar
+        uses: actions/upload-artifact@v3
+        with:
+          name: aws-discovery-client.jar
+          path: aws-discovery-suite/terraform/tools/client/aws-discovery-client.jar
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Build Hazelcast Image
+        id: get-hz-image-tag
+        working-directory: aws-discovery-suite/terraform/tools
+        run: |
+          HZ_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
+          echo "HZ_IMG=${HZ_IMG}" >> $GITHUB_OUTPUT
+          docker build -f Dockerfile -t ${HZ_IMG} .
+          docker push ${HZ_IMG}
+
+      - name: Build Client Image
+        id: get-cl-image-tag
+        working-directory: aws-discovery-suite/terraform/tools/client
+        run: |
+          CL_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
+          echo "CL_IMG=${CL_IMG}" >> $GITHUB_OUTPUT
+          docker build -f Dockerfile -t ${CL_IMG} .
+          docker push ${CL_IMG}
+
+  test:
+    name: Run Tests
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        suite: ['ec2_cl_to_ec2_m', 'ec2_cl_to_fargate_ecs_m', 'fargate_ecs_cl_to_ec2_m', 'fargate_ecs_cl_to_fargate_ecs_m']
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Checkout Auto Discovery Test Suite
+        uses: actions/checkout@v3
+        with:
+          repository: hazelcast/auto-discovery-test-suite
+          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+          path: aws-discovery-suite
+
+      - name: Download hazelcast.jar
+        uses: actions/download-artifact@v3
+        with:
+          name: hazelcast.jar
+          path: aws-discovery-suite/terraform/tools
+
+      - name: Download aws-discovery-client.jar
+        uses: actions/download-artifact@v3
+        with:
+          name: aws-discovery-client.jar
+          path: aws-discovery-suite/terraform/tools/client
 
       - name : Set-up Terraform
-        uses: hashicorp/setup-terraform@v2.0.0
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
-          terraform_version: 1.1.8
+          terraform_version: 1.5.4
+          terraform_wrapper: false
 
-      - name: Terraform Init
-        working-directory: .github/terraform/aws
-        run: terraform init
+      - name: Cache Golang dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-      - name: Terraform Apply
-        working-directory: .github/terraform/aws
+      - name: Run Tests
         run: |
-          terraform apply \
-            -var="hazelcast_mancenter_version=latest-snapshot" \
-            -var="hazelcast_path=~/hazelcast.jar" \
-            -auto-approve
-
-      - name: Terraform Destroy
-        if: ${{ always() }}
-        working-directory: .github/terraform/aws
-        run: terraform destroy -auto-approve
+          go test -v -timeout 20m -run TestSuite -suite ${{ matrix.suite }} -member-image ${{ needs.build.outputs.HZ_IMG }} -client-image ${{ needs.build.outputs.CL_IMG }}

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -76,7 +76,6 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
-        working-directory: main
         run: |
           echo ${GITHUB_WORKSPACE}
           HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "1CN-930*"
+      - "CN-930*"
   pull_request_target:
     types:
       - labeled
@@ -20,7 +20,7 @@ env:
 
 defaults:
   run:
-    working-directory: aws-discovery-suite/terraform/test
+    working-directory: auto-discovery-suite/terraform/test
 
 jobs:
   build:
@@ -43,7 +43,8 @@ jobs:
         with:
           repository: hazelcast/auto-discovery-test-suite
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
-          path: aws-discovery-suite
+          path: auto-discovery-suite
+          ref: 'CN-944-refactoring-tests'
 
       - name: Decide which ref to checkout
         id: decide-ref
@@ -58,6 +59,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{steps.decide-ref.outputs.ref}}
+          path: hazelcast
 
       - name: Setup JDK
         uses: actions/setup-java@v3
@@ -76,6 +78,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
+        working-directory: hazelcast
         run: |
           echo ${GITHUB_WORKSPACE}
           HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
@@ -94,10 +97,10 @@ jobs:
            -Dattribution.skip \
            -Danimal.sniffer.skip=true \
            -Dmaven.source.skip=true
-            cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ${GITHUB_WORKSPACE}/aws-discovery-suite/terraform/tools/hazelcast.jar
+            cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ${GITHUB_WORKSPACE}/auto-discovery-suite/terraform/tools/hazelcast.jar
 
       - name: Build client jar
-        working-directory: aws-discovery-suite/terraform/tools/client
+        working-directory: auto-discovery-suite/terraform/tools/client
         run: |
           mvn versions:set-property -Dproperty=hazelcast.version -DnewVersion=$HAZELCAST_VERSION
           mvn clean package
@@ -107,13 +110,13 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: hazelcast.jar
-          path: aws-discovery-suite/terraform/tools/hazelcast.jar
+          path: auto-discovery-suite/terraform/tools/hazelcast.jar
 
       - name: Upload aws-discovery-client.jar
         uses: actions/upload-artifact@v3
         with:
           name: aws-discovery-client.jar
-          path: aws-discovery-suite/terraform/tools/client/aws-discovery-client.jar
+          path: auto-discovery-suite/terraform/tools/client/aws-discovery-client.jar
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2
@@ -124,7 +127,7 @@ jobs:
 
       - name: Build Hazelcast Image
         id: get-hz-image-tag
-        working-directory: aws-discovery-suite/terraform/tools
+        working-directory: auto-discovery-suite/terraform/tools
         run: |
           HZ_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
           echo "HZ_IMG=${HZ_IMG}" >> $GITHUB_OUTPUT
@@ -133,7 +136,7 @@ jobs:
 
       - name: Build Client Image
         id: get-cl-image-tag
-        working-directory: aws-discovery-suite/terraform/tools/client
+        working-directory: auto-discovery-suite/terraform/tools/client
         run: |
           CL_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
           echo "CL_IMG=${CL_IMG}" >> $GITHUB_OUTPUT
@@ -160,19 +163,19 @@ jobs:
         with:
           repository: hazelcast/auto-discovery-test-suite
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
-          path: aws-discovery-suite
+          path: auto-discovery-suite
 
       - name: Download hazelcast.jar
         uses: actions/download-artifact@v3
         with:
           name: hazelcast.jar
-          path: aws-discovery-suite/terraform/tools
+          path: auto-discovery-suite/terraform/tools
 
       - name: Download aws-discovery-client.jar
         uses: actions/download-artifact@v3
         with:
           name: aws-discovery-client.jar
-          path: aws-discovery-suite/terraform/tools/client
+          path: auto-discovery-suite/terraform/tools/client
 
       - name : Set-up Terraform
         uses: hashicorp/setup-terraform@v2.0.3

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -3,6 +3,8 @@ name: aws-tests
 on:
   workflow_dispatch:
   push:
+    branches:
+      - "CN-930*"
   pull_request_target:
     types:
       - labeled
@@ -24,14 +26,6 @@ jobs:
   build:
     name: AWS Tests
     runs-on: ubuntu-latest
-    if: >-
-      github.repository_owner == 'hazelcast' && 
-      ( github.event_name == 'workflow_dispatch' || 
-        (github.event_name == 'pull_request_target' && 
-          github.event.action == 'labeled' && 
-          github.event.label.name == 'run-discovery-tests' 
-        )
-      )
     outputs:
       HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
       CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -2,6 +2,9 @@ name: aws-tests
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "CN-930-*"
   pull_request_target:
     types:
       - labeled
@@ -22,14 +25,6 @@ jobs:
   build:
     name: AWS Tests
     runs-on: ubuntu-latest
-    if: >-
-      github.repository_owner == 'hazelcast' && 
-      ( github.event_name == 'workflow_dispatch' || 
-        (github.event_name == 'pull_request_target' && 
-          github.event.action == 'labeled' && 
-          github.event.label.name == 'run-discovery-tests' 
-        )
-      )
     outputs:
       HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
       CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -6,7 +6,7 @@ on:
     types:
       - labeled
     branches:
-      - "CN-930-*"
+      - "master"
 
 env:
   GAR_PROJECT_ID: hazelcast-33

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -76,7 +76,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
-        working-directory: master
+        working-directory: main
         run: |
           echo ${GITHUB_WORKSPACE}
           HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -3,13 +3,12 @@ name: aws-tests
 on:
   workflow_dispatch:
   push:
-    branches:
-      - "CN-930-*"
   pull_request_target:
     types:
       - labeled
     branches:
       - "master"
+      - "*.z"
 
 env:
   GAR_PROJECT_ID: hazelcast-33
@@ -25,6 +24,14 @@ jobs:
   build:
     name: AWS Tests
     runs-on: ubuntu-latest
+    if: >-
+      github.repository_owner == 'hazelcast' && 
+      ( github.event_name == 'workflow_dispatch' || 
+        (github.event_name == 'pull_request_target' && 
+          github.event.action == 'labeled' && 
+          github.event.label.name == 'run-discovery-tests' 
+        )
+      )
     outputs:
       HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
       CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}

--- a/.github/workflows/aws-terraform-integration-tests.yml
+++ b/.github/workflows/aws-terraform-integration-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "CN-930*"
+      - "1CN-930*"
   pull_request_target:
     types:
       - labeled

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{steps.decide-ref.outputs.ref}}
+          path: hazelcast
 
       - name: Setup JDK
         uses: actions/setup-java@v3
@@ -69,9 +70,8 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
-        working-directory: ./
+        working-directory: hazelcast
         run: |
-          ls
           echo ${GITHUB_WORKSPACE}
           HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "HAZELCAST_VERSION=${HAZELCAST_VERSION}" >> $GITHUB_ENV
@@ -89,7 +89,7 @@ jobs:
            -Dattribution.skip \
            -Danimal.sniffer.skip=true \
            -Dmaven.source.skip=true
-            cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ${GITHUB_WORKSPACE}/auto-discovery-suite/terraform/tools/hazelcast.jar
+          cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ${GITHUB_WORKSPACE}/auto-discovery-suite/terraform/tools/hazelcast.jar
 
       - name: Build client jar
         working-directory: auto-discovery-suite/terraform/tools/client

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -69,7 +69,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
-        working-directory: hazelcast
+        working-directory: ./
         run: ls -la
 
       - name: Build hazelcast jar

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -69,7 +69,6 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
-        working-directory: main
         run: |
           echo ${GITHUB_WORKSPACE}
           HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -69,6 +69,9 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
+        run: ls -la
+
+      - name: Build hazelcast jar
         run: |
           ls
           echo ${GITHUB_WORKSPACE}

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Build hazelcast jar
         run: |
+          ls
           echo ${GITHUB_WORKSPACE}
           HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "HAZELCAST_VERSION=${HAZELCAST_VERSION}" >> $GITHUB_ENV

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -6,7 +6,7 @@ on:
     types:
       - labeled
     branches:
-      - "CN-930-*"
+      - "master"
 
 env:
   GAR_PROJECT_ID: hazelcast-33

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -20,7 +20,7 @@ env:
 
 defaults:
   run:
-    working-directory: aws-discovery-suite/terraform/test
+    working-directory: auto-discovery-suite/terraform/test
 
 jobs:
   build:
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: hazelcast/auto-discovery-test-suite
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
-          path: aws-discovery-suite
+          path: auto-discovery-suite
 
       - name: Decide which ref to checkout
         id: decide-ref
@@ -70,9 +70,6 @@ jobs:
 
       - name: Build hazelcast jar
         working-directory: ./
-        run: ls -la
-
-      - name: Build hazelcast jar
         run: |
           ls
           echo ${GITHUB_WORKSPACE}
@@ -92,10 +89,10 @@ jobs:
            -Dattribution.skip \
            -Danimal.sniffer.skip=true \
            -Dmaven.source.skip=true
-            cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ${GITHUB_WORKSPACE}/aws-discovery-suite/terraform/tools/hazelcast.jar
+            cp hazelcast/target/hazelcast-*-SNAPSHOT.jar ${GITHUB_WORKSPACE}/auto-discovery-suite/terraform/tools/hazelcast.jar
 
       - name: Build client jar
-        working-directory: aws-discovery-suite/terraform/tools/client
+        working-directory: auto-discovery-suite/terraform/tools/client
         run: |
           mvn versions:set-property -Dproperty=hazelcast.version -DnewVersion=$HAZELCAST_VERSION
           mvn clean package
@@ -105,13 +102,13 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: hazelcast.jar
-          path: aws-discovery-suite/terraform/tools/hazelcast.jar
+          path: auto-discovery-suite/terraform/tools/hazelcast.jar
 
       - name: Upload aws-discovery-client.jar
         uses: actions/upload-artifact@v3
         with:
           name: aws-discovery-client.jar
-          path: aws-discovery-suite/terraform/tools/client/aws-discovery-client.jar
+          path: auto-discovery-suite/terraform/tools/client/aws-discovery-client.jar
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2
@@ -122,7 +119,7 @@ jobs:
 
       - name: Build Hazelcast Image
         id: get-hz-image-tag
-        working-directory: aws-discovery-suite/terraform/tools
+        working-directory: auto-discovery-suite/terraform/tools
         run: |
           HZ_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
           echo "HZ_IMG=${HZ_IMG}" >> $GITHUB_OUTPUT
@@ -131,7 +128,7 @@ jobs:
 
       - name: Build Client Image
         id: get-cl-image-tag
-        working-directory: aws-discovery-suite/terraform/tools/client
+        working-directory: auto-discovery-suite/terraform/tools/client
         run: |
           CL_IMG="${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPO }}/$(uuidgen):3d"
           echo "CL_IMG=${CL_IMG}" >> $GITHUB_OUTPUT
@@ -153,7 +150,7 @@ jobs:
         with:
           repository: hazelcast/auto-discovery-test-suite
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
-          path: aws-discovery-suite
+          path: auto-discovery-suite
 
       - name : Set-up Terraform
         uses: hashicorp/setup-terraform@v2.0.3

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -69,6 +69,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
+        working-directory: hazelcast
         run: ls -la
 
       - name: Build hazelcast jar

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -30,12 +30,25 @@ jobs:
       HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
       CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
+            DEVOPS_GITHUB_TOKEN,CN/DEVOPS_GITHUB_TOKEN
+            GCP_SA_KEY,CN/GKE_SA_KEY
 
       - name: Checkout Auto Discovery Test Suite
         uses: actions/checkout@v3
         with:
           repository: hazelcast/auto-discovery-test-suite
-          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+          token: ${{ env.DEVOPS_GITHUB_TOKEN }}
           path: auto-discovery-suite
 
       - name: Decide which ref to checkout
@@ -115,7 +128,7 @@ jobs:
         with:
           registry: us-east1-docker.pkg.dev
           username: _json_key
-          password: ${{ secrets.GCP_SA_KEY }}
+          password: ${{ env.GCP_SA_KEY }}
 
       - name: Build Hazelcast Image
         id: get-hz-image-tag
@@ -142,14 +155,26 @@ jobs:
     strategy:
       matrix:
         suite: ['gke']
-    env:
-      GCLOUD_KEYFILE_JSON=: ${{ secrets.GCP_KEY_FILE }}
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
+            DEVOPS_GITHUB_TOKEN,CN/DEVOPS_GITHUB_TOKEN
+            GCLOUD_KEYFILE_JSON,CN/GKE_SA_KEY
+
       - name: Checkout Auto Discovery Test Suite
         uses: actions/checkout@v3
         with:
           repository: hazelcast/auto-discovery-test-suite
-          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+          token: ${{ env.DEVOPS_GITHUB_TOKEN }}
           path: auto-discovery-suite
 
       - name : Set-up Terraform

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -20,7 +20,7 @@ defaults:
 
 jobs:
   build:
-    name: AWS Tests
+    name: Kubernetes Tests
     runs-on: ubuntu-latest
     if: >-
       github.repository_owner == 'hazelcast' && 
@@ -34,13 +34,6 @@ jobs:
       HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
       CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}
     steps:
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2.0.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
 
       - name: Checkout Auto Discovery Test Suite
         uses: actions/checkout@v3
@@ -151,33 +144,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        suite: ['ec2_cl_to_ec2_m', 'ec2_cl_to_fargate_ecs_m', 'fargate_ecs_cl_to_ec2_m', 'fargate_ecs_cl_to_fargate_ecs_m']
+        suite: ['gke']
+    env:
+      GCLOUD_KEYFILE_JSON=: ${{ secrets.GCP_KEY_FILE }}
     steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2.0.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-
       - name: Checkout Auto Discovery Test Suite
         uses: actions/checkout@v3
         with:
           repository: hazelcast/auto-discovery-test-suite
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
           path: aws-discovery-suite
-
-      - name: Download hazelcast.jar
-        uses: actions/download-artifact@v3
-        with:
-          name: hazelcast.jar
-          path: aws-discovery-suite/terraform/tools
-
-      - name: Download aws-discovery-client.jar
-        uses: actions/download-artifact@v3
-        with:
-          name: aws-discovery-client.jar
-          path: aws-discovery-suite/terraform/tools/client
 
       - name : Set-up Terraform
         uses: hashicorp/setup-terraform@v2.0.3

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -2,6 +2,9 @@ name: aws-tests
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "CN-930-*"
   pull_request_target:
     types:
       - labeled
@@ -22,14 +25,6 @@ jobs:
   build:
     name: Kubernetes Tests
     runs-on: ubuntu-latest
-    if: >-
-      github.repository_owner == 'hazelcast' && 
-      ( github.event_name == 'workflow_dispatch' || 
-        (github.event_name == 'pull_request_target' && 
-          github.event.action == 'labeled' && 
-          github.event.label.name == 'run-discovery-tests' 
-        )
-      )
     outputs:
       HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
       CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -1,4 +1,4 @@
-name: aws-tests
+name: k8s-tests
 
 on:
   workflow_dispatch:
@@ -69,7 +69,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build hazelcast jar
-        working-directory: master
+        working-directory: main
         run: |
           echo ${GITHUB_WORKSPACE}
           HAZELCAST_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -2,14 +2,12 @@ name: aws-tests
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "CN-930-*"
   pull_request_target:
     types:
       - labeled
     branches:
       - "master"
+      - "*.z"
 
 env:
   GAR_PROJECT_ID: hazelcast-33
@@ -25,6 +23,14 @@ jobs:
   build:
     name: Kubernetes Tests
     runs-on: ubuntu-latest
+    if: >-
+      github.repository_owner == 'hazelcast' && 
+      ( github.event_name == 'workflow_dispatch' || 
+        (github.event_name == 'pull_request_target' && 
+          github.event.action == 'labeled' && 
+          github.event.label.name == 'run-discovery-tests' 
+        )
+      )
     outputs:
       HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
       CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}

--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -2,6 +2,9 @@ name: aws-tests
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "CN-930*"
   pull_request_target:
     types:
       - labeled
@@ -23,14 +26,6 @@ jobs:
   build:
     name: Kubernetes Tests
     runs-on: ubuntu-latest
-    if: >-
-      github.repository_owner == 'hazelcast' && 
-      ( github.event_name == 'workflow_dispatch' || 
-        (github.event_name == 'pull_request_target' && 
-          github.event.action == 'labeled' && 
-          github.event.label.name == 'run-discovery-tests' 
-        )
-      )
     outputs:
       HZ_IMG: ${{ steps.get-hz-image-tag.outputs.HZ_IMG }}
       CL_IMG: ${{ steps.get-cl-image-tag.outputs.CL_IMG }}


### PR DESCRIPTION
Add K8s auto discovery test workflow

Fixes CN-930

Checklist:
- [+] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [+] Label `Add to Release Notes` or `Not Release Notes content` set
- [+] Request reviewers if possible
- [+] Send backports/forwardports if fix needs to be applied to past/future releases
- [+] New public APIs have `@Nonnull/@Nullable` annotations
- [+] New public APIs have `@since` tags in Javadoc
