### PR TITLE
Fix incorrect PartitioningStrategy lookup on Clients [HZ-2738]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
@@ -150,14 +150,11 @@ public class DefaultClientExtension implements ClientExtension {
     }
 
     protected PartitioningStrategy getPartitioningStrategy(ClassLoader configClassLoader) throws Exception {
-        // This method historically fetched our strategy from the client's local System Properties - this
-        //  behaviour is not correct (it should read the ClientConfig properties), but to maintain backwards
-        //  compatibility, we should use the system property value if it exists.
-        String partitioningStrategyClassName = ClusterProperty.PARTITIONING_STRATEGY_CLASS.getSystemProperty();
-        if (partitioningStrategyClassName == null || partitioningStrategyClassName.isEmpty()) {
-            partitioningStrategyClassName = client.getProperties().getString(ClusterProperty.PARTITIONING_STRATEGY_CLASS);
-        }
-
+        // This method historically only fetched our strategy from the client's local System Properties - this
+        //  behaviour is not correct (it should read the ClientConfig properties). By using ClientConfig#getProperty
+        //  we will be checking the ClientConfig first, and otherwise falling back to a System Property.
+        String partitioningStrategyClassName = client.getClientConfig().getProperty(
+                ClusterProperty.PARTITIONING_STRATEGY_CLASS.getName());
         if (partitioningStrategyClassName != null && !partitioningStrategyClassName.isEmpty()) {
             return ClassLoaderUtil.newInstance(configClassLoader, partitioningStrategyClassName);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
@@ -150,8 +150,15 @@ public class DefaultClientExtension implements ClientExtension {
     }
 
     protected PartitioningStrategy getPartitioningStrategy(ClassLoader configClassLoader) throws Exception {
+        // This method historically fetched our strategy from the client's local System Properties - this
+        //  behaviour is not correct (it should read the ClientConfig properties), but to maintain backwards
+        //  compatibility, we should use the system property value if it exists.
         String partitioningStrategyClassName = ClusterProperty.PARTITIONING_STRATEGY_CLASS.getSystemProperty();
-        if (partitioningStrategyClassName != null && partitioningStrategyClassName.length() > 0) {
+        if (partitioningStrategyClassName == null || partitioningStrategyClassName.isEmpty()) {
+            partitioningStrategyClassName = client.getProperties().getString(ClusterProperty.PARTITIONING_STRATEGY_CLASS);
+        }
+
+        if (partitioningStrategyClassName != null && !partitioningStrategyClassName.isEmpty()) {
             return ClassLoaderUtil.newInstance(configClassLoader, partitioningStrategyClassName);
         } else {
             return new DefaultPartitioningStrategy();


### PR DESCRIPTION
Currently, `DefaultClientExtension#getPartitioningStrategy` looks at the local System Properties to find a match for the Hazelcast property `PARTITIONING_STRATEGY_CLASS`, when it should be checking the provided Hazelcast cluster properties map, defined via `ClientConfig` overrides.

This requires a simple solution - altering this method to check the provided properties map instead of the local System Properties. However, since this method has obtained the `PartitioningStrategy` via System Property for over 8 years, to maintain a greater degree of backwards compatibility, we make sure to use the `ClientConfig#getProperty` function for this, which checks to see if a local System Property exists if a config defined property override is not present. 

Fixes https://hazelcast.atlassian.net/browse/HZ-2738

Breaking changes (list specific methods/types/messages):
* Customers who rely on accurate Client `PartitioningStrategy` results may see changes in behaviour if they define a custom strategy in their config (which would have been ignored prior to this fix, but would now be used after this fix).
