### PR TITLE
Move PartitionMigrationComputeIntensiveTest to NightlyTest [HZ-2623]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationComputeIntensiveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationComputeIntensiveTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -39,7 +39,7 @@ import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_COUNT;
 import static com.hazelcast.spi.properties.ClusterProperty.SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({SlowTest.class})
+@Category({NightlyTest.class})
 public class PartitionMigrationComputeIntensiveTest extends HazelcastTestSupport {
 
     private static final ILogger LOGGER = Logger.getLogger(PartitionMigrationComputeIntensiveTest.class);
@@ -52,7 +52,6 @@ public class PartitionMigrationComputeIntensiveTest extends HazelcastTestSupport
         HazelcastInstance[] instances = factory.newInstances(config, 10);
 
         assertClusterSizeEventually(instances.length, instances);
-        waitAllForSafeState(instances);
 
         LOGGER.info("Cluster formed and in safe state, warming up partitions...");
         warmUpPartitions(instances);


### PR DESCRIPTION
As the name suggests, this test is very computationally expensive, and as such is prone to false flag failures on build executors that are already under pressure during tests (such as Sonar builds). This is shown in https://github.com/hazelcast/hazelcast/issues/24791 where the recently added logging shows all nodes experience slow operations while warming up partitions, and it is simply a case of all processing being hampered; this is demonstrated by logs showing the slow operations do make progress, but not fast enough, while health monitor shows system load at maximum capacity.

Moving this test to `@NightlyTest` will stop it being run on Sonar builds and keep it reserved to the nightly executions where pressure is reduced. Another approach would be to reduce the `PARTITION_COUNT` for this test, but as this test is designed to be intensive, I think that should be kept as a last resort.

Fixes https://hazelcast.atlassian.net//browse/HZ-2623
Closes https://github.com/hazelcast/hazelcast/issues/24791