### PR TITLE
Do not generate redundant sort/merge operations for sorted index scans [HZ-2791]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -583,6 +583,7 @@ public interface SqlConnector {
          * * - these are currently not implemented, but are a simple example.
          *
          * @return if result should be sorted if possible
+         * @since 5.4
          */
         boolean mayNeedSorting();
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -282,7 +282,7 @@ public class IMapSqlConnector implements SqlConnector {
         // the index will be scanned twice and each time half of the partitions will be thrown out.
         scanner.localParallelism(1);
 
-        if (tableIndex.getType() == IndexType.SORTED) {
+        if (tableIndex.getType() == IndexType.SORTED && context.mayNeedSorting()) {
             Vertex sorter = context.getDag().newUniqueVertex(
                     "SortCombine",
                     ProcessorMetaSupplier.forceTotalParallelismOne(

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateTopLevelDagVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateTopLevelDagVisitor.java
@@ -736,6 +736,13 @@ public class CreateTopLevelDagVisitor extends CreateDagVisitorBase<Vertex> {
         return objectKeys;
     }
 
+
+    /**
+     * Execute given subtree visiting operation in the context in which order of
+     * produced results is irrelevant.
+     *
+     * @see SqlConnector.DagBuildContext#mayNeedSorting
+     */
     private <T> T orderIrrelevant(Supplier<T> operation) {
         return dagBuildContext.withSorting(false, operation);
     }


### PR DESCRIPTION
Remove redundant `SortCombine` step for sorted index scan if the order is not needed (eg. for aggregations).

In some cases we know that the vertex input does not have to be sorted, because the order of the result does not depend on the order of input (strictly speaking, the output ordering guarantee does not depend on input ordering guarantees). This is the case for aggregations, sorting and UNION ALL.

In some cases ordering is not changed, eg. for joins, streaming operators with only streaming inputs.

Limitation in this implementation is that it cannot remove `SortCombine` for some queries without ORDER BY if they do not contain any of the operations mentioned above. For example query with index scans and joins only will still have redundant sorting step. However, for the most trivial case `SELECT * FROM table WHERE indexed_predicate` the overhead will not be big because `SortCombine` will be immediately followed by `RootResultConsumerSink` and the edge will use only local communication.

Better approach would be to get the information if the RelNode output ordering is expected directly from Calcite SQL optimiser but for that we might have to switch to Cascades optimiser.

Fixes HZ-2791

Breaking changes (list specific methods/types/messages):
* technically not a breaking change: some queries that returned ordered results without `ORDER BY` due to use of sorted index scan will no longer return sorted result (they were never guaranteed to return sorted result) unless explicitly requested by `ORDER BY` clause

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
