### PR TITLE
Add back remoteOperationCount JMX alias [HZ-2818]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -406,6 +406,7 @@ public final class MetricDescriptorConstants {
     public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_USED_PERCENTAGE = "usedPercentage";
     public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_LAST_CALL_ID = "lastCallId";
     public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_PENDING = "pending";
+    public static final String OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_REMOTE_COUNT = "remoteOperationCount";
     public static final String OPERATION_METRIC_OPERATION_RUNNER_EXECUTED_OPERATIONS_COUNT = "executedOperationsCount";
     public static final String OPERATION_METRIC_OPERATION_SERVICE_ASYNC_OPERATIONS = "asyncOperations";
     public static final String OPERATION_METRIC_OPERATION_SERVICE_TIMEOUT_COUNT = "operationTimeoutCount";

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -60,6 +60,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_REMOTE_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_METRIC_OPERATION_SERVICE_ASYNC_OPERATIONS;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_METRIC_OPERATION_SERVICE_CALL_TIMEOUT_COUNT;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.OPERATION_METRIC_OPERATION_SERVICE_FAILED_BACKUPS;
@@ -247,6 +248,7 @@ public final class OperationServiceImpl implements StaticMetricsProvider, LiveOp
         return operationExecutor.getExecutedOperationCount();
     }
 
+    @Probe(name = OPERATION_METRIC_INVOCATION_REGISTRY_INVOCATIONS_REMOTE_COUNT, level = MANDATORY)
     @Override
     public int getRemoteOperationsCount() {
         return invocationRegistry.size();


### PR DESCRIPTION
Pre-patch https://github.com/hazelcast/hazelcast/pull/16425 there appeared to be two names by which `InvocationRegistry.invocations.size()`  was referred: `operation.remoteOperationCount` and `operation.invocations.pending`.  Post  https://github.com/hazelcast/hazelcast/pull/16425 the `operation.remoteOperationCount` was removed, leaving a single name for attaining such information: `operation.invocations.pending`. IMO having a single name for a metric makes sense: aliases can confuse. That said, I am posting the simple fix here if the missing JMX alias is causing issues for those upgrading from 3.x to 5.x.

Fixes #25110

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
