### PR TITLE
Resolve gpl spdx third party license master [HZ-2159, HZ-2774] (#25150)

### DIFF
--- a/hazelcast-build-utils/src/main/resources/hazelcast-thirdparty-template.ftl
+++ b/hazelcast-build-utils/src/main/resources/hazelcast-thirdparty-template.ftl
@@ -12,10 +12,17 @@ List of third-party dependencies grouped by their license type:
 
 <#list licenseMap as e>
 <#if e.getValue()?size != 0>
+<#-- 
+  Some dependencies are dual-licensed. 
+  Hazelcast uses the dependencies under one of the licenses.
+  The other license is usually a copy-left license, which only confuses our users, so we exclude it.
+-->
+<#if e.getKey() != "LGPL-2.1-or-later" && e.getKey() != "GPL2 w/ CPE" && e.getKey() != "GNU General Public License, version 2 (GPL2), with the classpath exception">
 ${e.getKey()}
 <#list e.getValue() as a>
   ${a.name + ":" + a.version?trim}
 </#list>
+</#if>
 </#if>
 </#list>
 

--- a/pom.xml
+++ b/pom.xml
@@ -547,37 +547,94 @@
                             <failOnMissing>true</failOnMissing>
                             <fileTemplate>${main.basedir}/hazelcast-build-utils/src/main/resources/hazelcast-thirdparty-template.ftl</fileTemplate>
                             <includedLicenses>
-                                <includedLicense>CC0</includedLicense>
-                                <includedLicense>Apache License, Version 2.0</includedLicense>
-                                <includedLicense>MIT License</includedLicense>
-                                <includedLicense>Public Domain</includedLicense>
-                                <includedLicense>EPL 2.0</includedLicense>
+                                <!-- 
+                                  Always use SPDX license identifiers listed in https://spdx.org/licenses (when available)
+                                  note: GPL licenses are excluded in https://github.com/hazelcast/hazelcast/blob/master/hazelcast-build-utils/src/main/resources/hazelcast-thirdparty-template.ftl
+                                -->
+                                <includedLicense>Apache-2.0</includedLicense>
+                                <includedLicense>MIT</includedLicense>
+                                <includedLicense>BSD-2-Clause</includedLicense>
+                                <includedLicense>BSD-3-Clause</includedLicense>
+                                <includedLicense>CC0-1.0</includedLicense>
+                                <includedLicense>CDDL</includedLicense>
                                 <includedLicense>Eclipse Distribution License - v 1.0</includedLicense>
-                                <includedLicense>BSD 3-Clause License</includedLicense>
-                                <includedLicense>BSD 2-Clause License</includedLicense>
-                                <includedLicense>The JSON License</includedLicense>
+                                <includedLicense>EPL-1.0</includedLicense>
+                                <includedLicense>EPL-2.0</includedLicense>
+                                <includedLicense>JSON</includedLicense>
+                                <includedLicense>Public Domain</includedLicense>
                             </includedLicenses>
                             <licenseMerges>
+                                <!-- 
+                                  Only merge new 3rd Party dependency license if you get a license build failure
+                                -->
                                 <licenseMerge>
-                                    Apache License, Version 2.0|Apache License v2.0|
-                                    Apache Software License 2.0|The Apache Software License, Version 2.0|
-                                    Apache License, version 2.0|The Apache Software License, version 2.0|
-                                    Apache 2|Apache 2.0|Apache-2.0|Apache License 2.0|The Apache License, Version 2.0|
-                                    Apache Software License - Version 2.0|Apache License Version 2.0
+                                    Apache-2.0 |
+                                    Apache License v2.0 |
+                                    Apache Software License 2.0 |
+                                    The Apache Software License, Version 2.0 |
+                                    The Apache Software License, version 2.0 |
+                                    Apache License, Version 2.0 |
+                                    Apache 2 |
+                                    Apache 2.0 |
+                                    The Apache License, Version 2.0 |
+                                    Apache Software License - Version 2.0 |
+                                    Apache License Version 2.0 |
+                                    Apache License 2.0
                                 </licenseMerge>
-                                <licenseMerge>MIT License|MIT|The MIT License|MIT license|The MIT License (MIT)</licenseMerge>
                                 <licenseMerge>
-                                    BSD 3-Clause License|BSD License|BSD|BSD licence|The BSD License|3-Clause BSD License|
-                                    New BSD License|New BSD license|The New BSD License|Revised BSD|BSD New license|
-                                    BSD-3-Clause|BSD 3-clause
-                                </licenseMerge>
-                                <licenseMerge>BSD 2-Clause License|BSD-2-Clause|BSD 2-Clause license</licenseMerge>
-                                <licenseMerge>CC0|Public Domain, per Creative Commons CC0</licenseMerge>
-                                <licenseMerge>
-                                    CDDL|CDDL + GPLv2 with classpath exception|CDDL License|CDDL/GPLv2+CE
+                                    MIT |
+                                    The MIT License |
+                                    MIT License |
+                                    MIT license |
+                                    The MIT License (MIT)
                                 </licenseMerge>
                                 <licenseMerge>
-                                    Eclipse Distribution License - v 1.0|EDL 1.0
+                                    BSD-2-Clause |
+                                    BSD 2-Clause License |
+                                    BSD 2-Clause license
+                                </licenseMerge>
+                                <licenseMerge>
+                                    BSD-3-Clause |
+                                    BSD 3-Clause License |
+                                    BSD |
+                                    BSD licence |
+                                    The BSD License |
+                                    3-Clause BSD License |
+                                    New BSD license |
+                                    The New BSD License |
+                                    Revised BSD |
+                                    BSD New license |
+                                    BSD 3-clause
+                                </licenseMerge>
+                                <licenseMerge>
+                                    CC0-1.0 |
+                                    CC0 |
+                                    Public Domain, per Creative Commons CC0
+                                </licenseMerge>
+                                <licenseMerge>
+                                    CDDL |
+                                    CDDL + GPLv2 with classpath exception |
+                                    CDDL License |
+                                    CDDL/GPLv2+CE
+                                </licenseMerge>
+                                <licenseMerge>
+                                    Eclipse Distribution License - v 1.0 |
+                                    EDL 1.0
+                                </licenseMerge>
+                                <licenseMerge>
+                                    EPL-1.0 |
+                                    EPL 1.0 |
+                                    Eclipse Public License - Version 1.0
+                                </licenseMerge>
+                                <licenseMerge>
+                                    EPL-2.0 |
+                                    EPL 2.0 |
+                                    Eclipse Public License - Version 2.0 |
+                                    Eclipse Public License, Version 2.0
+                                </licenseMerge>
+                                <licenseMerge>
+                                    JSON |
+                                    The JSON License
                                 </licenseMerge>
                             </licenseMerges>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -601,6 +601,8 @@
                                     The BSD License |
                                     3-Clause BSD License |
                                     New BSD license |
+                                    New BSD License |
+                                    Modified BSD License |
                                     The New BSD License |
                                     Revised BSD |
                                     BSD New license |


### PR DESCRIPTION
Forward-port of #25150 to master
additional fix for #25167

1. Remove GPL license. Some dependencies are dual-licensed. Hazelcast uses the dependencies under one of the licenses. The other license is usually a copy-left license, which only confuses our users, so we exclude it
2. use SPDX identifiers for all 'included' licenses for clarity and reduce license merge lines proliferation

Fixes [HZ-2159](https://hazelcast.atlassian.net/browse/HZ-2159), [HZ-2774](https://hazelcast.atlassian.net/browse/HZ-2774)

[HZ-2159]: https://hazelcast.atlassian.net/browse/HZ-2159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HZ-2774]: https://hazelcast.atlassian.net/browse/HZ-2774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ