### PR TITLE
Use netty-tcnative version from netty-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1945,10 +1945,6 @@
               <version>1.1.3.Final</version>
             </dependency>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative-classes</artifactId>
-            </dependency>
-            <dependency>
                 <groupId>com.google.api-client</groupId>
                 <artifactId>google-api-client</artifactId>
                 <version>1.32.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1947,7 +1947,6 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-classes</artifactId>
-                <version>2.0.61.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.google.api-client</groupId>


### PR DESCRIPTION
As we already import `netty` BOM in the `dependencyManagement`, we don't need to specify the `netty-tcnative` version which is covered.