### PR TITLE
Do not generate redundant sort/merge operations for sorted index scans [HZ-2791]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -257,8 +257,8 @@ public class IMapSqlConnector implements SqlConnector {
             @Nonnull List<HazelcastRexNode> projection,
             @Nullable IndexFilter indexFilter,
             @Nullable ComparatorEx<JetSqlRow> comparator,
-            boolean descending
-    ) {
+            boolean descending,
+            boolean requiresSort) {
         PartitionedMapTable table = context.getTable();
         MapIndexScanMetadata indexScanMetadata = new MapIndexScanMetadata(
                 table.getMapName(),
@@ -282,7 +282,7 @@ public class IMapSqlConnector implements SqlConnector {
         // the index will be scanned twice and each time half of the partitions will be thrown out.
         scanner.localParallelism(1);
 
-        if (tableIndex.getType() == IndexType.SORTED) {
+        if (tableIndex.getType() == IndexType.SORTED && requiresSort) {
             Vertex sorter = context.getDag().newUniqueVertex(
                     "SortCombine",
                     ProcessorMetaSupplier.forceTotalParallelismOne(

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/FieldCollation.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/FieldCollation.java
@@ -46,6 +46,12 @@ public class FieldCollation implements Serializable, IdentifiedDataSerializable 
         nullDirection = coll.nullDirection;
     }
 
+    public FieldCollation(int index, Direction direction, NullDirection nullDirection) {
+        this.index = index;
+        this.direction = direction;
+        this.nullDirection = nullDirection;
+    }
+
     public static List<FieldCollation> convertCollation(List<RelFieldCollation> colls) {
         return Util.toList(colls, FieldCollation::new);
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/cost/CostUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/cost/CostUtils.java
@@ -38,6 +38,9 @@ public final class CostUtils {
     /** CPU multiplier applied to index scan (hash). */
     public static final double INDEX_SCAN_CPU_MULTIPLIER_HASH = 1.1d;
 
+    /** CPU multiplier applied to sorted index scan when ordering is required. */
+    public static final double INDEX_SCAN_CPU_MULTIPLIER_SORTED_ORDER_REQUIRED = 0.1d;
+
     /** Multiplier for the CPU part of the cost. Assumes 1ns per item. */
     public static final double CPU_COST_MULTIPLIER = 1.0d;
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateTopLevelDagVisitor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/CreateTopLevelDagVisitor.java
@@ -269,7 +269,8 @@ public class CreateTopLevelDagVisitor extends CreateDagVisitorBase<Vertex> {
                         wrap(rel.projection()),
                         rel.getIndexFilter(),
                         rel.getComparator(),
-                        rel.isDescending()
+                        rel.isDescending(),
+                        rel.requiresSort()
                 );
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
@@ -92,7 +92,7 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
 
     public ComparatorEx<JetSqlRow> getComparator() {
         if (index.getType() == IndexType.SORTED) {
-            RelCollation relCollation = getTraitSet().getTrait(RelCollationTraitDef.INSTANCE);
+            RelCollation relCollation = getTraitSet().getCollation();
             assert relCollation != null;
             List<FieldCollation> collations;
             if (relCollation != RelCollations.EMPTY) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
@@ -218,7 +218,7 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
         // Note that no full sorting is performed, sorted row streams are only merged.
         double sortCpu = requiresSort ? CostUtils.INDEX_SCAN_CPU_MULTIPLIER_SORTED_ORDER_REQUIRED * projectCpu : 0;
 
-        // 4. Finally, return sum of both scan and project.
+        // 5. Finally, return sum of both scan and project.
         return planner.getCostFactory().makeCost(
                 filterRowCount,
                 scanCpu + filterCpu + projectCpu + sortCpu,

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
@@ -99,7 +99,7 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
                 collations = FieldCollation.convertCollation(relCollation.getFieldCollations());
             } else {
                 // order is not forced, use default comparator for the index columns
-                collations = getIndex().getFieldOrdinals().stream()
+                collations = index.getFieldOrdinals().stream()
                         .map(i -> new FieldCollation(i, RelFieldCollation.Direction.ASCENDING,
                                 RelFieldCollation.NullDirection.UNSPECIFIED))
                         .collect(toList());

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
@@ -36,7 +36,6 @@ import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/IndexScanMapPhysicalRel.java
@@ -37,6 +37,8 @@ import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.TableScan;
@@ -91,9 +93,16 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
     public ComparatorEx<JetSqlRow> getComparator() {
         if (index.getType() == IndexType.SORTED) {
             RelCollation relCollation = getTraitSet().getTrait(RelCollationTraitDef.INSTANCE);
-            List<FieldCollation> collations = relCollation.getFieldCollations().stream()
-                    .map(FieldCollation::new)
-                    .collect(toList());
+            assert relCollation != null;
+            List<FieldCollation> collations;
+            if (relCollation != RelCollations.EMPTY) {
+                collations = FieldCollation.convertCollation(relCollation.getFieldCollations());
+            } else {
+                // order is not forced, use default comparator for the index columns
+                collations = getIndex().getFieldOrdinals().stream()
+                        .map(i -> new FieldCollation(i, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.UNSPECIFIED))
+                        .collect(toList());
+            }
             return ExpressionUtil.comparisonFn(collations);
         } else {
             return null;
@@ -102,7 +111,7 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
 
     public boolean isDescending() {
         boolean descending = false;
-        RelCollation relCollation = getTraitSet().getTrait(RelCollationTraitDef.INSTANCE);
+        RelCollation relCollation = getTraitSet().getCollation();
 
         // Take first direction as main direction.
         // In case of different directions Scan + Sort relations combination should be used.
@@ -112,6 +121,11 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
 
         return descending;
     }
+
+    public boolean requiresSort() {
+        return index.getType() == IndexType.SORTED && getTraitSet().getCollation() != RelCollations.EMPTY;
+    }
+
 
     @Override
     public RexNode filter() {
@@ -176,6 +190,7 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
                 CostUtils.indexScanCpuMultiplier(index.getType()),
                 hasFilter,
                 filterRowCount,
+                requiresSort(),
                 getTableUnwrapped().getProjects().size()
         );
     }
@@ -186,6 +201,7 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
             double scanCostMultiplier,
             boolean hasFilter,
             double filterRowCount,
+            boolean requiresSort,
             int projectCount
     ) {
         // 1. Get cost of the scan itself.
@@ -197,10 +213,12 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
         // 3. Get cost of the project taking into account the filter and number of expressions. Project never produces IO.
         double projectCpu = CostUtils.adjustCpuForConstrainedScan(CostUtils.getProjectCpu(filterRowCount, projectCount));
 
+        double sortCpu = requiresSort ? 0.1 * projectCpu : 0;
+
         // 4. Finally, return sum of both scan and project.
         return planner.getCostFactory().makeCost(
                 filterRowCount,
-                scanCpu + filterCpu + projectCpu,
+                scanCpu + filterCpu + projectCpu + sortCpu,
                 0
         );
     }
@@ -210,11 +228,30 @@ public class IndexScanMapPhysicalRel extends TableScan implements HazelcastPhysi
         return super.explainTerms(pw)
                 .item("index", index.getName())
                 .item("indexExp", indexExp)
-                .item("remainderExp", remainderExp);
+                .item("remainderExp", remainderExp)
+                .itemIf("requiresSort", requiresSort(), requiresSort());
     }
 
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
         return new IndexScanMapPhysicalRel(getCluster(), traitSet, getTable(), index, indexFilter, indexExp, remainderExp);
+    }
+
+
+    /**
+     * Return copy of this RelNode without collation - without guaranteed order.
+     * <p>
+     * Sorted index scan can work in two modes because it is distributed scatter-gather operation:
+     * <ol>
+     *     <li>with guaranteed order which is defined by index columns. This mode requires gathering
+     *     all results before further processing to guarantee the order</li>
+     *     <li>without guaranteed order, if the order is not needed. This mode does not require
+     *     gathering results so should be much more performant.</li>
+     * </ol>
+     * Some operations do not care about the order of input data (e.g. aggregations) so they can
+     * benefit from this mode of operation.
+     */
+    public RelNode withoutCollation() {
+        return copy(traitSet.replace(RelCollations.EMPTY), getInputs());
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/SortPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/SortPhysicalRule.java
@@ -23,7 +23,6 @@ import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.immutables.value.Value;
@@ -74,7 +73,7 @@ final class SortPhysicalRule extends RelRule<RelRule.Config> {
         for (RelNode physicalInput : OptUtils.extractPhysicalRelsFromSubset(sort.getInput())) {
             boolean requiresSort = requiresSort(
                     sort.getCollation(),
-                    physicalInput.getTraitSet().getTrait(RelCollationTraitDef.INSTANCE)
+                    physicalInput.getTraitSet().getCollation()
             );
             RelNode input = physicalInput;
             if (requiresSort) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
@@ -153,15 +153,15 @@ public final class IndexResolver {
                     fullScanRels.add(relDescending);
 
                     // For full scan we do not add unsorted scan (unlike in case of filters)
-                    // because it would be never chosen.
+                    // because it would never be chosen.
                     //
-                    // Full index scan will never be cheaper than full table scan.
-                    // This might be possible if the index covered all columns in the query.
-                    // However, we do not support this use (index scan always fetches entire entry)
-                    // and even if we did, full scan might still be cheaper.
-                    // The only use case where full index scan makes sense is if order is needed
-                    // but then EMPTY collation will not be beneficial: Sort + unsorted index scan
-                    // would be worse that just sorted index scan.
+                    // Full index scan will never be cheaper than full table scan. This might be
+                    // possible if the index covers all columns in the query. However, we do not
+                    // support this use (index scan always fetches entire entry) and even if we
+                    // did, full scan might still be cheaper. The only use case where full index
+                    // scan makes sense is if order is needed, but in that case, EMPTY collation
+                    // will not be beneficial since [Sort + unsorted index scan] would be worse
+                    // than just sorted index scan.
                 }
             }
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
@@ -252,7 +252,7 @@ public final class IndexResolver {
     }
 
     private static RelNode removeCollation(RelNode rel) {
-        return ((IndexScanMapPhysicalRel)rel).withoutCollation();
+        return ((IndexScanMapPhysicalRel) rel).withoutCollation();
     }
 
     /**

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
@@ -151,6 +151,17 @@ public final class IndexResolver {
                     fullScanRels.add(relAscending);
                     RelNode relDescending = replaceCollationDirection(relAscending, DESCENDING);
                     fullScanRels.add(relDescending);
+
+                    // For full scan we do not add unsorted scan (unlike in case of filters)
+                    // because it would be never chosen.
+                    //
+                    // Full index scan will never be cheaper than full table scan.
+                    // This might be possible if the index covered all columns in the query.
+                    // However, we do not support this use (index scan always fetches entire entry)
+                    // and even if we did, full scan might still be cheaper.
+                    // The only use case where full index scan makes sense is if order is needed
+                    // but then EMPTY collation will not be beneficial: Sort + unsorted index scan
+                    // would be worse that just sorted index scan.
                 }
             }
         }
@@ -201,6 +212,10 @@ public final class IndexResolver {
                     RelCollation relDescCollation = getCollation(relDescending);
                     // Exclude a full scan that has the same collation
                     fullScanRelsMap.remove(relDescCollation);
+
+                    // Add variant without enforced collation which may be cheaper
+                    // if the ordering of the result is not required.
+                    rels.add(removeCollation(relAscending));
                 }
             }
         }
@@ -210,7 +225,7 @@ public final class IndexResolver {
     }
 
     private static RelCollation getCollation(RelNode rel) {
-        return rel.getTraitSet().getTrait(RelCollationTraitDef.INSTANCE);
+        return rel.getTraitSet().getCollation();
     }
 
     /**
@@ -234,6 +249,10 @@ public final class IndexResolver {
         traitSet = OptUtils.traitPlus(traitSet, newCollation);
 
         return rel.copy(traitSet, rel.getInputs());
+    }
+
+    private static RelNode removeCollation(RelNode rel) {
+        return ((IndexScanMapPhysicalRel)rel).withoutCollation();
     }
 
     /**

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlOrderByTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlOrderByTest.java
@@ -359,6 +359,32 @@ public class SqlOrderByTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testSelectWithOrderBy2FieldsAndWhere1Conditions() {
+        getTarget().getMap(mapName());
+        String intValField = "intVal";
+        String realValField = "realVal";
+        addIndex(Arrays.asList(intValField, realValField), SORTED);
+
+        String sql = "SELECT " + intValField + ", " + realValField + " FROM " + mapName()
+                + " WHERE " + intValField + " = 1 ORDER BY " + intValField + ", " + realValField;
+
+        assertSqlResultOrdered(sql, singletonList(realValField), singletonList(false), 1);
+    }
+
+    @Test
+    public void testSelectWithOrderBy2FieldsAndWhere2Conditions() {
+        getTarget().getMap(mapName());
+        String intValField = "intVal";
+        String realValField = "realVal";
+        addIndex(Arrays.asList(intValField, realValField), SORTED);
+
+        String sql = "SELECT " + intValField + ", " + realValField + " FROM " + mapName()
+                + " WHERE " + intValField + " = 1 AND " + realValField + " = 1 ORDER BY " + intValField + ", " + realValField;
+
+        assertSqlResultOrdered(sql, singletonList(realValField), singletonList(false), 1);
+    }
+
+    @Test
     public void testSelectWithOrderByAndWhere2ConditionsHashIndex() {
         getTarget().getMap(mapName());
         String intValField = "intVal";

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/ExplainStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/ExplainStatementTest.java
@@ -117,7 +117,7 @@ public class ExplainStatementTest extends SqlTestSupport {
         createMapping("map", Integer.class, Integer.class);
         assertRowsOrdered(sql, singletonList(
                 new Row("IndexScanMapPhysicalRel(table=[[hazelcast, public, map[projects=[$0, $1]]]], " +
-                        "index=[map_sorted_this], indexExp=[null], remainderExp=[null])")
+                        "index=[map_sorted_this], indexExp=[null], remainderExp=[null], requiresSort=[true])")
         ));
     }
 
@@ -136,7 +136,7 @@ public class ExplainStatementTest extends SqlTestSupport {
         assertRowsOrdered(sql, asList(
                 new Row("LimitPhysicalRel(offset=[1:TINYINT(1)], fetch=[1:TINYINT(1)])"),
                 new Row("  IndexScanMapPhysicalRel(table=[[hazelcast, public, map[projects=[$0, $1]]]], " +
-                        "index=[map_sorted_this], indexExp=[null], remainderExp=[null])")
+                        "index=[map_sorted_this], indexExp=[null], remainderExp=[null], requiresSort=[true])")
         ));
     }
 
@@ -155,6 +155,27 @@ public class ExplainStatementTest extends SqlTestSupport {
                 new Row("  UnionPhysicalRel(all=[true])"),
                 new Row("    FullScanPhysicalRel(table=[[hazelcast, public, map[projects=[$0, $1]]]], discriminator=[0])"),
                 new Row("    FullScanPhysicalRel(table=[[hazelcast, public, map[projects=[$0, $1]]]], discriminator=[0])")
+        ));
+    }
+
+    @Test
+    public void test_explainStatementOrderedScanBelowUnionWithIndexScan() {
+        IMap<Integer, Integer> map = instance().getMap("map");
+        map.put(1, 1);
+        map.put(2, 2);
+        map.put(3, 3);
+        map.addIndex(IndexType.SORTED, "this");
+
+        String sql = "EXPLAIN PLAN FOR SELECT * FROM map WHERE this > 2" +
+                " UNION ALL SELECT * FROM map WHERE this < 2 ORDER BY this DESC";
+
+        createMapping("map", Integer.class, Integer.class);
+        assertRowsOrdered(sql, asList(
+                new Row("SortPhysicalRel(sort0=[$1], dir0=[DESC])"),
+                new Row("  UnionPhysicalRel(all=[true])"),
+                // note that index scan does not require sorting
+                new Row("    IndexScanMapPhysicalRel(table=[[hazelcast, public, map[projects=[$0, $1]]]], index=[map_sorted_this], indexExp=[>($1, 2)], remainderExp=[null])"),
+                new Row("    IndexScanMapPhysicalRel(table=[[hazelcast, public, map[projects=[$0, $1]]]], index=[map_sorted_this], indexExp=[<($1, 2)], remainderExp=[null])")
         ));
     }
 


### PR DESCRIPTION
Remove redundant SortCombine step for sorted index scan if the order is not needed (e.g. for aggregations). 

IndexResolver for sorted index scan generates both variants that ensure that the output is sorted: variant with collation (more expensive) and variant without such guarantee (without collation - cheaper). Later, the optimizer chooses the cheaper one that satisfies the collation of the query.

Fixes HZ-2791

Breaking changes (list specific methods/types/messages):
* Technically not a breaking change: some queries that returned ordered results without `ORDER BY` due to the use of sorted index scan will no longer return sorted result (they were never guaranteed to return sorted result) unless explicitly requested by `ORDER BY` clause.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
