### PR TITLE
Create ClientProperty for PARTITIONING_STRATEGY_CLASS and use on clients [HZ-2879]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
@@ -25,6 +25,7 @@ import com.hazelcast.client.impl.connection.tcp.ClientPlainChannelInitializer;
 import com.hazelcast.client.impl.proxy.ClientMapProxy;
 import com.hazelcast.client.impl.spi.ClientProxyFactory;
 import com.hazelcast.client.map.impl.nearcache.NearCachedClientMapProxy;
+import com.hazelcast.client.properties.ClientProperty;
 import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.InstanceTrackingConfig.InstanceMode;
 import com.hazelcast.config.InstanceTrackingConfig.InstanceProductName;
@@ -154,7 +155,7 @@ public class DefaultClientExtension implements ClientExtension {
         //  behaviour is not correct (it should read the ClientConfig properties). By using ClientConfig#getProperty
         //  we will be checking the ClientConfig first, and otherwise falling back to a System Property.
         String partitioningStrategyClassName = client.getClientConfig().getProperty(
-                ClusterProperty.PARTITIONING_STRATEGY_CLASS.getName());
+                ClientProperty.PARTITIONING_STRATEGY_CLASS.getName());
         if (partitioningStrategyClassName != null && !partitioningStrategyClassName.isEmpty()) {
             return ClassLoaderUtil.newInstance(configClassLoader, partitioningStrategyClassName);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
@@ -57,7 +57,6 @@ import com.hazelcast.nio.SocketInterceptor;
 import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
 import com.hazelcast.spi.impl.executionservice.TaskScheduler;
-import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -333,7 +333,7 @@ public final class ClientProperty {
      * defines key to partition mapping. Client-side equivalent of member property
      * {@link com.hazelcast.spi.properties.ClusterProperty#PARTITIONING_STRATEGY_CLASS}.
      * <p>
-     * This property does not contain the "client" prefix as has been used on the client with
+     * This property does not contain the "hazelcast.client" prefix as has been used on the client with
      * this property name for over 8 years, so it is maintained for backwards compatibility.
      */
     public static final HazelcastProperty PARTITIONING_STRATEGY_CLASS

--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -328,6 +328,17 @@ public final class ClientProperty {
     public static final HazelcastProperty PARTITION_ARGUMENT_CACHE_SIZE
             = new HazelcastProperty("hazelcast.client.sql.partition.argument.cache.size", 1024);
 
+    /**
+     * Class name implementing {@link com.hazelcast.partition.PartitioningStrategy}, which
+     * defines key to partition mapping. Client-side equivalent of member property
+     * {@link com.hazelcast.spi.properties.ClusterProperty#PARTITIONING_STRATEGY_CLASS}.
+     * <p>
+     * This property does not contain the "client" prefix as has been used on the client with
+     * this property name for over 8 years, so it is maintained for backwards compatibility.
+     */
+    public static final HazelcastProperty PARTITIONING_STRATEGY_CLASS
+            = new HazelcastProperty("hazelcast.partitioning.strategy.class", "");
+
     private ClientProperty() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -737,7 +737,8 @@ public final class ClusterProperty {
 
     /**
      * Class name implementing {@link com.hazelcast.partition.PartitioningStrategy}, which
-     * defines key to partition mapping.
+     * defines key to partition mapping. Member-side equivalent of client property
+     * {@link com.hazelcast.client.properties.ClientProperty#PARTITIONING_STRATEGY_CLASS}.
      */
     public static final HazelcastProperty PARTITIONING_STRATEGY_CLASS
             = new HazelcastProperty("hazelcast.partitioning.strategy.class", "");


### PR DESCRIPTION
There is the `HazelcastProperty` of `PARTITIONING_STRATEGY_CLASS` (which has property key `hazelcast.partitioning.strategy.class`), which is used on both the member-side and client-side. Currently, we are referencing the `ClusterProperty` class for this from the client, but really this property should be contained within `ClientProperty` for consistency.

I have copied the property from `ClusterProperty` into `ClientProperty`, maintaining the existing property name as it has been the same for the last 8 years, and we do not want to break backwards compatibility. By including this property in the `ClientProperty` class we make it clear to everyone (including the documentation team) that this property is valid for use on the client as well.

Fixes https://hazelcast.atlassian.net/browse/HZ-2879
