### PR TITLE
Use vectorizable byte array comparison in DataComparator [HZ-2885]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.query.Predicate;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -544,15 +545,7 @@ public class OrderedIndexStore extends BaseSingleValueIndexStore {
         public int compare(Data o1, Data o2) {
             byte[] thisBytes = o1.toByteArray();
             byte[] thatBytes = o2.toByteArray();
-            int minLen = Math.min(thisBytes.length, thatBytes.length);
-            for (int i = 0; i < minLen; i++) {
-                int diff = thisBytes[i] - thatBytes[i];
-                if (diff == 0) {
-                    continue;
-                }
-                return diff;
-            }
-            return thisBytes.length - thatBytes.length;
+            return Arrays.compare(thisBytes, thatBytes);
         }
     }
 }


### PR DESCRIPTION
`DataComparator` compares `Data` using custom implemented code, byte by byte, instead of using method from JVM which can use vectorization and intrinsics.

This affects:
* Sorted index in general (is used by `OrderedIndexStore`), but the difference could be visible with very large number of index operations on big IMap or with long keys with similar prefix. `OrderedIndexStore` uses `ConcurrentSkipListMap` and `TreeMap` with `DataComparator` as key comparator, so the number of comparisons per operation is relatively small.
* Sorted index scan in SQL when there more that FETCH_SIZE_HINT (128) rows with same key - in that case we skip some rows by comparing keys as `Data`. This is very bad case for index scan (HZ-2881) and the difference is better visible: approx. 10% improvement - but this highly depends on setup, length of the key etc.

Additional factor is that `Data` has common prefix of 12 bytes which will be usually the same.

Fixes HZ-2885

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

