### PR TITLE
Add Data Serializable serialization to Mongo Connector

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/WriteMode.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/WriteMode.java
@@ -43,5 +43,5 @@ public enum WriteMode {
      * Replace is different from UPSERT in handling of missing fields. Replace will set them to null,
      * while upsert won't affect such fields in the entity.
      */
-    REPLACE
+    REPLACE;
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/FieldResolver.java
@@ -174,7 +174,8 @@ class FieldResolver {
                                                  .filter(eq("name", collectionName))
                                                  .into(new ArrayList<>());
             if (collections.isEmpty()) {
-                throw new IllegalArgumentException("collection " + collectionName + " was not found");
+                ArrayList<String> list = database.listCollectionNames().into(new ArrayList<>());
+                throw new IllegalArgumentException("collection " + collectionName + " was not found, maybe you mean: " + list);
             }
             Document collectionInfo = collections.get(0);
             Document properties = getIgnoringNulls(collectionInfo, "options", "validator", "$jsonSchema", "properties");

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/InsertProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/InsertProcessorSupplier.java
@@ -145,7 +145,7 @@ public class InsertProcessorSupplier implements ProcessorSupplier, DataSerializa
         out.writeString(databaseName);
         out.writeString(collectionName);
         out.writeStringArray(paths);
-        out.writeObject(writeMode);
+        out.writeString(writeMode == null ? null : writeMode.name());
         out.writeObject(types);
         var typesLocal = externalTypes == null ? new BsonType[0] : externalTypes;
         out.writeIntArray(stream(typesLocal).mapToInt(BsonType::getValue).toArray());
@@ -159,7 +159,8 @@ public class InsertProcessorSupplier implements ProcessorSupplier, DataSerializa
         databaseName = in.readString();
         collectionName = in.readString();
         paths = in.readStringArray();
-        writeMode = in.readObject();
+        String writeModeName = in.readString();
+        writeMode = writeModeName == null ? null : WriteMode.valueOf(writeModeName);
         types = in.readObject();
         int[] extTypes = in.readIntArray();
         externalTypes = stream(extTypes == null ? new int[0] : extTypes).mapToObj(BsonType::findByValue).toArray(BsonType[]::new);

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/InsertProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/InsertProcessorSupplier.java
@@ -21,6 +21,9 @@ import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.mongodb.WriteMode;
 import com.hazelcast.jet.mongodb.impl.WriteMongoP;
 import com.hazelcast.jet.mongodb.impl.WriteMongoParams;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.security.permission.ConnectorPermission;
 import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.sql.impl.type.QueryDataType;
@@ -31,6 +34,7 @@ import org.bson.Document;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.security.Permission;
 import java.util.Collection;
 import java.util.List;
@@ -45,18 +49,21 @@ import static java.util.Collections.singletonList;
  * ProcessorSupplier that creates {@linkplain WriteMongoP} processors on each instance
  * that will insert given item.
  */
-public class InsertProcessorSupplier implements ProcessorSupplier {
+public class InsertProcessorSupplier implements ProcessorSupplier, DataSerializable {
 
-    private final String connectionString;
-    private final String databaseName;
-    private final String collectionName;
-    private final String[] paths;
-    private final WriteMode writeMode;
-    private final QueryDataType[] types;
-    private final BsonType[] externalTypes;
+    private String connectionString;
+    private String databaseName;
+    private String collectionName;
+    private String[] paths;
+    private WriteMode writeMode;
+    private QueryDataType[] types;
+    private BsonType[] externalTypes;
+    private String dataConnectionName;
+    private String idField;
     private transient SupplierEx<MongoClient> clientSupplier;
-    private final String dataConnectionName;
-    private final String idField;
+
+    public InsertProcessorSupplier() {
+    }
 
     InsertProcessorSupplier(MongoTable table, WriteMode writeMode) {
         this.connectionString = table.connectionString;
@@ -130,4 +137,29 @@ public class InsertProcessorSupplier implements ProcessorSupplier {
         return doc;
     }
 
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeString(connectionString);
+        out.writeString(databaseName);
+        out.writeString(collectionName);
+        out.writeStringArray(paths);
+        out.writeObject(writeMode);
+        out.writeObject(types);
+        out.writeObject(externalTypes);
+        out.writeString(dataConnectionName);
+        out.writeString(idField);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        connectionString = in.readString();
+        databaseName = in.readString();
+        collectionName = in.readString();
+        paths = in.readStringArray();
+        writeMode = in.readObject();
+        types = in.readObject();
+        externalTypes = in.readObject();
+        dataConnectionName = in.readString();
+        idField = in.readString();
+    }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnector.java
@@ -76,10 +76,11 @@ public class MongoSqlConnector extends MongoSqlConnectorBase {
                                                           })
                                                           .collect(toList());
 
+        String[] fieldNamesArray = fieldNames.toArray(String[]::new);
         if (hasInput) {
             return context.getDag().newUniqueVertex(
                     "Update(" + table.getSqlName() + ")",
-                    new UpdateProcessorSupplier(table, fieldNames, updates, null, hasInput)
+                    new UpdateProcessorSupplier(table, fieldNamesArray, updates, null, hasInput)
             );
         } else {
             Object predicateRaw = predicate == null
@@ -92,7 +93,7 @@ public class MongoSqlConnector extends MongoSqlConnectorBase {
             return context.getDag().newUniqueVertex(
                     "Update(" + table.getSqlName() + ")",
                     forceTotalParallelismOne(
-                        new UpdateProcessorSupplier(table, fieldNames, updates, translated, hasInput)
+                        new UpdateProcessorSupplier(table, fieldNamesArray, updates, translated, hasInput)
                     )
             );
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoSqlConnectorBase.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hazelcast.jet.mongodb.impl.Mappers.bsonToDocument;
 import static com.hazelcast.sql.impl.QueryUtils.quoteCompoundIdentifier;
 import static com.hazelcast.sql.impl.type.QueryDataType.OBJECT;
@@ -115,7 +116,9 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
                              @Nonnull String schemaName, @Nonnull String mappingName,
                              @Nonnull SqlExternalResource externalResource,
                              @Nonnull List<MappingField> resolvedFields) {
-        if (!ALLOWED_OBJECT_TYPES.contains(externalResource.objectType())) {
+        String objectType = checkNotNull(externalResource.objectType(),
+                "object type is required in Mongo connector");
+        if (!ALLOWED_OBJECT_TYPES.contains(objectType)) {
             throw QueryException.error("Mongo connector allows only object types: " + ALLOWED_OBJECT_TYPES);
         }
         String collectionName = externalResource.externalName().length == 2
@@ -128,11 +131,13 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
 
         List<TableField> fields = new ArrayList<>(resolvedFields.size());
         boolean containsId = false;
-        boolean isStreaming = isStream(externalResource.objectType());
+        boolean isStreaming = isStream(objectType);
         boolean hasPK = false;
         for (MappingField resolvedField : resolvedFields) {
             String externalNameFromName = (isStreaming ? "fullDocument." : "") + resolvedField.name();
             String fieldExternalName = firstNonNull(resolvedField.externalName(), externalNameFromName);
+            String externalType = checkNotNull(resolvedField.externalType(),
+                    "external type cannot be null in Mongo connector");
 
             if (fieldResolver.isId(fieldExternalName, isStreaming)) {
                 containsId = true;
@@ -142,7 +147,7 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
                     resolvedField.type(),
                     fieldExternalName,
                     false,
-                    resolvedField.externalType(),
+                    externalType,
                     resolvedField.isPrimaryKey()));
             hasPK |= resolvedField.isPrimaryKey();
         }
@@ -158,7 +163,7 @@ public abstract class MongoSqlConnectorBase implements SqlConnector {
         }
         return new MongoTable(schemaName, mappingName, databaseName, collectionName,
                 externalResource.dataConnection(), externalResource.options(), this,
-                fields, stats, externalResource.objectType());
+                fields, stats, objectType);
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoTableField.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/MongoTableField.java
@@ -19,18 +19,23 @@ import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.type.QueryDataType;
 import org.bson.BsonType;
 
+import javax.annotation.Nonnull;
 import java.util.Objects;
+
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 class MongoTableField extends TableField {
     final String externalName;
     final BsonType externalType;
     final boolean primaryKey;
 
-    MongoTableField(String name, QueryDataType type, String externalName, boolean hidden,
-                    String externalType, boolean primaryKey) {
+    MongoTableField(@Nonnull String name, @Nonnull QueryDataType type, @Nonnull String externalName, boolean hidden,
+                    @Nonnull String externalType, boolean primaryKey) {
         super(name, type, hidden);
+        checkNotNull(externalName, "external name cannot be null");
+        checkNotNull(externalType, "external type cannot be null");
         this.externalName = externalName;
-        this.externalType = externalType == null ? null : BsonType.valueOf(externalType);
+        this.externalType = BsonType.valueOf(externalType);
         this.primaryKey = primaryKey;
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/SelectProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/SelectProcessorSupplier.java
@@ -77,6 +77,7 @@ public class SelectProcessorSupplier implements ProcessorSupplier, DataSerializa
     private boolean forceMongoParallelismOne;
     private transient ExpressionEvalContext evalContext;
 
+    @SuppressWarnings("unused")
     public SelectProcessorSupplier() {
     }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/SelectProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/SelectProcessorSupplier.java
@@ -22,6 +22,9 @@ import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.mongodb.impl.ReadMongoP;
 import com.hazelcast.jet.mongodb.impl.ReadMongoParams;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.security.permission.ConnectorPermission;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.row.JetSqlRow;
@@ -34,6 +37,7 @@ import org.bson.conversions.Bson;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.security.Permission;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -57,22 +61,24 @@ import static java.util.stream.Collectors.toList;
 /**
  * ProcessorSupplier that creates {@linkplain com.hazelcast.jet.mongodb.impl.ReadMongoP} processors on each instance.
  */
-public class SelectProcessorSupplier implements ProcessorSupplier {
+public class SelectProcessorSupplier implements ProcessorSupplier, DataSerializable {
     private transient SupplierEx<? extends MongoClient> clientSupplier;
-    private final String databaseName;
-    private final String collectionName;
-    private final boolean stream;
-    private final FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider;
-    private final Document predicate;
-    private final List<ProjectionData> projection;
-    private final String[] externalNames;
+    private String databaseName;
+    private String collectionName;
+    private boolean stream;
+    private FunctionEx<ExpressionEvalContext, EventTimePolicy<JetSqlRow>> eventTimePolicyProvider;
+    private Document predicate;
+    private List<ProjectionData> projection;
+    private String[] externalNames;
 
-    private final Long startAt;
-    private final String connectionString;
-    private final String dataConnectionName;
+    private Long startAt;
+    private String connectionString;
+    private String dataConnectionName;
+    private boolean forceMongoParallelismOne;
     private transient ExpressionEvalContext evalContext;
 
-    private final boolean forceMongoParallelismOne;
+    public SelectProcessorSupplier() {
+    }
 
     SelectProcessorSupplier(MongoTable table, Document predicate,
                             List<ProjectionData> projection,
@@ -215,5 +221,36 @@ public class SelectProcessorSupplier implements ProcessorSupplier {
         return projection.stream().filter(p -> p.externalName.equals(columnName))
                          .map(p -> p.index)
                          .findAny().orElse(-1);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeString(databaseName);
+        out.writeString(collectionName);
+        out.writeBoolean(stream);
+        out.writeObject(eventTimePolicyProvider);
+        out.writeObject(predicate);
+        out.writeObject(projection);
+        out.writeStringArray(externalNames);
+        out.writeLong(startAt == null ? -1 : startAt);
+        out.writeString(connectionString);
+        out.writeString(dataConnectionName);
+        out.writeBoolean(forceMongoParallelismOne);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        databaseName = in.readString();
+        collectionName = in.readString();
+        stream = in.readBoolean();
+        eventTimePolicyProvider = in.readObject();
+        predicate = in.readObject();
+        projection = in.readObject();
+        externalNames = in.readStringArray();
+        long startAtDirect = in.readLong();
+        startAt = startAtDirect == -1 ? null : startAtDirect;
+        connectionString = in.readString();
+        dataConnectionName = in.readString();
+        forceMongoParallelismOne = in.readBoolean();
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/UpdateProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/UpdateProcessorSupplier.java
@@ -66,7 +66,7 @@ public class UpdateProcessorSupplier implements ProcessorSupplier, DataSerializa
     private String connectionString;
     private String databaseName;
     private String collectionName;
-    private List<String> updatedFieldNames;
+    private String[] updatedFieldNames;
     private List<? extends Serializable> updates;
     private String dataConnectionName;
     private String[] externalNames;
@@ -80,7 +80,8 @@ public class UpdateProcessorSupplier implements ProcessorSupplier, DataSerializa
     public UpdateProcessorSupplier() {
     }
 
-    UpdateProcessorSupplier(MongoTable table, List<String> updatedFieldNames,
+    UpdateProcessorSupplier(MongoTable table,
+                            @Nonnull String[] updatedFieldNames,
                             List<? extends Serializable> updates,
                             Serializable predicate,
                             boolean hasInput) {
@@ -194,8 +195,8 @@ public class UpdateProcessorSupplier implements ProcessorSupplier, DataSerializa
         Object pkValue = values[0];
 
         List<Bson> updateToPerform = new ArrayList<>();
-        for (int i = 0; i < updatedFieldNames.size(); i++) {
-            String fieldName = updatedFieldNames.get(i);
+        for (int i = 0; i < updatedFieldNames.length; i++) {
+            String fieldName = updatedFieldNames[i];
             Object updateExpr = updates.get(i);
             if (updateExpr instanceof Bson) {
                 Document document = Document.parse(((Bson) updateExpr)
@@ -223,7 +224,7 @@ public class UpdateProcessorSupplier implements ProcessorSupplier, DataSerializa
         out.writeString(connectionString);
         out.writeString(databaseName);
         out.writeString(collectionName);
-        out.writeStringArray(updatedFieldNames == null ? new String[0] : updatedFieldNames.toArray(String[]::new));
+        out.writeStringArray(updatedFieldNames);
         out.writeObject(updates);
         out.writeString(dataConnectionName);
         out.writeStringArray(externalNames);
@@ -237,8 +238,7 @@ public class UpdateProcessorSupplier implements ProcessorSupplier, DataSerializa
         connectionString = in.readString();
         databaseName = in.readString();
         collectionName = in.readString();
-        String[] fields = in.readStringArray();
-        updatedFieldNames = asList(fields == null ? new String[0] : fields);
+        updatedFieldNames = in.readStringArray();
         updates = in.readObject();
         dataConnectionName = in.readString();
         externalNames = in.readStringArray();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/UpdateProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/UpdateProcessorSupplier.java
@@ -76,6 +76,7 @@ public class UpdateProcessorSupplier implements ProcessorSupplier, DataSerializa
     private String pkExternalName;
     private Serializable predicate;
 
+    @SuppressWarnings("unused")
     public UpdateProcessorSupplier() {
     }
 


### PR DESCRIPTION
Performance figures for GenericMapStore put/get benchmark:
1 threaded:

session | Before_10m_1t | Before_10m_1t | After_10m_1t | After_10m_1t
-- | -- | -- | -- | --
benchmark | MongoGenericMapStoreTest-put | MongoGenericMapStoreTest-get | MongoGenericMapStoreTest-put | MongoGenericMapStoreTest-get
10%(us) | 7897.087 | 4143.103 | 7852.031 | 4149.247
20%(us) | 8114.175 | 4179.967 | 8073.215 | 4222.975
50%(us) | 8970.239 | 5214.207 | 8863.743 | 5197.823
75%(us) | 9650.175 | 5296.127 | 9134.079 | 5279.743
90%(us) | 10313.727 | 5394.431 | 9945.087 | 5365.759
95%(us) | 11067.391 | 5578.751 | 10207.231 | 5558.271
99%(us) | 104071.167 | 101318.655 | 11304.959 | 6381.567
99.9%(us) | 112197.631 | 109445.119 | 16875.519 | 8171.519
99.99%(us) | 116391.935 | 114950.143 | 21315.583 | 16211.967
max(us) | 117899.263 | 126681.087 | 27820.031 | 16842.751
operations | 34580 | 34345 | 43013 | 43094
duration(ms) | 596043 | 596043 | 595043 | 595043
throughput | 58.01594851378172 | 57.62168165719587 | 72.28553230606863 | 72.42165692227285

20 threads:


session | Before_10m_mt | Before_10m_mt | After_10m_mt | After_10m_mt
-- | -- | -- | -- | --
benchmark | MongoGenericMapStoreTest-put | MongoGenericMapStoreTest-get | MongoGenericMapStoreTest-put | MongoGenericMapStoreTest-get
10%(us) | 47284.223 | 30785.535 | 48922.623 | 33816.575
20%(us) | 66387.967 | 44040.191 | 64520.191 | 45613.055
50%(us) | 164626.431 | 121307.135 | 99221.503 | 68288.511
75%(us) | 287834.111 | 227672.063 | 139853.823 | 93913.087
90%(us) | 451936.255 | 354942.975 | 208666.623 | 169213.951
95%(us) | 672661.503 | 559939.583 | 280231.935 | 244580.351
99%(us) | 1725956.095 | 1659895.807 | 1174405.119 | 1118830.591
99.9%(us) | 2441084.927 | 2348810.239 | 2248146.943 | 2302672.895
99.99%(us) | 3397386.239 | 3231711.231 | 2988441.599 | 3051356.159
max(us) | 4007657.471 | 3951034.367 | 4668260.351 | 4575985.663
operations | 70463 | 70604 | 131315 | 130954
duration(ms) | 597042 | 597042 | 597041 | 597041
throughput | 118.02017278516419 | 118.25633707511365 | 219.94301898864566 | 219.33837039667293

Breaking changes (list specific methods/types/messages):
* serialized form - but it's beta anyway
* external name and external type properties in Mapping will be now required - meaning user will need to recreate mapping if it didn't contain such fields. Beta anyway, so it's possible to change for us.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
