### PR TITLE
[BACKPORT] Try to load the class for the type name of the Compact GenericRecord once [API-2120] [API-2070] (#24449)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializableRegistration.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializableRegistration.java
@@ -26,10 +26,16 @@ import javax.annotation.Nonnull;
  * associated with them.
  */
 public class CompactSerializableRegistration {
-
+    public static final CompactSerializableRegistration GENERIC_RECORD_REGISTRATION = new CompactSerializableRegistration();
     private final Class clazz;
     private final CompactSerializer compactSerializer;
     private final String typeName;
+
+    private CompactSerializableRegistration() {
+        this.clazz = null;
+        this.typeName = null;
+        this.compactSerializer = null;
+    }
 
     public CompactSerializableRegistration(@Nonnull Class clazz, @Nonnull String typeName,
                                            @Nonnull CompactSerializer compactSerializer) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -178,8 +178,9 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
         Schema schema = getOrReadSchema(input, schemaIncludedInBinary);
         CompactSerializableRegistration registration = getOrCreateRegistration(schema.getTypeName());
 
-        if (registration == null) {
-            //we have tried to load class via class loader, it did not work. We are returning a GenericRecord.
+        if (registration == CompactSerializableRegistration.GENERIC_RECORD_REGISTRATION) {
+            // We have tried to load class via class loader, it did not work.
+            // We are returning a GenericRecord.
             return readGenericRecord(input, schema, schemaIncludedInBinary);
         }
 
@@ -187,7 +188,6 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
                 registration.getClazz(), schemaIncludedInBinary);
         Object object = registration.getSerializer().read(reader);
         return managedContext != null ? managedContext.initialize(object) : object;
-
     }
 
     private Schema getOrReadSchema(ObjectDataInput input, boolean schemaIncludedInBinary) throws IOException {
@@ -225,17 +225,20 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
         return typeNameToRegistrationMap.computeIfAbsent(typeName, s -> {
             Class<?> clazz;
             try {
-                //when the registration does not exist, we treat typeName as className to check if there is a class
-                //with the given name in the classpath.
+                // When the registration does not exist, we treat typeName as className
+                // to check if there is a class with the given name in the classpath.
                 clazz = ClassLoaderUtil.loadClass(classLoader, typeName);
             } catch (Exception e) {
-                return null;
+                // There is no such class that has typeName as its name.
+                // We should try to read this as GenericRecord. We are
+                // returning this registration here to remember that we
+                // should read instances of this typeName as GenericRecords,
+                // instead of trying to load a class with that name over
+                // and over.
+                return CompactSerializableRegistration.GENERIC_RECORD_REGISTRATION;
             }
-            try {
-                return getOrCreateRegistration(clazz);
-            } catch (Exception e) {
-                throw new HazelcastSerializationException("Class " + clazz + " must have an empty constructor", e);
-            }
+
+            return getOrCreateRegistration(clazz);
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializerTest.java
@@ -283,8 +283,8 @@ public class CompactStreamSerializerTest {
     public void testBits() throws IOException {
         // Share schemaService to make schema available to ss2
         SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
-        InternalSerializationService ss1 = (InternalSerializationService) createSerializationService(schemaService);
-        InternalSerializationService ss2 = (InternalSerializationService) createSerializationService(schemaService);
+        InternalSerializationService ss1 = createSerializationService(schemaService);
+        InternalSerializationService ss2 = createSerializationService(schemaService);
 
         BitsDTO bitsDTO = new BitsDTO();
         bitsDTO.a = true;

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactTestUtil.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.CompactSerializationConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.compact.CompactSerializer;
@@ -221,7 +222,7 @@ public final class CompactTestUtil {
         return new ArrayOfFixedSizeFieldsDTO(null, null, null, null, null, null, null);
     }
 
-    public static SerializationService createSerializationService() {
+    public static InternalSerializationService createSerializationService() {
         SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
         return new DefaultSerializationServiceBuilder()
                 .setSchemaService(schemaService)
@@ -229,14 +230,14 @@ public final class CompactTestUtil {
                 .build();
     }
 
-    public static SerializationService createSerializationService(SchemaService schemaService) {
+    public static InternalSerializationService createSerializationService(SchemaService schemaService) {
         return new DefaultSerializationServiceBuilder()
                 .setSchemaService(schemaService)
                 .setConfig(new SerializationConfig())
                 .build();
     }
 
-    public static SerializationService createSerializationService(SerializationConfig config) {
+    public static InternalSerializationService createSerializationService(SerializationConfig config) {
         SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
         return new DefaultSerializationServiceBuilder()
                 .setSchemaService(schemaService)
@@ -244,7 +245,7 @@ public final class CompactTestUtil {
                 .build();
     }
 
-    public static SerializationService createSerializationService(CompactSerializationConfig compactSerializationConfig) {
+    public static InternalSerializationService createSerializationService(CompactSerializationConfig compactSerializationConfig) {
         SerializationConfig config = new SerializationConfig();
         config.setCompactSerializationConfig(compactSerializationConfig);
         SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
@@ -254,7 +255,7 @@ public final class CompactTestUtil {
                 .build();
     }
 
-    public static <T> SerializationService createSerializationService(Supplier<CompactSerializer<T>> serializerSupplier) {
+    public static <T> InternalSerializationService createSerializationService(Supplier<CompactSerializer<T>> serializerSupplier) {
         SchemaService schemaService = CompactTestUtil.createInMemorySchemaService();
         CompactSerializationConfig compactSerializationConfig = new CompactSerializationConfig();
         compactSerializationConfig.addSerializer(serializerSupplier.get());
@@ -264,7 +265,7 @@ public final class CompactTestUtil {
                 .build();
     }
 
-    public static <T> SerializationService createSerializationService(
+    public static <T> InternalSerializationService createSerializationService(
             Supplier<CompactSerializer<T>> serializerSupplier, SchemaService schemaService
     ) {
         CompactSerializationConfig compactSerializationConfig = new CompactSerializationConfig();
@@ -272,6 +273,13 @@ public final class CompactTestUtil {
         return new DefaultSerializationServiceBuilder()
                 .setSchemaService(schemaService)
                 .setConfig(new SerializationConfig().setCompactSerializationConfig(compactSerializationConfig))
+                .build();
+    }
+
+    public static InternalSerializationService createSerializationService(ClassLoader classLoader, SchemaService schemaService) {
+        return new DefaultSerializationServiceBuilder()
+                .setSchemaService(schemaService)
+                .setClassLoader(classLoader)
                 .build();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordBuilderTest.java
@@ -43,7 +43,7 @@ public class GenericRecordBuilderTest {
 
     @Test
     public void testBuildFromCompactInternalGenericRecord() throws IOException {
-        InternalSerializationService serializationService = (InternalSerializationService) createSerializationService();
+        InternalSerializationService serializationService = createSerializationService();
 
         GenericRecordBuilder builder = compact("fooBarTypeName");
         builder.setInt32("foo", 1);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/GenericRecordTest.java
@@ -40,8 +40,10 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createCompactGenericRecord;
+import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createInMemorySchemaService;
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createMainDTO;
 import static com.hazelcast.internal.serialization.impl.compact.CompactTestUtil.createSerializationService;
 import static com.hazelcast.nio.serialization.genericrecord.GenericRecordBuilder.compact;
@@ -116,7 +118,7 @@ public class GenericRecordTest {
 
     @Test
     public void testCloneCompactInternalGenericRecord() throws IOException {
-        InternalSerializationService serializationService = (InternalSerializationService) createSerializationService();
+        InternalSerializationService serializationService = createSerializationService();
 
         GenericRecordBuilder builder = compact("fooBarTypeName");
         builder.setInt32("foo", 1);
@@ -197,7 +199,7 @@ public class GenericRecordTest {
             record.getInt32("doesNotExist");
         }).isInstanceOf(HazelcastSerializationException.class).hasMessageContaining("Invalid field name");
 
-        InternalSerializationService serializationService = (InternalSerializationService) createSerializationService();
+        InternalSerializationService serializationService = createSerializationService();
         Data data = serializationService.toData(record);
 
         InternalGenericRecord internalGenericRecord = serializationService.readAsInternalGenericRecord(data);
@@ -214,7 +216,7 @@ public class GenericRecordTest {
             record.getInt64("foo");
         }).isInstanceOf(HazelcastSerializationException.class).hasMessageContaining("Invalid field kind");
 
-        InternalSerializationService serializationService = (InternalSerializationService) createSerializationService();
+        InternalSerializationService serializationService = createSerializationService();
         Data data = serializationService.toData(record);
 
         InternalGenericRecord internalGenericRecord = serializationService.readAsInternalGenericRecord(data);
@@ -222,5 +224,43 @@ public class GenericRecordTest {
         assertThatThrownBy(() -> {
             internalGenericRecord.getInt64("foo");
         }).isInstanceOf(HazelcastSerializationException.class).hasMessageContaining("Invalid field kind");
+    }
+
+    @Test
+    public void testReadingGenericRecord_classLoaderShouldBeInvokedOncePerTypeName() {
+        SchemaService schemaService = createInMemorySchemaService();
+        InternalSerializationService ss1 = createSerializationService(schemaService);
+        GenericRecord record = compact("test").setInt32("foo", 123).build();
+        Data recordData = ss1.toData(record);
+
+        CountingClassLoader classLoader = new CountingClassLoader("test");
+        InternalSerializationService ss2 = createSerializationService(classLoader, schemaService);
+        assertEquals(0, classLoader.getCount());
+        assertEquals(record, ss2.toObject(recordData));
+        assertEquals(record, ss2.toObject(recordData));
+        assertEquals(record, ss2.toObject(recordData));
+        assertEquals(1, classLoader.getCount());
+    }
+
+    private static final class CountingClassLoader extends ClassLoader {
+        private final String classNameToCount;
+        private final AtomicInteger count;
+
+        CountingClassLoader(String classNameToCount) {
+            this.classNameToCount = classNameToCount;
+            this.count = new AtomicInteger();
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (classNameToCount.equals(name)) {
+                count.incrementAndGet();
+            }
+            return super.loadClass(name);
+        }
+
+        public int getCount() {
+            return count.get();
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/reader/CompactStreamSerializerValueReaderQuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/reader/CompactStreamSerializerValueReaderQuickTest.java
@@ -367,7 +367,7 @@ public class CompactStreamSerializerValueReaderQuickTest extends HazelcastTestSu
     //
 
     public GenericRecordQueryReader reader(Car car) throws IOException {
-        InternalSerializationService ss = (InternalSerializationService) createSerializationService();
+        InternalSerializationService ss = createSerializationService();
         Data data = ss.toData(car);
         return new GenericRecordQueryReader(ss.readAsInternalGenericRecord(data));
     }


### PR DESCRIPTION
Try to load the class for the type name of the Compact GenericRecord once [API-2070] (#24449)

Compact serialization supports zero-configuration. In that case, it uses the fully qualified class name as its type name.

While reading Compact classes, when we can't find a registration for the given type name, there are three possible cases:

- It was serialized with zero-config
- It was serialized as GenericRecord
- It was serialized with an explicit serializer, but there is no configuration for it on the reader side.

When it is serialized with zero-config and we have the class in our classpath, the read operation should return an instance of that class.

To do that, we were trying to load the class associated with the type name of the Compact object. If that is successful, we assume that it was serialized with zero-config. If not, we know that the object must be read as GenericRecord.

There is nothing wrong with this approach, but we were not caching the result of this class loading operation. That means, while reading GenericRecords, we were constantly trying to load a class with the given typeName, which might hurt the performance.

To fix it, we now have a special registration that can be used to identify typeNames that must read as GenericRecords. And, when the class loading operation fails for a given type name, we cache this special value to signal for later operations that we should read the Compact object as GenericRecord.

I have also removed the leftover try-catch block that we had while creating a registration for our reflective serializers.

Also, I have fixed some tests to use GenericRecords, while we assume the server does not have classes in its classpath.

closes https://github.com/hazelcast/hazelcast/issues/24447


[API-2070]: https://hazelcast.atlassian.net/browse/API-2070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ