### PR TITLE
Do not throw and log NPE and finish operation logic when clearing empty IMap

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -70,10 +70,9 @@ public class ClearOperation extends MapOperation
 
     @Override
     public void afterRunInternal() {
-        if (recordStore == null) {
-            return;
+        if (mapContainer != null) {
+            invalidateAllKeysInNearCaches();
         }
-        invalidateAllKeysInNearCaches();
         hintMapEvent();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -19,8 +19,8 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.operation.steps.ClearOpSteps;
-import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.operation.steps.engine.State;
+import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -70,9 +70,11 @@ public class ClearOperation extends MapOperation
 
     @Override
     public void afterRunInternal() {
+        if (recordStore == null) {
+            return;
+        }
         invalidateAllKeysInNearCaches();
         hintMapEvent();
-        super.afterRunInternal();
     }
 
     private void hintMapEvent() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -57,6 +57,9 @@ public class EvictAllOperation extends MapOperation
 
     @Override
     public void afterRunInternal() {
+        if (recordStore == null) {
+            return;
+        }
         hintMapEvent();
         invalidateAllKeysInNearCaches();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -57,11 +57,10 @@ public class EvictAllOperation extends MapOperation
 
     @Override
     public void afterRunInternal() {
-        if (recordStore == null) {
-            return;
-        }
         hintMapEvent();
-        invalidateAllKeysInNearCaches();
+        if (mapContainer != null) {
+            invalidateAllKeysInNearCaches();
+        }
     }
 
     private void hintMapEvent() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -403,7 +403,7 @@ public abstract class MapOperation extends AbstractNamedOperation
      * one-partition which matches partitionId of the map name.
      */
     protected final void invalidateAllKeysInNearCaches() {
-        if (mapContainer.hasInvalidationListener()) {
+        if (mapContainer != null && mapContainer.hasInvalidationListener()) {
             int partitionId = getPartitionId();
             Invalidator invalidator = getNearCacheInvalidator();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -403,7 +403,7 @@ public abstract class MapOperation extends AbstractNamedOperation
      * one-partition which matches partitionId of the map name.
      */
     protected final void invalidateAllKeysInNearCaches() {
-        if (mapContainer != null && mapContainer.hasInvalidationListener()) {
+        if (mapContainer.hasInvalidationListener()) {
             int partitionId = getPartitionId();
             Invalidator invalidator = getNearCacheInvalidator();
 


### PR DESCRIPTION
Executing `IMap.clear()` (eg. `instance().getMap("whatever").clear()`) on non-existent IMap caused the following exception to be logged:

```
13:21:33,052 ERROR || - [ClearOperation] hz.SqlFilterProjectTest_vibrant_tharp.partition-operation.thread-1 - [127.0.0.1]:5701 [dev] [5.4.0-SNAPSHOT] Cannot invoke "com.hazelcast.map.impl.MapContainer.hasInvalidationListener()" because "this.mapContainer" is null
java.lang.NullPointerException: Cannot invoke "com.hazelcast.map.impl.MapContainer.hasInvalidationListener()" because "this.mapContainer" is null
	at com.hazelcast.map.impl.operation.MapOperation.invalidateAllKeysInNearCaches(MapOperation.java:406) ~[classes/:?]
	at com.hazelcast.map.impl.operation.ClearOperation.afterRunInternal(ClearOperation.java:73) ~[classes/:?]
	at com.hazelcast.map.impl.operation.MapOperation.afterRun(MapOperation.java:269) ~[classes/:?]
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.afterRun(OperationRunnerImpl.java:384) [classes/:?]
```

The exception was logged on ERROR level and not propagated to caller. Some parts of `afterRun` were not executed. I am not sure how important are they in this case.

This error is possible in Jet which tries to clear snapshot IMaps before writing to them. On first use the IMap does not yet exist.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible

