### PR TITLE
Upgrade google-http-client-bom to 1.43.3 [HZ-2920]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1658,7 +1658,7 @@
             <dependency>
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client-bom</artifactId>
-                <version>1.43.2</version>
+                <version>1.43.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Dependepot opened an issue for this. But the PRs  always fail when a BOM version is upgraded. 

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible