### PR TITLE
Fix K8s service port [CN-894] [5.3.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiProvider.java
@@ -51,14 +51,14 @@ interface KubernetesApiProvider {
         JsonArray ports = toJsonArray(subsetJson.asObject().get("ports"));
         for (JsonValue port : ports) {
             JsonValue hazelcastServicePort = port.asObject().get("name");
-            if (hazelcastServicePort != null && hazelcastServicePort.asString().equals("hazelcast-service-port")) {
+            if (hazelcastServicePort != null && hazelcastServicePort.asString().equals("hazelcast")) {
                 JsonValue servicePort = port.asObject().get("port");
                 if (servicePort != null && servicePort.isNumber()) {
                     return servicePort.asInt();
                 }
             }
         }
-        if (ports.size() > 0) {
+        if (ports.size() == 1) {
             JsonValue port = ports.get(0);
             return port.asObject().get("port").asInt();
         }

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesApiEndpointProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesApiEndpointProviderTest.java
@@ -199,7 +199,7 @@ public class KubernetesApiEndpointProviderTest
                + "              \"port\": 5701\n"
                + "            },\n"
                + "            {\n"
-               + "              \"name\": \"hazelcast-service-port\",\n"
+               + "              \"name\": \"hazelcast\",\n"
                + "              \"protocol\": \"TCP\",\n"
                + "              \"port\": 5702\n"
                + "            }\n"

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesApiEndpointSlicesProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesApiEndpointSlicesProviderTest.java
@@ -313,7 +313,7 @@ public class KubernetesApiEndpointSlicesProviderTest
                + "          \"port\": 5701\n"
                + "        },\n"
                + "        {\n"
-               + "          \"name\": \"hazelcast-service-port\",\n"
+               + "          \"name\": \"hazelcast\",\n"
                + "          \"protocol\": \"TCP\",\n"
                + "          \"port\": 5702\n"
                + "        }\n"

--- a/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -166,7 +166,7 @@ public class KubernetesClientTest {
                 endpointsList(
                         endpoints("192.168.0.25", "hazelcast-1",
                                 endpointPort("some-port", 5701),
-                                endpointPort("hazelcast-service-port", 5702)),
+                                endpointPort("hazelcast", 5702)),
                         endpoints("172.17.0.5", "172.17.0.6", "hazelcast-1", 5701)
                 ));
         stub(String.format("/api/v1/namespaces/%s/pods/hazelcast-0", NAMESPACE),
@@ -193,7 +193,7 @@ public class KubernetesClientTest {
                 endpointsList(
                         endpoints("192.168.0.25", "hazelcast-1",
                                 endpointPort("some-port", 5701),
-                                endpointPort("hazelcast-service-port", 5702)),
+                                endpointPort("hazelcast", 5702)),
                         endpoints("172.17.0.5", "172.17.0.6", "hazelcast-1", 5701)
                 ));
         stub(String.format("/api/v1/namespaces/%s/pods/hazelcast-0", NAMESPACE),


### PR DESCRIPTION
Backport of: https://github.com/hazelcast/hazelcast/pull/24834

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible
- [X] Send backports/forwardports if fix needs to be applied to past/future releases
- [X] New public APIs have `@Nonnull/@Nullable` annotations
- [X] New public APIs have `@since` tags in Javadoc
