### PR TITLE
Do not check order of indexes when MapConfig is added via dynamic configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/IndexConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/IndexConfig.java
@@ -33,10 +33,13 @@ import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeN
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
- * Configuration of an index. Hazelcast support two types of indexes: sorted index and hash index.
+ * Configuration of an index. Hazelcast support three types of indexes: sorted index, hash index
+ * and bitmap index.
  * Sorted indexes could be used with equality and range predicates and have logarithmic search time.
  * Hash indexes could be used with equality predicates and have constant search time assuming the hash
  * function of the indexed field disperses the elements properly.
+ * Bitmap indexes are similar to hash index. They are able to achieve a much higher memory efficiency
+ * for low cardinality attributes at the cost of reduced query performance.
  * <p>
  * Index could be created on one or more attributes.
  *

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readNullableList;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeNullableList;
@@ -129,6 +130,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
     private WanReplicationRef wanReplicationRef;
     private List<EntryListenerConfig> entryListenerConfigs;
     private List<MapPartitionLostListenerConfig> partitionLostListenerConfigs;
+    // order of index configs is not relevant
     private List<IndexConfig> indexConfigs;
     private List<AttributeConfig> attributeConfigs;
     private List<QueryCacheConfig> queryCacheConfigs;
@@ -899,7 +901,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         if (!getPartitionLostListenerConfigs().equals(that.getPartitionLostListenerConfigs())) {
             return false;
         }
-        if (!getIndexConfigs().equals(that.getIndexConfigs())) {
+        if (!Set.copyOf(getIndexConfigs()).equals(Set.copyOf(that.getIndexConfigs()))) {
             return false;
         }
         if (!getAttributeConfigs().equals(that.getAttributeConfigs())) {
@@ -950,7 +952,7 @@ public class MapConfig implements IdentifiedDataSerializable, NamedConfig, Versi
         result = 31 * result + metadataPolicy.hashCode();
         result = 31 * result + (wanReplicationRef != null ? wanReplicationRef.hashCode() : 0);
         result = 31 * result + getEntryListenerConfigs().hashCode();
-        result = 31 * result + getIndexConfigs().hashCode();
+        result = 31 * result + Set.copyOf(getIndexConfigs()).hashCode();
         result = 31 * result + getAttributeConfigs().hashCode();
         result = 31 * result + getQueryCacheConfigs().hashCode();
         result = 31 * result + getPartitionLostListenerConfigs().hashCode();

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -19,10 +19,10 @@ package com.hazelcast.config;
 import com.hazelcast.internal.config.MapConfigReadOnly;
 import com.hazelcast.internal.config.MapPartitionLostListenerConfigReadOnly;
 import com.hazelcast.internal.config.MapStoreConfigReadOnly;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.map.listener.MapPartitionLostListener;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.merge.DiscardMergePolicy;
 import com.hazelcast.spi.merge.PassThroughMergePolicy;
 import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
@@ -227,6 +227,22 @@ public class MapConfigTest {
         assertEquals(2, listenerConfigs.size());
         assertEquals(listener, listenerConfigs.get(0).getImplementation());
         assertEquals(listener, listenerConfigs.get(1).getImplementation());
+    }
+
+    @Test
+    public void testMapIndexConfigOrderIrrelevant() {
+        MapConfig config = new MapConfig("m");
+        IndexConfig idx1 = new IndexConfig(IndexType.SORTED, "foo");
+        idx1.setName("idx1");
+        IndexConfig idx2 = new IndexConfig(IndexType.SORTED, "bar");
+        idx2.setName("idx2");
+        config.setIndexConfigs(List.of(idx1, idx2));
+
+        MapConfig reordered = new MapConfig("m");
+        reordered.setIndexConfigs(List.of(idx2, idx1));
+
+        assertEquals(config, reordered);
+        assertEquals(config.hashCode(), reordered.hashCode());
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -91,6 +91,7 @@ import org.junit.runner.RunWith;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -100,6 +101,7 @@ import static com.hazelcast.config.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.config.MultiMapConfig.ValueCollectionType.LIST;
 import static com.hazelcast.test.TestConfigUtils.NON_DEFAULT_BACKUP_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -457,6 +459,25 @@ public class DynamicConfigTest extends HazelcastTestSupport {
         driver.getConfig().addMapConfig(config);
 
         assertConfigurationsEqualOnAllMembers(config);
+    }
+
+    @Test
+    public void testMapConfig_withDifferentOrderOfIndexes() {
+        MapConfig config = new MapConfig(name);
+        IndexConfig idx1 = new IndexConfig(IndexType.SORTED, "foo");
+        idx1.setName("idx1");
+        IndexConfig idx2 = new IndexConfig(IndexType.SORTED, "bar");
+        idx2.setName("idx2");
+        config.setIndexConfigs(List.of(idx1, idx2));
+
+        MapConfig reordered = new MapConfig(name);
+        reordered.setIndexConfigs(List.of(idx2, idx1));
+
+        driver.getConfig().addMapConfig(config);
+        assertThatNoException().isThrownBy(() -> driver.getConfig().addMapConfig(reordered));
+
+        assertConfigurationsEqualOnAllMembers(config);
+        assertConfigurationsEqualOnAllMembers(reordered);
     }
 
     @Test


### PR DESCRIPTION
Index order generally does not matter. Indexes are matched by name and chosen for the query based on the attributes. MapConfigs with different index order should be treated as equivalent.

Reported via community slack: https://hazelcastcommunity.slack.com/archives/C015Q2TUBKL/p1692188601524379

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
