### PR TITLE
RaftService handling 0 metrics period.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -234,8 +234,10 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
                     REMOVE_MISSING_MEMBER_TASK_PERIOD_SECONDS, REMOVE_MISSING_MEMBER_TASK_PERIOD_SECONDS, SECONDS);
         }
 
-        MetricsRegistry metricsRegistry = this.nodeEngine.getMetricsRegistry();
-        metricsRegistry.scheduleAtFixedRate(new PublishNodeMetricsTask(), metricsPeriod, SECONDS, ProbeLevel.INFO);
+        if (metricsPeriod > 0) {
+            MetricsRegistry metricsRegistry = this.nodeEngine.getMetricsRegistry();
+            metricsRegistry.scheduleAtFixedRate(new PublishNodeMetricsTask(), metricsPeriod, SECONDS, ProbeLevel.INFO);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -285,6 +285,7 @@ public interface MetricsRegistry {
      * @param probeLevel the ProbeLevel publisher it publishing on. This is needed to prevent scheduling
      *                   publishers if their probe level isn't sufficient.
      * @throws NullPointerException if publisher or timeUnit is null.
+     * @throws IllegalArgumentException if period is less than or equal to 0.
      * @return the ScheduledFuture that can be used to cancel the task, or null if nothing got scheduled.
      */
     ScheduledFuture<?> scheduleAtFixedRate(Runnable publisher, long period, TimeUnit timeUnit, ProbeLevel probeLevel);


### PR DESCRIPTION
If the hazelcast.diagnostics.metrics.period.seconds is set to 0, the RaftService init fails because it registers with a 0 period.
