### PR TITLE
Cancel read from Ringbuffer reliable topic listener is removed [hz-2930]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/MessageRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/MessageRunner.java
@@ -29,6 +29,7 @@ import com.hazelcast.topic.MessageListener;
 import com.hazelcast.topic.ReliableMessageListener;
 
 import java.util.UUID;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
@@ -54,8 +55,10 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
     private final Executor executor;
     private final int batchSize;
     private volatile boolean cancelled;
+    // The future to be able to cancel readManyAsync() call on ringBuffer, when listener is removed
+    private CompletionStage<ReadResultSet<ReliableTopicMessage>> readRingBufferCompletionStage;
 
-    public MessageRunner(UUID id,
+    protected MessageRunner(UUID id,
                          ReliableMessageListener<E> listener,
                          Ringbuffer<ReliableTopicMessage> ringbuffer,
                          String topicName,
@@ -86,8 +89,10 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
         if (cancelled) {
             return;
         }
-        ringbuffer.readManyAsync(sequence, 1, batchSize, null)
-                  .whenCompleteAsync(this, executor);
+        // Save the Future so that we can cancel readManyAsync()
+        readRingBufferCompletionStage = ringbuffer.readManyAsync(sequence, 1, batchSize, null);
+        readRingBufferCompletionStage
+                .whenCompleteAsync(this, executor);
     }
 
     @Override
@@ -135,7 +140,7 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
     private Message<E> toMessage(ReliableTopicMessage m) {
         Member member = getMember(m);
         E payload = serializationService.toObject(m.getPayload());
-        return new Message<E>(topicName, payload, m.getPublishTime(), member);
+        return new Message<>(topicName, payload, m.getPublishTime(), member);
     }
 
     protected abstract Member getMember(ReliableTopicMessage m);
@@ -233,6 +238,9 @@ public abstract class MessageRunner<E> implements BiConsumer<ReadResultSet<Relia
     public void cancel() {
         cancelled = true;
         runnersMap.remove(id);
+        if (readRingBufferCompletionStage != null) {
+            readRingBufferCompletionStage.toCompletableFuture().cancel(true);
+        }
     }
 
     private boolean terminate(Throwable failure) {

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicAbstractTest.java
@@ -89,7 +89,7 @@ public abstract class ReliableTopicAbstractTest extends HazelcastTestSupport {
     public void addRemoveMessageListeners() {
         // Add and remove a lot of listeners without sending a message
         final List<String> objects = new CopyOnWriteArrayList<>();
-        for (int index = 0; index < 100; index ++ ) {
+        for (int index = 0; index < 100; index++) {
             UUID id = topic.addMessageListener(message -> objects.add(message.getMessageObject()));
 
             boolean removed = topic.removeMessageListener(id);

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicAbstractTest.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -84,6 +85,25 @@ public abstract class ReliableTopicAbstractTest extends HazelcastTestSupport {
     }
 
     // ============== removeMessageListener ==============================
+    @Test
+    public void addRemoveMessageListeners() {
+        // Add and remove a lot of listeners without sending a message
+        final List<String> objects = new CopyOnWriteArrayList<>();
+        for (int index = 0; index < 100; index ++ ) {
+            UUID id = topic.addMessageListener(message -> objects.add(message.getMessageObject()));
+
+            boolean removed = topic.removeMessageListener(id);
+            assertTrue(removed);
+        }
+        // The listener map should be empty
+        assertEquals(0, topic.runnersMap.size());
+
+        // Now send a message
+        topic.publish("1");
+
+        // No listener should receive the message
+        assertTrueDelayed5sec(() -> assertEquals(0, objects.size()));
+    }
 
     @Test
     public void removeMessageListener_whenExisting() {
@@ -137,9 +157,9 @@ public abstract class ReliableTopicAbstractTest extends HazelcastTestSupport {
         final ReliableMessageListenerMock listener = new ReliableMessageListenerMock();
         topic.addMessageListener(listener);
 
-        final List<String> items = new ArrayList<String>();
+        final List<String> items = new ArrayList<>();
         for (int k = 0; k < 5; k++) {
-            items.add("" + k);
+            items.add(String.valueOf(k));
         }
 
         for (String item : items) {


### PR DESCRIPTION
In the current design the listener calls ringbuffer.readManyAsync() and then waits for at least one message. Is no message is sent, the listener is not GC'ed. If a message is sent, then readManyAsync() completes and listener is removed. So effectively the listener gets removed with a lag. One received message later. We can fix it by cancelling the Future for readManyAsync() when listener is removed.

Fixes:  https://github.com/hazelcast/hazelcast/issues/15409
Jira : https://hazelcast.atlassian.net/browse/HZ-2930

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible