### PR TITLE
Upgrade checkstyle to 10.12.1

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -119,7 +119,7 @@
         <!-- Only for methods on public APIs we agreed to have JavaDoc. -->
         <!-- TODO: figure out how to do that -->
         <!--<module name="JavadocMethod">-->
-        <!--<property name="scope" value="public"/>-->
+        <!--<property name="accessModifiers" value="public"/>-->
         <!--<property name="allowMissingParamTags" value="true"/>-->
         <!--</module>-->
         <module name="JavadocType">

--- a/checkstyle/checkstyle_jet.xml
+++ b/checkstyle/checkstyle_jet.xml
@@ -116,7 +116,7 @@
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <!-- Only for methods on public APIs we agreed to have JavaDoc. -->
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="validateThrows" value="false"/>

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operand/MultiTypeOperandChecker.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/validate/operand/MultiTypeOperandChecker.java
@@ -28,7 +28,7 @@ public final class MultiTypeOperandChecker extends TypedOperandChecker {
 
     private MultiTypeOperandChecker(
             final TypedOperandChecker primaryTypeChecker,
-            final TypedOperandChecker ...secondaryOperandCheckers
+            final TypedOperandChecker... secondaryOperandCheckers
     ) {
         super(primaryTypeChecker.type);
         if (secondaryOperandCheckers == null || secondaryOperandCheckers.length == 0) {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlJsonTypeTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlJsonTypeTest.java
@@ -207,11 +207,11 @@ public class SqlJsonTypeTest extends SqlJsonTestSupport {
 
     }
 
-    public void execute(final String sql, final Object ...arguments) {
+    public void execute(final String sql, final Object... arguments) {
         instance().getSql().execute(sql, arguments);
     }
 
-    public void executeClient(final String sql, final Object ...arguments) {
+    public void executeClient(final String sql, final Object... arguments) {
         client().getSql().execute(sql, arguments);
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/json/JsonArrayFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/json/JsonArrayFunctionIntegrationTest.java
@@ -117,7 +117,7 @@ public class JsonArrayFunctionIntegrationTest extends SqlJsonTestSupport {
                 rows(1, json("[\"foo\",42,[1,2,3]]")));
     }
 
-    private List<Row> jsonArrayRow(final Object ...values) {
+    private List<Row> jsonArrayRow(final Object... values) {
         return rows(1, json(jsonString(values)));
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/string/PositionFunctionIntegrationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/string/PositionFunctionIntegrationTest.java
@@ -151,7 +151,7 @@ public class PositionFunctionIntegrationTest extends ExpressionTestSupport {
         checkEquals(f, deserialized, true);
     }
 
-    private void check(String sql, Integer expectedResult, Object ...parameters) {
+    private void check(String sql, Integer expectedResult, Object... parameters) {
         List<SqlRow> rows =  execute(sql, parameters);
         assertEquals("size", 1, rows.size());
         SqlRow row = rows.get(0);

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InstantiationUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InstantiationUtils.java
@@ -46,7 +46,7 @@ public final class InstantiationUtils {
      * @return a new instance of a given class
      * @throws AmbiguousInstantiationException when multiple constructors matching the parameters
      */
-    public static <T> T newInstanceOrNull(Class<? extends T> clazz, Object...params)  {
+    public static <T> T newInstanceOrNull(Class<? extends T> clazz, Object... params)  {
         Constructor<T> constructor = selectMatchingConstructor(clazz, params);
         if (constructor == null) {
             return null;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ReflectionUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ReflectionUtils.java
@@ -175,7 +175,7 @@ public final class ReflectionUtils {
     private static Method findPropertyAccessor(
             @Nonnull Class<?> clazz,
             @Nonnull String propertyName,
-            @Nonnull String ...prefixes
+            @Nonnull String... prefixes
     ) {
         final Set<String> accessorNames = stream(prefixes)
                 .map(prefix -> prefix + toUpperCase(propertyName.charAt(0)) + propertyName.substring(1))

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigTest.java
@@ -357,7 +357,7 @@ public class ConfigTest extends HazelcastTestSupport {
         assertNull(config.getDeviceConfig(DEFAULT_DEVICE_NAME));
     }
 
-    private static String getSimpleXmlConfigStr(String ...tagAndVal) {
+    private static String getSimpleXmlConfigStr(String... tagAndVal) {
         if (tagAndVal.length % 2 != 0) {
             throw new IllegalArgumentException("The number of tags and values parameters is odd."
                     + " Please provide these tags and values as pairs.");
@@ -372,7 +372,7 @@ public class ConfigTest extends HazelcastTestSupport {
         return sb.toString();
     }
 
-    private static String getSimpleYamlConfigStr(String ...tagAndVal) {
+    private static String getSimpleYamlConfigStr(String... tagAndVal) {
         if (tagAndVal.length % 2 != 0) {
             throw new IllegalArgumentException("The number of tags and values parameters is odd."
                     + " Please provide these tags and values as pairs.");

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/ClassPathFormattingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/phonehome/ClassPathFormattingTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 
 public class ClassPathFormattingTest {
 
-    private static String path(String ...fileNames) {
+    private static String path(String... fileNames) {
         return File.separator + join(File.separator, fileNames);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <javaModuleArgs/>
 
         <!-- needed for CheckStyle -->
-        <checkstyle.version>10.12.1</checkstyle.version>
+        <checkstyle.version>9.3</checkstyle.version>
         <checkstyle.configLocation>${main.basedir}/checkstyle/checkstyle.xml</checkstyle.configLocation>
         <checkstyle.supressionsLocation>${main.basedir}/checkstyle/suppressions.xml</checkstyle.supressionsLocation>
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <javaModuleArgs/>
 
         <!-- needed for CheckStyle -->
-        <checkstyle.version>9.3</checkstyle.version>
+        <checkstyle.version>10.12.1</checkstyle.version>
         <checkstyle.configLocation>${main.basedir}/checkstyle/checkstyle.xml</checkstyle.configLocation>
         <checkstyle.supressionsLocation>${main.basedir}/checkstyle/suppressions.xml</checkstyle.supressionsLocation>
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <javaModuleArgs/>
 
         <!-- needed for CheckStyle -->
-        <checkstyle.version>8.38</checkstyle.version>
+        <checkstyle.version>10.12.1</checkstyle.version>
         <checkstyle.configLocation>${main.basedir}/checkstyle/checkstyle.xml</checkstyle.configLocation>
         <checkstyle.supressionsLocation>${main.basedir}/checkstyle/suppressions.xml</checkstyle.supressionsLocation>
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>


### PR DESCRIPTION
Extension of #24919 with code changes actioned:

- `JavadocMethod` checkstyle configuration updated to use [new access modifier syntax](https://github.com/checkstyle/checkstyle/issues/7417)
- Replace `String ...vargs` with `String... vargs`
- Update to 10.12.1

This is *not* the latest version (10.12.2), it's one behind.
The latest version is in #25128.
The latest version [now identifies inner classes that could/should be final](https://github.com/checkstyle/checkstyle/issues/11338), and as such a lot of classes need to change.
It's probably easier to do all of those separately.
