### PR TITLE
Cluster join async repartition (test suite run only)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -63,8 +63,12 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
@@ -92,6 +96,7 @@ public class ClusterJoinManager {
     private static final int DEFAULT_STALE_JOIN_PREVENTION_DURATION_IN_SECS = 30;
     private static final int CLUSTER_OPERATION_RETRY_COUNT = 100;
 
+    final Map<Address, MemberInfo> joiningMembers = new LinkedHashMap<>();
     private final ILogger logger;
     private final Node node;
     private final NodeEngineImpl nodeEngine;
@@ -100,7 +105,6 @@ public class ClusterJoinManager {
     private final ClusterClockImpl clusterClock;
     private final ClusterStateManager clusterStateManager;
 
-    private final Map<Address, MemberInfo> joiningMembers = new LinkedHashMap<>();
     private final Map<UUID, Long> recentlyJoinedMemberUuids = new HashMap<>();
 
     /**
@@ -117,10 +121,12 @@ public class ClusterJoinManager {
     private final long maxWaitMillisBeforeJoin;
     private final long waitMillisBeforeJoin;
     private final long staleJoinPreventionDurationInMillis;
+    private final AtomicBoolean migrationDelayActive = new AtomicBoolean();
+    private final ClusterJoinManagerSyncJoinStrategy syncJoinStrategy;
 
-    private long firstJoinRequest;
-    private long timeToStartJoin;
     private volatile boolean joinInProgress;
+    private ScheduledFuture<?> minDelayFuture;
+    private ScheduledFuture<?> maxDelayFuture;
 
     ClusterJoinManager(Node node, ClusterServiceImpl clusterService, Lock clusterServiceLock) {
         this.node = node;
@@ -136,6 +142,8 @@ public class ClusterJoinManager {
         waitMillisBeforeJoin = node.getProperties().getMillis(ClusterProperty.WAIT_SECONDS_BEFORE_JOIN);
         staleJoinPreventionDurationInMillis = TimeUnit.SECONDS.toMillis(
             Integer.getInteger(STALE_JOIN_PREVENTION_DURATION_PROP, DEFAULT_STALE_JOIN_PREVENTION_DURATION_IN_SECS));
+        syncJoinStrategy = node.getProperties().getBoolean(ClusterProperty.WAIT_SECONDS_BEFORE_JOIN_ASYNC)
+                ? null : new ClusterJoinManagerSyncJoinStrategy(logger, maxWaitMillisBeforeJoin, waitMillisBeforeJoin);
     }
 
     boolean isJoinInProgress() {
@@ -280,7 +288,11 @@ public class ClusterJoinManager {
                 return;
             }
 
-            startJoinRequest(joinRequest.toMemberInfo(), joinRequest.getPreJoinOperation());
+            if (syncJoinStrategy == null) {
+                startJoin(joinRequest.toMemberInfo(), joinRequest.getPreJoinOperation());
+            } else {
+                syncJoinStrategy.startJoinRequest(this, joinRequest.toMemberInfo(), joinRequest.getPreJoinOperation());
+            }
         } finally {
             clusterServiceLock.unlock();
         }
@@ -430,47 +442,6 @@ public class ClusterJoinManager {
             }
         }
         return true;
-    }
-
-    /**
-     * Start processing the join request. This method is executed by the master node. In the case that there hasn't been any
-     * previous join requests from the {@code memberInfo}'s address the master will first respond by sending the master answer.
-     *
-     * Also, during the first {@link ClusterProperty#MAX_WAIT_SECONDS_BEFORE_JOIN} period since the master received the first
-     * join request from any node, the master will always wait for {@link ClusterProperty#WAIT_SECONDS_BEFORE_JOIN} before
-     * allowing any join request to proceed. This means that in the initial period from receiving the first ever join request,
-     * every new join request from a different address will prolong the wait time. After the initial period, join requests
-     * will get processed as they arrive for the first time.
-     *
-     * @param memberInfo the joining member info
-     * @param preJoinOperation which is prepared on joining members and will run on the master
-     */
-    private void startJoinRequest(MemberInfo memberInfo, OnJoinOp preJoinOperation) {
-        long now = Clock.currentTimeMillis();
-        if (logger.isFineEnabled()) {
-            String timeToStart = (timeToStartJoin > 0 ? ", timeToStart: " + (timeToStartJoin - now) : "");
-            logger.fine(format("Handling join from %s, joinInProgress: %b%s", memberInfo.getAddress(),
-                    joinInProgress, timeToStart));
-        }
-
-        if (firstJoinRequest == 0) {
-            firstJoinRequest = now;
-        }
-
-        final MemberInfo existing = joiningMembers.put(memberInfo.getAddress(), memberInfo);
-        if (existing == null) {
-            sendMasterAnswer(memberInfo.getAddress());
-            if (now - firstJoinRequest < maxWaitMillisBeforeJoin) {
-                timeToStartJoin = now + waitMillisBeforeJoin;
-            }
-        } else if (!existing.getUuid().equals(memberInfo.getUuid())) {
-            logger.warning("Received a new join request from " + memberInfo.getAddress()
-                    + " with a new UUID " + memberInfo.getUuid()
-                    + ". Previous UUID was " + existing.getUuid());
-        }
-        if (now >= timeToStartJoin) {
-            startJoin(preJoinOperation);
-        }
     }
 
     /**
@@ -642,7 +613,7 @@ public class ClusterJoinManager {
      *
      * @param target the node receiving the master answer
      */
-    private void sendMasterAnswer(Address target) {
+    void sendMasterAnswer(Address target) {
         Address masterAddress = clusterService.getMasterAddress();
         if (masterAddress == null) {
             logger.info(format("Cannot send master answer to %s since master node is not known yet", target));
@@ -770,20 +741,30 @@ public class ClusterJoinManager {
      *
      * @param preJoinOperation joining member's preJoinOperation, not master's
      */
-    private void startJoin(OnJoinOp preJoinOperation) {
+    void startJoin(MemberInfo memberInfo, OnJoinOp preJoinOperation) {
         logger.fine("Starting join...");
+        if (syncJoinStrategy == null) {
+            sendMasterAnswer(memberInfo.getAddress());
+        }
         clusterServiceLock.lock();
         try {
             InternalPartitionService partitionService = node.getPartitionService();
-            boolean shouldTriggerRepartition = true;
+            boolean migrationPaused = false;
             try {
                 joinInProgress = true;
+                if (syncJoinStrategy == null && (maxWaitMillisBeforeJoin > 0 && waitMillisBeforeJoin > 0)) {
+                    scheduleMigrationDelay();
+                } else {
+                    // pause migrations until join, member-update and post-join operations are completed
+                    partitionService.pauseMigration();
+                    migrationPaused = true;
+                }
 
-                // pause migrations until join, member-update and post-join operations are completed
-                partitionService.pauseMigration();
                 MemberMap memberMap = clusterService.getMembershipManager().getMemberMap();
 
-                MembersView newMembersView = MembersView.cloneAdding(memberMap.toMembersView(), joiningMembers.values());
+                MembersView newMembersView = MembersView.cloneAdding(memberMap.toMembersView(),
+                    syncJoinStrategy == null ? Stream.of(memberInfo).collect(Collectors.toList())
+                            : joiningMembers.values());
 
                 long time = clusterClock.getClusterTime();
 
@@ -794,51 +775,72 @@ public class ClusterJoinManager {
                     return;
                 }
 
-                OnJoinOp preJoinOp = preparePreJoinOps();
-
                 if (preJoinOperation != null) {
                     nodeEngine.getOperationService().run(preJoinOperation);
                 }
 
-                // post join operations must be lock free, that means no locks at all:
-                // no partition locks, no key-based locks, no service level locks!
-                OnJoinOp postJoinOp = preparePostJoinOp();
-
                 // this is the current partition assignment state, not taking into account the
                 // currently joining members
                 PartitionRuntimeState partitionRuntimeState = partitionService.createPartitionState();
-                for (MemberInfo member : joiningMembers.values()) {
-                    if (isMemberRestartingWithPersistence(member.getAttributes())
-                        && isMemberRejoining(memberMap, member.getAddress(), member.getUuid())) {
-                        logger.info(member + " is rejoining the cluster");
-                        // do not trigger repartition immediately, wait for joining member to load hot-restart data
-                        shouldTriggerRepartition = false;
-                    }
-                    long startTime = clusterClock.getClusterStartTime();
-                    Operation op = new FinalizeJoinOp(member.getUuid(), newMembersView, preJoinOp, postJoinOp, time,
-                            clusterService.getClusterId(), startTime, clusterStateManager.getState(),
-                            clusterService.getClusterVersion(), partitionRuntimeState, !shouldTriggerRepartition,
-                            node.getClusterTopologyIntent());
-                    op.setCallerUuid(thisUuid);
-                    invokeClusterOp(op, member.getAddress());
-                }
-                for (MemberImpl member : memberMap.getMembers()) {
-                    if (member.localMember() || joiningMembers.containsKey(member.getAddress())) {
-                        continue;
-                    }
-                    Operation op = new MembersUpdateOp(member.getUuid(), newMembersView, time, partitionRuntimeState, true);
-                    op.setCallerUuid(thisUuid);
-                    invokeClusterOp(op, member.getAddress());
-                }
-
+                migrationPaused &= shouldTriggerRepartitionSyncStrategyOnly(memberMap);
+                sendFinalizeJoinOp(thisUuid, newMembersView, partitionRuntimeState, time, migrationPaused);
+                updateMembers(memberInfo, memberMap, newMembersView, thisUuid, time, partitionRuntimeState);
             } finally {
                 reset();
-                if (shouldTriggerRepartition) {
+                if (migrationPaused) {
                     partitionService.resumeMigration();
                 }
             }
         } finally {
             clusterServiceLock.unlock();
+        }
+    }
+
+    private boolean shouldTriggerRepartitionSyncStrategyOnly(MemberMap memberMap) {
+        boolean trigger = true;
+        if (syncJoinStrategy != null) {
+            for (MemberInfo member : joiningMembers.values()) {
+                if (isMemberRestartingWithPersistence(member.getAttributes())
+                    && isMemberRejoining(memberMap, member.getAddress(), member.getUuid())) {
+                    logger.info(member + " is rejoining the cluster");
+                    // do not trigger repartition immediately, wait for joining member to load hot-restart data
+                    trigger = false;
+                }
+            }
+        }
+        return trigger;
+    }
+
+    private void sendFinalizeJoinOp(UUID thisUuid, MembersView newMembersView,
+            PartitionRuntimeState partitionRuntimeState, long time, boolean shouldTriggerRepartition) {
+        // post join operations must be lock free, that means no locks at all:
+        // no partition locks, no key-based locks, no service level locks!
+        OnJoinOp preJoinOp = preparePreJoinOps();
+        OnJoinOp postJoinOp = preparePostJoinOp();
+
+        for (MemberInfo member : joiningMembers.values()) {
+            long startTime = clusterClock.getClusterStartTime();
+            Operation finalizeJoinOp = new FinalizeJoinOp(member.getUuid(), newMembersView, preJoinOp, postJoinOp, time,
+                    clusterService.getClusterId(), startTime, clusterStateManager.getState(),
+                    clusterService.getClusterVersion(), partitionRuntimeState, !shouldTriggerRepartition,
+                    node.getClusterTopologyIntent());
+            finalizeJoinOp.setCallerUuid(thisUuid);
+            invokeClusterOp(finalizeJoinOp, member.getAddress());
+        }
+    }
+
+    private void updateMembers(MemberInfo memberInfo, MemberMap memberMap, MembersView newMembersView, UUID thisUuid,
+            long time, PartitionRuntimeState partitionRuntimeState) {
+        for (MemberImpl member : memberMap.getMembers()) {
+            if (member.localMember() || memberInfo.getAddress().equals(member.getAddress())) {
+                continue;
+            }
+            if (joiningMembers.containsKey(member.getAddress())) {
+                continue;
+            }
+            Operation op = new MembersUpdateOp(member.getUuid(), newMembersView, time, partitionRuntimeState, true);
+            op.setCallerUuid(thisUuid);
+            invokeClusterOp(op, member.getAddress());
         }
     }
 
@@ -1023,13 +1025,54 @@ public class ClusterJoinManager {
         try {
             joinInProgress = false;
             joiningMembers.clear();
-            timeToStartJoin = Clock.currentTimeMillis() + waitMillisBeforeJoin;
-            firstJoinRequest = 0;
+            if (syncJoinStrategy == null) {
+                if (cancelMigrationTimeout()) {
+                    node.getPartitionService().resumeMigration();
+                }
+            } else {
+                syncJoinStrategy.reset(this);
+            }
         } finally {
             clusterServiceLock.unlock();
         }
     }
 
+    /**
+     * assumes clusterServiceLock is locked
+     *
+     * @return true if timeout needed to be canceled
+     */
+    private boolean cancelMigrationTimeout() {
+        boolean timedOut = migrationDelayActive.getAndSet(false);
+        if (timedOut) {
+            minDelayFuture.cancel(false);
+            maxDelayFuture.cancel(false);
+            // only for posterity's sake
+            minDelayFuture = null;
+            maxDelayFuture = null;
+        }
+        return timedOut;
+    }
+
+    /**
+     * assumes clusterServiceLock is locked
+     */
+    private void scheduleMigrationDelay() {
+        boolean subsequentJoinAttempt = migrationDelayActive.getAndSet(true);
+        if (subsequentJoinAttempt) {
+            assert minDelayFuture.cancel(false) : "Something went wrong canceling min delay future";
+        }
+        minDelayFuture = nodeEngine.getExecutionService().schedule(this::reset,
+                waitMillisBeforeJoin, TimeUnit.MILLISECONDS);
+        if (!subsequentJoinAttempt) {
+            // pause migrations until no more members are trying to join in the same period
+            node.getPartitionService().pauseMigration();
+            maxDelayFuture = nodeEngine.getExecutionService().schedule(this::reset,
+                    maxWaitMillisBeforeJoin, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    // only used for sync join trategy
     void removeJoin(Address address) {
         joiningMembers.remove(address);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManagerSyncJoinStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManagerSyncJoinStrategy.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.internal.cluster.MemberInfo;
+import com.hazelcast.internal.cluster.impl.operations.OnJoinOp;
+import com.hazelcast.internal.util.Clock;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.properties.ClusterProperty;
+import static java.lang.String.format;
+
+/**
+ * mimics functionality when join is delayed and clients are blocked until a
+ * certain timeout
+ * Can be removed when this strategy is obsoleted
+ *
+ * @author lprimak
+ */
+public class ClusterJoinManagerSyncJoinStrategy {
+    private final ILogger logger;
+    private final long maxWaitMillisBeforeJoin;
+    private final long waitMillisBeforeJoin;
+
+    private long firstJoinRequest;
+    private long timeToStartJoin;
+
+    ClusterJoinManagerSyncJoinStrategy(ILogger logger, long maxWaitMillisBeforeJoin,
+            long waitMillisBeforeJoin) {
+        this.logger = logger;
+        this.maxWaitMillisBeforeJoin = maxWaitMillisBeforeJoin;
+        this.waitMillisBeforeJoin = waitMillisBeforeJoin;
+    }
+
+    /**
+     * Start processing the join request. This method is executed by the master node. In the case that there hasn't been any
+     * previous join requests from the {@code memberInfo}'s address the master will first respond by sending the master answer.
+     *
+     * Also, during the first {@link ClusterProperty#MAX_WAIT_SECONDS_BEFORE_JOIN} period since the master received the first
+     * join request from any node, the master will always wait for {@link ClusterProperty#WAIT_SECONDS_BEFORE_JOIN} before
+     * allowing any join request to proceed. This means that in the initial period from receiving the first ever join request,
+     * every new join request from a different address will prolong the wait time. After the initial period, join requests
+     * will get processed as they arrive for the first time.
+     *
+     * @param memberInfo the joining member info
+     * @param preJoinOperation which is prepared on joining members and will run on the master
+     */
+    void startJoinRequest(ClusterJoinManager manager, MemberInfo memberInfo, OnJoinOp preJoinOperation) {
+        long now = Clock.currentTimeMillis();
+        if (logger.isFineEnabled()) {
+            String timeToStart = (timeToStartJoin > 0 ? ", timeToStart: " + (timeToStartJoin - now) : "");
+            logger.fine(format("Handling join from %s, joinInProgress: %b%s", memberInfo.getAddress(),
+                    manager.isJoinInProgress(), timeToStart));
+        }
+
+        if (firstJoinRequest == 0) {
+            firstJoinRequest = now;
+        }
+
+        final MemberInfo existing = manager.joiningMembers.put(memberInfo.getAddress(), memberInfo);
+        if (existing == null) {
+            manager.sendMasterAnswer(memberInfo.getAddress());
+            if (now - firstJoinRequest < maxWaitMillisBeforeJoin) {
+                timeToStartJoin = now + waitMillisBeforeJoin;
+            }
+        } else if (!existing.getUuid().equals(memberInfo.getUuid())) {
+            logger.warning("Received a new join request from " + memberInfo.getAddress()
+                    + " with a new UUID " + memberInfo.getUuid()
+                    + ". Previous UUID was " + existing.getUuid());
+        }
+        if (now >= timeToStartJoin) {
+            manager.startJoin(memberInfo, preJoinOperation);
+        }
+    }
+
+    void reset(ClusterJoinManager manager) {
+        timeToStartJoin = Clock.currentTimeMillis() + waitMillisBeforeJoin;
+        firstJoinRequest = 0;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -729,6 +729,7 @@ public class MembershipManager {
             }
 
             logger.info("Removing " + member);
+            // the following is only used when sync join strategy is used
             clusterService.getClusterJoinManager().removeJoin(address);
             clusterService.getClusterJoinManager().addLeftMember(member);
             clusterService.getClusterHeartbeatManager().removeMember(member);

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -582,6 +582,13 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.max.wait.seconds.before.join", 20, SECONDS);
 
     /**
+     * if true, join returns right away and background tasks are waiting for above timeouts
+     * this reduces latency when new members join clusters one-by-one
+     */
+    public static final HazelcastProperty WAIT_SECONDS_BEFORE_JOIN_ASYNC
+            = new HazelcastProperty("hazelcast.wait.seconds.before.join.async", true);
+
+    /**
      * Join timeout, maximum time to try to join before giving up.
      */
     public static final HazelcastProperty MAX_JOIN_SECONDS

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -586,7 +586,7 @@ public final class ClusterProperty {
      * this reduces latency when new members join clusters one-by-one
      */
     public static final HazelcastProperty WAIT_SECONDS_BEFORE_JOIN_ASYNC
-            = new HazelcastProperty("hazelcast.wait.seconds.before.join.async", true);
+            = new HazelcastProperty("hazelcast.wait.seconds.before.join.async", false);
 
     /**
      * Join timeout, maximum time to try to join before giving up.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterJoinDelayTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterJoinDelayTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.TcpIpConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
+import static com.hazelcast.spi.properties.ClusterProperty.WAIT_SECONDS_BEFORE_JOIN_ASYNC;
+import static com.hazelcast.test.OverridePropertyRule.set;
+import static com.hazelcast.test.TestEnvironment.HAZELCAST_TEST_USE_NETWORK;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Make sure there are no delays when joining the cluster
+ *
+ * @author lprimak
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClusterJoinDelayTest extends HazelcastTestSupport {
+    @Rule
+    public final OverridePropertyRule overridePropertyRule = set(HAZELCAST_TEST_USE_NETWORK, "true");
+    @Rule
+    public final OverridePropertyRule overridePropertyRule2 = set(WAIT_SECONDS_BEFORE_JOIN_ASYNC.getName(), "true");
+
+    private TestHazelcastInstanceFactory fact;
+    private final int numInstances = 3;
+
+    @Before
+    public void beforeRun() {
+        fact = createHazelcastInstanceFactory(numInstances);
+    }
+
+    @After
+    public void afterRun() {
+        fact.shutdownAll();
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = new Config();
+        // make sure the wait is longer than the tested-for delay.
+        // here we make sure that the newHazelcastInstance() call returns w/o blocking
+        config.setProperty(ClusterProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "120");
+        config.setProperty(ClusterProperty.MAX_WAIT_SECONDS_BEFORE_JOIN.getName(), "480");
+        TcpIpConfig tcpIpConfig = new TcpIpConfig();
+        tcpIpConfig.setEnabled(true).addMember("localhost");
+        config.getNetworkConfig().setPublicAddress("localhost").getJoin().setTcpIpConfig(tcpIpConfig);
+        return config;
+    }
+
+    @Test(timeout = 30 * 1000)
+    public void noBlockingBeforeJoin() {
+        HazelcastInstance hz1 = fact.newHazelcastInstance(getConfig());
+        HazelcastInstance hz2 = fact.newHazelcastInstance(getConfig());
+        HazelcastInstance hz3 = fact.newHazelcastInstance(getConfig());
+        assertClusterSizeEventually(numInstances, hz1, hz2, hz3);
+    }
+}


### PR DESCRIPTION
this is updated #17582 with reversed default wait-seconds-before-join to get a test suite run