### PR TITLE
Remove Java 8 references from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ see used in the comments on your PR:
 * `run-sonar` - run SonarCloud analysis
 * `run-arm64` - run the tests on arm64 machine
 
-Where not indicated, the builds run on a Linux machine with Oracle JDK 8.
+Where not indicated, the builds run on a Linux machine with Oracle JDK 11.
 
 ### Creating PRs for Hazelcast SQL
 


### PR DESCRIPTION
The `README.md` specifies that `JDK 8` is used, but the [`hazelcast-pr-builder`](https://jenkins.hazelcast.com/view/PR%20Builders/job/Hazelcast-pr-builder/configure) is actually using Java 11.

```
if [ "$ghprbTargetBranch" = "master" ]; then
	eval $(/home/jenkins/switch-java-version.sh oracle-11)
else 
	eval $(/home/jenkins/switch-java-version.sh oracle-8)
fi
```

EE PR: [#6372](https://github.com/hazelcast/hazelcast-enterprise/pull/6372)
