### PR TITLE
Refactor split brain test config access [HZ-2917]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainLiteMemberOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainLiteMemberOnlyTest.java
@@ -24,6 +24,8 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.function.Supplier;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainLiteMemberOnlyTest
@@ -31,11 +33,12 @@ public class DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainLiteMemberOnl
 
     // start 2 data members and 1 lite member
     @Override
-    protected HazelcastInstance[] startInitialCluster(Config config, int clusterSize) {
+    protected HazelcastInstance[] startInitialCluster(Supplier<Config> configSupplier, int clusterSize) {
+        Config config = configSupplier.get();
         HazelcastInstance[] hazelcastInstances = new HazelcastInstance[clusterSize];
         factory = createHazelcastInstanceFactory(clusterSize);
         for (int i = 0; i < clusterSize - 1; i++) {
-            HazelcastInstance hz = factory.newHazelcastInstance(config);
+            HazelcastInstance hz = factory.newHazelcastInstance(configSupplier.get());
             hazelcastInstances[i] = hz;
         }
         config.setLiteMember(true);

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Supplier;
 
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
@@ -95,9 +96,8 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
         brains = brains();
         validateBrainsConfig(brains);
 
-        Config config = config();
         int clusterSize = getClusterSize();
-        instances = startInitialCluster(config, clusterSize);
+        instances = startInitialCluster(() -> config(), clusterSize);
     }
 
     @After
@@ -207,11 +207,11 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
         onAfterSplitBrainHealed(instances);
     }
 
-    protected HazelcastInstance[] startInitialCluster(Config config, int clusterSize) {
+    protected HazelcastInstance[] startInitialCluster(Supplier<Config> configSupplier, int clusterSize) {
         HazelcastInstance[] hazelcastInstances = new HazelcastInstance[clusterSize];
         factory = createHazelcastInstanceFactory(clusterSize);
         for (int i = 0; i < clusterSize; i++) {
-            HazelcastInstance hz = factory.newHazelcastInstance(config);
+            HazelcastInstance hz = factory.newHazelcastInstance(configSupplier.get());
             hazelcastInstances[i] = hz;
         }
         return hazelcastInstances;


### PR DESCRIPTION
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/6373

used config supplier, to adapt it tstore config.