### PR TITLE
Escape PK column in MSSQLUpsertQueryBuilder [HZ-2963]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLUpsertQueryBuilder.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLUpsertQueryBuilder.java
@@ -59,7 +59,7 @@ public class MSSQLUpsertQueryBuilder extends AbstractQueryBuilder {
     void appendMatchedClause(StringBuilder sb) {
         sb.append("WHEN MATCHED THEN ");
         sb.append("UPDATE ");
-        sb.append(" SET");
+        sb.append("SET");
         Iterator<String> it = jdbcTable.dbFieldNames().iterator();
         while (it.hasNext()) {
             String dbFieldName = it.next();
@@ -83,10 +83,10 @@ public class MSSQLUpsertQueryBuilder extends AbstractQueryBuilder {
         for (int i = 0; i < pkFields.size(); i++) {
             String field = pkFields.get(i);
             dialect.quoteIdentifier(sb, jdbcTable.getExternalNameList());
-            sb.append(".")
-                    .append(field)
-                    .append(" = source.")
-                    .append(field);
+            sb.append(".");
+            dialect.quoteIdentifier(sb, field);
+            sb.append(" = source.");
+            dialect.quoteIdentifier(sb, field);
             if (i < pkFields.size() - 1) {
                 sb.append(" AND ");
             }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLUpsertQueryBuilderTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLUpsertQueryBuilderTest.java
@@ -61,7 +61,7 @@ public class MSSQLUpsertQueryBuilderTest {
         StringBuilder sb = new StringBuilder();
         builder.appendMergeClause(sb);
         String mergeClause = sb.toString();
-        assertThat(mergeClause).isEqualTo("MERGE [table1] USING (VALUES (?, ?)) AS source ([field1], [field2]) ON [table1].pk1 = source.pk1 AND [table1].pk2 = source.pk2");
+        assertThat(mergeClause).isEqualTo("MERGE [table1] USING (VALUES (?, ?)) AS source ([field1], [field2]) ON [table1].[pk1] = source.[pk1] AND [table1].[pk2] = source.[pk2]");
     }
 
     @Test
@@ -82,7 +82,7 @@ public class MSSQLUpsertQueryBuilderTest {
 
         String matchedClause = sb.toString();
         assertThat(matchedClause).isEqualTo(
-                "WHEN MATCHED THEN UPDATE  SET [field1] = source.[field1], [field2] = source.[field2] "
+                "WHEN MATCHED THEN UPDATE SET [field1] = source.[field1], [field2] = source.[field2] "
                         + "WHEN NOT MATCHED THEN INSERT ([field1], [field2]) VALUES(source.[field1], source.[field2]);");
     }
 
@@ -91,8 +91,8 @@ public class MSSQLUpsertQueryBuilderTest {
         MSSQLUpsertQueryBuilder builder = new MSSQLUpsertQueryBuilder(jdbcTable, dialect);
         String result = builder.query();
         assertThat(result).isEqualTo(
-                "MERGE [table1] USING (VALUES (?, ?)) AS source ([field1], [field2]) ON [table1].pk1 = source.pk1 AND [table1].pk2 = source.pk2 "
-                        + "WHEN MATCHED THEN UPDATE  SET [field1] = source.[field1], [field2] = source.[field2] "
+                "MERGE [table1] USING (VALUES (?, ?)) AS source ([field1], [field2]) ON [table1].[pk1] = source.[pk1] AND [table1].[pk2] = source.[pk2] "
+                        + "WHEN MATCHED THEN UPDATE SET [field1] = source.[field1], [field2] = source.[field2] "
                         + "WHEN NOT MATCHED THEN INSERT ([field1], [field2]) VALUES(source.[field1], source.[field2]);"
         );
     }


### PR DESCRIPTION
Fixes #25261

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible