### PR TITLE
Restore implements Versioned where required

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.transaction.impl.TargetAwareTransactionLogRecord;
 
@@ -38,7 +39,8 @@ import java.util.UUID;
  * @see ClusterState
  * @see Cluster#changeClusterState(ClusterState, com.hazelcast.transaction.TransactionOptions)
  */
-public class ClusterStateTransactionLogRecord implements TargetAwareTransactionLogRecord {
+// RU_COMPAT_5_3 "implements Versioned" can be removed in 5.5
+public class ClusterStateTransactionLogRecord implements TargetAwareTransactionLogRecord, Versioned {
 
     ClusterStateChange stateChange;
     Address initiator;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.cluster.impl.MembersViewMetadata;
 import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -31,7 +32,8 @@ import java.util.HashSet;
 import java.util.UUID;
 
 /** A heartbeat sent from one cluster member to another. The sent timestamp is the cluster clock time of the sending member */
-public final class HeartbeatOp extends AbstractClusterOperation {
+// RU_COMPAT_5_3 "implements Versioned" can be removed in 5.5
+public final class HeartbeatOp extends AbstractClusterOperation implements Versioned {
 
     private MembersViewMetadata senderMembersViewMetadata;
     private UUID targetUuid;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
@@ -27,6 +27,7 @@ import com.hazelcast.internal.util.UUIDSerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.operationservice.ExceptionAction;
@@ -37,8 +38,9 @@ import com.hazelcast.transaction.TransactionException;
 import java.io.IOException;
 import java.util.UUID;
 
+// RU_COMPAT_5_3 "implements Versioned" can be removed in 5.5
 public class LockClusterStateOp  extends Operation implements AllowedDuringPassiveState, UrgentSystemOperation,
-        IdentifiedDataSerializable {
+        IdentifiedDataSerializable, Versioned {
 
     private ClusterStateChange stateChange;
     private Address initiator;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -27,6 +27,7 @@ import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -49,9 +50,10 @@ import static com.hazelcast.map.impl.record.Record.UNSET;
  * Used to reduce the number of remote invocations
  * of an {@link IMap#putAll(Map)} or {@link IMap#setAll(Map)} call.
  */
+// RU_COMPAT_5_3 "implements Versioned" can be removed in 5.5
 public class PutAllOperation extends MapOperation
         implements PartitionAwareOperation, BackupAwareOperation,
-        MutatingOperation {
+        MutatingOperation, Versioned {
 
     private transient int currentIndex;
     private MapEntries mapEntries;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactory.java
@@ -21,6 +21,7 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -34,7 +35,8 @@ import java.util.Map;
  * <p>
  * Used to reduce the number of remote invocations of an {@link IMap#putAll(Map)} or {@link IMap#setAll(Map)} call.
  */
-public class PutAllPartitionAwareOperationFactory extends PartitionAwareOperationFactory {
+// RU_COMPAT_5_3 "implements Versioned" can be removed in 5.5
+public class PutAllPartitionAwareOperationFactory extends PartitionAwareOperationFactory implements Versioned {
 
     protected String name;
     protected MapEntries[] mapEntries;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Query.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Query.java
@@ -24,6 +24,7 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
@@ -36,7 +37,8 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 /**
  * Object representing a Query together with all possible co-variants: like a predicate, iterationType, etc.
  */
-public class Query implements IdentifiedDataSerializable {
+// RU_COMPAT_5_3 "implements Versioned" can be removed in 5.5
+public class Query implements IdentifiedDataSerializable, Versioned {
 
     private String mapName;
     private Predicate predicate;


### PR DESCRIPTION
Cleanup of rolling-upgrade code paths in #24595 is the cause of compatibility regressions due to eagerly removing Versioned interface. Proper code cleanup for rolling-upgrade conditional serde requires that the `Versioned` interface is still implemented one version after the conditional serde code is removed, to ensure that major.minor version bytes are still written to the network output and previous-version serde will find the proper `in.getVersion` to deserialize correctly.

Some fixes of issue caused by #24595 are included in #25263 
