### PR TITLE
Print warning log when NodePorts are used as public IPs in Kubernetes plugin [CN-207]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -97,6 +97,7 @@ class KubernetesClient {
 
     private boolean isNoPublicIpAlreadyLogged;
     private boolean isKnownExceptionAlreadyLogged;
+    private boolean isNodePortWarningAlreadyLogged;
 
     KubernetesClient(String namespace, String kubernetesMaster, KubernetesTokenProvider tokenProvider,
                      String caCertificate, int retries, ExposeExternallyMode exposeExternallyMode,
@@ -477,6 +478,13 @@ class KubernetesClient {
                     }
                     publicIps.put(privateAddress.getIp(), nodePublicAddress);
                     publicPorts.put(privateAddress.getIp(), nodePort);
+                    // Log warning only once.
+                    if (!isNodePortWarningAlreadyLogged && exposeExternallyMode == ExposeExternallyMode.ENABLED) {
+                        LOGGER.warning(
+                                "Using NodePort service type for public addresses may lead to connection issues from outside of " +
+                                        "the Kubernetes cluster. Ensure external accessibility of the NodePort IPs.");
+                        isNodePortWarningAlreadyLogged = true;
+                    }
                 }
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -481,8 +481,8 @@ class KubernetesClient {
                     // Log warning only once.
                     if (!isNodePortWarningAlreadyLogged && exposeExternallyMode == ExposeExternallyMode.ENABLED) {
                         LOGGER.warning(
-                                "Using NodePort service type for public addresses may lead to connection issues from outside " +
-                                        "of the Kubernetes cluster. Ensure external accessibility of the NodePort IPs.");
+                                "Using NodePort service type for public addresses may lead to connection issues from outside of "
+                                        + "the Kubernetes cluster. Ensure external accessibility of the NodePort IPs.");
                         isNodePortWarningAlreadyLogged = true;
                     }
                 }

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -454,7 +454,6 @@ class KubernetesClient {
             Map<String, Integer> publicPorts = new HashMap<>();
             Map<String, String> cachedNodePublicIps = new HashMap<>();
 
-
             for (Map.Entry<EndpointAddress, String> serviceEntry : services.entrySet()) {
                 EndpointAddress privateAddress = serviceEntry.getKey();
                 String service = serviceEntry.getValue();
@@ -480,9 +479,8 @@ class KubernetesClient {
                     publicPorts.put(privateAddress.getIp(), nodePort);
                     // Log warning only once.
                     if (!isNodePortWarningAlreadyLogged && exposeExternallyMode == ExposeExternallyMode.ENABLED) {
-                        LOGGER.warning(
-                                "Using NodePort service type for public addresses may lead to connection issues from outside of "
-                                        + "the Kubernetes cluster. Ensure external accessibility of the NodePort IPs.");
+                        LOGGER.warning("Using NodePort service type for public addresses may lead to connection issues from "
+                                + "outside of the Kubernetes cluster. Ensure external accessibility of the NodePort IPs.");
                         isNodePortWarningAlreadyLogged = true;
                     }
                 }
@@ -497,9 +495,8 @@ class KubernetesClient {
             LOGGER.finest(e);
             // Log warning only once.
             if (!isNoPublicIpAlreadyLogged) {
-                LOGGER.warning(
-                        "Cannot fetch public IPs of Hazelcast Member PODs, you won't be able to use Hazelcast Smart Client from "
-                                + "outside of the Kubernetes network");
+                LOGGER.warning("Cannot fetch public IPs of Hazelcast Member PODs, you won't be able to use "
+                        + "Hazelcast Smart Client from outside of the Kubernetes network");
                 isNoPublicIpAlreadyLogged = true;
             }
             return endpoints;

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -481,8 +481,8 @@ class KubernetesClient {
                     // Log warning only once.
                     if (!isNodePortWarningAlreadyLogged && exposeExternallyMode == ExposeExternallyMode.ENABLED) {
                         LOGGER.warning(
-                                "Using NodePort service type for public addresses may lead to connection issues from outside of " +
-                                        "the Kubernetes cluster. Ensure external accessibility of the NodePort IPs.");
+                                "Using NodePort service type for public addresses may lead to connection issues from outside " +
+                                        "of the Kubernetes cluster. Ensure external accessibility of the NodePort IPs.");
                         isNodePortWarningAlreadyLogged = true;
                     }
                 }


### PR DESCRIPTION
There are scenarios that the usage of NodePorts might cause connection issues. We agreed to print a warning log when NodePorts are used to provide public addresses.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
