### PR TITLE
Inherit versions from managed plugin declarations

### DIFF
--- a/hazelcast-build-utils/pom.xml
+++ b/hazelcast-build-utils/pom.xml
@@ -56,7 +56,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven.jar.plugin.version}</version>
                 <configuration>
                     <archive>
                         <index>true</index>
@@ -108,7 +107,6 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>${maven.shade.plugin.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/hazelcast-it/pom.xml
+++ b/hazelcast-it/pom.xml
@@ -69,7 +69,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.plugin.version}</version>
                 <configuration>
                     <!-- Use TCP for IPC communication to avoid warnings: Corrupted STDOUT by directly writing... -->
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -93,7 +93,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven.jar.plugin.version}</version>
                 <configuration>
                     <archive>
                         <index>true</index>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -82,7 +82,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>${maven.resources.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy-fmpp-resources</id>

--- a/modulepath-tests/pom.xml
+++ b/modulepath-tests/pom.xml
@@ -82,7 +82,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${maven.surefire.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>default-test</id>


### PR DESCRIPTION
The root `pom.xml` declares `version`s for plugins in the `pluginManagement` section.

This means that, for example, in `hazelcast-sql/pom.xml`, the `version` isn't required when the `maven-jar-plugin` is used, so it's not specified.

Although most follow that pattern, it's not consistent whether child `pom`s specify the version of these plugins:
- explicitly - referencing the version via a property inherited from the parent
- implicitly - inheriting the version from the parents `pluginManagement`

This PR normalises all child `pom` declarations of managed plugins to use the implicit scheme.

No functional problem is introduced by this inconsistency - this is purely a cleanup.