### PR TITLE
Include missing cloud config in generated client XML [HZ-2984]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -161,6 +161,7 @@ public final class ClientConfigXmlGenerator {
         aliasedDiscoveryConfigsGenerator(gen, aliasedDiscoveryConfigsFrom(network));
         autoDetection(gen, network.getAutoDetectionConfig());
         discovery(gen, network.getDiscoveryConfig());
+        cloud(gen, network.getCloudConfig());
         outboundPort(gen, network.getOutboundPortDefinitions());
         icmp(gen, network.getClientIcmpPingConfig());
 
@@ -575,6 +576,14 @@ public final class ClientConfigXmlGenerator {
                     .close();
         }
         gen.close();
+    }
+
+    private static void cloud(XmlGenerator gen, ClientCloudConfig cloudConfig) {
+        if (cloudConfig != null && cloudConfig.getDiscoveryToken() != null) {
+            gen.open("hazelcast-cloud", "enabled", cloudConfig.isEnabled())
+               .node("discovery-token", cloudConfig.getDiscoveryToken());
+            gen.close();
+        }
     }
 
     private static void outboundPort(XmlGenerator gen, Collection<String> outboundPortDefinitions) {

--- a/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/ClientConfigXmlGeneratorTest.java
@@ -314,6 +314,16 @@ public class ClientConfigXmlGeneratorTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void cloud() {
+        ClientCloudConfig clientCloudConfig = new ClientCloudConfig()
+                .setEnabled(true)
+                .setDiscoveryToken("some-discovery-token");
+        clientConfig.getNetworkConfig().setCloudConfig(clientCloudConfig);
+        ClientConfig actual = newConfigViaGenerator();
+        assertThat(actual.getNetworkConfig().getCloudConfig()).isEqualTo(clientCloudConfig);
+    }
+
+    @Test
     public void credentialsFactory() {
         Properties props = new Properties();
         props.setProperty("foo", "bar");


### PR DESCRIPTION


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [X ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

Backport to 5.3.z after review.