### PR TITLE
Upgrade checkstyle to 10.12.2

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -280,7 +280,11 @@
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
+        <!-- 
+        Disabled it forces the majority of private inner classes to be final, which just adds noise
+        https://github.com/hazelcast/hazelcast-enterprise/pull/6368/#issuecomment-1689625486
         <module name="FinalClass"/>
+        -->
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>
         <module name="VisibilityModifier">

--- a/checkstyle/checkstyle_jet.xml
+++ b/checkstyle/checkstyle_jet.xml
@@ -268,7 +268,11 @@
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
+        <!-- 
+        Disabled it forces the majority of private inner classes to be final, which just adds noise
+        https://github.com/hazelcast/hazelcast-enterprise/pull/6368/#issuecomment-1689625486
         <module name="FinalClass"/>
+        -->
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>
         <module name="VisibilityModifier">

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -408,7 +408,7 @@
             checks="TypeName|MemberName|ConstantName|LocalVariableName|LocalFinalVariableName|MethodName"
             files="[\\/]src[\\/]test[\\/]"/>
     <suppress
-            checks="FinalClass|HideUtilityClassConstructor|InnerAssignment|EmptyBlock|DeclarationOrder|VisibilityModifier"
+            checks="HideUtilityClassConstructor|InnerAssignment|EmptyBlock|DeclarationOrder|VisibilityModifier"
             files="[\\/]src[\\/]test[\\/]"/>
     <suppress
             checks="ExplicitInitialization|EqualsHashCode|MissingSwitchDefault|TrailingComment"

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -48,7 +48,7 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 /**
  * Contains all indexes for a data-structure, e.g. an IMap.
  */
-@SuppressWarnings({"checkstyle:finalclass", "rawtypes"})
+@SuppressWarnings("rawtypes")
 public class Indexes {
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.deploy.plugin.version>3.1.1</maven.deploy.plugin.version>
 
         <maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
-        <maven.checkheckstyle.plugin.version>3.3.0</maven.checkheckstyle.plugin.version>
+        <maven.checkstyle.plugin.version>3.3.0</maven.checkstyle.plugin.version>
         <maven.jacoco.plugin.version>0.8.10</maven.jacoco.plugin.version>
         <maven.failsafe.plugin.version>3.1.2</maven.failsafe.plugin.version>
         <maven.cobertura.plugin.version>2.7</maven.cobertura.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.deploy.plugin.version>3.1.1</maven.deploy.plugin.version>
 
         <maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
-        <maven.checkstyle.plugin.version>3.3.0</maven.checkstyle.plugin.version>
+        <maven.checkheckstyle.plugin.version>3.3.0</maven.checkheckstyle.plugin.version>
         <maven.jacoco.plugin.version>0.8.10</maven.jacoco.plugin.version>
         <maven.failsafe.plugin.version>3.1.2</maven.failsafe.plugin.version>
         <maven.cobertura.plugin.version>2.7</maven.cobertura.plugin.version>
@@ -176,7 +176,7 @@
         <hazelcast.module.name>ALL-UNNAMED</hazelcast.module.name>
 
         <!-- needed for CheckStyle -->
-        <checkstyle.version>10.12.1</checkstyle.version>
+        <checkstyle.version>10.12.2</checkstyle.version>
         <checkstyle.configLocation>${main.basedir}/checkstyle/checkstyle.xml</checkstyle.configLocation>
         <checkstyle.supressionsLocation>${main.basedir}/checkstyle/suppressions.xml</checkstyle.supressionsLocation>
         <checkstyle.headerLocation>${main.basedir}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>


### PR DESCRIPTION
`FinalClass` warning suppressed.

EE PR: [#6368](https://github.com/hazelcast/hazelcast-enterprise/pull/6368)
