### PR TITLE
Don't record partition migration timings for failed migrations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -1447,7 +1447,10 @@ public class MigrationManager {
             }
 
             return future.handleAsync((done, t) -> {
-                stats.recordMigrationOperationTime();
+                if (done) {
+                    stats.recordMigrationOperationTime();
+                }
+
                 logger.fine("Migration operation response received -> " + migration + ", success: " + done + ", failure: " + t);
 
                 if (t != null) {
@@ -1476,7 +1479,9 @@ public class MigrationManager {
                     return CompletableFuture.completedFuture(false);
                 }
             }, asyncExecutor).handleAsync((result, t) -> {
-                stats.recordMigrationTaskTime();
+                if (result) {
+                    stats.recordMigrationTaskTime();
+                }
 
                 partitionService.getPartitionEventManager().sendMigrationEvent(stats.toMigrationState(), migration,
                         TimeUnit.NANOSECONDS.toMillis(Timer.nanosElapsed(start)));


### PR DESCRIPTION
When the master member receives a response from initiating a partition migration, it records the execution timer of the partition migration in `com.hazelcast.internal.partition.impl.MigrationStats`.

When investigating #25164, it was identified when the migration failed, the timing statistics were still being recorded. The status of the migration was not being checked.

Specifically, in that scenario:
- There was a cluster with a single member
- Another member was started
- When the members became visible to each other, a migration was started
- Sometimes (due to `gc` pause), the second member did not start quickly enough for the migration to be successful - `java.lang.IllegalStateException: Migration operation is received before startup is completed`
- Eventually, the second member started and the migration completed successfully

Because of the aforementioned issue, the value of the `elapsedMigrationTime` & `totalElapsedMigrationTime` were different, despite the `plannedMigrations` / `completedMigrations` counts always being the same value (`271`)

This scenario was reproduced by deliberately adding `Thread.sleep(5000)` to `com.hazelcast.internal.cluster.impl.ClusterServiceImpl.finalizeJoin(MembersView, Address, UUID, UUID, UUID, ClusterState, Version, long, long, OnJoinOp)`, immediately preceding `setJoined(true)`.
It was not possible to deliberately and consistently delay the application at the right point with available access points, preventing a dedicated unit test being written.

[The documentation](totalElapsedMigrationTime) says they should be 
> time from start of migration tasks **to their completion**


Fixes [#25164](https://github.com/hazelcast/hazelcast/issues/25164) / [HZ-2939](https://hazelcast.atlassian.net/browse/HZ-2939)

Checklist:
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases


[HZ-2939]: https://hazelcast.atlassian.net/browse/HZ-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ