### PR TITLE
`HazelcastProxyFactory` - replace `ConcurrentReferenceHashMap` with `ConcurrentHashMap`

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.test.starter;
 
-import com.hazelcast.internal.util.ConcurrentReferenceHashMap;
 import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.test.starter.constructor.EnumConstructor;
 import net.bytebuddy.ByteBuddy;

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
@@ -75,12 +75,10 @@ public class HazelcastProxyFactory {
 
     // <Class toProxy, ClassLoader targetClassLoader> -> Class<?> proxy mapping for subclass proxies
     // java.lang.reflect.Proxy already maintains its own cache
-    private static final Map<ProxySource, Class<?>> PROXIES
-            = new ConcurrentHashMap<ProxySource, Class<?>>(16);
+    private static final Map<ProxySource, Class<?>> PROXIES = new ConcurrentHashMap<>();
 
     // <Class targetClass, ClassLoader targetClassLoader> -> ConstructorFunction<?>
-    private static final Map<Class<?>, ConstructorFunction<Object, Object>> CONSTRUCTORS
-            = new ConcurrentHashMap<Class<?>, ConstructorFunction<Object, Object>>(16);
+    private static final Map<Class<?>, ConstructorFunction<Object, Object>> CONSTRUCTORS = new ConcurrentHashMap<>();
 
     static {
         Map<String, Constructor<ConstructorFunction<Object, Object>>> notProxiedClasses


### PR DESCRIPTION
From the `ConcurrentReferenceHashMap` javadoc:
> While this table does allow the use of both strong keys and values, it is recommended you use java.util.concurrent.ConcurrentHashMap for such a configuration, since it is optimized for that case.


Based on this, updated `com.hazelcast.test.starter.HazelcastProxyFactory.PROXIES` & `com.hazelcast.test.starter.HazelcastProxyFactory.CONSTRUCTORS`