### PR TITLE
Replace deprecated `java.lang.Class.newInstance()`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigBuilder.java
@@ -214,7 +214,7 @@ public abstract class AbstractXmlConfigBuilder extends AbstractXmlConfigHelper {
                 fillProperties(n, properties);
             }
         }
-        ConfigReplacer replacer = (ConfigReplacer) Class.forName(replacerClass).newInstance();
+        ConfigReplacer replacer = (ConfigReplacer) Class.forName(replacerClass).getDeclaredConstructor().newInstance();
         replacer.init(properties);
         return replacer;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractYamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractYamlConfigBuilder.java
@@ -232,7 +232,7 @@ public abstract class AbstractYamlConfigBuilder extends AbstractConfigBuilder {
                 fillReplacerProperties(n, properties);
             }
         }
-        ConfigReplacer replacer = (ConfigReplacer) Class.forName(replacerClass).newInstance();
+        ConfigReplacer replacer = (ConfigReplacer) Class.forName(replacerClass).getDeclaredConstructor().newInstance();
         replacer.init(properties);
         return replacer;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -131,7 +131,7 @@ public final class ClassLoaderUtil {
         final Class primitiveClass = tryPrimitiveClass(className);
         if (primitiveClass != null) {
             // Note: this will always throw java.lang.InstantiationException
-            return (T) primitiveClass.newInstance();
+            return (T) primitiveClass.getDeclaredConstructor().newInstance();
         }
 
         // Note: Class.getClassLoader() and Thread.getContextClassLoader() are

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -130,6 +130,7 @@ public final class ClassLoaderUtil {
         isNotNull(className, "className");
         final Class primitiveClass = tryPrimitiveClass(className);
         if (primitiveClass != null) {
+            // Note: this will always throw java.lang.InstantiationException
             return (T) primitiveClass.getDeclaredConstructor().newInstance();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -130,7 +130,6 @@ public final class ClassLoaderUtil {
         isNotNull(className, "className");
         final Class primitiveClass = tryPrimitiveClass(className);
         if (primitiveClass != null) {
-            // Note: this will always throw java.lang.InstantiationException
             return (T) primitiveClass.getDeclaredConstructor().newInstance();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -125,7 +125,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
         DataSerializable ds = null;
         if (null != aClass) {
             try {
-                ds = (DataSerializable) aClass.newInstance();
+                ds = (DataSerializable) aClass.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 e = tryClarifyInstantiationException(aClass, e);
                 throw new HazelcastSerializationException("Requested class " + aClass + " could not be instantiated.", e);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -127,7 +127,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
             try {
                 ds = (DataSerializable) aClass.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
-                e = tryClarifyInstantiationException(aClass, e);
+                e = tryClarifyReflectiveOperationException(aClass, e);
                 throw new HazelcastSerializationException("Requested class " + aClass + " could not be instantiated.", e);
             }
         }
@@ -198,7 +198,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
      *         <li>Otherwise, {code exception}
      *         </ul>
      */
-    private Exception tryClarifyInstantiationException(Class<?> aClass, Exception exception) {
+    private Exception tryClarifyReflectiveOperationException(Class<?> aClass, Exception exception) {
         if (!(exception instanceof ReflectiveOperationException)) {
             return exception;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -194,7 +194,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
      * @return
      *         <ul>
      *         <li>If {@code exception} is an {@link NoSuchMethodError} and matches criteria of
-     *         {@link #tryGenerateClarifiedExceptionMessage(Class)}, a new {@link InstantiationException} with the new message
+     *         {@link #tryGenerateClarifiedExceptionMessage(Class)}, a new {@link ReflectiveOperationException} with the new message
      *         <li>Otherwise, {code exception}
      *         </ul>
      */
@@ -208,7 +208,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
             return exception;
         }
 
-        InstantiationException clarifiedException = new InstantiationException(message);
+        Exception clarifiedException = new ReflectiveOperationException(message);
         clarifiedException.initCause(exception);
         return clarifiedException;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -119,7 +119,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
         return readInternal(in, aClass);
     }
 
-    private DataSerializable readInternal(ObjectDataInput in, Class aClass)
+    private DataSerializable readInternal(ObjectDataInput in, Class<?> aClass)
             throws IOException {
         setInputVersion(in, version);
         DataSerializable ds = null;
@@ -190,19 +190,26 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
                 + ", exception: " + e.getMessage(), e);
     }
 
-    private Exception tryClarifyInstantiationException(Class aClass, Exception exception) {
-        if (!(exception instanceof InstantiationException)) {
+    /**
+     * @return
+     *         <ul>
+     *         <li>If {@code exception} is an {@link NoSuchMethodError} and matches criteria of
+     *         {@link #tryGenerateClarifiedExceptionMessage(Class)}, a new {@link InstantiationException} with the new message
+     *         <li>Otherwise, {code exception}
+     *         </ul>
+     */
+    private Exception tryClarifyInstantiationException(Class<?> aClass, Exception exception) {
+        if (!(exception instanceof ReflectiveOperationException)) {
             return exception;
         }
-        InstantiationException instantiationException = (InstantiationException) exception;
 
         String message = tryGenerateClarifiedExceptionMessage(aClass);
         if (message == null) {
-            return instantiationException;
+            return exception;
         }
 
         InstantiationException clarifiedException = new InstantiationException(message);
-        clarifiedException.initCause(instantiationException);
+        clarifiedException.initCause(exception);
         return clarifiedException;
     }
 
@@ -212,7 +219,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
         }
         NoSuchMethodException noSuchMethodException = (NoSuchMethodException) exception;
 
-        Class aClass;
+        Class<?> aClass;
         try {
             ClassLoader effectiveClassLoader = classLoader == null ? ClassLoaderUtil.class.getClassLoader() : classLoader;
             aClass = ClassLoaderUtil.loadClass(effectiveClassLoader, className);
@@ -264,8 +271,16 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
         ((VersionedObjectDataInput) in).setVersion(version);
     }
 
-    private static String tryGenerateClarifiedExceptionMessage(Class aClass) {
-        String classType;
+    /**
+     * @return an error message if {@code aClass} is:
+     *         <ul>
+     *         <li>{@link Class#isAnonymousClass()}
+     *         <li>{@link Class#isLocalClass()}
+     *         <li>non-{@code static} {@link Class#isMemberClass()}
+     *         </ul>
+     */
+    private static String tryGenerateClarifiedExceptionMessage(Class<?> aClass) {
+        final String classType;
         if (aClass.isAnonymousClass()) {
             classType = "Anonymous";
         } else if (aClass.isLocalClass()) {
@@ -279,5 +294,4 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
         return String.format("%s classes can't conform to DataSerializable since they can't "
                 + "provide an explicit no-arguments constructor.", classType);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -194,7 +194,8 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
      * @return
      *         <ul>
      *         <li>If {@code exception} is an {@link NoSuchMethodError} and matches criteria of
-     *         {@link #tryGenerateClarifiedExceptionMessage(Class)}, a new {@link ReflectiveOperationException} with the new message
+     *         {@link #tryGenerateClarifiedExceptionMessage(Class)}, a new {@link ReflectiveOperationException} with the new
+     *         message
      *         <li>Otherwise, {code exception}
      *         </ul>
      */

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ExtractorHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ExtractorHelper.java
@@ -66,17 +66,13 @@ public final class ExtractorHelper {
     private static ValueExtractor instantiateExtractorWithConfigClassLoader(AttributeConfig config, ClassLoader classLoader) {
         try {
             Class<?> clazz = classLoader.loadClass(config.getExtractorClassName());
-            Object extractor = clazz.newInstance();
+            Object extractor = clazz.getDeclaredConstructor().newInstance();
             if (extractor instanceof ValueExtractor) {
                 return (ValueExtractor) extractor;
             } else {
                 throw new IllegalArgumentException("Extractor does not extend ValueExtractor class " + config);
             }
-        } catch (IllegalAccessException ex) {
-            throw new IllegalArgumentException("Could not initialize extractor " + config, ex);
-        } catch (InstantiationException ex) {
-            throw new IllegalArgumentException("Could not initialize extractor " + config, ex);
-        } catch (ClassNotFoundException ex) {
+        } catch (ReflectiveOperationException ex) {
             throw new IllegalArgumentException("Could not initialize extractor " + config, ex);
         }
     }
@@ -84,17 +80,13 @@ public final class ExtractorHelper {
     private static ValueExtractor instantiateExtractorWithClassForName(AttributeConfig config) {
         try {
             Class<?> clazz = Class.forName(config.getExtractorClassName());
-            Object extractor = clazz.newInstance();
+            Object extractor = clazz.getDeclaredConstructor().newInstance();
             if (extractor instanceof ValueExtractor) {
                 return (ValueExtractor) extractor;
             } else {
                 throw new IllegalArgumentException("Extractor does not extend ValueExtractor class " + config);
             }
-        } catch (IllegalAccessException ex) {
-            throw new IllegalArgumentException("Could not initialize extractor " + config, ex);
-        } catch (InstantiationException ex) {
-            throw new IllegalArgumentException("Could not initialize extractor " + config, ex);
-        } catch (ClassNotFoundException ex) {
+        } catch (ReflectiveOperationException ex) {
             throw new IllegalArgumentException("Could not initialize extractor " + config, ex);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
@@ -345,10 +345,10 @@ public class SqlPredicate
             predicates = new Predicate[]{predicateLeft, predicateRight};
         }
         try {
-            T compoundPredicate = klass.newInstance();
+            T compoundPredicate = klass.getDeclaredConstructor().newInstance();
             compoundPredicate.setPredicates(predicates);
             return compoundPredicate;
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             throw new IllegalArgumentException(String.format("%s must have a public default constructor", klass.getName()));
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -116,7 +116,7 @@ public class DefaultDiscoveryService
                 }
 
                 String className = discoveryConfig.getNodeFilterClass();
-                return (NodeFilter) cl.loadClass(className).newInstance();
+                return (NodeFilter) cl.loadClass(className).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw new RuntimeException("Failed to configure discovery node filter", e);
             }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
@@ -126,7 +126,7 @@ public class DataSerializableSerializationTest extends HazelcastTestSupport {
             try {
                 ss.toObject(ss.toData(throwingInstance), throwingInstance.getClass());
             } catch (HazelcastSerializationException e) {
-                assertInstanceOf(InstantiationException.class, e.getCause());
+                assertInstanceOf(ReflectiveOperationException.class, e.getCause());
                 assertContains(e.getCause().getMessage(), "can't conform to DataSerializable");
                 continue;
             }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.version.Version;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -41,11 +42,14 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-
 public class DataSerializableSerializationTest extends HazelcastTestSupport {
+    private static SerializationService ss;
 
-    private SerializationService ss = new DefaultSerializationServiceBuilder().setVersion(InternalSerializationService.VERSION_1)
-                                                                              .build();
+    @BeforeClass
+    public static void setUp() {
+        ss = new DefaultSerializationServiceBuilder().setVersion(InternalSerializationService.VERSION_1)
+                .build();
+    }
 
     @Test
     public void serializeAndDeserialize_DataSerializable() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
@@ -113,7 +113,6 @@ public class DataSerializableSerializationTest extends HazelcastTestSupport {
             } catch (HazelcastSerializationException e) {
                 assertInstanceOf(NoSuchMethodException.class, e.getCause());
                 assertContains(e.getCause().getMessage(), "can't conform to DataSerializable");
-                assertInstanceOf(NoSuchMethodException.class, e.getCause().getCause());
                 continue;
             }
             fail("deserialization of '" + throwingInstance.getClass() + "' is expected to fail");
@@ -125,7 +124,6 @@ public class DataSerializableSerializationTest extends HazelcastTestSupport {
             } catch (HazelcastSerializationException e) {
                 assertInstanceOf(InstantiationException.class, e.getCause());
                 assertContains(e.getCause().getMessage(), "can't conform to DataSerializable");
-                assertInstanceOf(InstantiationException.class, e.getCause().getCause());
                 continue;
             }
             fail("deserialization of '" + throwingInstance.getClass() + "' is expected to fail");


### PR DESCRIPTION
`java.lang.Class.newInstance()` [was deprecated in Java 9](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#newInstance()).

I've updated any references to the new `clazz.getDeclaredConstructor().newInstance()`

`DataSerializableSerializer` was a little tricky - it was catching the `InstantiationException` that `Class.newInstance` threw in the no-default-constructor case and rejigging the message, and a test asserted this behaviour.
I've amended it so that it still catches the `NoSuchMethod` exception, but still throws a `InstantiationException` with the right message, just with an updated `cause`.

EE PR: [#6400](https://github.com/hazelcast/hazelcast-enterprise/pull/6400)