### PR TITLE
Handle possibility that `MetricsRegistryImpl#gauges` values can be null

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -32,7 +32,6 @@ import com.hazelcast.logging.Logger;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 
 import static com.hazelcast.internal.metrics.impl.MetricsUtil.adjustExclusionsWithLevel;
@@ -102,7 +101,11 @@ class MetricsCollectionCycle {
     }
 
     void notifyAllGauges(Collection<AbstractGauge> gauges) {
-        gauges.stream().filter(Objects::nonNull).forEach(gauge -> gauge.onCollectionCompleted(collectionId));
+        for (AbstractGauge gauge : gauges) {
+            if (gauge != null) {
+                gauge.onCollectionCompleted(collectionId);
+            }
+        }
     }
 
     private MetricValueCatcher lookupMetricValueCatcher(MetricDescriptor descriptor) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -32,6 +32,7 @@ import com.hazelcast.logging.Logger;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 import static com.hazelcast.internal.metrics.impl.MetricsUtil.adjustExclusionsWithLevel;
@@ -101,9 +102,7 @@ class MetricsCollectionCycle {
     }
 
     void notifyAllGauges(Collection<AbstractGauge> gauges) {
-        for (AbstractGauge gauge : gauges) {
-            gauge.onCollectionCompleted(collectionId);
-        }
+        gauges.stream().filter(Objects::nonNull).forEach(gauge -> gauge.onCollectionCompleted(collectionId));
     }
 
     private MetricValueCatcher lookupMetricValueCatcher(MetricDescriptor descriptor) {


### PR DESCRIPTION
`com.hazelcast.internal.metrics.impl.MetricsRegistryImpl.gauges` uses a `ConcurrentReferenceHashMap` with weak values, which means the lifespan of the values cannot be guaranteed.

As a result, typically anything acting on a value from `gauges` is `null`-safe, but `notifyAllGauges` is not

Unfortunately I'm not able to manufacture a test to repeat this defect outside of just adding `Thread.sleep(5000)` in the `FinalizeJoinOp` class immediately preceding `finalized = `

Making `gauges` use strongly-references values prevents the issue also which confirms the root cause.

I've made `notifyAllGauges` `null`-safe and the issue can no longer be recreated.

Fixes [#25290](https://github.com/hazelcast/hazelcast/issues/25290)