### PR TITLE
Fix UdpSourceTest by using automatically allocated port [HZ-3001]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketPIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketPIntegrationTest.java
@@ -70,9 +70,9 @@ public class StreamSocketPIntegrationTest extends JetTestSupport {
         CountDownLatch latch = new CountDownLatch(1);
         int localPort;
         // Given
-        try (ServerSocket socket = new ServerSocket(0) ) {
+        try (ServerSocket socket = new ServerSocket(0)) {
             localPort = socket.getLocalPort();
-            new Thread(() -> uncheckRun(() -> {
+            spawn(() -> uncheckRun(() -> {
                 Socket accept1 = socket.accept();
                 Socket accept2 = socket.accept();
                 PrintWriter writer1 = new PrintWriter(accept1.getOutputStream());


### PR DESCRIPTION
Test is failing due to BindException. Change the test to use automatically allocated port

Fixes : https://github.com/hazelcast/hazelcast-enterprise/issues/6319

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible