### PR TITLE
Handle possibility that `MetricsRegistryImpl#gauges` values can be null [5.2.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -102,7 +102,9 @@ class MetricsCollectionCycle {
 
     void notifyAllGauges(Collection<AbstractGauge> gauges) {
         for (AbstractGauge gauge : gauges) {
-            gauge.onCollectionCompleted(collectionId);
+            if (gauge != null) {
+                gauge.onCollectionCompleted(collectionId);
+            }
         }
     }
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/25295

`com.hazelcast.internal.metrics.impl.MetricsRegistryImpl.gauges` uses a `ConcurrentReferenceHashMap` with weak values, which means the lifespan of the values cannot be guaranteed.

As a result, typically anything acting on a value from `gauges` is `null`-safe, but `notifyAllGauges` is not

Unfortunately I'm not able to manufacture a test to repeat this defect outside of just adding `Thread.sleep(5000)` in the `FinalizeJoinOp` class immediately preceding `finalized = `

Making `gauges` use strongly-references values prevents the issue also which confirms the root cause.

I've made `notifyAllGauges` `null`-safe and the issue can no longer be recreated.

Fixes [#25290](https://github.com/hazelcast/hazelcast/issues/25290)