### PR TITLE
Allow MIT-0 Licence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,6 +546,7 @@
                                 -->
                                 <includedLicense>Apache-2.0</includedLicense>
                                 <includedLicense>MIT</includedLicense>
+                                <includedLicense>MIT-0</includedLicense>
                                 <includedLicense>BSD-2-Clause</includedLicense>
                                 <includedLicense>BSD-3-Clause</includedLicense>
                                 <includedLicense>CC0-1.0</includedLicense>


### PR DESCRIPTION
The `org.reactivestreams:reactive-streams:1.0.4` transitive dependency uses an [MIT-0 licence](https://spdx.org/licenses/MIT-0.html), which was not specifically allowed in the `license-maven-plugin` configuration.

`reactive-streams` has been on [MIT-0 for a long time](https://github.com/reactive-streams/reactive-streams-jvm/commit/006202eb877c54cf64b258a8a78328e4fb38cab6), but only since #25284 - where the `S3` client was updated to use new `reactive-streams` - has this become a problem.

This caused intermittent failures of the PR builder.
This intermittency was presumably caused by the fact that the licence check [was recently turned off](https://github.com/hazelcast/hazelcast/pull/24742) by default for performance reasons (see comments on the `license.skipAddThirdParty` property).
Although the original PR builder execution failed the first time with this error, the second time it passed and was merged - and then caused more PR builder execution failures on other, unrelated PRs.
Unfortunately I don't have a solution on how to prevent this problem in future.

As MIT-0 is a less restrictive version of the MIT licence (which is included), so I've included this also.

INSERT_PR_DESCRIPTION_HERE

Fixes INSERT_LINK_TO_THE_ISSUE_HERE

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
