### PR TITLE
Remove test utils unnecessary variables

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/json/JsonArray_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/json/JsonArray_Test.java
@@ -33,7 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.hazelcast.internal.json.TestUtil.assertException;
-import static com.hazelcast.internal.json.TestUtil.serializeAndDeserialize;
+import static com.hazelcast.test.TestJavaSerializationUtils.serializeAndDeserialize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;

--- a/hazelcast/src/test/java/com/hazelcast/internal/json/JsonLiteral_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/json/JsonLiteral_Test.java
@@ -21,20 +21,25 @@
  ******************************************************************************/
 package com.hazelcast.internal.json;
 
-import static com.hazelcast.internal.json.Json.*;
-import static com.hazelcast.internal.json.TestUtil.serializeAndDeserialize;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
-import java.io.IOException;
+import static com.hazelcast.internal.json.Json.FALSE;
+import static com.hazelcast.internal.json.Json.NULL;
+import static com.hazelcast.internal.json.Json.TRUE;
+import static com.hazelcast.test.TestJavaSerializationUtils.serializeAndDeserialize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import com.hazelcast.internal.json.Json;
-import com.hazelcast.internal.json.JsonArray;
-import com.hazelcast.internal.json.JsonWriter;
 import com.hazelcast.test.annotation.QuickTest;
+
+import java.io.IOException;
 
 @Category(QuickTest.class)
 public class JsonLiteral_Test {

--- a/hazelcast/src/test/java/com/hazelcast/internal/json/JsonNumber_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/json/JsonNumber_Test.java
@@ -22,19 +22,19 @@
 package com.hazelcast.internal.json;
 
 import static com.hazelcast.internal.json.TestUtil.assertException;
-import static com.hazelcast.internal.json.TestUtil.serializeAndDeserialize;
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.io.StringWriter;
+import static com.hazelcast.test.TestJavaSerializationUtils.serializeAndDeserialize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import com.hazelcast.internal.json.JsonNumber;
-import com.hazelcast.internal.json.JsonWriter;
 import com.hazelcast.test.annotation.QuickTest;
+
+import java.io.IOException;
+import java.io.StringWriter;
 
 @Category(QuickTest.class)
 public class JsonNumber_Test {

--- a/hazelcast/src/test/java/com/hazelcast/internal/json/JsonObject_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/json/JsonObject_Test.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static com.hazelcast.internal.json.TestUtil.assertException;
-import static com.hazelcast.internal.json.TestUtil.serializeAndDeserialize;
+import static com.hazelcast.test.TestJavaSerializationUtils.serializeAndDeserialize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;

--- a/hazelcast/src/test/java/com/hazelcast/internal/json/JsonString_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/json/JsonString_Test.java
@@ -22,19 +22,19 @@
 package com.hazelcast.internal.json;
 
 import static com.hazelcast.internal.json.TestUtil.assertException;
-import static com.hazelcast.internal.json.TestUtil.serializeAndDeserialize;
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.io.StringWriter;
+import static com.hazelcast.test.TestJavaSerializationUtils.serializeAndDeserialize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import com.hazelcast.internal.json.JsonString;
-import com.hazelcast.internal.json.JsonWriter;
 import com.hazelcast.test.annotation.QuickTest;
+
+import java.io.IOException;
+import java.io.StringWriter;
 
 @Category(QuickTest.class)
 public class JsonString_Test {

--- a/hazelcast/src/test/java/com/hazelcast/internal/json/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/json/TestUtil.java
@@ -74,24 +74,9 @@ public class TestUtil {
     }
   }
 
-  @SuppressWarnings("unchecked")
-  public static <T> T serializeAndDeserialize(T instance) throws Exception {
-    return (T)deserialize(serialize(instance));
-  }
-
-  public static byte[] serialize(Object object) throws IOException {
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    new ObjectOutputStream(outputStream).writeObject(object);
-    return outputStream.toByteArray();
-  }
-
-  public static Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
-    ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
-    return new ObjectInputStream(inputStream).readObject();
-  }
-
   private static RunnableEx adapt(final Runnable runnable) {
     return new RunnableEx() {
+      @Override
       public void run() {
         runnable.run();
       }

--- a/hazelcast/src/test/java/com/hazelcast/test/JarUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/JarUtil.java
@@ -16,18 +16,18 @@
 
 package com.hazelcast.test;
 
-import org.apache.commons.io.IOUtils;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.util.Lists.newArrayList;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.util.Lists.newArrayList;
 
 /**
  * Util class to work with (create) jar files for tests. Usually used when testing classloading features.
@@ -69,8 +69,8 @@ public class JarUtil {
 
     private static void writeEntry(JarOutputStream jarOS, String sourceFolder, String name) throws IOException {
         jarOS.putNextEntry(new JarEntry(name));
-        try (FileInputStream fis = new FileInputStream(sourceFolder + name)) {
-            jarOS.write(IOUtils.toByteArray(fis));
+        try (InputStream fis = new FileInputStream(sourceFolder + name)) {
+            fis.transferTo(jarOS);
         }
         jarOS.closeEntry();
     }
@@ -79,7 +79,7 @@ public class JarUtil {
         if (fileNames.size() != data.size()) {
             throw new IllegalArgumentException("fileNames and data must have same size()");
         }
-        try (FileOutputStream out = new FileOutputStream(outputJar);
+        try (OutputStream out = new FileOutputStream(outputJar);
              JarOutputStream jarOS = new JarOutputStream(out)) {
 
             for (int i = 0; i < fileNames.size(); i++) {
@@ -90,5 +90,4 @@ public class JarUtil {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.test;
 
-import java.util.Arrays;
+import com.google.common.collect.Sets;
+
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -35,8 +35,7 @@ public final class TestCollectionUtils {
      * @return a new instance of Set with all items passed as an argument
      */
     public static <T> Set<T> setOf(T... items) {
-        List<T> list = Arrays.asList(items);
-        return new HashSet<T>(list);
+        return Sets.newHashSet(items);
     }
 
     public static Set<Integer> setOfValuesBetween(int from, int to) {


### PR DESCRIPTION
Some of the test util classes are creating unnecessary variables:

- `com.hazelcast.test.JarUtil.writeEntry(JarOutputStream, String, String)` unnecessarily buffers to a `byte[]` before writing
- `com.hazelcast.test.TestCollectionUtils.setOf(T...)` is already implemented in Guava, without an unnecessary `List` creation

Also noticed that `com.hazelcast.internal.json.TestUtil.serializeAndDeserialize` and `com.hazelcast.test.TestJavaSerializationUtils.serializeAndDeserialize` are identical, removed the former.