### PR TITLE
Fix(Memory Leak): Remove FencedLockProxy upon FencedLock#destroy [HZ-3039]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/LockService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/LockService.java
@@ -244,4 +244,12 @@ public class LockService extends AbstractBlockingService<LockInvocationKey, Lock
         }
     }
 
+    @Override
+    public boolean destroyRaftObject(CPGroupId groupId, String name) {
+        boolean result = super.destroyRaftObject(groupId, name);
+        name = withoutDefaultGroupName(name + "@" + groupId.getName());
+        FencedLockProxy proxy = proxies.get(name);
+        proxies.remove(name, proxy);
+        return result;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/LockService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/LockService.java
@@ -247,9 +247,8 @@ public class LockService extends AbstractBlockingService<LockInvocationKey, Lock
     @Override
     public boolean destroyRaftObject(CPGroupId groupId, String name) {
         boolean result = super.destroyRaftObject(groupId, name);
-        name = withoutDefaultGroupName(name + "@" + groupId.getName());
-        FencedLockProxy proxy = proxies.get(name);
-        proxies.remove(name, proxy);
+        String proxyName = withoutDefaultGroupName(name + "@" + groupId.getName());
+        proxies.remove(proxyName);
         return result;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockBasicTest.java
@@ -18,24 +18,19 @@ package com.hazelcast.cp.internal.datastructures.lock;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.exception.CPGroupDestroyedException;
-import com.hazelcast.cp.internal.datastructures.lock.proxy.FencedLockProxy;
 import com.hazelcast.cp.lock.FencedLock;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.internal.util.RandomPicker;
-import com.hazelcast.test.starter.ReflectionUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.hazelcast.test.Accessors.getNodeEngineImpl;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -107,37 +102,5 @@ public class FencedLockBasicTest extends AbstractFencedLockBasicTest {
         }
 
         proxyInstance.getCPSubsystem().getLock(lock.getName());
-    }
-
-
-    @Test
-    public void testDestroy_AllMembersRemoveLockProxyDefaultCpGroup() {
-        allMembersRemoveLockProxy(randomName());
-    }
-
-    @Test
-    public void testDestroy_AllMembersRemoveLockProxyCustomCpGroup() {
-        allMembersRemoveLockProxy(randomName() + "@mygroup");
-    }
-
-    private void allMembersRemoveLockProxy(String lockName) {
-        FencedLock myLockMember0 = instances[0].getCPSubsystem().getLock(lockName);
-        FencedLock myLockMember1 = instances[1].getCPSubsystem().getLock(lockName);
-        FencedLock myLockMember2 = instances[2].getCPSubsystem().getLock(lockName);
-
-        myLockMember0.lock();
-        try {
-        } finally {
-            myLockMember0.unlock();
-        }
-        myLockMember0.destroy();
-
-        for (HazelcastInstance instance : instances) {
-            assertTrueEventually(() -> {
-                LockService service = getNodeEngineImpl(instance).getService(LockService.SERVICE_NAME);
-                ConcurrentMap<String, FencedLockProxy> proxies = ReflectionUtils.getFieldValueReflectively(service, "proxies");
-                assertFalse(proxies.containsKey(lockName));
-            });
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockBasicTest.java
@@ -18,19 +18,25 @@ package com.hazelcast.cp.internal.datastructures.lock;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.exception.CPGroupDestroyedException;
+import com.hazelcast.cp.internal.datastructures.lock.proxy.FencedLockProxy;
 import com.hazelcast.cp.lock.FencedLock;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.internal.util.RandomPicker;
+import com.hazelcast.test.starter.ReflectionUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -102,5 +108,23 @@ public class FencedLockBasicTest extends AbstractFencedLockBasicTest {
         }
 
         proxyInstance.getCPSubsystem().getLock(lock.getName());
+    }
+
+    @Test(timeout = 60000)
+    public void testDestroy_RemovesLockProxy() {
+        String lockName = UUID.randomUUID().toString();
+        FencedLock myLock = instances[0].getCPSubsystem().getLock(lockName);
+        myLock.lock();
+        try {
+        } finally {
+            myLock.unlock();
+        }
+        myLock.destroy();
+
+        assertTrueEventually(() -> {
+            LockService service = getNodeEngineImpl(instances[0]).getService(LockService.SERVICE_NAME);
+            ConcurrentMap<String, FencedLockProxy> proxies = ReflectionUtils.getFieldValueReflectively(service, "proxies");
+            assertFalse(proxies.containsKey(lockName));
+        });
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockBasicTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -110,28 +109,18 @@ public class FencedLockBasicTest extends AbstractFencedLockBasicTest {
         proxyInstance.getCPSubsystem().getLock(lock.getName());
     }
 
-    @Test(timeout = 60000)
-    public void testDestroy_RemovesLockProxy() {
-        String lockName = UUID.randomUUID().toString();
-        FencedLock myLock = instances[0].getCPSubsystem().getLock(lockName);
-        myLock.lock();
-        try {
-        } finally {
-            myLock.unlock();
-        }
-        myLock.destroy();
 
-        assertTrueEventually(() -> {
-            LockService service = getNodeEngineImpl(instances[0]).getService(LockService.SERVICE_NAME);
-            ConcurrentMap<String, FencedLockProxy> proxies = ReflectionUtils.getFieldValueReflectively(service, "proxies");
-            assertFalse(proxies.containsKey(lockName));
-        });
+    @Test
+    public void testDestroy_AllMembersRemoveLockProxyDefaultCpGroup() {
+        allMembersRemoveLockProxy(randomName());
     }
 
+    @Test
+    public void testDestroy_AllMembersRemoveLockProxyCustomCpGroup() {
+        allMembersRemoveLockProxy(randomName() + "@mygroup");
+    }
 
-    @Test(timeout = 60000)
-    public void testDestroy_AllMembersRemoveProxy() {
-        String lockName = UUID.randomUUID().toString();
+    private void allMembersRemoveLockProxy(String lockName) {
         FencedLock myLockMember0 = instances[0].getCPSubsystem().getLock(lockName);
         FencedLock myLockMember1 = instances[1].getCPSubsystem().getLock(lockName);
         FencedLock myLockMember2 = instances[2].getCPSubsystem().getLock(lockName);

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockProxyRemovalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockProxyRemovalTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.datastructures.lock;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.cp.internal.datastructures.lock.proxy.FencedLockProxy;
+import com.hazelcast.cp.lock.FencedLock;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.ReflectionUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class FencedLockProxyRemovalTest extends HazelcastRaftTestSupport {
+    protected HazelcastInstance[] instances;
+
+    @Before
+    public void setup() {
+        instances = newInstances(3);
+    }
+
+    @Test
+    public void testDestroy_AllMembersRemoveLockProxyDefaultCpGroup() {
+        allMembersRemoveLockProxy(randomName());
+    }
+
+    @Test
+    public void testDestroy_AllMembersRemoveLockProxyCustomCpGroup() {
+        allMembersRemoveLockProxy(randomName() + "@mygroup");
+    }
+
+    private void allMembersRemoveLockProxy(String lockName) {
+        FencedLock myLockMember0 = instances[0].getCPSubsystem().getLock(lockName);
+        FencedLock myLockMember1 = instances[1].getCPSubsystem().getLock(lockName);
+        FencedLock myLockMember2 = instances[2].getCPSubsystem().getLock(lockName);
+
+        myLockMember0.lock();
+        try {
+        } finally {
+            myLockMember0.unlock();
+        }
+        myLockMember0.destroy();
+
+        for (HazelcastInstance instance : instances) {
+            assertTrueEventually(() -> {
+                LockService service = getNodeEngineImpl(instance).getService(LockService.SERVICE_NAME);
+                ConcurrentMap<String, FencedLockProxy> proxies = ReflectionUtils.getFieldValueReflectively(service, "proxies");
+                assertTrue(proxies.isEmpty());
+            });
+        }
+    }
+}


### PR DESCRIPTION
Removes the `FencedLockProxy` from `LockService.proxies` _after_ calling legacy semantics of `AbstractBlockingService#destroyRaftObject`. Previously the `FencedLockProxy` would be resident in `LockService.proxies` until the CP system was reset. 

Fixes #25344

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
