### PR TITLE
Update grpc version from 1.48.0 to 1.57.0 [HZ-3031]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <calcite.version>1.32.0</calcite.version>
         <classgraph.version>4.8.162</classgraph.version>
         <debezium.version>1.9.7.Final</debezium.version>
-        <grpc.version>1.48.0</grpc.version>
+        <grpc.version>1.57.0</grpc.version>
         <guava.version>32.1.2-jre</guava.version>
         <hadoop.version>3.3.6</hadoop.version>
         <h2.version>2.2.220</h2.version>


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.bamboohr.com/jobs
-->

Updated grpc version from 1.48.0 to 1.57.0 due to 1.48.0 having high vulnerability.

Fixes https://github.com/hazelcast/hazelcast/issues/25351
