### PR TITLE
Add connection health checking to static discovery strategy for WAN [HZ-2888]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -699,6 +699,9 @@ public final class MetricDescriptorConstants {
     public static final String WAN_METRIC_ACK_DELAY_CURRENT_MILLIS = "ackDelayCurrentMillis";
     public static final String WAN_METRIC_ACK_DELAY_LAST_START = "ackDelayLastStart";
     public static final String WAN_METRIC_ACK_DELAY_LAST_END = "ackDelayLastEnd";
+    public static final String WAN_METRIC_CONNECTION_HEALTH = "connectionHealth";
+    public static final String WAN_DISCRIMINATOR_CONNECTION_ADDRESS = "address";
+    public static final String WAN_TAG_DISCOVERY_STRATEGY = "discoveryStrategy";
     public static final String WAN_QUEUE_FILL_PERCENT = "queueFillPercent";
     // ===[/WAN]========================================================
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.discovery;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 
 import java.util.Collection;
@@ -125,6 +126,7 @@ public interface DiscoveryStrategy {
      * @param address the address to mark as unhealthy
      * @since 5.4
      */
+    @PrivateApi
     default void markEndpointAsUnhealthy(Address address) { }
 
     /**
@@ -135,6 +137,7 @@ public interface DiscoveryStrategy {
      *  underlying implementation, otherwise an empty set.
      * @since 5.4
      */
+    @PrivateApi
     default Set<Address> getUnhealthyEndpoints() {
         return Collections.emptySet();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.spi.discovery;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The <code>DiscoveryStrategy</code> itself is the actual implementation to discover
@@ -112,4 +115,27 @@ public interface DiscoveryStrategy {
      * @since 3.7
      */
     Map<String, String> discoverLocalMetadata();
+
+    /**
+     * Marks the passed {@link Address} as unhealthy, which prevents it from being offered as a
+     * viable endpoint in some {@link DiscoveryStrategy} implementations, usually prompting
+     * this endpoint to be periodically probed for liveliness. If not supported by the underlying
+     * implementation, then this call does nothing.
+     *
+     * @param address the address to mark as unhealthy
+     * @since 5.4
+     */
+    default void markEndpointAsUnhealthy(Address address) { }
+
+    /**
+     * Fetches a set of {@link Address} marked as unhealthy by the underlying implementation.
+     * If not supported by the underlying implementation, then this call returns an empty set.
+     *
+     * @return set of {@link Address} which are currently marked as unhealthy if supported by the
+     *  underlying implementation, otherwise an empty set.
+     * @since 5.4
+     */
+    default Set<Address> getUnhealthyEndpoints() {
+        return Collections.emptySet();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -107,17 +107,17 @@ public class DefaultDiscoveryService implements DiscoveryService {
 
     @Override
     public Set<Address> getUnhealthyEndpoints() {
-        Set<Address> addresses = null;
+        Set<Address> combinedAddresses = null;
         for (DiscoveryStrategy strategy : discoveryStrategies) {
-            Set<Address> local = strategy.getUnhealthyEndpoints();
-            if (!local.isEmpty()) {
-                if (addresses == null) {
-                    addresses = new HashSet<>(local.size());
+            Set<Address> strategyAddresses = strategy.getUnhealthyEndpoints();
+            if (!strategyAddresses.isEmpty()) {
+                if (combinedAddresses == null) {
+                    combinedAddresses = new HashSet<>(strategyAddresses.size());
                 }
-                addresses.addAll(local);
+                combinedAddresses.addAll(strategyAddresses);
             }
         }
-        return addresses == null ? Collections.emptySet() : addresses;
+        return combinedAddresses == null ? Collections.emptySet() : combinedAddresses;
     }
 
     public Iterable<DiscoveryStrategy> getDiscoveryStrategies() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.discovery.impl;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.InvalidConfigurationException;
@@ -41,8 +42,7 @@ import java.util.Set;
 
 import static com.hazelcast.internal.util.CollectionUtil.nullToEmpty;
 
-public class DefaultDiscoveryService
-        implements DiscoveryService {
+public class DefaultDiscoveryService implements DiscoveryService {
 
     private static final String SERVICE_LOADER_TAG = DiscoveryStrategyFactory.class.getCanonicalName();
 
@@ -96,6 +96,28 @@ public class DefaultDiscoveryService
         for (DiscoveryStrategy discoveryStrategy : discoveryStrategies) {
             discoveryStrategy.destroy();
         }
+    }
+
+    @Override
+    public void markEndpointAsUnhealthy(Address address) {
+        for (DiscoveryStrategy discoveryStrategy : discoveryStrategies) {
+            discoveryStrategy.markEndpointAsUnhealthy(address);
+        }
+    }
+
+    @Override
+    public Set<Address> getUnhealthyEndpoints() {
+        Set<Address> addresses = null;
+        for (DiscoveryStrategy strategy : discoveryStrategies) {
+            Set<Address> local = strategy.getUnhealthyEndpoints();
+            if (!local.isEmpty()) {
+                if (addresses == null) {
+                    addresses = new HashSet<>(local.size());
+                }
+                addresses.addAll(local);
+            }
+        }
+        return addresses == null ? Collections.emptySet() : addresses;
     }
 
     public Iterable<DiscoveryStrategy> getDiscoveryStrategies() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/PredefinedDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/PredefinedDiscoveryService.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.spi.discovery.impl;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 import java.util.Map;
+import java.util.Set;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
@@ -50,7 +52,21 @@ public class PredefinedDiscoveryService implements DiscoveryService {
     }
 
     @Override
+    public void markEndpointAsUnhealthy(Address address) {
+        strategy.markEndpointAsUnhealthy(address);
+    }
+
+    @Override
+    public Set<Address> getUnhealthyEndpoints() {
+        return strategy.getUnhealthyEndpoints();
+    }
+
+    @Override
     public void destroy() {
         strategy.destroy();
+    }
+
+    public DiscoveryStrategy getStrategy() {
+        return strategy;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.discovery.integration;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.NodeFilter;
@@ -98,6 +99,7 @@ public interface DiscoveryService {
      * @param address the address to mark as unhealthy
      * @since 5.4
      */
+    @PrivateApi
     default void markEndpointAsUnhealthy(Address address) { }
 
     /**
@@ -110,6 +112,7 @@ public interface DiscoveryService {
      *  underlying implementation, otherwise an empty set.
      * @since 5.4
      */
+    @PrivateApi
     default Set<Address> getUnhealthyEndpoints() {
         return Collections.emptySet();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.discovery.integration;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.NodeFilter;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The <code>DiscoveryService</code> interface defines the basic entry point
@@ -83,4 +86,31 @@ public interface DiscoveryService {
      * @since 3.7
      */
     Map<String, String> discoverLocalMetadata();
+
+    /**
+     * Marks the passed {@link Address} as unhealthy, which prevents it from being offered as a
+     * viable endpoint in some {@link DiscoveryStrategy} implementations, usually prompting
+     * this endpoint to be periodically probed for liveliness. If not supported by the underlying
+     * implementation, then this call does nothing.
+     *
+     * @see DiscoveryStrategy#markEndpointAsUnhealthy(Address)
+     *
+     * @param address the address to mark as unhealthy
+     * @since 5.4
+     */
+    default void markEndpointAsUnhealthy(Address address) { }
+
+    /**
+     * Fetches a set of {@link Address} marked as unhealthy by the underlying {@link DiscoveryStrategy}.
+     * If not supported by the underlying implementation, then this call returns an empty set.
+     *
+     * @see DiscoveryStrategy#getUnhealthyEndpoints()
+     *
+     * @return set of {@link Address} which are currently marked as unhealthy if supported by the
+     *  underlying implementation, otherwise an empty set.
+     * @since 5.4
+     */
+    default Set<Address> getUnhealthyEndpoints() {
+        return Collections.emptySet();
+    }
 }


### PR DESCRIPTION
This commit applies several improvements to our existing static discovery strategy used in WAN replication; for a full overview of the expectations for these changes, please refer to the description of HZ-2888.

At a high level, this commit introduces health checking for connections in WAN, managed through the `StaticDiscoveryStrategy`, with various properties defined in `StaticDiscoveryProperties`, passed through the `WanBatchPublisherConfig` properties mapping.

Connections are marked as "unhealthy" under the circumstances where they would previously have only been removed from the target endpoints list; these "unhealthy" endpoints are then no longer returned during discovery, and instead they are periodically probed for liveliness. If the connection becomes live again, it will be returned to the active target list during the next discovery task.

`ConnectionHealthData` is maintained for each unhealthy endpoint, which tracks data related to its health checks, and is used for functionality such as "failed probe" removal, and configurable back-off for checks.

Metrics are now recorded for each WAN connection, with a single metric used for all connections alongside a discriminator containing each individual endpoint's address, and the value being `0` for unhealthy endpoints and `1` for healthy ones.

This commit also contains regression tests for all new functionality, contained within `StaticDiscoveryEndpointsTest`.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6442
Closes https://hazelcast.atlassian.net/browse/HZ-2888