### PR TITLE
Clarify expected PartitionAware semantics for equivalent key objects [HZ-2860]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionAware.java
@@ -37,6 +37,15 @@ package com.hazelcast.partition;
  * {@link com.hazelcast.core.DistributedObject} also has a notion of the partition key which is of type String
  * to ensure that the same partition as distributed Objects Strings is used for the partition key.
  *
+ * Additionally, it is expected that partition key remains same for a given object throughout its lifetime in the
+ * hazelcast storage and the key itself is produced from the value of the Object (following similar semantics to
+ * equals and hashcode). For example if at the time of Object insertion getPartitionKey() returns "test"
+ * as the partition key, it is expected that this Object instance or equivalent Object instances will always
+ * return "test" as the partition key. Returning different partition keys at the time of insertion and at the time
+ * of querying (for a given otherwise equivalent Object), while technically possible, will likely result in inability
+ * to query the inserted object because a different partitionKey will produce different partition which might be
+ * located on entirely different cluster member than the one where the Object was put at the insertion time.
+ *
  * @see com.hazelcast.core.DistributedObject
  * @param <T> key type
  */
@@ -46,6 +55,10 @@ public interface PartitionAware<T> {
     /**
      * The key that will be used by Hazelcast to specify the partition.
      * You should give the same key for objects that you want to be in the same partition.
+     * It is expected that objects stored in the Hazelcast cluster will not change their partition key value
+     * over time. If the partitionKey were to return different partition keys for the same (equivalent) Object
+     * at the Object insertion and querying time respectively, it would result in inability to query the inserted
+     * Object.
      *
      * @return the key that specifies the partition
      */


### PR DESCRIPTION
Add an explanation of what is expected semantics from implementations of PartitionAware interface, specifically that it is expected that equivalent objects will always return same PartitionKey throughout their lifetime in the cluster at the very least.

It is technically possible for a Key object to return one PartitionKey during insertion (e.g. `IMap.put`) and then during querying an equivalent key object might opt to return a different PartitionKey. While the motivation of such implementation is highly debatable, it is most likely worth clarifying in the javadoc that this breaks querying. 

A sample (highly unlikely) scenario might look like this: 
```java
class KeyObject {
    private transient String tempKey;
    private String stableKey; 
    Object getPartitionKey() { return tempKey != null ? tempKey : stableKey; }

    // equals() and hashcode() using only stableKey
}
var key = new KeyObject("tempKey" + Math.random(), "stableKey");
imap.put(key, "test");
key.setTempKey(null);
imap.get(key) // this will result in a different member being sent the IMap.get operation. 
```
While the justification for such usage is highly questionable, it would be good to clarify that this scenario is not supported.
