### PR TITLE
Remove API team as code owners for Serialization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,3 @@
 
 **/client/**           @hazelcast/apis
 **/hazelcast-client**  @hazelcast/apis
-**/serialization**     @hazelcast/apis


### PR DESCRIPTION
Serialization is shared between teams - removing individual ownership.

