### PR TITLE
Change a logging level to info when a CP members list is updated [HZ-3046] [5.3.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RaftInvocationContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RaftInvocationContext.java
@@ -77,7 +77,7 @@ public class RaftInvocationContext {
             CPMembersContainer currentContainer = membersContainer.get();
             if (newContainer.version.compareTo(currentContainer.version) > 0) {
                 if (membersContainer.compareAndSet(currentContainer, newContainer)) {
-                    logger.fine("Replaced " + currentContainer + " with " + newContainer);
+                    logger.info("Replaced " + currentContainer + " with " + newContainer);
                     return true;
                 }
             } else {


### PR DESCRIPTION
Changing the logging level should help analyze the behavior of the CP subsystem if the internal list of CP members is updated.

Backport of: https://github.com/hazelcast/hazelcast/pull/25371

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
