### PR TITLE
Fix test_singleStaged_hop test for little endianness [HZ-2418]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/aggregate/SqlStreamingJoinAndAggregationTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/aggregate/SqlStreamingJoinAndAggregationTest.java
@@ -77,8 +77,9 @@ public class SqlStreamingJoinAndAggregationTest extends SqlTestSupport {
                 "    GROUP BY window_end) st2" +
                 " ON st1.we1 = st2.we2";
 
-        assertRowsEventuallyInAnyOrder(sql, asList(
-                new Row(timestampTz(10L), 3L, 2)
+        assertTipOfStream(sql, asList(
+                new Row(timestampTz(10L), 3L, 2),
+                new Row(timestampTz(20L), 3L, 2)
         ));
     }
 


### PR DESCRIPTION
The test tries to check only the first event incoming to the sink. 
In fact, we have two windowed aggregations, and for the little-endian setup, the second result of join arrives first, and it is allowed behavior (the bigger window wasn't closed yet).  