### PR TITLE
Throw user cancellation exception if the job was cancelled before it was initialized

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -85,6 +85,7 @@ import java.util.stream.Collectors;
 
 import static com.hazelcast.function.Functions.entryKey;
 import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
+import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.config.ProcessingGuarantee.NONE;
@@ -112,7 +113,6 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.isRestartableException;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.isTopologyException;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
-import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFinest;
 import static com.hazelcast.jet.impl.util.Util.doWithClassLoader;
 import static com.hazelcast.jet.impl.util.Util.formatJobDuration;
@@ -207,7 +207,7 @@ public class MasterJobContext {
     /**
      * Creates exception with appropriate type for job cancellation.
      */
-    private Throwable createCancellationException() {
+    private RuntimeException createCancellationException() {
         return isUserInitiatedTermination() ? new CancellationByUserException() : new CancellationException();
     }
 
@@ -331,7 +331,7 @@ public class MasterJobContext {
         try {
             if (isCancelled()) {
                 logger.fine("Skipping init job '" + mc.jobName() + "': is already cancelled.");
-                throw new CancellationException();
+                throw createCancellationException();
             }
             if (mc.jobStatus() != NOT_RUNNING) {
                 logger.fine("Not starting job '" + mc.jobName() + "': status is " + mc.jobStatus());


### PR DESCRIPTION
Wrong exception was thrown if the job was cancelled very early by the user. Instead of specific `CancellationByUserException` the generic `CancellationException` was thrown. This caused some flakiness in unit tests (see eg. https://jenkins.hazelcast.com/job/Hazelcast-pr-builder/20340/testReport/junit/com.hazelcast.jet.impl/JobSummaryTest/when_batchJob_cancelled/)

Not adding unit test because there does not seem to be an easy way to trigger this situation. 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
