### PR TITLE
Change javadoc of BufferingInputStream [HZ-3050]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/BufferingInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/BufferingInputStream.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.util;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -23,6 +24,8 @@ import static java.lang.System.arraycopy;
 
 /**
  * {@link InputStream} implementation with a configurable buffer.
+ * Unlike {@link BufferedInputStream} this class has un-synchronized methods and performs better when used
+ * by a single thread.
  */
 public class BufferingInputStream extends InputStream {
 


### PR DESCRIPTION
Change javadoc of BufferingInputStream to reflect that it is un-synchronized and performs better than BufferedInputStream  [HZ-3050]

Jira : https://hazelcast.atlassian.net/browse/HZ-3050

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible


[HZ-3050]: https://hazelcast.atlassian.net/browse/HZ-3050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ