### PR TITLE
Don't set SO_REUSEPORT on Windows (#23947) [5.3.z]

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptions.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncServerSocketOptions.java
@@ -16,14 +16,17 @@
 
 package com.hazelcast.internal.tpcengine.nio;
 
-import com.hazelcast.internal.tpcengine.net.AsyncSocketOptions;
 import com.hazelcast.internal.tpcengine.Option;
+import com.hazelcast.internal.tpcengine.net.AsyncSocketOptions;
+import com.hazelcast.internal.tpcengine.util.OS;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.nio.channels.ServerSocketChannel;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.hazelcast.internal.tpcengine.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.tpcengine.util.ReflectionUtil.findStaticFieldValue;
@@ -36,6 +39,12 @@ public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
     // This option is available since Java 9, so we need to use reflection.
     private static final SocketOption<Boolean> STD_SOCK_OPT_SO_REUSEPORT
             = findStaticFieldValue(StandardSocketOptions.class, "SO_REUSEPORT");
+    private static final Set<SocketOption<?>> WINDOWS_UNSUPPORTED_OPTIONS;
+
+    static {
+        WINDOWS_UNSUPPORTED_OPTIONS = new HashSet<>();
+        WINDOWS_UNSUPPORTED_OPTIONS.add(STD_SOCK_OPT_SO_REUSEPORT);
+    }
 
     private final ServerSocketChannel serverSocketChannel;
 
@@ -64,7 +73,13 @@ public class NioAsyncServerSocketOptions implements AsyncSocketOptions {
     }
 
     private boolean isSupported(SocketOption socketOption) {
-        return socketOption != null && serverSocketChannel.supportedOptions().contains(socketOption);
+        if (socketOption == null) {
+            return false;
+        }
+        if (OS.isWindows() && WINDOWS_UNSUPPORTED_OPTIONS.contains(socketOption)) {
+            return false;
+        }
+        return serverSocketChannel.supportedOptions().contains(socketOption);
     }
 
     @Override


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/25378

SO_REUSEADDR flag works as expected on POSIX platforms, but will cause indeterminate behaviors on Windows sockets.

See:
- https://github.com/eclipse/jetty.project/issues/6661#issuecomment-1281521862
- https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse#using-so_reuseaddr

Fixes https://github.com/hazelcast/hazelcast/issues/23947
Fixes https://hazelcast.atlassian.net/browse/HZ-2213

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
