### PR TITLE
Remove TestCollectionUtils.setOf and use Java 11 Set.of() instead [HZ-3080]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/LatencyTrackingQueueStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/LatencyTrackingQueueStoreTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestCollectionUtils;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -57,7 +56,7 @@ public class LatencyTrackingQueueStoreTest extends HazelcastTestSupport {
         HazelcastInstance hz = createHazelcastInstance();
         plugin = new StoreLatencyPlugin(getNodeEngineImpl(hz));
         delegate = mock(QueueStore.class);
-        queueStore = new LatencyTrackingQueueStore<String>(delegate, plugin, NAME);
+        queueStore = new LatencyTrackingQueueStore<>(delegate, plugin, NAME);
     }
 
     @Test
@@ -76,7 +75,7 @@ public class LatencyTrackingQueueStoreTest extends HazelcastTestSupport {
     @Test
     public void loadAll() {
         Collection<Long> keys = Arrays.asList(1L, 2L);
-        Map<Long, String> values = new HashMap<Long, String>();
+        Map<Long, String> values = new HashMap<>();
         values.put(1L, "value1");
         values.put(2L, "value2");
 
@@ -90,7 +89,7 @@ public class LatencyTrackingQueueStoreTest extends HazelcastTestSupport {
 
     @Test
     public void loadAllKeys() {
-        Set<Long> keys = TestCollectionUtils.setOf(1L, 2L);
+        Set<Long> keys = Set.of(1L, 2L);
 
         when(delegate.loadAllKeys()).thenReturn(keys);
 
@@ -133,7 +132,7 @@ public class LatencyTrackingQueueStoreTest extends HazelcastTestSupport {
 
     @Test
     public void storeAll() {
-        Map<Long, String> values = new HashMap<Long, String>();
+        Map<Long, String> values = new HashMap<>();
         values.put(1L, "value1");
         values.put(2L, "value2");
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigSchemaLocationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigSchemaLocationTest.java
@@ -40,7 +40,6 @@ import org.w3c.dom.Element;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
 import java.io.InputStream;
 import java.net.URL;
 import java.util.HashSet;
@@ -48,7 +47,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static com.hazelcast.internal.util.XmlUtil.getNsAwareDocumentBuilderFactory;
-import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -56,7 +54,7 @@ import static org.junit.Assert.assertEquals;
 public class XmlConfigSchemaLocationTest extends HazelcastTestSupport {
 
     // list of schema location URLs which we do not want to check
-    private static final Set<String> WHITELIST = setOf();
+    private static final Set<String> WHITELIST = Set.of();
 
     private static final String XML_SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance";
     private static final String XML_SCHEMA_LOCATION_ATTRIBUTE = "schemaLocation";
@@ -72,7 +70,7 @@ public class XmlConfigSchemaLocationTest extends HazelcastTestSupport {
     public void setUp() throws ParserConfigurationException {
         httpClient = HttpClients.createDefault();
         documentBuilderFactory = getNsAwareDocumentBuilderFactory();
-        validUrlsCache = new HashSet<String>();
+        validUrlsCache = new HashSet<>();
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadMigrationStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadMigrationStrategyTest.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -51,14 +50,14 @@ public class LoadMigrationStrategyTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        ownerToPipelines = new HashMap<NioThread, Set<MigratablePipeline>>();
-        loadCounter = new ItemCounter<MigratablePipeline>();
+        ownerToPipelines = new HashMap<>();
+        loadCounter = new ItemCounter<>();
         imbalance = new LoadImbalance(ownerToPipelines, loadCounter);
         strategy = new LoadMigrationStrategy();
     }
 
     @Test
-    public void testImbalanceDetected_shouldReturnFalseWhenNoKnownMinimum() throws Exception {
+    public void testImbalanceDetected_shouldReturnFalseWhenNoKnownMinimum() {
         imbalance.minimumLoad = Long.MIN_VALUE;
 
         boolean imbalanceDetected = strategy.imbalanceDetected(imbalance);
@@ -66,7 +65,7 @@ public class LoadMigrationStrategyTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testImbalanceDetected_shouldReturnFalseWhenNoKnownMaximum() throws Exception {
+    public void testImbalanceDetected_shouldReturnFalseWhenNoKnownMaximum() {
         imbalance.maximumLoad = Long.MAX_VALUE;
 
         boolean imbalanceDetected = strategy.imbalanceDetected(imbalance);
@@ -74,7 +73,7 @@ public class LoadMigrationStrategyTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testImbalanceDetected_shouldReturnFalseWhenBalanced() throws Exception {
+    public void testImbalanceDetected_shouldReturnFalseWhenBalanced() {
         imbalance.maximumLoad = 1000;
         imbalance.minimumLoad = (long) (1000 * 0.8);
 
@@ -83,7 +82,7 @@ public class LoadMigrationStrategyTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testImbalanceDetected_shouldReturnTrueWhenNotBalanced() throws Exception {
+    public void testImbalanceDetected_shouldReturnTrueWhenNotBalanced() {
         imbalance.maximumLoad = 1000;
         imbalance.minimumLoad = (long) (1000 * 0.8) - 1;
 
@@ -92,7 +91,7 @@ public class LoadMigrationStrategyTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testFindPipelineToMigrate() throws Exception {
+    public void testFindPipelineToMigrate() {
         NioThread srcOwner = mock(NioThread.class);
         NioThread dstOwner = mock(NioThread.class);
         imbalance.srcOwner = srcOwner;
@@ -108,7 +107,7 @@ public class LoadMigrationStrategyTest extends HazelcastTestSupport {
         MigratablePipeline pipeline3 = mock(MigratablePipeline.class);
         loadCounter.set(pipeline2, 200L);
         loadCounter.set(pipeline3, 100L);
-        ownerToPipelines.put(srcOwner, setOf(pipeline2, pipeline3));
+        ownerToPipelines.put(srcOwner, Set.of(pipeline2, pipeline3));
 
         MigratablePipeline pipelineToMigrate = strategy.findPipelineToMigrate(imbalance);
         assertEquals(pipeline3, pipelineToMigrate);

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/MonkeyMigrationStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/MonkeyMigrationStrategyTest.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static java.lang.Math.abs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -52,7 +51,7 @@ public class MonkeyMigrationStrategyTest extends HazelcastTestSupport {
 
     @Test
     public void imbalanceDetected_shouldReturnFalseWhenNoPipelineExist() {
-        ownerPipelines.put(imbalance.srcOwner, Collections.<MigratablePipeline>emptySet());
+        ownerPipelines.put(imbalance.srcOwner, Collections.emptySet());
 
         boolean imbalanceDetected = strategy.imbalanceDetected(imbalance);
         assertFalse(imbalanceDetected);
@@ -60,8 +59,8 @@ public class MonkeyMigrationStrategyTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        ownerPipelines = new HashMap<NioThread, Set<MigratablePipeline>>();
-        pipelineLoadCounter = new ItemCounter<MigratablePipeline>();
+        ownerPipelines = new HashMap<>();
+        pipelineLoadCounter = new ItemCounter<>();
         imbalance = new LoadImbalance(ownerPipelines, pipelineLoadCounter);
         imbalance.srcOwner = mock(NioThread.class);
 
@@ -72,7 +71,7 @@ public class MonkeyMigrationStrategyTest extends HazelcastTestSupport {
     public void imbalanceDetected_shouldReturnTrueWhenPipelineExist() {
         MigratablePipeline pipeline = mock(MigratablePipeline.class);
 
-        ownerPipelines.put(imbalance.srcOwner, setOf(pipeline));
+        ownerPipelines.put(imbalance.srcOwner, Set.of(pipeline));
         boolean imbalanceDetected = strategy.imbalanceDetected(imbalance);
         assertTrue(imbalanceDetected);
     }
@@ -81,7 +80,7 @@ public class MonkeyMigrationStrategyTest extends HazelcastTestSupport {
     public void findPipelineToMigrate_shouldWorkEvenWithASinglePipelineAvailable() {
         MigratablePipeline pipeline = mock(MigratablePipeline.class);
 
-        ownerPipelines.put(imbalance.srcOwner, setOf(pipeline));
+        ownerPipelines.put(imbalance.srcOwner, Set.of(pipeline));
         MigratablePipeline pipelineToMigrate = strategy.findPipelineToMigrate(imbalance);
         assertEquals(pipeline, pipelineToMigrate);
     }
@@ -93,7 +92,7 @@ public class MonkeyMigrationStrategyTest extends HazelcastTestSupport {
 
         MigratablePipeline pipeline1 = mock(MigratablePipeline.class);
         MigratablePipeline pipeline2 = mock(MigratablePipeline.class);
-        ownerPipelines.put(imbalance.srcOwner, setOf(pipeline1, pipeline2));
+        ownerPipelines.put(imbalance.srcOwner, Set.of(pipeline1, pipeline2));
 
         assertFairSelection(iterationCount, toleranceFactor, pipeline1, pipeline2);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
@@ -66,7 +66,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.internal.nio.IOUtil.toByteArray;
-import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -168,9 +167,9 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         //the definition loaded by the child classloader -> it only delegates to the parent -> it's a duplicated
         ServiceLoader.ServiceDefinition definition2 = new ServiceLoader.ServiceDefinition(hook.getName(), childClassloader);
 
-        Set<ServiceLoader.ServiceDefinition> definitions = setOf(definition1, definition2);
+        Set<ServiceLoader.ServiceDefinition> definitions = Set.of(definition1, definition2);
         ServiceLoader.ClassIterator<PortableHook> iterator
-                = new ServiceLoader.ClassIterator<PortableHook>(definitions, PortableHook.class);
+                = new ServiceLoader.ClassIterator<>(definitions, PortableHook.class);
 
         assertTrue(iterator.hasNext());
         Class<PortableHook> hookFromIterator = iterator.next();
@@ -189,7 +188,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ServiceLoader.ServiceDefinition definition = new ServiceLoader.ServiceDefinition(otherHook.getName(), otherClassloader);
         Set<ServiceLoader.ServiceDefinition> definitions = singleton(definition);
         ServiceLoader.ClassIterator<PortableHook> iterator
-                = new ServiceLoader.ClassIterator<PortableHook>(definitions, PortableHook.class);
+                = new ServiceLoader.ClassIterator<>(definitions, PortableHook.class);
 
         assertFalse(iterator.hasNext());
     }
@@ -205,7 +204,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ServiceLoader.ServiceDefinition definition = new ServiceLoader.ServiceDefinition(otherHook.getName(), otherClassloader);
         Set<ServiceLoader.ServiceDefinition> definitions = singleton(definition);
         ServiceLoader.ClassIterator<PortableHook> iterator
-                = new ServiceLoader.ClassIterator<PortableHook>(definitions, PortableHook.class);
+                = new ServiceLoader.ClassIterator<>(definitions, PortableHook.class);
 
         assertFalse(iterator.hasNext());
     }
@@ -216,7 +215,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
                 = new ServiceLoader.ServiceDefinition("com.hazelcast.DoesNotExist", getClass().getClassLoader());
         Set<ServiceLoader.ServiceDefinition> definitions = singleton(definition);
         ServiceLoader.ClassIterator<PortableHook> iterator
-                = new ServiceLoader.ClassIterator<PortableHook>(definitions, PortableHook.class);
+                = new ServiceLoader.ClassIterator<>(definitions, PortableHook.class);
 
         assertFalse(iterator.hasNext());
     }
@@ -227,7 +226,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
                 = new ServiceLoader.ServiceDefinition("non.a.hazelcast.DoesNotExist", getClass().getClassLoader());
         Set<ServiceLoader.ServiceDefinition> definitions = singleton(definition);
         ServiceLoader.ClassIterator<PortableHook> iterator
-                = new ServiceLoader.ClassIterator<PortableHook>(definitions, PortableHook.class);
+                = new ServiceLoader.ClassIterator<>(definitions, PortableHook.class);
         assertFalse(iterator.hasNext());
     }
 
@@ -245,7 +244,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ServiceLoader.ServiceDefinition definition2
                 = new ServiceLoader.ServiceDefinition(SpiDataSerializerHook.class.getName(), SpiDataSerializerHook.class.getClassLoader());
 
-        Set<ServiceLoader.ServiceDefinition> definitions = setOf(definition1, definition2);
+        Set<ServiceLoader.ServiceDefinition> definitions = Set.of(definition1, definition2);
         ServiceLoader.ClassIterator<DataSerializerHook> iterator
                 = new ServiceLoader.ClassIterator<>(definitions, DataSerializerHook.class);
 
@@ -262,9 +261,9 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ServiceLoader.ServiceDefinition definition = new ServiceLoader.ServiceDefinition(hookName, classLoader);
 
         ServiceLoader.ClassIterator<PortableHook> classIterator
-                = new ServiceLoader.ClassIterator<PortableHook>(singleton(definition), PortableHook.class);
+                = new ServiceLoader.ClassIterator<>(singleton(definition), PortableHook.class);
         ServiceLoader.NewInstanceIterator<PortableHook> instanceIterator
-                = new ServiceLoader.NewInstanceIterator<PortableHook>(classIterator);
+                = new ServiceLoader.NewInstanceIterator<>(classIterator);
 
         assertTrue(instanceIterator.hasNext());
         DummyPrivatePortableHook hook = (DummyPrivatePortableHook) instanceIterator.next();
@@ -278,9 +277,9 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ServiceLoader.ServiceDefinition definition = new ServiceLoader.ServiceDefinition(hookName, classLoader);
 
         ServiceLoader.ClassIterator<SerializerHook> classIterator
-                = new ServiceLoader.ClassIterator<SerializerHook>(singleton(definition), SerializerHook.class);
+                = new ServiceLoader.ClassIterator<>(singleton(definition), SerializerHook.class);
         ServiceLoader.NewInstanceIterator<SerializerHook> instanceIterator
-                = new ServiceLoader.NewInstanceIterator<SerializerHook>(classIterator);
+                = new ServiceLoader.NewInstanceIterator<>(classIterator);
 
         assertTrue(instanceIterator.hasNext());
         DummyPrivateSerializerHook hook = (DummyPrivateSerializerHook) instanceIterator.next();
@@ -357,7 +356,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         Class<ServiceLoaderTestInterface> type = ServiceLoaderTestInterface.class;
         String factoryId = "com.hazelcast.ServiceLoaderTestInterface";
 
-        Set<ServiceLoaderTestInterface> implementations = new HashSet<ServiceLoaderTestInterface>();
+        Set<ServiceLoaderTestInterface> implementations = new HashSet<>();
         Iterator<ServiceLoaderTestInterface> iterator = ServiceLoader.iterator(type, factoryId, null);
         while (iterator.hasNext()) {
             implementations.add(iterator.next());
@@ -373,7 +372,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
 
         ClassLoader given = new URLClassLoader(new URL[0]);
 
-        Set<ServiceLoaderTestInterface> implementations = new HashSet<ServiceLoaderTestInterface>();
+        Set<ServiceLoaderTestInterface> implementations = new HashSet<>();
         Iterator<ServiceLoaderTestInterface> iterator = ServiceLoader.iterator(type, factoryId, given);
         while (iterator.hasNext()) {
             implementations.add(iterator.next());
@@ -391,7 +390,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ClassLoader tccl = current.getContextClassLoader();
         current.setContextClassLoader(new URLClassLoader(new URL[0]));
 
-        Set<ServiceLoaderTestInterface> implementations = new HashSet<ServiceLoaderTestInterface>();
+        Set<ServiceLoaderTestInterface> implementations = new HashSet<>();
         Iterator<ServiceLoaderTestInterface> iterator = ServiceLoader.iterator(type, factoryId, null);
         while (iterator.hasNext()) {
             implementations.add(iterator.next());
@@ -412,7 +411,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ClassLoader tccl = current.getContextClassLoader();
         current.setContextClassLoader(new URLClassLoader(new URL[0]));
 
-        Set<ServiceLoaderTestInterface> implementations = new HashSet<ServiceLoaderTestInterface>();
+        Set<ServiceLoaderTestInterface> implementations = new HashSet<>();
         Iterator<ServiceLoaderTestInterface> iterator = ServiceLoader.iterator(type, factoryId, given);
         while (iterator.hasNext()) {
             implementations.add(iterator.next());
@@ -433,7 +432,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         ClassLoader tccl = current.getContextClassLoader();
         current.setContextClassLoader(same);
 
-        Set<ServiceLoaderTestInterface> implementations = new HashSet<ServiceLoaderTestInterface>();
+        Set<ServiceLoaderTestInterface> implementations = new HashSet<>();
         Iterator<ServiceLoaderTestInterface> iterator = ServiceLoader.iterator(type, factoryId, same);
         while (iterator.hasNext()) {
             implementations.add(iterator.next());
@@ -451,7 +450,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         URL url = ClassLoader.getSystemResource("test with special chars^/");
         ClassLoader given = new URLClassLoader(new URL[]{url});
 
-        Set<ServiceLoaderSpecialCharsTestInterface> implementations = new HashSet<ServiceLoaderSpecialCharsTestInterface>();
+        Set<ServiceLoaderSpecialCharsTestInterface> implementations = new HashSet<>();
         Iterator<ServiceLoaderSpecialCharsTestInterface> iterator = ServiceLoader.iterator(type, factoryId, given);
         while (iterator.hasNext()) {
             implementations.add(iterator.next());
@@ -469,7 +468,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         // Handles META-INF/services/com.hazelcast.CustomServiceLoaderTestInterface
         ClassLoader given = new CustomUrlStreamHandlerClassloader(parent);
 
-        Set<ServiceLoaderTestInterface> implementations = new HashSet<ServiceLoaderTestInterface>();
+        Set<ServiceLoaderTestInterface> implementations = new HashSet<>();
         Iterator<ServiceLoaderTestInterface> iterator = ServiceLoader.iterator(type, factoryId, given);
         while (iterator.hasNext()) {
             implementations.add(iterator.next());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/LocalKeySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/LocalKeySetTest.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.test.Accessors.getSerializationService;
-import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -95,7 +94,7 @@ public class LocalKeySetTest extends HazelcastTestSupport {
 
         Set<String> result = map.localKeySet();
 
-        assertEquals(setOf(localKey1, localKey2), result);
+        assertEquals(Set.of(localKey1, localKey2), result);
     }
 
     @Test
@@ -106,7 +105,7 @@ public class LocalKeySetTest extends HazelcastTestSupport {
 
         Set<String> result = map.localKeySet(Predicates.alwaysTrue());
 
-        assertEquals(setOf(localKey1, localKey2), result);
+        assertEquals(Set.of(localKey1, localKey2), result);
     }
 
     @Test
@@ -120,7 +119,7 @@ public class LocalKeySetTest extends HazelcastTestSupport {
 
         Set<String> result = map.localKeySet(new GoodPredicate());
 
-        assertEquals(setOf(localKey1, localKey3), result);
+        assertEquals(Set.of(localKey1, localKey3), result);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/LocalValuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/LocalValuesTest.java
@@ -33,9 +33,9 @@ import org.junit.runner.RunWith;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 import static com.hazelcast.test.Accessors.getSerializationService;
-import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -95,7 +95,7 @@ public class LocalValuesTest extends HazelcastTestSupport {
 
         Collection<String> result = map.localValues();
 
-        assertEquals(setOf("a", "b"), result);
+        assertEquals(Set.of("a", "b"), result);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class LocalValuesTest extends HazelcastTestSupport {
 
         Collection<String> result = map.localValues(Predicates.alwaysTrue());
 
-        assertEquals(setOf("a", "b"), result);
+        assertEquals(Set.of("a", "b"), result);
     }
 
     @Test
@@ -120,7 +120,7 @@ public class LocalValuesTest extends HazelcastTestSupport {
 
         Collection<String> result = map.localValues(new GoodPredicate());
 
-        assertEquals(setOf("good1", "good2"), result);
+        assertEquals(Set.of("good1", "good2"), result);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapKeySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapKeySetTest.java
@@ -42,7 +42,6 @@ import java.util.Set;
 
 import static com.hazelcast.query.Predicates.partitionPredicate;
 import static com.hazelcast.test.Accessors.getSerializationService;
-import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -86,7 +85,7 @@ public class MapKeySetTest extends HazelcastTestSupport {
 
         Set<String> result = map.keySet();
 
-        assertEquals(setOf("1", "2", "3"), result);
+        assertEquals(Set.of("1", "2", "3"), result);
     }
 
     @Test
@@ -97,7 +96,7 @@ public class MapKeySetTest extends HazelcastTestSupport {
 
         Set<String> result = map.keySet(Predicates.alwaysTrue());
 
-        assertEquals(setOf("1", "2", "3"), result);
+        assertEquals(Set.of("1", "2", "3"), result);
     }
 
     @Test
@@ -108,7 +107,7 @@ public class MapKeySetTest extends HazelcastTestSupport {
 
         Set<String> result = map.keySet(new GoodPredicate());
 
-        assertEquals(setOf("1", "3"), result);
+        assertEquals(Set.of("1", "3"), result);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
@@ -16,9 +16,7 @@
 
 package com.hazelcast.test;
 
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -29,18 +27,8 @@ public final class TestCollectionUtils {
     private TestCollectionUtils() {
     }
 
-    /**
-     * Creates a new set containing items passed as arguments.
-     *
-     * @return a new instance of Set with all items passed as an argument
-     */
-    public static <T> Set<T> setOf(T... items) {
-        List<T> list = Arrays.asList(items);
-        return new HashSet<T>(list);
-    }
-
     public static Set<Integer> setOfValuesBetween(int from, int to) {
-        HashSet<Integer> set = new HashSet<Integer>();
+        HashSet<Integer> set = new HashSet<>();
         for (int i = from; i < to; i++) {
             set.add(i);
         }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.test;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 


### PR DESCRIPTION
- Java 11 provides the same functionality
- Also clean up unnecessary types to diamond operator in the changed tests

Jira : https://hazelcast.atlassian.net/browse/HZ-3080

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible