### PR TITLE
Fix KafkaConnectIntegrationTest.test_reading_and_writing_to_map test  [HZ-3116]

### DIFF
--- a/extensions/kafka-connect/pom.xml
+++ b/extensions/kafka-connect/pom.xml
@@ -71,13 +71,14 @@
                         <goals>
                             <goal>wget</goal>
                         </goals>
+                        <configuration>
+                            <url>https://repository.hazelcast.com/download/tests/confluentinc-kafka-connect-datagen-0.6.0.zip</url>
+                            <unpack>false</unpack>
+                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <url>https://repository.hazelcast.com/download/tests/confluentinc-kafka-connect-datagen-0.6.0.zip</url>
-                    <unpack>false</unpack>
-                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                </configuration>
+
             </plugin>
         </plugins>
     </build>

--- a/extensions/kafka-connect/pom.xml
+++ b/extensions/kafka-connect/pom.xml
@@ -32,14 +32,6 @@
         <version>5.4.0-SNAPSHOT</version>
     </parent>
 
-    <!-- Repository to download kafka-connect-datagen. Because this resource does not exist on maven central    -->
-    <repositories>
-        <repository>
-            <id>devel-repository</id>
-            <url>https://hazelcast.jfrog.io/artifactory/devel</url>
-        </repository>
-    </repositories>
-
     <build>
         <plugins>
             <plugin>
@@ -68,14 +60,14 @@
                     </filters>
                 </configuration>
             </plugin>
+            <!--version 1.7.1 is buggy and does not use the cache properly-->
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.7.1</version>
+                <version>1.6.8</version>
                 <executions>
                     <execution>
                         <id>download-zip-file</id>
-                        <phase>process-resources</phase>
                         <goals>
                             <goal>wget</goal>
                         </goals>
@@ -85,7 +77,6 @@
                     <url>https://repository.hazelcast.com/download/tests/confluentinc-kafka-connect-datagen-0.6.0.zip</url>
                     <unpack>false</unpack>
                     <outputDirectory>${project.build.directory}/classes</outputDirectory>
-
                 </configuration>
             </plugin>
         </plugins>
@@ -146,13 +137,5 @@
             <version>4.4.12</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.confluent.kafka.connect</groupId>
-            <artifactId>kafka-connect-datagen</artifactId>
-            <version>0.6.0</version>
-            <type>zip</type>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-
 </project>

--- a/extensions/kafka-connect/pom.xml
+++ b/extensions/kafka-connect/pom.xml
@@ -126,6 +126,13 @@
             <version>4.4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.confluent.kafka.connect</groupId>
+            <artifactId>kafka-connect-datagen</artifactId>
+            <version>0.6.0</version>
+            <type>zip</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/kafka-connect/pom.xml
+++ b/extensions/kafka-connect/pom.xml
@@ -32,6 +32,14 @@
         <version>5.4.0-SNAPSHOT</version>
     </parent>
 
+    <!-- Repository to download kafka-connect-datagen. Because this resource does not exist on maven central    -->
+    <repositories>
+        <repository>
+            <id>devel-repository</id>
+            <url>https://hazelcast.jfrog.io/artifactory/devel</url>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>

--- a/extensions/kafka-connect/pom.xml
+++ b/extensions/kafka-connect/pom.xml
@@ -68,6 +68,26 @@
                     </filters>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.7.1</version>
+                <executions>
+                    <execution>
+                        <id>download-zip-file</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <url>https://repository.hazelcast.com/download/tests/confluentinc-kafka-connect-datagen-0.6.0.zip</url>
+                    <unpack>false</unpack>
+                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
@@ -54,12 +54,11 @@ import javax.annotation.Nonnull;
 import javax.management.MBeanServer;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
+import java.io.File;
 import java.io.Serializable;
 import java.lang.management.ManagementFactory;
-import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -97,7 +96,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConnectIntegrationTest.class);
 
     @Test
-    public void test_reading_without_timestamps() throws MalformedURLException {
+    public void test_reading_without_timestamps() throws URISyntaxException {
         Properties randomProperties = new Properties();
         randomProperties.setProperty("name", "datagen-connector");
         randomProperties.setProperty("connector.class", "io.confluent.kafka.connect.datagen.DatagenConnector");
@@ -139,7 +138,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
 
     @Test
     public void windowing_withNativeTimestamps_should_fail_when_records_without_native_timestamps()
-            throws MalformedURLException {
+            throws URISyntaxException {
         JobConfig jobConfig = new JobConfig();
         jobConfig.addJarsInZip(getDataGenConnectorURL());
 
@@ -170,7 +169,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
     }
 
     @Test
-    public void windowing_withIngestionTimestamps_should_work() throws MalformedURLException {
+    public void windowing_withIngestionTimestamps_should_work() throws URISyntaxException {
         JobConfig jobConfig = new JobConfig();
         jobConfig.addJarsInZip(getDataGenConnectorURL());
 
@@ -209,7 +208,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
     }
 
     @Test
-    public void test_reading_and_writing_to_map() throws MalformedURLException {
+    public void test_reading_and_writing_to_map() throws URISyntaxException {
         Properties randomProperties = new Properties();
         randomProperties.setProperty("name", "datagen-connector");
         randomProperties.setProperty("connector.class", "io.confluent.kafka.connect.datagen.DatagenConnector");
@@ -273,7 +272,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
 
     @Test
     @Ignore
-    public void test_scaling() throws MalformedURLException {
+    public void test_scaling() throws URISyntaxException {
         int localParallelism = 3;
         Properties randomProperties = new Properties();
         randomProperties.setProperty("name", "datagen-connector");
@@ -351,7 +350,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
     }
 
     @Test
-    public void test_snapshotting() throws MalformedURLException {
+    public void test_snapshotting() throws URISyntaxException {
         Config config = smallInstanceConfig();
         enableEventJournal(config);
         config.getJetConfig().setResourceUploadEnabled(true);
@@ -419,20 +418,12 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         }
     }
 
-    private URL getDataGenConnectorURL() throws MalformedURLException {
-        Path localM2Repository = Paths.get(System.getProperty("user.home"), ".m2",
-                "io", "confluent", "kafka", "kafka-connect-datagen", "0.6.0", "kafka-connect-datagen-0.6.0.zip");
-
-
-        if (localM2Repository.toFile().exists()) {
-            LOGGER.info("kafka-connect-datagen path is " + localM2Repository);
-            return localM2Repository.toUri().toURL();
-        }
-
-        localM2Repository = Paths.get(System.getProperty("user.home"), ".m2", "repository",
-                "io", "confluent", "kafka", "kafka-connect-datagen", "0.6.0", "kafka-connect-datagen-0.6.0.zip");
-        LOGGER.info("kafka-connect-datagen path is " + localM2Repository);
-        return localM2Repository.toUri().toURL();
+    private URL getDataGenConnectorURL() throws URISyntaxException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        final String CONNECTOR_FILE_PATH = "confluentinc-kafka-connect-datagen-0.6.0.zip";
+        URL resource = classLoader.getResource(CONNECTOR_FILE_PATH);
+        assertThat(new File(resource.toURI())).exists();
+        return resource;
     }
 
     private void waitForNextSnapshot(HazelcastInstance hazelcastInstance, Job job) {

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
@@ -91,13 +91,12 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
     public static final OverridePropertyRule enableLogging = set("hazelcast.logging.type", "log4j2");
     public static final int ITEM_COUNT = 1_000;
 
-    private static final String CONNECTOR_URL = "https://repository.hazelcast.com/download/tests/"
-            + "confluentinc-kafka-connect-datagen-0.6.0.zip";
+    private static final String CONNECTOR_FILE_PATH = "confluentinc-kafka-connect-datagen-0.6.0.zip";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConnectIntegrationTest.class);
 
     @Test
-    public void test_reading_without_timestamps() throws Exception {
+    public void test_reading_without_timestamps() {
         Properties randomProperties = new Properties();
         randomProperties.setProperty("name", "datagen-connector");
         randomProperties.setProperty("connector.class", "io.confluent.kafka.connect.datagen.DatagenConnector");
@@ -115,7 +114,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
                         list -> assertEquals(ITEM_COUNT, list.size())));
 
         JobConfig jobConfig = new JobConfig();
-        jobConfig.addJarsInZip(new URL(CONNECTOR_URL));
+        jobConfig.addJarsInZip(getDataGenConnectorURL());
 
         Config config = smallInstanceConfig();
         config.getJetConfig().setResourceUploadEnabled(true);
@@ -138,9 +137,9 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
     }
 
     @Test
-    public void windowing_withNativeTimestamps_should_fail_when_records_without_native_timestamps() throws Exception {
+    public void windowing_withNativeTimestamps_should_fail_when_records_without_native_timestamps() {
         JobConfig jobConfig = new JobConfig();
-        jobConfig.addJarsInZip(new URL(CONNECTOR_URL));
+        jobConfig.addJarsInZip(getDataGenConnectorURL());
 
         Config config = smallInstanceConfig();
         config.getJetConfig().setResourceUploadEnabled(true);
@@ -169,9 +168,9 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
     }
 
     @Test
-    public void windowing_withIngestionTimestamps_should_work() throws Exception {
+    public void windowing_withIngestionTimestamps_should_work() {
         JobConfig jobConfig = new JobConfig();
-        jobConfig.addJarsInZip(new URL(CONNECTOR_URL));
+        jobConfig.addJarsInZip(getDataGenConnectorURL());
 
         Config config = smallInstanceConfig();
         config.getJetConfig().setResourceUploadEnabled(true);
@@ -208,7 +207,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
     }
 
     @Test
-    public void test_reading_and_writing_to_map() throws Exception {
+    public void test_reading_and_writing_to_map() {
         Properties randomProperties = new Properties();
         randomProperties.setProperty("name", "datagen-connector");
         randomProperties.setProperty("connector.class", "io.confluent.kafka.connect.datagen.DatagenConnector");
@@ -230,7 +229,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
                         list -> assertEquals(ITEM_COUNT, list.size())));
 
         JobConfig jobConfig = new JobConfig();
-        jobConfig.addJarsInZip(new URL(CONNECTOR_URL));
+        jobConfig.addJarsInZip(getDataGenConnectorURL());
 
         Config config = smallInstanceConfig();
         config.getJetConfig().setResourceUploadEnabled(true);
@@ -272,7 +271,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
 
     @Test
     @Ignore
-    public void test_scaling() throws Exception {
+    public void test_scaling() {
         int localParallelism = 3;
         Properties randomProperties = new Properties();
         randomProperties.setProperty("name", "datagen-connector");
@@ -296,7 +295,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
                         }));
 
         JobConfig jobConfig = new JobConfig();
-        jobConfig.addJarsInZip(new URL(CONNECTOR_URL));
+        jobConfig.addJarsInZip(getDataGenConnectorURL());
 
         Config config = smallInstanceConfig();
         config.getJetConfig().setResourceUploadEnabled(true);
@@ -350,7 +349,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
     }
 
     @Test
-    public void test_snapshotting() throws Exception {
+    public void test_snapshotting() {
         Config config = smallInstanceConfig();
         enableEventJournal(config);
         config.getJetConfig().setResourceUploadEnabled(true);
@@ -371,7 +370,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         streamStage.writeTo(Sinks.list("testResults"));
 
         JobConfig jobConfig = new JobConfig();
-        jobConfig.addJarsInZip(new URL(CONNECTOR_URL));
+        jobConfig.addJarsInZip(getDataGenConnectorURL());
         enableSnapshotting(jobConfig);
 
         Job job = hazelcastInstance.getJet().newJob(pipeline, jobConfig);
@@ -418,6 +417,10 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         }
     }
 
+    private URL getDataGenConnectorURL() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        return classLoader.getResource(CONNECTOR_FILE_PATH);
+    }
     private void waitForNextSnapshot(HazelcastInstance hazelcastInstance, Job job) {
         JobRepository jobRepository = new JobRepository(hazelcastInstance);
         waitForNextSnapshot(jobRepository, job.getId(), 30, false);


### PR DESCRIPTION
The test is downloading the DataGen connector zip file from JFrog. In one of the test runs it failed with error message :
 java.net.SocketException: Connection reset

 It would be better to have the connector zip as local resource to avoid download failures in the future  [HZ-3116]

Fixes : https://github.com/hazelcast/hazelcast/issues/24905

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible


[HZ-3116]: https://hazelcast.atlassian.net/browse/HZ-3116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ