### PR TITLE
Update PartitionMigrationListenerTest expectations to handle failed m…

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -426,11 +426,10 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
                         MetricDescriptorConstants.MIGRATION_METRIC_ELAPSED_MIGRATION_TIME), 0,
                 elapsedMigrationTime);
 
-        assertEquals(MessageFormat.format("With only one migration, {0} ({2}) and {1} ({3}) times should be equal",
-                        MetricDescriptorConstants.MIGRATION_METRIC_TOTAL_ELAPSED_MIGRATION_TIME,
-                        MetricDescriptorConstants.MIGRATION_METRIC_ELAPSED_MIGRATION_TIME,
-                        totalElapsedMigrationTime, elapsedMigrationTime), totalElapsedMigrationTime,
-                elapsedMigrationTime);
+        assertTrue(MessageFormat.format("With only one migration, {0} ({2}) should be greater than or equal to {1} ({3})",
+                MetricDescriptorConstants.MIGRATION_METRIC_TOTAL_ELAPSED_MIGRATION_TIME,
+                MetricDescriptorConstants.MIGRATION_METRIC_ELAPSED_MIGRATION_TIME, totalElapsedMigrationTime,
+                elapsedMigrationTime), totalElapsedMigrationTime >= elapsedMigrationTime);
 
         LOGGER.fine("Triggering another migration...");
         hz2.shutdown();


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/25410

Following on from the discussion [this issue](https://github.com/hazelcast/hazelcast/pull/25292#issuecomment-1705374524), completed != successful.

In #25164, a migration was rejected but it's execution time was still being counted.
It was then retried successfully, but the total counter was therefore higher than the last migration time.
The expectations of the test did not account for this and therefore failed in this case.

Fixes [#25164](https://github.com/hazelcast/hazelcast/issues/25164) / [HZ-2939](https://hazelcast.atlassian.net/browse/HZ-2939)


[HZ-2939]: https://hazelcast.atlassian.net/browse/HZ-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ