### PR TITLE
Fix JobTimeoutTest.java [HZ-3120]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobTimeoutTest.java
@@ -89,8 +89,8 @@ public class JobTimeoutTest extends JetTestSupport {
         final JobConfig jobConfig = new JobConfig().setTimeoutMillis(1000L);
         final Job job = hz.getJet().newJob(streamingDag(), jobConfig);
 
-        // If the job times out during execution of these operations
-        // catch and ignore the error to continue testing. The job should finish with CancellationException
+        // If the job times out before or during execution of these operations
+        // catch and ignore the error to continue testing. The job should eventually finish with CancellationException
         // due to timeout
         try {
             assertJobStatusEventually(job, RUNNING, 10);
@@ -112,8 +112,8 @@ public class JobTimeoutTest extends JetTestSupport {
         final JobConfig jobConfig = new JobConfig().setTimeoutMillis(1000L);
         final Job job = hz.getJet().newJob(streamingDag(), jobConfig);
 
-        // If the job times out during execution of these operations
-        // catch and ignore the error to continue testing. The job should finish with CancellationException
+        // If the job times out before or during execution of these operations
+        // catch and ignore the error to continue testing. The job should eventually finish with CancellationException
         // due to timeout
         try {
             assertJobStatusEventually(job, RUNNING);

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobTimeoutTest.java
@@ -89,11 +89,17 @@ public class JobTimeoutTest extends JetTestSupport {
         final JobConfig jobConfig = new JobConfig().setTimeoutMillis(1000L);
         final Job job = hz.getJet().newJob(streamingDag(), jobConfig);
 
-        assertJobStatusEventually(job, RUNNING);
-        job.suspend();
+        // If the job times out during execution of these operations
+        // catch and ignore the error to continue testing. The job should finish with CancellationException
+        // due to timeout
+        try {
+            assertJobStatusEventually(job, RUNNING, 10);
+            job.suspend();
 
-        assertJobStatusEventually(job, SUSPENDED);
-        job.resume();
+            assertJobStatusEventually(job, SUSPENDED, 10);
+            job.resume();
+        } catch (Throwable ignored) {
+        }
 
         assertThrows(CancellationException.class, job::join);
         assertEquals(FAILED, job.getStatus());
@@ -106,11 +112,16 @@ public class JobTimeoutTest extends JetTestSupport {
         final JobConfig jobConfig = new JobConfig().setTimeoutMillis(1000L);
         final Job job = hz.getJet().newJob(streamingDag(), jobConfig);
 
-        assertJobStatusEventually(job, RUNNING);
-        job.suspend();
+        // If the job times out during execution of these operations
+        // catch and ignore the error to continue testing. The job should finish with CancellationException
+        // due to timeout
+        try {
+            assertJobStatusEventually(job, RUNNING);
+            job.suspend();
 
-        assertJobStatusEventually(job, SUSPENDED);
-
+            assertJobStatusEventually(job, SUSPENDED);
+        } catch (Throwable ignored) {
+        }
         assertThrows(CancellationException.class, job::join);
         assertEquals(FAILED, job.getStatus());
         assertFalse(job.isUserCancelled());

--- a/hazelcast/src/test/java/com/hazelcast/jet/core/JobTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/core/JobTimeoutTest.java
@@ -98,7 +98,7 @@ public class JobTimeoutTest extends JetTestSupport {
 
             assertJobStatusEventually(job, SUSPENDED, 10);
             job.resume();
-        } catch (Throwable ignored) {
+        } catch (AssertionError | IllegalStateException ignored) {
         }
 
         assertThrows(CancellationException.class, job::join);
@@ -120,7 +120,7 @@ public class JobTimeoutTest extends JetTestSupport {
             job.suspend();
 
             assertJobStatusEventually(job, SUSPENDED);
-        } catch (Throwable ignored) {
+        } catch (AssertionError | IllegalStateException ignored) {
         }
         assertThrows(CancellationException.class, job::join);
         assertEquals(FAILED, job.getStatus());


### PR DESCRIPTION
Catch the error and ignore it if the job times out before or during suspend() resume() operation
The test will fail if the error is not caught.
If the error is caught and ignored then the job should eventually fail with CancellationException

Fixes : https://github.com/hazelcast/hazelcast/issues/25362

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
