### PR TITLE
`HttpsRestTest` test failure - `java.net.http.HttpClient` misconfiguration

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -49,7 +49,6 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -139,7 +138,8 @@ public class HTTPCommunicator {
         @Override
         public void checkServerTrusted(final X509Certificate[] c, final String a) {
         }
-    }};
+    }
+    };
 
     private final String address;
     private final boolean sslEnabled;
@@ -555,7 +555,7 @@ public class HTTPCommunicator {
                     .POST(HttpRequest.BodyPublishers.ofString(data))
                     .build();
         }
-        try {            
+        try {
             // Send the request and get the response
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -16,27 +16,19 @@
 
 package com.hazelcast.internal.ascii;
 
-import static com.hazelcast.instance.EndpointQualifier.REST;
-import static com.hazelcast.test.Accessors.getNode;
-
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.config.AdvancedNetworkConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.ascii.rest.HttpCommandProcessor;
-import com.hazelcast.internal.util.collection.ArrayUtils;
 import com.hazelcast.logging.ILogger;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509ExtendedTrustManager;
-
 import java.io.IOException;
-import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -45,13 +37,15 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.logging.Level;
+
+import static com.hazelcast.instance.EndpointQualifier.REST;
+import static com.hazelcast.test.Accessors.getNode;
 
 @SuppressWarnings("SameParameterValue")
 public class HTTPCommunicator {
@@ -107,39 +101,6 @@ public class HTTPCommunicator {
     public static final String URI_CONFIG_RELOAD = "config/reload";
     public static final String URI_CONFIG_UPDATE = "config/update";
     public static final String URI_TCP_IP_MEMBER_LIST = "config/tcp-ip/member-list";
-
-    /** Replacement for SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER */
-    private static final TrustManager[] ALLOW_ALL_HOSTNAME_TRUST_MANAGER = new TrustManager[] {new X509ExtendedTrustManager() {
-        @Override
-        public void checkClientTrusted(final X509Certificate[] chain, final String authType, final Socket socket) {
-        }
-
-        @Override
-        public void checkServerTrusted(final X509Certificate[] chain, final String authType, final Socket socket) {
-        }
-
-        @Override
-        public void checkClientTrusted(final X509Certificate[] chain, final String authType, final SSLEngine engine) {
-        }
-
-        @Override
-        public void checkServerTrusted(final X509Certificate[] chain, final String authType, final SSLEngine engine) {
-        }
-
-        @Override
-        public X509Certificate[] getAcceptedIssuers() {
-            return null;
-        }
-
-        @Override
-        public void checkClientTrusted(final X509Certificate[] c, final String a) {
-        }
-
-        @Override
-        public void checkServerTrusted(final X509Certificate[] c, final String a) {
-        }
-    }
-    };
 
     private final String address;
     private final boolean sslEnabled;
@@ -599,8 +560,7 @@ public class HTTPCommunicator {
             }
 
             try {
-                sslContext.init(clientKeyManagers, ArrayUtils.append(ALLOW_ALL_HOSTNAME_TRUST_MANAGER, clientTrustManagers),
-                        new SecureRandom());
+                sslContext.init(clientKeyManagers, clientTrustManagers, new SecureRandom());
             } catch (KeyManagementException e) {
                 throw new IOException(e);
             }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.internal.ascii;
 
+import static com.hazelcast.instance.EndpointQualifier.REST;
+import static com.hazelcast.test.Accessors.getNode;
+
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.config.AdvancedNetworkConfig;
 import com.hazelcast.config.SSLConfig;
@@ -46,12 +49,10 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.logging.Level;
-
-import static com.hazelcast.instance.EndpointQualifier.REST;
-import static com.hazelcast.test.Accessors.getNode;
 
 @SuppressWarnings("SameParameterValue")
 public class HTTPCommunicator {
@@ -109,7 +110,7 @@ public class HTTPCommunicator {
     public static final String URI_TCP_IP_MEMBER_LIST = "config/tcp-ip/member-list";
 
     /** Replacement for SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER */
-    private static final TrustManager[] DISTRUST_MANAGER = new TrustManager[] {new X509ExtendedTrustManager() {
+    private static final TrustManager[] ALLOW_ALL_HOSTNAME_TRUST_MANAGER = new TrustManager[] {new X509ExtendedTrustManager() {
         @Override
         public void checkClientTrusted(final X509Certificate[] chain, final String authType, final Socket socket) {
         }
@@ -554,7 +555,7 @@ public class HTTPCommunicator {
                     .POST(HttpRequest.BodyPublishers.ofString(data))
                     .build();
         }
-        try {
+        try {            
             // Send the request and get the response
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
@@ -598,7 +599,7 @@ public class HTTPCommunicator {
             }
 
             try {
-                sslContext.init(clientKeyManagers, ArrayUtils.append(DISTRUST_MANAGER, clientTrustManagers),
+                sslContext.init(clientKeyManagers, ArrayUtils.append(ALLOW_ALL_HOSTNAME_TRUST_MANAGER, clientTrustManagers),
                         new SecureRandom());
             } catch (KeyManagementException e) {
                 throw new IOException(e);


### PR DESCRIPTION
In #25418, Apache's HttpClient was replaced with the java.net one.

This has caused a test failure.

Specifically:
- `com.hazelcast.internal.ascii.HTTPCommunicator.doPost(String, String...)` is doing `HttpClient.newHttpClient()`, not `newClient()`, so SSL configuration is not being used. This is obviously an easy fix.

- The `SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER` configuration has been removed and not replaced. Resolved by moving this configuration to the `HttpsRestTest` EE test instead, as already done in `EnterpriseInvalidEndpointTest` (and done in such a way it's shared).

Breaking changes (list specific methods/types/messages):
* `com.hazelcast.internal.ascii.HTTPCommunicator` (this is a **`test`** class) no longer allows certificates with mismatched hostnames, although this behaviour [was never documented](https://github.com/hazelcast/hazelcast/pull/25434#issuecomment-1718264532).

EE PR: [#6486](https://github.com/hazelcast/hazelcast-enterprise/pull/6486)

Fixes [#6485 (EE)](https://github.com/hazelcast/hazelcast-enterprise/issues/6485)