### PR TITLE
Disable host name verification when creating http client.  [HZ-3087]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -474,7 +474,7 @@ public class HTTPCommunicator {
             HttpResponse<String> httpResponse = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             return new ConnectionResponse(httpResponse);
         } catch (InterruptedException exception) {
-            throw  new IOException(exception);
+            throw new IOException(exception);
         }
     }
 
@@ -496,7 +496,7 @@ public class HTTPCommunicator {
     public ConnectionResponse doPost(String url, String... params) throws IOException {
         logRequest("POST", url);
         // Create an HttpClient instance
-        HttpClient httpClient = HttpClient.newHttpClient();
+        HttpClient httpClient = newClient();
 
         // Prepare the request body
         String data = String.join("&", params);
@@ -571,8 +571,20 @@ public class HTTPCommunicator {
         // configure timeout on the entire client
         int timeout = 20;
         builder.connectTimeout(Duration.ofSeconds(timeout));
-        return builder
-                .build();
+
+        // Disable host name verification in the certificate
+        final String propertyName = "jdk.internal.httpclient.disableHostnameVerification";
+        final String value = System.setProperty(propertyName, Boolean.TRUE.toString());
+        try {
+            return builder
+                    .build();
+        } finally {
+            if (value == null) {
+                System.clearProperty(propertyName);
+            } else {
+                System.setProperty(propertyName, value);
+            }
+        }
     }
 
     public ConnectionResponse headRequestToMapURI() throws IOException {


### PR DESCRIPTION
When converting from Apache to Java Http client the disabling host name verification was overlooked. It was causing test failures when using self signed certificates.

Fixes [#6485 (EE)](https://github.com/hazelcast/hazelcast-enterprise/issues/6485)

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
