### PR TITLE
Close InputStream in JetClassLoader and some tests  [HZ-3146]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.impl.deployment;
 
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.impl.util.Util;
@@ -27,6 +26,7 @@ import com.hazelcast.spi.impl.NodeEngine;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -40,7 +40,6 @@ import java.util.zip.InflaterInputStream;
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.JobRepository.classKeyName;
 import static com.hazelcast.jet.impl.util.ReflectionUtils.toClassResourceId;
-import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 
 public class JetClassLoader extends JetDelegatingClassLoader {
 
@@ -74,14 +73,17 @@ public class JetClassLoader extends JetDelegatingClassLoader {
         if (isEmpty(name)) {
             return null;
         }
-        InputStream classBytesStream = resourceStream(toClassResourceId(name));
-        if (classBytesStream == null) {
-            throw new ClassNotFoundException(name + ". Add it using " + JobConfig.class.getSimpleName()
-                    + " or start all members with it on classpath");
+        try (InputStream classBytesStream = resourceStream(toClassResourceId(name))) {
+            if (classBytesStream == null) {
+                throw new ClassNotFoundException(name + ". Add it using " + JobConfig.class.getSimpleName()
+                                                 + " or start all members with it on classpath");
+            }
+            byte[] classBytes = classBytesStream.readAllBytes();
+            definePackage(name);
+            return defineClass(name, classBytes, 0, classBytes.length);
+        } catch (IOException exception) {
+            throw new ClassNotFoundException("Error reading class data: " + name, exception);
         }
-        byte[] classBytes = uncheckCall(() -> IOUtil.toByteArray(classBytesStream));
-        definePackage(name);
-        return defineClass(name, classBytes, 0, classBytes.length);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlYamlClientConfigBuilderEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlYamlClientConfigBuilderEqualsTest.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -117,7 +118,7 @@ public class XmlYamlClientConfigBuilderEqualsTest {
     private String readResourceToString(String resource) throws IOException {
         try (InputStream xmlInputStream = getClass().getClassLoader().getResourceAsStream(resource)) {
             assert xmlInputStream != null;
-            return new String(xmlInputStream.readAllBytes());
+            return new String(xmlInputStream.readAllBytes(), UTF_8);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/config/XmlYamlClientConfigBuilderEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/config/XmlYamlClientConfigBuilderEqualsTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.config;
 
 import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -116,8 +115,10 @@ public class XmlYamlClientConfigBuilderEqualsTest {
     }
 
     private String readResourceToString(String resource) throws IOException {
-        InputStream xmlInputStream = getClass().getClassLoader().getResourceAsStream(resource);
-        return new String(IOUtil.toByteArray(xmlInputStream));
+        try (InputStream xmlInputStream = getClass().getClassLoader().getResourceAsStream(resource)) {
+            assert xmlInputStream != null;
+            return new String(xmlInputStream.readAllBytes());
+        }
     }
 
     private static ClientConfig buildConfigFromXml(String xml) {

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
@@ -127,8 +127,10 @@ public class XmlYamlConfigBuilderEqualsTest extends HazelcastTestSupport {
     }
 
     public static String readResourceToString(String resource) throws IOException {
-        InputStream xmlInputStream = XmlYamlConfigBuilderEqualsTest.class.getClassLoader().getResourceAsStream(resource);
-        return new String(IOUtil.toByteArray(xmlInputStream));
+        try (InputStream xmlInputStream = XmlYamlConfigBuilderEqualsTest.class.getClassLoader().getResourceAsStream(resource)) {
+            assert xmlInputStream != null;
+            return new String(xmlInputStream.readAllBytes());
+        }
     }
 
     static File createPasswordFile(String passwordFileName, String passwordFileContent) throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
@@ -33,6 +33,7 @@ import java.util.Comparator;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -129,7 +130,7 @@ public class XmlYamlConfigBuilderEqualsTest extends HazelcastTestSupport {
     public static String readResourceToString(String resource) throws IOException {
         try (InputStream xmlInputStream = XmlYamlConfigBuilderEqualsTest.class.getClassLoader().getResourceAsStream(resource)) {
             assert xmlInputStream != null;
-            return new String(xmlInputStream.readAllBytes());
+            return new String(xmlInputStream.readAllBytes(), UTF_8);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.util;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.portable.PortableHook;
 import com.hazelcast.nio.serialization.ClassDefinition;
@@ -65,7 +64,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.hazelcast.internal.nio.IOUtil.toByteArray;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -661,22 +659,15 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
 
         private byte[] loadBytecodeFromParent(String className) {
             String resource = className.replace('.', '/').concat(".class");
-            InputStream is = null;
-            try {
-                is = parent.getResourceAsStream(resource);
+            try (InputStream is = parent.getResourceAsStream(resource)) {
                 if (is != null) {
-                    try {
-                        return toByteArray(is);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
+                    return is.readAllBytes();
                 }
-            } finally {
-                IOUtil.closeResource(is);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
             return null;
         }
-
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/nio/ClassLoaderUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ClassLoaderUtilTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.nio;
 
 import com.hazelcast.internal.nio.ClassLoaderUtil;
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -27,6 +26,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -74,8 +74,9 @@ public class ClassLoaderUtilTest extends HazelcastTestSupport {
             @Override
             protected Class<?> findClass(String name) throws ClassNotFoundException {
                 if (name.equals("mock.Class")) {
-                    try {
-                        byte[] classData = IOUtil.toByteArray(getClass().getResourceAsStream("mock-class-data.dat"));
+                    try (InputStream inputStream = getClass().getResourceAsStream("mock-class-data.dat")) {
+                        assert inputStream != null;
+                        byte[] classData = inputStream.readAllBytes();
                         return defineClass(name, classData, 0, classData.length);
                     } catch (IOException e) {
                         throw new RuntimeException(e);


### PR DESCRIPTION
The InputStream for reading resources need to be closed

This PR fixes some tests but most important it also fixes JetClassLoader

Please review JetClassLoader carefully

Jira : https://hazelcast.atlassian.net/browse/HZ-3146


Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible