### PR TITLE
Fix HazelcastVersionLocator Maven repository lookup test failure

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
@@ -18,17 +18,6 @@ package com.hazelcast.test.starter;
 
 import static com.hazelcast.internal.util.Preconditions.checkState;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.internal.impl.DefaultLocalRepositoryProvider;
@@ -41,33 +30,52 @@ import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.util.OsHelper;
 import com.hazelcast.version.Version;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 public class HazelcastVersionLocator {
     public enum Artifact {
-        OS_JAR(false, false, "hazelcast"),
-        OS_TEST_JAR(false, true, "hazelcast"),
-        SQL_JAR(false, false, "hazelcast-sql"),
-        EE_JAR(true, false, "hazelcast-enterprise");
+        OS_JAR(false, false, "hazelcast", "OS"),
+        OS_TEST_JAR(false, true, "hazelcast", "OS tests"),
+        SQL_JAR(false, false, "hazelcast-sql", "SQL"),
+        EE_JAR(true, false, "hazelcast-enterprise", "EE");
 
         private static final String GROUP_ID = "com.hazelcast";
+        private static final Path MAVEN_REPOSITORY;
         private static final LocalRepositoryManager REPOSITORY_MANAGER;
 
         static {
             try {
-                // https://stackoverflow.com/a/16218772
-                // Ideally you'd run this using the maven-invoker plugin, but I couldn't get this to work -
-                // https://stackoverflow.com/q/76866880
-                final Process process = new ProcessBuilder(getMvn(), "help:evaluate", "-Dexpression=settings.localRepository",
-                        "--quiet", "--batch-mode", "-DforceStdout").start();
+                final DefaultLocalRepositoryProvider repositoryProvider = new DefaultLocalRepositoryProvider();
 
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                    final DefaultLocalRepositoryProvider repositoryProvider = new DefaultLocalRepositoryProvider();
+                repositoryProvider.setLocalRepositoryManagerFactories(
+                        Collections.singletonList(new SimpleLocalRepositoryManagerFactory()));
 
-                    repositoryProvider.setLocalRepositoryManagerFactories(
-                            Collections.singletonList(new SimpleLocalRepositoryManagerFactory()));
+                // You can query this dynamically with the command:
+                // mvn help:evaluate -Dexpression=settings.localRepository --quiet --batch-mode -DforceStdout
+                //
+                // But can be problematic to parse when additional VM arguments print logging information to stdout as well
+                // https://github.com/hazelcast/hazelcast/issues/25451
+                MAVEN_REPOSITORY = Paths.get(System.getProperty("user.home")).resolve(".m2").resolve("repository");
 
-                    final LocalRepository localRepo = new LocalRepository(reader.readLine());
+                if (Files.exists(MAVEN_REPOSITORY)) {
+                    final LocalRepository localRepo = new LocalRepository(MAVEN_REPOSITORY.toFile());
                     REPOSITORY_MANAGER = repositoryProvider.newLocalRepositoryManager(MavenRepositorySystemUtils.newSession(),
                             localRepo);
+                } else {
+                    throw new NoSuchFileException(MAVEN_REPOSITORY.toString(), null, "Maven repository");
                 }
             } catch (final IOException | NoLocalRepositoryManagerException e) {
                 throw new RuntimeException(e);
@@ -77,25 +85,33 @@ public class HazelcastVersionLocator {
         private final boolean enterprise;
         private final boolean test;
         private final String artifactId;
+        private final String label;
 
-        Artifact(final boolean enterprise, final boolean test, final String artifactId) {
+        Artifact(final boolean enterprise, final boolean test, final String artifactId, final String label) {
             this.enterprise = enterprise;
             this.test = test;
             this.artifactId = artifactId;
+            this.label = label;
         }
 
         private org.eclipse.aether.artifact.Artifact toAetherArtifact(final String version) {
             return new DefaultArtifact(GROUP_ID, artifactId, test ? "tests" : null, null, version);
         }
 
-        /** @return a path to the artifact in the local Maven repository, downloading if required */
-        private File locateArtifact(final String version) {
-            final File localCopy = new File(REPOSITORY_MANAGER.getRepository().getBasedir(),
-                    REPOSITORY_MANAGER.getPathForLocalArtifact(toAetherArtifact(version)) + ".jar");
+        /** @return a {@link Path} to the artifact in the local Maven repository, downloading if required */
+        private Path locateArtifact(final String version) {
+            final Path localCopy = MAVEN_REPOSITORY
+                    .resolve(REPOSITORY_MANAGER.getPathForLocalArtifact(toAetherArtifact(version)) + ".jar");
 
-            if (!localCopy.exists()) {
+            if (!Files.exists(localCopy)) {
                 downloadArtifact(version);
+
+                if (!Files.exists(localCopy)) {
+                    throw new UncheckedIOException(new NoSuchFileException(localCopy.toString(), null,
+                            MessageFormat.format("{0} (version \"{1}\") not found after download", this, version)));
+                }
             }
+
             return localCopy;
         }
 
@@ -112,7 +128,8 @@ public class HazelcastVersionLocator {
                 checkState(successful, "Maven dependency:get timed out");
                 checkState(process.exitValue() == 0, "Maven dependency:get failed");
             } catch (InterruptedException | IOException e) {
-                throw new RuntimeException("Problem in invoking Maven dependency:get " + toString() + ":" + version, e);
+                throw new RuntimeException(
+                        MessageFormat.format("Problem in invoking Maven dependency:get {0}:{1}", this, version), e);
             }
         }
 
@@ -138,6 +155,11 @@ public class HazelcastVersionLocator {
 
             return builder.build();
         }
+
+        @Override
+        public String toString() {
+            return label;
+        }
     }
 
     public static Map<Artifact, File> locateVersion(final String version, final boolean enterprise) {
@@ -150,6 +172,7 @@ public class HazelcastVersionLocator {
         if (enterprise) {
             files.add(Artifact.EE_JAR);
         }
-        return files.build().collect(Collectors.toMap(Function.identity(), artifact -> artifact.locateArtifact(version)));
+        return files.build()
+                .collect(Collectors.toMap(Function.identity(), artifact -> artifact.locateArtifact(version).toFile()));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
@@ -16,57 +16,67 @@
 
 package com.hazelcast.test.starter.test;
 
-import com.google.common.hash.HashCode;
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hashing;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.SlowTest;
-import com.hazelcast.test.starter.HazelcastVersionLocator;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-
-import java.io.File;
-import java.util.Map;
-
-import static com.google.common.io.Files.toByteArray;
 import static com.hazelcast.test.starter.HazelcastVersionLocator.Artifact.EE_JAR;
 import static com.hazelcast.test.starter.HazelcastVersionLocator.Artifact.OS_JAR;
 import static com.hazelcast.test.starter.HazelcastVersionLocator.Artifact.OS_TEST_JAR;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-@SuppressWarnings("UnstableApiUsage")
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({SlowTest.class, ParallelJVMTest.class})
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.starter.HazelcastVersionLocator;
+import com.hazelcast.test.starter.HazelcastVersionLocator.Artifact;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * TODO This test doesn't force a re-download, so if an artifact is cached in the local repository, the download won't be
+ * exercised. It's difficult to modify the local Maven repository as it's not encapsulated for the scope of testing
+ */
+@RunWith(HazelcastParametrizedRunner.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class HazelcastVersionLocatorTest {
+    private static HashFunction hashFunction;
+    private static Map<HazelcastVersionLocator.Artifact, File> files;
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
-
-    @SuppressWarnings("deprecation")
-    private final HashFunction md5Hash = Hashing.md5();
-
-    @Test
-    public void testDownloadVersion() throws Exception {
-        // TODO This test doesn't force a re-download, so if an artifact is cached in the local repository, the download won't
-        // be excercised. It's difficult to modify the local Maven repository as it's not encapsulated for the scope of testing
-        final Map<HazelcastVersionLocator.Artifact, File> files = HazelcastVersionLocator.locateVersion("4.0", true);
-
-        assertHash(files.get(OS_JAR), "bc409b12b96ece6d05c3bd1e99b202bb", "OS");
-
-        assertHash(files.get(OS_TEST_JAR), "220509ece9fc152525c91ba7c75ce600", "OS tests");
-
-        assertHash(files.get(EE_JAR), "765816e628ca4ca57d5bd7387e761eaa", "EE");
+    @BeforeClass
+    public static void setUp() {
+        hashFunction = Hashing.crc32c();
+        files = HazelcastVersionLocator.locateVersion("4.0", true);
     }
 
-    private void assertHash(final File file, final String expectedHash, final String label) throws Exception {
-        assertTrue("File \"" + file + "\" not found", file.exists());
-        final byte[] memberBytes = toByteArray(file);
-        final HashCode memberHash = md5Hash.hashBytes(memberBytes);
-        assertEquals("Expected hash of Hazelcast " + label + " JAR to be " + expectedHash, expectedHash, memberHash.toString());
+    @Parameter(0)
+    public Artifact artifact;
+
+    @Parameter(1)
+    public String expectedHash;
+
+    @Parameters(name = "artifact: {0}")
+    public static Collection<Object[]> parameters() {
+        return List.of(new Object[] {OS_JAR, "4db18099"}, new Object[] {OS_TEST_JAR, "80f97565"},
+                new Object[] {EE_JAR, "806220c1"});
+    }
+
+    @Test
+    public void testDownloadVersion() throws IOException {
+        final File file = files.get(artifact);
+        final HashCode memberHash = Files.asByteSource(file).hash(hashFunction);
+        assertEquals(MessageFormat.format("Expected hash of Hazelcast {0} JAR to be {1}", artifact, expectedHash), expectedHash,
+                memberHash.toString());
     }
 }


### PR DESCRIPTION
As part of #25178, `HazelcastVersionLocator` was refactored to dynamically lookup the Maven repository location using a Maven command, rather than a hardcoded value.

[Due to extra VM arguments in one of the test instances, this lookup is returning a result that's not being parsed correctly](https://github.com/hazelcast/hazelcast/issues/25451#issuecomment-1720248676).

- Rolled back to using a hardcoded Maven repository location
- Added more error handling to give better error messages for missing files or directories
- Refactored the code to use `java.nio.Path` over `java.util.File` (again for better error messages)
- Refactored the test
   - Split the one test into a parameterized version so can be executed in parallel
   - Replaced `Hashing.md5()` with non-deprecated hashing function
   - Used a Guava's `bytesource` to avoid having to explicitly load the entire JAR into memory (by abstracting this out, Guava are free to implement the hashing function in whatever way they deem most performant).

Fixes #25451 / [HZ-3144](https://hazelcast.atlassian.net/browse/HZ-3144)

[HZ-3144]: https://hazelcast.atlassian.net/browse/HZ-3144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ