### PR TITLE
Ask for replica sync if offloaded backup fails [HZ-3147]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/UtilSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/UtilSteps.java
@@ -16,10 +16,15 @@
 
 package com.hazelcast.map.impl.operation.steps;
 
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.partition.PartitionReplicaVersionManager;
+import com.hazelcast.internal.services.ServiceNamespace;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.steps.engine.State;
 import com.hazelcast.map.impl.operation.steps.engine.Step;
 import com.hazelcast.map.impl.operation.steps.engine.StepResponseUtil;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.BackupOperation;
 import com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
@@ -70,7 +75,35 @@ public enum UtilSteps implements IMapOpStep {
                 operationRunner.handleOperationError(state.getOperation(), state.getThrowable());
             } finally {
                 state.setThrowable(null);
+                markReplicaAsSyncRequiredForBackupOps(state);
             }
+        }
+
+        /**
+         * When backup operation fails with an exception,
+         * we need to mark replica as sync required
+         * otherwise data inconsistencies can happen.
+         */
+        private void markReplicaAsSyncRequiredForBackupOps(State state) {
+            MapOperation operation = state.getOperation();
+            if (!(operation instanceof BackupOperation)) {
+                return;
+            }
+
+            PartitionReplicaVersionManager versionManager = getPartitionReplicaVersionManager(state);
+
+            int partitionId = state.getPartitionId();
+            ServiceNamespace namespace = versionManager.getServiceNamespace(operation);
+            int replicaIndex = operation.getReplicaIndex();
+
+            versionManager.markPartitionReplicaAsSyncRequired(partitionId, namespace, replicaIndex);
+        }
+
+        private PartitionReplicaVersionManager getPartitionReplicaVersionManager(State state) {
+            NodeEngineImpl nodeEngine = ((NodeEngineImpl) state.getRecordStore()
+                    .getMapContainer().getMapServiceContext().getNodeEngine());
+            InternalPartitionService partitionService = nodeEngine.getPartitionService();
+            return partitionService.getPartitionReplicaVersionManager();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.ThreadUtil;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.operation.BaseRemoveOperation;
 import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
 import com.hazelcast.map.impl.operation.steps.RemoveOpSteps;
@@ -30,11 +31,13 @@ import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.operationservice.BackupOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParametrizedRunner;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -42,19 +45,35 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.Collection;
+
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParametrizedRunner.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MapRemoveFailingBackupTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameters(name = "offload: {0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {true},
+                {false}
+        });
+    }
+
+    @Parameterized.Parameter
+    public boolean offload;
 
     @Test
     public void testMapRemoveFailingBackupShouldNotLeadToStaleDataWhenReadBackupIsEnabled() {
@@ -65,6 +84,7 @@ public class MapRemoveFailingBackupTest extends HazelcastTestSupport {
         Config config = getConfig();
         config.getSerializationConfig().addDataSerializableFactory(100, new Factory());
         config.setProperty(ClusterProperty.PARTITION_BACKUP_SYNC_INTERVAL.getName(), "5");
+        config.setProperty(MapServiceContext.PROP_FORCE_OFFLOAD_ALL_OPERATIONS, String.valueOf(offload));
         config.getMapConfig(mapName).setReadBackupData(true);
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);
@@ -169,7 +189,8 @@ public class MapRemoveFailingBackupTest extends HazelcastTestSupport {
         }
     }
 
-    private static class ExceptionThrowingRemoveBackupOperation extends KeyBasedMapOperation {
+    private static class ExceptionThrowingRemoveBackupOperation
+            extends KeyBasedMapOperation implements BackupOperation {
 
         private ExceptionThrowingRemoveBackupOperation() {
         }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/25158

This PR continuation of the fixes here: https://github.com/hazelcast/hazelcast/pull/24280
The missing part was when offloaded-backup-op fails, replica sync was not aware. This PR asks for replica sync if an offloaded-backup-op fails. There is no problem with not-offloaded-backup-ops, they are workign correctly.
