### PR TITLE
Replace IOUtil.getPath with JDK Paths.get [HZ-3151]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
@@ -18,6 +18,9 @@ package com.hazelcast.internal.nearcache.impl.preloader;
 
 import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
+import com.hazelcast.internal.monitor.impl.NearCacheStatsImpl;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.util.BufferingInputStream;
 import com.hazelcast.internal.util.Timer;
@@ -26,9 +29,6 @@ import com.hazelcast.internal.util.collection.InflatableSet.Builder;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.memory.MemoryUnit;
-import com.hazelcast.internal.monitor.impl.NearCacheStatsImpl;
-import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -36,6 +36,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Paths;
 import java.util.Iterator;
 
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
@@ -43,7 +44,6 @@ import static com.hazelcast.internal.nio.Bits.readIntB;
 import static com.hazelcast.internal.nio.Bits.writeIntB;
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
 import static com.hazelcast.internal.nio.IOUtil.deleteQuietly;
-import static com.hazelcast.internal.nio.IOUtil.getPath;
 import static com.hazelcast.internal.nio.IOUtil.readFullyOrNothing;
 import static com.hazelcast.internal.nio.IOUtil.rename;
 import static com.hazelcast.internal.nio.IOUtil.toFileName;
@@ -296,6 +296,6 @@ public class NearCachePreloader<K> {
         if (isNullOrEmpty(directory)) {
             return filename;
         }
-        return getPath(directory, filename);
+        return Paths.get(directory, filename).toString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -643,33 +643,6 @@ public final class IOUtil {
         return name.replaceAll("[:\\\\/*\"?|<>',]", "_");
     }
 
-    /**
-     * Concatenates path parts to a single path using the {@link File#separator} where it applies.
-     * There is no validation done on the newly formed path.
-     *
-     * @param parts The path parts that together should form a path
-     * @return The path formed using the parts
-     * @throws IllegalArgumentException if the parts param is null or empty
-     */
-    public static String getPath(String... parts) {
-        if (parts == null || parts.length == 0) {
-            throw new IllegalArgumentException("Parts is null or empty.");
-        }
-
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < parts.length; i++) {
-            String part = parts[i];
-            builder.append(part);
-
-            boolean hasMore = i < parts.length - 1;
-            if (!part.endsWith(File.separator) && hasMore) {
-                builder.append(File.separator);
-            }
-        }
-
-        return builder.toString();
-    }
-
     public static File getFileFromResources(String resourceFileName) {
         try {
             URL resource = IOUtil.class.getClassLoader().getResource(resourceFileName);

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -66,7 +66,6 @@ import static com.hazelcast.internal.nio.IOUtil.decompress;
 import static com.hazelcast.internal.nio.IOUtil.delete;
 import static com.hazelcast.internal.nio.IOUtil.deleteQuietly;
 import static com.hazelcast.internal.nio.IOUtil.getFileFromResources;
-import static com.hazelcast.internal.nio.IOUtil.getPath;
 import static com.hazelcast.internal.nio.IOUtil.newInputStream;
 import static com.hazelcast.internal.nio.IOUtil.newOutputStream;
 import static com.hazelcast.internal.nio.IOUtil.readFully;
@@ -81,7 +80,6 @@ import static com.hazelcast.internal.serialization.impl.SerializationUtil.create
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static java.lang.Integer.min;
-import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 import static java.nio.file.StandardOpenOption.CREATE;
@@ -794,16 +792,6 @@ public class IOUtilTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testGetPath_shouldFormat() {
-        String root = "root";
-        String parent = "parent";
-        String child = "child";
-        String expected = format("%s%s%s%s%s", root, File.separator, parent, File.separator, child);
-        String actual = getPath(root, parent, child);
-        assertEquals(expected, actual);
-    }
-
-    @Test
     public void testMove_targetDoesntExist() throws IOException {
         Path src = tempFolder.newFile("source.txt").toPath();
         Path target = src.resolveSibling("target.txt");
@@ -828,11 +816,6 @@ public class IOUtilTest extends HazelcastTestSupport {
         Files.delete(src);
         Path target = src.resolveSibling("target.txt");
         Assert.assertThrows(NoSuchFileException.class, () -> IOUtil.move(src, target));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetPath_whenPathsInvalid() {
-        getPath();
     }
 
     private File newFile(String filename) {


### PR DESCRIPTION
Java already provides the same functionality 

Jira : https://hazelcast.atlassian.net/browse/HZ-3151

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible