### PR TITLE
Use tmpfs for MySQL database provider [HZ-2430]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/MySQLDatabaseProvider.java
@@ -20,6 +20,7 @@ import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.Network;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import static java.util.stream.Collectors.joining;
 
@@ -40,7 +41,11 @@ public class MySQLDatabaseProvider implements TestDatabaseProvider {
                 .withDatabaseName(dbName)
                 .withUsername("root")
                 .withUrlParam("user", "root")
-                .withUrlParam("password", "test");
+                .withUrlParam("password", "test")
+                .withTmpFs(Map.of(
+                        "/var/lib/mysql/", "rw",
+                        "/tmp/", "rw"
+                ));
         container.start();
         String jdbcUrl = container.getJdbcUrl();
         waitForDb(jdbcUrl, LOGIN_TIMEOUT);


### PR DESCRIPTION
The test inserts 10k items in 10 iterations. This results in 10k transactions, and MySQL in a Docker container is slow when committing the transactions.

This commit uses tmpfs for the database filesystem, effectively running it in memory. Provides roughly 10x speedup on my local machine.

Fixes #24549

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
