### PR TITLE
Replace IOUtil.toByteArray with JDK readAllBytes [HZ-3145]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientUserCodeDeploymentService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientUserCodeDeploymentService.java
@@ -40,7 +40,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
-import static com.hazelcast.internal.nio.IOUtil.toByteArray;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 
 public class ClientUserCodeDeploymentService {
@@ -68,18 +67,14 @@ public class ClientUserCodeDeploymentService {
     private void loadClasses() throws ClassNotFoundException {
         for (String className : clientUserCodeDeploymentConfig.getClassNames()) {
             String resource = className.replace('.', '/').concat(".class");
-            InputStream is = null;
-            try {
-                is = configClassLoader.getResourceAsStream(resource);
+            try (InputStream is = configClassLoader.getResourceAsStream(resource)) {
                 if (is == null) {
                     throw new ClassNotFoundException(resource);
                 }
-                byte[] bytes = toByteArray(is);
+                byte[] bytes = is.readAllBytes();
                 classDefinitionList.add(new AbstractMap.SimpleEntry<>(className, bytes));
             } catch (IOException e) {
                 ignore(e);
-            } finally {
-                closeResource(is);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config.replacer;
 
-import com.hazelcast.internal.nio.IOUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -103,11 +102,8 @@ public class EncryptionReplacer extends AbstractPbeReplacer {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             if (passwordFile != null) {
-                FileInputStream fis = new FileInputStream(passwordFile);
-                try {
-                    baos.write(IOUtil.toByteArray(fis));
-                } finally {
-                    IOUtil.closeResource(fis);
+                try (FileInputStream fis = new FileInputStream(passwordFile)) {
+                    fis.transferTo(baos);
                 }
             }
             if (passwordUserProperties) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -793,13 +793,6 @@ public final class IOUtil {
         }
     }
 
-    public static byte[] toByteArray(InputStream is) throws IOException {
-        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-            is.transferTo(os);
-            return os.toByteArray();
-        }
-    }
-
     public static void drainTo(InputStream input, OutputStream output) throws IOException {
         byte[] buffer = new byte[1024];
         int n;

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProvider.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.usercodedeployment.impl;
 
 import com.hazelcast.config.UserCodeDeploymentConfig;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.internal.nio.IOUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.internal.nio.IOUtil.toByteArray;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 
 /**
@@ -153,18 +151,12 @@ public final class ClassDataProvider {
 
     private byte[] loadBytecodeFromParent(String className) {
         String resource = className.replace('.', '/').concat(".class");
-        InputStream is = null;
-        try {
-            is = parent.getResourceAsStream(resource);
+        try (InputStream is = parent.getResourceAsStream(resource)) {
             if (is != null) {
-                try {
-                    return toByteArray(is);
-                } catch (IOException e) {
-                    logger.severe(e);
-                }
+                return is.readAllBytes();
             }
-        } finally {
-            IOUtil.closeResource(is);
+        } catch (IOException e) {
+            logger.severe(e);
         }
         return null;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Set;
 
-import static com.hazelcast.internal.nio.IOUtil.toByteArray;
 import static com.hazelcast.test.compatibility.SamplingSerializationService.isTestClass;
 import static com.hazelcast.test.starter.HazelcastStarterUtils.debug;
 import static java.util.Collections.enumeration;
@@ -131,7 +130,7 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
             if (classInputStream != null) {
                 byte[] classBytes = null;
                 try {
-                    classBytes = toByteArray(classInputStream);
+                    classBytes = classInputStream.readAllBytes();
                 } catch (IOException e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
The same functionality exists in Java

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x ] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible