### PR TITLE
Update `README.md` badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Hazelcast
 
 [![Slack](https://img.shields.io/badge/slack-chat-green.svg)](https://slack.hazelcast.com/) 
-[![javadoc](https://javadoc.io/badge2/com.hazelcast/hazelcast/5.0/javadoc.svg)](https://javadoc.io/doc/com.hazelcast/hazelcast/5.0)
+[![javadoc](https://javadoc.io/badge2/com.hazelcast/hazelcast/latest/javadoc.svg)](https://javadoc.io/doc/com.hazelcast/hazelcast/latest)
 [![Docker pulls](https://img.shields.io/docker/pulls/hazelcast/hazelcast)](https://img.shields.io/docker/pulls/hazelcast/hazelcast)
-[![Total Alerts](https://img.shields.io/lgtm/alerts/g/hazelcast/hazelcast.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/hazelcast/hazelcast/alerts)
-[![Code Quality: Java](https://img.shields.io/lgtm/grade/java/g/hazelcast/hazelcast.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/hazelcast/hazelcast/context:java)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=hz-os-master&metric=alert_status)](https://sonarcloud.io/dashboard?id=hz-os-master)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=hazelcast_hazelcast&metric=alert_status)](https://sonarcloud.io/dashboard?id=hazelcast_hazelcast)
 
 ----
 


### PR DESCRIPTION
The badges in the `README.md` are outdated:
![image](https://github.com/hazelcast/hazelcast/assets/8626721/2acaac6f-1614-4f3d-94b4-7a327715d5c2)

- `javadoc` is linking to `5.0` (not `5.3`) - updated to `latest`
- `lgtm` was [closed in 2022](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/) - removed
- `quality gate` is linking to the wrong project ([`hz-os-master`](https://sonarcloud.io/project/overview?id=hz-os-master) hasn't been used since February 2023) - updated to `hazelcast_hazelcast` (of note - this is still failing the quality gate)