### PR TITLE
Test the emptiness of the list before assertion

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
@@ -550,7 +550,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
                 LINEARIZABLE);
 
         List<CPMember> activeEndpoints = f1.get();
-        assertThat(activeEndpoints).doesNotContain(endpoint);
+        assertThat(activeEndpoints).isNotEmpty().doesNotContain(endpoint);
 
         InternalCompletableFuture<CPGroup> f2 = invocationService.query(metadataGroupId, new GetRaftGroupOp(metadataGroupId),
                 LINEARIZABLE);
@@ -597,8 +597,8 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
         HazelcastInstance leader = getInstance(leaderNode.getLocalMember());
         CPGroup group3 = queryRaftGroupLocally(leader, groupId3);
         assertNotNull(group3);
-        assertThat(group3.members()).doesNotContain(endpoint3);
-        assertThat(group3.members()).doesNotContain(endpoint4);
+        assertThat(group3.members()).isNotEmpty().doesNotContain(endpoint3);
+        assertThat(group3.members()).isNotEmpty().doesNotContain(endpoint4);
 
         CPGroup group4 = queryRaftGroupLocally(leader, groupId4);
         assertNotNull(group4);


### PR DESCRIPTION
Issue found by Sonar analysis

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible