### PR TITLE
Correctly WAN replicate IMap metadata when updating existing records [HZ-3078]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1127,6 +1127,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             boolean persist = persistenceEnabledFor(provenance);
             updateRecord(record, key, oldValue, newValue, true, UNSET, UNSET, UNSET,
                     now, null, persist, true, false);
+            mergeRecordExpiration(key, record, mergingEntry, now);
             return MapMergeResponse.RECORD_UPDATED;
         }
     }


### PR DESCRIPTION
Prior to this commit, when an existing key was updated with a new value, the metadata of that operation was not replicated. I.e. if we called `IMap#put(1, 2)` then `IMap#put(1, 3, 60, TimeUnit.SECONDS)`, this 60s TTL metadata was not replicated. This applied to all operations that updated value and metadata in the same call (`IMap#set` with TTL,
 `IMap#put` with TTL, etc).

This commit introduces the simple fix of merging expiration metadata (the only metadata replicated by WAN) when we update existing records. This commit also introduces a number of new tests to ensure TTL is replicated correctly for all loaded methods.

Fixes https://hazelcast.atlassian.net/browse/HZ-3078
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6514
