### PR TITLE
Replace IOUtil#copyStream with Java [HZ-3171]

### DIFF
--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
@@ -40,7 +40,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.jet.impl.util.IOUtil.copyStream;
 import static com.hazelcast.jet.impl.util.Util.editPermissionsRecursively;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
@@ -192,7 +191,7 @@ class PythonServiceContext {
                     PythonServiceContext.class.getClassLoader().getResourceAsStream(fname), fname);
                  OutputStream out = Files.newOutputStream(destPath)
             ) {
-                copyStream(in, out);
+                in.transferTo(out);
             }
             if (EXECUTABLE_SCRIPTS.contains(fname)) {
                 makeExecutable(destPath);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/IOUtil.java
@@ -34,8 +34,6 @@ import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 
 public final class IOUtil {
 
-    private static final int BUFFER_SIZE = 1 << 14;
-
     private IOUtil() {
     }
 
@@ -85,18 +83,9 @@ public final class IOUtil {
     public static void packStreamIntoZip(
             @Nonnull InputStream source, @Nonnull OutputStream destination, @Nonnull String fileName
     ) throws IOException {
-        try (
-                ZipOutputStream dstZipStream = new ZipOutputStream(destination)
-        ) {
+        try (ZipOutputStream dstZipStream = new ZipOutputStream(destination)) {
             dstZipStream.putNextEntry(new ZipEntry(fileName));
-            copyStream(source, dstZipStream);
-        }
-    }
-
-    public static void copyStream(InputStream in, OutputStream out) throws IOException {
-        byte[] buf = new byte[BUFFER_SIZE];
-        for (int readCount; (readCount = in.read(buf)) > 0; ) {
-            out.write(buf, 0, readCount);
+            source.transferTo(dstZipStream);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/IMapInputOutputStreamTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/IMapInputOutputStreamTest.java
@@ -37,7 +37,6 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.ByteBuffer;
 
-import static com.hazelcast.jet.impl.util.IOUtil.copyStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -117,11 +116,10 @@ public class IMapInputOutputStreamTest extends SimpleTestInClusterSupport {
         IMap<String, byte[]> map = instance().getMap(randomMapName());
 
         // When
-        try (
-                InputStream in = resource.openStream();
-                IMapOutputStream ios = new IMapOutputStream(map, "test")
+        try (InputStream in = resource.openStream();
+             IMapOutputStream ios = new IMapOutputStream(map, "test")
         ) {
-            copyStream(in, ios);
+            in.transferTo(ios);
         }
 
         // Then
@@ -152,11 +150,10 @@ public class IMapInputOutputStreamTest extends SimpleTestInClusterSupport {
         IMap<String, byte[]> map = instance().getMap(randomMapName());
 
         // When
-        try (
-                InputStream inputStream = resource.openStream();
-                IMapOutputStream ios = new IMapOutputStream(map, "test")
+        try (InputStream inputStream = resource.openStream();
+             IMapOutputStream ios = new IMapOutputStream(map, "test")
         ) {
-            copyStream(inputStream, ios);
+            inputStream.transferTo(ios);
         }
 
         // Then


### PR DESCRIPTION
Java 11 provides transferTo method to copy InputStream to OutputStream

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible