### PR TITLE
Fix class name returned by custom StaticLoggerBinder

### DIFF
--- a/hazelcast-sql/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/hazelcast-sql/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -21,19 +21,24 @@ import org.slf4j.helpers.NOPLoggerFactory;
 import org.slf4j.spi.LoggerFactoryBinder;
 
 /**
- * Apache Calcite has a dependency on the {@code slf4j-api} artifact. In order to JAR hell in the runtime, we shade and
- * relocate the {@code slf4j-api} library into the {@code com.hazelcast} package during build.
+ * Apache Calcite has a dependency on the {@code slf4j-api} artifact. Due to JAR
+ * hell in the runtime, we shade and relocate the {@code slf4j-api} library into
+ * the {@code com.hazelcast} package during build.
  * <p>
- * SLF4J requires exactly one {@code StaticLoggerBinder} class to be in the JVM classpath. Otherwise a warning is printed
- * into the {@code System.err} unconditionally. See {@code LoggerFactory.bind} for more details.
+ * SLF4J requires exactly one {@code StaticLoggerBinder} class to be in the JVM
+ * classpath. Otherwise, a warning is printed into the {@code System.err}
+ * unconditionally. See {@link LoggerFactory#bind} for more details.
  * <p>
- * This class helps us get rid of the warning. During relocation both this class and {@code LoggerFactory} are moved to the
- * the {@code com.hazelcast} package. As a result the relocated factory finds the relocated binder and no warning is produced.
+ * This class helps us get rid of the warning. During relocation both this class and
+ * {@code LoggerFactory} are moved to the {@code com.hazelcast} package. As a result
+ * the relocated factory finds the relocated binder and no warning is produced.
  * <p>
- * At the same time, the normal SLF4J dependency still looks for the binder at the usual location, and therefore other runtime
- * classes that use SLF4J are not affected. That is, the current binder affects only the relocated Apache Calcite classes.
+ * At the same time, the normal SLF4J dependency still looks for the binder at the
+ * usual location, and therefore other runtime classes that use SLF4J are not affected.
+ * That is, the current binder affects only the relocated Apache Calcite classes.
  * <p>
- * The binder delegates to the no-op logger factory, suppressing all messages from the relocated Apache Calcite.
+ * The binder delegates to the no-op logger factory, suppressing all messages
+ * from the relocated Apache Calcite.
  */
 public class StaticLoggerBinder implements LoggerFactoryBinder {
 

--- a/hazelcast-sql/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/hazelcast-sql/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -50,6 +50,6 @@ public class StaticLoggerBinder implements LoggerFactoryBinder {
 
     @Override
     public String getLoggerFactoryClassStr() {
-        return StaticLoggerBinder.class.getName();
+        return NOPLoggerFactory.class.getName();
     }
 }


### PR DESCRIPTION
StaticLoggerBinder.getLoggerFactoryClassStr() should return class name of the logger factory, not of the binder.
Part of HZ-3195

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
