### PR TITLE
Remove ParallelJVM category from EventRegistrationTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/EventRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/EventRegistrationTest.java
@@ -27,7 +27,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Rule;

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/EventRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/EventRegistrationTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@Category({QuickTest.class})
 public class EventRegistrationTest extends HazelcastTestSupport {
 
     @Rule


### PR DESCRIPTION
This flag does not play well when HAZELCAST_TEST_USE_NETWORK is used in the same test. Identified in this comment from a separate PR: https://github.com/hazelcast/hazelcast/pull/17582#discussion_r1331230452

Fixes https://hazelcast.atlassian.net/browse/HZ-3205
