### PR TITLE
Make `StringUtil.isNullOrEmptyAfterTrim` use `String.isBlank`

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCacheManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCacheManager.java
@@ -111,7 +111,7 @@ public class HazelcastCacheManager implements CacheManager {
     }
 
     private void parseOptions(String options) {
-        if (StringUtil.isNullOrEmpty(options)) {
+        if (StringUtil.isNullOrEmptyAfterTrim(options)) {
             return;
         }
         for (String option : options.split(",")) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCacheManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCacheManager.java
@@ -18,6 +18,7 @@ package com.hazelcast.spring.cache;
 
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.map.IMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -110,7 +111,7 @@ public class HazelcastCacheManager implements CacheManager {
     }
 
     private void parseOptions(String options) {
-        if (null == options || options.trim().isEmpty()) {
+        if (StringUtil.isNullOrEmpty(options)) {
             return;
         }
         for (String option : options.split(",")) {

--- a/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -31,6 +31,7 @@ import com.hazelcast.instance.impl.HazelcastInstanceFactory.InstanceFuture;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.util.EmptyStatement;
 import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.internal.util.StringUtil;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -492,7 +493,7 @@ public final class HazelcastClient {
         } else {
             instanceName = failoverConfig.getClientConfigs().get(0).getInstanceName();
         }
-        if (instanceName == null || instanceName.trim().length() == 0) {
+        if (StringUtil.isNullOrEmptyAfterTrim(instanceName)) {
             instanceName = "hz.client_" + instanceNum;
         }
         return instanceName;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueStoreWrapper.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
@@ -246,7 +247,7 @@ public final class QueueStoreWrapper implements QueueStore<Data> {
 
     private static int parseInt(String name, int defaultValue, QueueStoreConfig storeConfig) {
         String val = storeConfig.getProperty(name);
-        if (val == null || val.trim().isEmpty()) {
+        if (StringUtil.isNullOrEmptyAfterTrim(val)) {
             return defaultValue;
         }
         try {

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/HazelcastInstanceFactory.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.jmx.ManagementService;
 import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.internal.util.ModularJavaUtils;
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.properties.ClusterProperty;
@@ -164,7 +165,7 @@ public final class HazelcastInstanceFactory {
     public static String getInstanceName(String instanceName, Config config) {
         String name = instanceName;
 
-        if (name == null || name.trim().length() == 0) {
+        if (StringUtil.isNullOrEmptyAfterTrim(name)) {
             name = createInstanceName(config);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/StringUtil.java
@@ -125,7 +125,7 @@ public final class StringUtil {
         if (s == null) {
             return true;
         }
-        return s.trim().isEmpty();
+        return s.isBlank();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
@@ -116,7 +116,7 @@ public final class IndexUtils {
         // Construct final index.
         String name = config.getName();
 
-        if (StringUtil.isNullOrEmpty(name)) {
+        if (StringUtil.isNullOrEmptyAfterTrim(name)) {
             name = null;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.BitmapIndexOptions.UniqueKeyTransformation;
 import com.hazelcast.config.ConfigXmlGenerator.XmlGenerator;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.memory.Capacity;
 import com.hazelcast.memory.MemoryUnit;
@@ -115,7 +116,7 @@ public final class IndexUtils {
         // Construct final index.
         String name = config.getName();
 
-        if (name != null && name.trim().isEmpty()) {
+        if (StringUtil.isNullOrEmpty(name)) {
             name = null;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
@@ -216,8 +216,6 @@ public class StringUtilTest extends HazelcastTestSupport {
     @Test
     public void isNotBlank() {
         assertFalse(StringUtil.isNullOrEmptyAfterTrim("string"));
-        // Non-breaking space
-        assertFalse(StringUtil.isNullOrEmptyAfterTrim(" "));
         // null unicode character
         assertFalse(StringUtil.isNullOrEmptyAfterTrim("\u0000"));
         // Non-breaking space

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
@@ -216,6 +216,9 @@ public class StringUtilTest extends HazelcastTestSupport {
     @Test
     public void isNotBlank() {
         assertTrue(!StringUtil.isNullOrEmptyAfterTrim("string"));
+        // Non-breaking space
+        assertTrue(!StringUtil.isNullOrEmptyAfterTrim(" "));
+
         assertFalse(!StringUtil.isNullOrEmptyAfterTrim("  "));
         assertFalse(!StringUtil.isNullOrEmptyAfterTrim(""));
         assertFalse(!StringUtil.isNullOrEmptyAfterTrim(null));

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
@@ -215,13 +215,22 @@ public class StringUtilTest extends HazelcastTestSupport {
 
     @Test
     public void isNotBlank() {
-        assertTrue(!StringUtil.isNullOrEmptyAfterTrim("string"));
+        assertFalse(StringUtil.isNullOrEmptyAfterTrim("string"));
         // Non-breaking space
-        assertTrue(!StringUtil.isNullOrEmptyAfterTrim(" "));
+        assertFalse(StringUtil.isNullOrEmptyAfterTrim(" "));
+        // null unicode character
+        assertFalse(StringUtil.isNullOrEmptyAfterTrim("\u0000"));
+        // Non-breaking space
+        assertFalse(StringUtil.isNullOrEmptyAfterTrim("\u00A0"));
 
-        assertFalse(!StringUtil.isNullOrEmptyAfterTrim("  "));
-        assertFalse(!StringUtil.isNullOrEmptyAfterTrim(""));
-        assertFalse(!StringUtil.isNullOrEmptyAfterTrim(null));
+        assertTrue(StringUtil.isNullOrEmptyAfterTrim("  "));
+        assertTrue(StringUtil.isNullOrEmptyAfterTrim(""));
+        // Em quad
+        assertTrue(StringUtil.isNullOrEmptyAfterTrim("\u2001"));
+        // Tab
+        assertTrue(StringUtil.isNullOrEmptyAfterTrim("\t"));
+        assertTrue(StringUtil.isNullOrEmptyAfterTrim("\n\r  "));
+        assertTrue(StringUtil.isNullOrEmptyAfterTrim(null));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/IndexCreateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/IndexCreateTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.IndexType;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceProxy;
+import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
@@ -239,7 +240,7 @@ public class IndexCreateTest extends HazelcastTestSupport {
     }
 
     private static String getExpectedName(IndexConfig config) {
-        if (config.getName() != null && !config.getName().trim().isEmpty()) {
+        if (!StringUtil.isNullOrEmptyAfterTrim(config.getName())) {
             return config.getName();
         }
 


### PR DESCRIPTION
`StringUtil.isNullOrEmptyAfterTrim` currently does `.trim().isEmpty()`

Java 11 introduced [`isBlank`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#isBlank()), which does broadly the same thing.

It's faster (in cases where a trim is required, at least), primarily by avoiding creating a new intermediate `trim`-med string.

Example JMH output:
```
Benchmark                                 (input)  Mode   Cnt     Score    Error   Units
.isBlank()                            " astring "  avgt  1000     1.780 ±  0.011   ns/op
.isBlank():gc.alloc.rate              " astring "  avgt  1000     0.046 ±  0.006  MB/sec

.isBlank()                               "string"  avgt  1000     1.041 ±  0.001   ns/op
.isBlank():gc.alloc.rate                 "string"  avgt  1000     0.046 ±  0.006  MB/sec

.trim().isEmpty()                     " astring "  avgt  1000     7.616 ±  0.022   ns/op
.trim().isEmpty():gc.alloc.rate       " astring "  avgt  1000  5974.203 ± 16.603  MB/sec

.trim().isEmpty()                        "string"  avgt  1000     0.952 ±  0.001   ns/op
.trim().isEmpty():gc.alloc.rate          "string"  avgt  1000     0.046 ±  0.006  MB/sec
```

There are some changes in behaviour, but only in edge cases:
- `\u0000` (null unicode character) was considered `NullOrEmpty`, but now isn't because it's not a whitespace character.
- `\u2001` (em quad) wasn't considered `NullOrEmpty`, but now is because it's a newer unicode space character.

I don't think either of these are an issue.

Summary of Changes
- Update implementation to use `.isBlank`
- Ensure the utility method is being used consistently

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6536