### PR TITLE
Fix test classes recognition in HazelcastAPIDelegatingClassloader [HZ-3206]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
@@ -162,6 +162,11 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
         if (!name.startsWith("com.hazelcast")) {
             return false;
         }
+        if (name.startsWith("com.hazelcast.shaded")) {
+            // test deps are not shaded but some of them might contain classes
+            // matching checks in isTestClass.
+            return false;
+        }
         return isTestClass(name);
     }
 


### PR DESCRIPTION
`isTestClass` method matches classes containing "Dummy" in their name. Some production classes, for example `com.hazelcast.shaded.com.google.common.collect.MapMakerInternalMap$WeakKeyDummyValueEntry$Helper` match this criterion. This caused `HazelcastAPIDelegatingClassloader` to load them in wrong classloader and that in turn caused compatibility test failures.

Fixes HZ-3206, https://github.com/hazelcast/hazelcast-enterprise/issues/6126

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6532

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible