### PR TITLE
Do not run MapDestroyTest.destroyRepeatedly in code coverage measurements [HZ-3220] [HZ-3219]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/MapDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapDestroyTest.java
@@ -32,9 +32,9 @@ import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -99,7 +99,7 @@ public class MapDestroyTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Category(SlowTest.class)
+    @Category(NightlyTest.class)
     public void destroyRepeatedly() {
         for (int rep = 0; rep < 1_000; ++rep) {
             createFillAndDestroyMap();


### PR DESCRIPTION
`MapDestroyTest.destroyRepeatedly` introduced in #25352 does not bring any additional value to code coverage and causes timeouts.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/6473, https://github.com/hazelcast/hazelcast-enterprise/issues/6498, https://github.com/hazelcast/hazelcast-enterprise/issues/6499, HZ-3220, HZ-3219

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
