### PR TITLE
Resolve Sonarlint `S4276 - Functional Interfaces should be as specialised as possible`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 
 /**
  * The client Engine.
@@ -156,9 +157,9 @@ public interface ClientEngine extends Consumer<ClientMessage> {
      */
     void onClientAcquiredResource(UUID uuid);
 
-    void addBackupListener(UUID clientUUID, Consumer<Long> backupListener);
+    void addBackupListener(UUID clientUUID, LongConsumer backupListener);
 
-    boolean deregisterBackupListener(UUID clientUUID, Consumer<Long> backupListener);
+    boolean deregisterBackupListener(UUID clientUUID, LongConsumer backupListener);
 
     void dispatchBackupEvent(UUID clientUUID, long clientCorrelationId);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -78,7 +78,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.stream.Collectors;
@@ -120,7 +119,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
     private final ClusterViewListenerService clusterListenerService;
     private final boolean advancedNetworkConfigEnabled;
     private final ClientLifecycleMonitor lifecycleMonitor;
-    private final Map<UUID, Consumer<Long>> backupListeners = new ConcurrentHashMap<>();
+    private final Map<UUID, LongConsumer> backupListeners = new ConcurrentHashMap<>();
     private final AddressChecker addressChecker;
     private final IOBufferAllocator responseBufAllocator = new ConcurrentIOBufferAllocator(4096, true);
     private final boolean tpcEnabled;
@@ -532,7 +531,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
 
     @Override
     public void dispatchBackupEvent(UUID clientUUID, long clientCorrelationId) {
-        Consumer<Long> backupListener = backupListeners.get(clientUUID);
+        LongConsumer backupListener = backupListeners.get(clientUUID);
         if (backupListener != null) {
             backupListener.accept(clientCorrelationId);
         }
@@ -543,7 +542,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
         return backupListeners.remove(clientUUID, backupListener);
     }
 
-    public Map<UUID, Consumer<Long>> getBackupListeners() {
+    public Map<UUID, LongConsumer> getBackupListeners() {
         return backupListeners;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -80,6 +80,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.LongConsumer;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.instance.EndpointQualifier.CLIENT;
@@ -525,7 +526,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
     }
 
     @Override
-    public void addBackupListener(UUID clientUuid, Consumer<Long> backupListener) {
+    public void addBackupListener(UUID clientUuid, LongConsumer backupListener) {
         backupListeners.put(clientUuid, backupListener);
     }
 
@@ -538,7 +539,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
     }
 
     @Override
-    public boolean deregisterBackupListener(UUID clientUUID, Consumer<Long> backupListener) {
+    public boolean deregisterBackupListener(UUID clientUUID, LongConsumer backupListener) {
         return backupListeners.remove(clientUUID, backupListener);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -158,7 +159,7 @@ public class NoOpClientEngine implements ClientEngine {
     }
 
     @Override
-    public void addBackupListener(UUID clientUUID, Consumer<Long> backupListener) {
+    public void addBackupListener(UUID clientUUID, LongConsumer backupListener) {
 
     }
 
@@ -168,7 +169,7 @@ public class NoOpClientEngine implements ClientEngine {
     }
 
     @Override
-    public boolean deregisterBackupListener(UUID clientUUID, Consumer<Long> backupListener) {
+    public boolean deregisterBackupListener(UUID clientUUID, LongConsumer backupListener) {
         return false;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
@@ -34,7 +34,6 @@ import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.Consumer;
 import java.util.function.LongConsumer;
 
 import static java.util.Collections.emptyList;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClusterDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClusterDiscoveryService.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.LifecycleService;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
@@ -43,11 +43,11 @@ public class ClusterDiscoveryService {
         this.lifecycleService = lifecycleService;
     }
 
-    public boolean tryNextCluster(BiFunction<CandidateClusterContext, CandidateClusterContext, Boolean> function) {
+    public boolean tryNextCluster(BiPredicate<CandidateClusterContext, CandidateClusterContext> function) {
         int tryCount = 0;
         while (lifecycleService.isRunning() && tryCount++ < maxTryCount) {
             for (int i = 0; i < candidateClusters.size(); i++) {
-                if (function.apply(current(), next())) {
+                if (function.test(current(), next())) {
                     return true;
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddBackupListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddBackupListenerMessageTask.java
@@ -26,6 +26,7 @@ import java.security.Permission;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddBackupListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddBackupListenerMessageTask.java
@@ -31,7 +31,7 @@ import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFutur
 
 public class AddBackupListenerMessageTask
         extends AbstractAddListenerMessageTask<Void>
-        implements Consumer<Long> {
+        implements LongConsumer {
 
     public AddBackupListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddBackupListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddBackupListenerMessageTask.java
@@ -59,7 +59,7 @@ public class AddBackupListenerMessageTask
     }
 
     @Override
-    public void accept(Long backupCorrelationId) {
+    public void accept(long backupCorrelationId) {
         ClientMessage eventMessage = ClientLocalBackupListenerCodec.encodeBackupEvent(backupCorrelationId);
         eventMessage.getStartFrame().flags |= ClientMessage.BACKUP_EVENT_FLAG;
         sendClientMessage(eventMessage);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddBackupListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddBackupListenerMessageTask.java
@@ -25,7 +25,6 @@ import com.hazelcast.internal.nio.Connection;
 import java.security.Permission;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import java.util.function.LongConsumer;
 
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 
 import static com.hazelcast.internal.eviction.ToBackupSender.newToBackupSender;
 import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
@@ -99,7 +100,7 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable {
                 newBackupExpiryOpFilter(), nodeEngine);
     }
 
-    protected BiFunction<Integer, Integer, Boolean> newBackupExpiryOpFilter() {
+    protected BiPredicate<Integer, Integer> newBackupExpiryOpFilter() {
         return (partitionId, replicaIndex) -> {
             IPartition partition = partitionService.getPartition(partitionId);
             return partition.getReplicaAddress(replicaIndex) != null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ToBackupSender.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ToBackupSender.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 
 /**
  * Helper class to create and send backup expiration operations.
@@ -38,12 +39,12 @@ public final class ToBackupSender<RS> {
 
     private final String serviceName;
     private final OperationService operationService;
-    private final BiFunction<Integer, Integer, Boolean> backupOpFilter;
+    private final BiPredicate<Integer, Integer> backupOpFilter;
     private final BiFunction<RS, Collection<ExpiredKey>, Operation> backupOpSupplier;
 
     private ToBackupSender(String serviceName,
                            BiFunction<RS, Collection<ExpiredKey>, Operation> backupOpSupplier,
-                           BiFunction<Integer, Integer, Boolean> backupOpFilter,
+                           BiPredicate<Integer, Integer> backupOpFilter,
                            NodeEngine nodeEngine) {
         this.serviceName = serviceName;
         this.backupOpFilter = backupOpFilter;
@@ -53,7 +54,7 @@ public final class ToBackupSender<RS> {
 
     static <S> ToBackupSender<S> newToBackupSender(String serviceName,
                                                    BiFunction<S, Collection<ExpiredKey>, Operation> operationSupplier,
-                                                   BiFunction<Integer, Integer, Boolean> backupOpFilter,
+                                                   BiPredicate<Integer, Integer> backupOpFilter,
                                                    NodeEngine nodeEngine) {
         return new ToBackupSender<S>(serviceName, operationSupplier, backupOpFilter, nodeEngine);
     }
@@ -88,7 +89,7 @@ public final class ToBackupSender<RS> {
     public void invokeBackupExpiryOperation(Collection<ExpiredKey> expiredKeys, int backupReplicaCount,
                                             int partitionId, RS recordStore) {
         for (int replicaIndex = 1; replicaIndex < backupReplicaCount + 1; replicaIndex++) {
-            if (backupOpFilter.apply(partitionId, replicaIndex)) {
+            if (backupOpFilter.test(partitionId, replicaIndex)) {
                 Operation operation = backupOpSupplier.apply(recordStore, expiredKeys);
                 operationService.invokeOnPartitionAsync(serviceName, operation, partitionId, replicaIndex);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsConfigHelper.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.properties.HazelcastProperty;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
@@ -119,7 +120,7 @@ public final class MetricsConfigHelper {
                 "ClientMetricsConfig.collectionFrequencySeconds", logger);
     }
 
-    private static void tryOverride(HazelcastProperty property, Function<String, String> getPropertyValueFn,
+    private static void tryOverride(HazelcastProperty property, UnaryOperator<String> getPropertyValueFn,
                                     Consumer<String> setterFn, Supplier<String> getterFn, String configOverridden,
                                     ILogger logger) {
         String propertyValue = getPropertyValueFn.apply(property.getName());

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsConfigHelper.java
@@ -30,7 +30,6 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
@@ -33,7 +33,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
 import static com.hazelcast.internal.util.ConcurrencyUtil.getOrPutIfAbsent;
@@ -64,7 +64,7 @@ public class BatchInvalidator extends Invalidator {
     private final AtomicBoolean runningBackgroundTask = new AtomicBoolean(false);
 
     public BatchInvalidator(String serviceName, int batchSize, int batchFrequencySeconds,
-                            Function<EventRegistration, Boolean> eventFilter, NodeEngine nodeEngine) {
+                            Predicate<EventRegistration> eventFilter, NodeEngine nodeEngine) {
         super(serviceName, eventFilter, nodeEngine);
 
         this.batchSize = batchSize;
@@ -140,7 +140,7 @@ public class BatchInvalidator extends Invalidator {
 
         Collection<EventRegistration> registrations = eventService.getRegistrations(serviceName, dataStructureName);
         for (EventRegistration registration : registrations) {
-            if (eventFilter.apply(registration)) {
+            if (eventFilter.test(registration)) {
                 // find worker queue of striped executor by using subscribers' address.
                 // we want to send all batch invalidations belonging to same subscriber go into
                 // the same workers queue.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
@@ -18,9 +18,7 @@ package com.hazelcast.internal.nearcache.impl.invalidation;
 
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 
-import java.util.function.Function;
-
-import static java.lang.Boolean.TRUE;
+import java.util.function.Predicate;
 
 /**
  * Utils for invalidations.
@@ -28,15 +26,15 @@ import static java.lang.Boolean.TRUE;
 public final class InvalidationUtils {
 
     public static final long NO_SEQUENCE = -1L;
-    public static final Function<EventRegistration, Boolean> TRUE_FILTER = new TrueFilter();
+    public static final Predicate<EventRegistration> TRUE_FILTER = new TrueFilter();
 
     private InvalidationUtils() {
     }
 
-    private static class TrueFilter implements Function<EventRegistration, Boolean> {
+    private static class TrueFilter implements Predicate<EventRegistration> {
         @Override
-        public Boolean apply(EventRegistration eventRegistration) {
-            return TRUE;
+        public boolean test(EventRegistration eventRegistration) {
+            return true;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
@@ -26,7 +26,7 @@ import com.hazelcast.internal.partition.IPartitionService;
 
 import java.util.Collection;
 import java.util.UUID;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.hazelcast.internal.util.ToHeapDataConverter.toHeapData;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -43,9 +43,9 @@ public abstract class Invalidator {
     protected final EventService eventService;
     protected final MetaDataGenerator metaDataGenerator;
     protected final IPartitionService partitionService;
-    protected final Function<EventRegistration, Boolean> eventFilter;
+    protected final Predicate<EventRegistration> eventFilter;
 
-    public Invalidator(String serviceName, Function<EventRegistration, Boolean> eventFilter, NodeEngine nodeEngine) {
+    public Invalidator(String serviceName, Predicate<EventRegistration> eventFilter, NodeEngine nodeEngine) {
         this.serviceName = serviceName;
         this.eventFilter = eventFilter;
         this.nodeEngine = nodeEngine;
@@ -123,7 +123,7 @@ public abstract class Invalidator {
 
         Collection<EventRegistration> registrations = eventService.getRegistrations(serviceName, dataStructureName);
         for (EventRegistration registration : registrations) {
-            if (eventFilter.apply(registration)) {
+            if (eventFilter.test(registration)) {
                 eventService.publishEvent(serviceName, registration, invalidation, orderKey);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/NonStopInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/NonStopInvalidator.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.nearcache.impl.invalidation;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.NodeEngine;
 
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 
 /**
@@ -27,7 +27,7 @@ import java.util.function.Function;
  */
 public class NonStopInvalidator extends Invalidator {
 
-    public NonStopInvalidator(String serviceName, Function<EventRegistration, Boolean> eventFilter, NodeEngine nodeEngine) {
+    public NonStopInvalidator(String serviceName, Predicate<EventRegistration> eventFilter, NodeEngine nodeEngine) {
         super(serviceName, eventFilter, nodeEngine);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -38,6 +38,7 @@ import java.time.OffsetDateTime;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.NULL_ARRAY_LENGTH;
@@ -787,7 +788,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     }
 
     private <T> T[] getPrimitiveArrayAsNullableArray(FieldDescriptor fieldDescriptor,
-                                                     Function<Integer, T[]> constructor,
+                                                     IntFunction<T[]> constructor,
                                                      Reader<T> reader) {
         int currentPos = in.position();
         try {
@@ -811,7 +812,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     }
 
     private <T> T[] getArrayOfVariableSize(FieldDescriptor fieldDescriptor,
-                                           Function<Integer, T[]> constructor,
+                                           IntFunction<T[]> constructor,
                                            Reader<T> reader) {
         int currentPos = in.position();
         try {
@@ -842,10 +843,8 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
         }
     }
 
-
     private <T> T[] getArrayOfVariableSize(@Nonnull String fieldName, FieldKind fieldKind,
-                                           Function<Integer, T[]> constructor,
-                                           Reader<T> reader) {
+            IntFunction<T[]> constructor, Reader<T> reader) {
         FieldDescriptor fieldDefinition = getFieldDescriptor(fieldName, fieldKind);
         return getArrayOfVariableSize(fieldDefinition, constructor, reader);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -764,7 +764,7 @@ public class CompactInternalGenericRecord extends CompactGenericRecord implement
     }
 
     private <T> T[] getArrayOfNullable(@Nonnull String fieldName, Reader<T> reader,
-                                       Function<Integer, T[]> constructor, FieldKind primitiveKind,
+                                       IntFunction<T[]> constructor, FieldKind primitiveKind,
                                        FieldKind nullableKind) {
         FieldDescriptor fd = getFieldDescriptor(fieldName);
         FieldKind fieldKind = fd.getKind();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactInternalGenericRecord.java
@@ -37,7 +37,6 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.function.Function;
 import java.util.function.IntFunction;
 
 import static com.hazelcast.internal.nio.Bits.INT_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
@@ -38,6 +38,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import static com.hazelcast.nio.serialization.FieldType.DATE_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.DECIMAL_ARRAY;
@@ -390,7 +391,7 @@ public class DefaultPortableReader implements PortableReader {
     }
 
     @Nullable
-    private <T> T[] readObjectArrayField(@Nonnull String fieldName, FieldType fieldType, Function<Integer, T[]> constructor,
+    private <T> T[] readObjectArrayField(@Nonnull String fieldName, FieldType fieldType, IntFunction<Integer> constructor,
                                          Reader<ObjectDataInput, T> reader) throws IOException {
         int currentPos = in.position();
         try {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
@@ -37,7 +37,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.IntFunction;
 
 import static com.hazelcast.nio.serialization.FieldType.DATE_ARRAY;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/DefaultPortableReader.java
@@ -390,7 +390,7 @@ public class DefaultPortableReader implements PortableReader {
     }
 
     @Nullable
-    private <T> T[] readObjectArrayField(@Nonnull String fieldName, FieldType fieldType, IntFunction<Integer> constructor,
+    private <T> T[] readObjectArrayField(@Nonnull String fieldName, FieldType fieldType, IntFunction<T[]> constructor,
                                          Reader<ObjectDataInput, T> reader) throws IOException {
         int currentPos = in.position();
         try {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
@@ -549,7 +549,7 @@ public class PortableInternalGenericRecord extends PortableGenericRecord impleme
         INTERNAL_GENERIC_RECORD
     }
 
-    private <T> T[] readNestedArray(@Nonnull String fieldName, IntFunction<Integer> constructor,
+    private <T> T[] readNestedArray(@Nonnull String fieldName, IntFunction<T[]> constructor,
                                     PortableReadMethod readMethod) {
         int currentPos = in.position();
         try {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
@@ -41,7 +41,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.IntFunction;
 
 import static com.hazelcast.internal.nio.Bits.BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/portable/PortableInternalGenericRecord.java
@@ -42,6 +42,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import static com.hazelcast.internal.nio.Bits.BOOLEAN_SIZE_IN_BYTES;
 import static com.hazelcast.internal.nio.Bits.BYTE_SIZE_IN_BYTES;
@@ -413,7 +414,7 @@ public class PortableInternalGenericRecord extends PortableGenericRecord impleme
     }
 
 
-    private <T> T[] readObjectArrayField(@Nonnull String fieldName, FieldType fieldType, Function<Integer, T[]> constructor,
+    private <T> T[] readObjectArrayField(@Nonnull String fieldName, FieldType fieldType, IntFunction<T[]> constructor,
                                          Reader<ObjectDataInput, T> reader) {
         int currentPos = in.position();
         try {
@@ -549,7 +550,7 @@ public class PortableInternalGenericRecord extends PortableGenericRecord impleme
         INTERNAL_GENERIC_RECORD
     }
 
-    private <T> T[] readNestedArray(@Nonnull String fieldName, Function<Integer, T[]> constructor,
+    private <T> T[] readNestedArray(@Nonnull String fieldName, IntFunction<Integer> constructor,
                                     PortableReadMethod readMethod) {
         int currentPos = in.position();
         try {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/UpdateMapP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/UpdateMapP.java
@@ -38,14 +38,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
 
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
 
 public final class UpdateMapP<T, K, V> extends AbstractUpdateMapP<T, K, V> {
 
     private final BiFunctionEx<? super V, ? super T, ? extends V> updateFn;
-    private final BiFunction<Object, Object, Object> remappingFunction =
+    private final BinaryOperator<Object> remappingFunction =
             (o, n) -> ApplyFnEntryProcessor.append(o, (Data) n);
 
     public UpdateMapP(HazelcastInstance instance,

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -301,7 +301,7 @@ public final class ExecutionPlanBuilder {
 
     private static List<EdgeDef> toEdgeDefs(
             List<Edge> edges, EdgeConfig defaultEdgeConfig,
-            Function<Edge, Integer> oppositeVtxId, boolean isJobDistributed
+            ToIntFunction<Edge> oppositeVtxId, boolean isJobDistributed
     ) {
         List<EdgeDef> list = new ArrayList<>(edges.size());
         for (Edge edge : edges) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -307,7 +307,7 @@ public final class ExecutionPlanBuilder {
         List<EdgeDef> list = new ArrayList<>(edges.size());
         for (Edge edge : edges) {
             list.add(new EdgeDef(edge, edge.getConfig() == null ? defaultEdgeConfig : edge.getConfig(),
-                    oppositeVtxId.apply(edge), isJobDistributed));
+                    oppositeVtxId.applyAsInt(edge), isJobDistributed));
         }
         return list;
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -54,6 +54,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
+import java.util.function.ToIntFunction;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/HashJoinCollectP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/processor/HashJoinCollectP.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 
 /**
@@ -34,7 +34,7 @@ import java.util.function.Function;
  */
 public class HashJoinCollectP<K, T, V> extends AbstractProcessor {
 
-    private static final BiFunction<Object, Object, Object> MERGE_FN = (o, n) -> {
+    private static final BinaryOperator<Object> MERGE_FN = (o, n) -> {
         if (o instanceof HashJoinArrayList) {
             ((HashJoinArrayList) o).add(n);
             return o;

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
@@ -27,7 +27,6 @@ import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.ToIntFunction;
 
 import static com.hazelcast.internal.util.HostnameUtil.getLocalHostname;

--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
@@ -28,6 +28,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.ToIntFunction;
 
 import static com.hazelcast.internal.util.HostnameUtil.getLocalHostname;
 
@@ -110,13 +111,13 @@ class KubernetesApiEndpointResolver
     }
 
     private Address createAddress(KubernetesClient.EndpointAddress address,
-                                  Function<KubernetesClient.EndpointAddress, Integer> portResolver) {
+            ToIntFunction<KubernetesClient.EndpointAddress> portResolver) {
         if (address == null) {
             return null;
         }
         String ip = address.getIp();
         InetAddress inetAddress = mapAddress(ip);
-        int port = portResolver.apply(address);
+        int port = portResolver.applyAsInt(address);
         return new Address(inetAddress, port);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -40,7 +40,6 @@ import com.hazelcast.spi.impl.operationservice.OperationService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static com.hazelcast.core.EntryEventType.INVALIDATION;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -41,6 +41,7 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.hazelcast.core.EntryEventType.INVALIDATION;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
@@ -90,10 +91,10 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
     /**
      * Filters out listeners other than invalidation related ones.
      */
-    private static class InvalidationAcceptorFilter implements Function<EventRegistration, Boolean> {
+    private static class InvalidationAcceptorFilter implements Predicate<EventRegistration> {
 
         @Override
-        public Boolean apply(EventRegistration eventRegistration) {
+        public boolean test(EventRegistration eventRegistration) {
             EventFilter filter = eventRegistration.getFilter();
             return filter instanceof EventListenerFilter && filter.eval(INVALIDATION.getType());
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/BackupListenerLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/listeners/leak/BackupListenerLeakTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 
 import static com.hazelcast.client.impl.clientside.ClientTestUtil.getHazelcastClientInstanceImpl;
 import static com.hazelcast.test.Accessors.getNode;
@@ -58,7 +58,7 @@ public class BackupListenerLeakTest {
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         client.shutdown();
-        Map<UUID, Consumer<Long>> backupListeners = ((ClientEngineImpl) getNode(hazelcast).clientEngine).getBackupListeners();
+        Map<UUID, LongConsumer> backupListeners = ((ClientEngineImpl) getNode(hazelcast).clientEngine).getBackupListeners();
         assertTrueEventually(() -> assertEquals(0, backupListeners.size()));
     }
 
@@ -74,7 +74,7 @@ public class BackupListenerLeakTest {
 
         connectionManager.reset();
 
-        Map<UUID, Consumer<Long>> backupListeners = ((ClientEngineImpl) getNode(hazelcast).clientEngine).getBackupListeners();
+        Map<UUID, LongConsumer> backupListeners = ((ClientEngineImpl) getNode(hazelcast).clientEngine).getBackupListeners();
         assertTrueEventually(() -> assertEquals(1, backupListeners.size()));
     }
 }


### PR DESCRIPTION
Replace functional interfaces (e.g. `Function<String, String>`) with specialised declaration (e.g. `UnaryOperator<String>`)

https://rules.sonarsource.com/java/RSPEC-4276/