### PR TITLE
Add Java 21 constant to `com.hazelcast.internal.util.JavaVersion` enum

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
@@ -44,7 +44,8 @@ public enum JavaVersion implements JavaMajorVersion {
     JAVA_17(17),
     JAVA_18(18),
     JAVA_19(19),
-    JAVA_20(20)
+    JAVA_20(20),
+    JAVA_21(21)
     ;
 
     public static final JavaMajorVersion UNKNOWN_VERSION = new UnknownVersion();


### PR DESCRIPTION
Added `JAVA_21` constant, tested resolved correctly with Java 21.

I have *not* tested the rest of the codebase against Java 21.

Fixes https://github.com/hazelcast/hazelcast/issues/25520
