### PR TITLE
Heal tstore indexes after split-brain [HZ-3189]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
@@ -249,7 +249,7 @@ public class PlanExecutor {
             // If `IF NOT EXISTS` isn't specified, we do a simple check for the existence of the index. This is not
             // OK if two clients concurrently try to create the index (they could both succeed), but covers the
             // common case. There's no atomic operation to create an index in IMDG, so it's not easy to implement.
-            if (mapContainer.getIndexes().getIndex(plan.indexName()) != null) {
+            if (mapContainer.getGlobalIndexRegistry().getIndex(plan.indexName()) != null) {
                 throw QueryException.error("Can't create index: index '" + plan.indexName() + "' already exists");
             }
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/map/MapTableUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/schema/map/MapTableUtils.java
@@ -79,7 +79,7 @@ public final class MapTableUtils {
             return Collections.emptyList();
         }
 
-        InternalIndex[] indexes = mapContainer.getIndexes().getIndexes();
+        InternalIndex[] indexes = mapContainer.getGlobalIndexRegistry().getIndexes();
 
         if (indexes == null || indexes.length == 0) {
             return Collections.emptyList();

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlCreateIndexTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlCreateIndexTest.java
@@ -93,19 +93,19 @@ public class SqlCreateIndexTest extends OptimizerTestSupport {
 
     @Test
     public void when_basicBitmapIndexCreated_then_succeeds() {
-        assertThat(mapContainer(map).getIndexes().getIndex(MAP_NAME)).isNull();
+        assertThat(mapContainer(map).getGlobalIndexRegistry().getIndex(MAP_NAME)).isNull();
 
         String indexName = SqlTestSupport.randomName();
         String sql = "CREATE INDEX IF NOT EXISTS " + indexName + " ON " + MAP_NAME + " (__key) TYPE BITMAP; ";
 
         instance().getSql().execute(sql);
 
-        assertThat(mapContainer(map).getIndexes().getIndex(indexName)).isNotNull();
+        assertThat(mapContainer(map).getGlobalIndexRegistry().getIndex(indexName)).isNotNull();
     }
 
     @Test
     public void when_bitmapIndexWithOptionCreated_then_succeeds() {
-        assertThat(mapContainer(map).getIndexes().getIndex(MAP_NAME)).isNull();
+        assertThat(mapContainer(map).getGlobalIndexRegistry().getIndex(MAP_NAME)).isNull();
 
         String indexName = SqlTestSupport.randomName();
         String sql = "CREATE INDEX IF NOT EXISTS " + indexName + " ON " + MAP_NAME + " (__key) TYPE BITMAP " +
@@ -113,7 +113,7 @@ public class SqlCreateIndexTest extends OptimizerTestSupport {
 
         instance().getSql().execute(sql);
 
-        assertThat(mapContainer(map).getIndexes().getIndex(indexName)).isNotNull();
+        assertThat(mapContainer(map).getGlobalIndexRegistry().getIndex(indexName)).isNotNull();
     }
 
     @Test
@@ -124,7 +124,7 @@ public class SqlCreateIndexTest extends OptimizerTestSupport {
 
         instance().getSql().execute(sql);
 
-        assertThat(mapContainer(instance().getMap(mapName)).getIndexes().getIndex(indexName)).isNotNull();
+        assertThat(mapContainer(instance().getMap(mapName)).getGlobalIndexRegistry().getIndex(indexName)).isNotNull();
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlPlanCacheTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlPlanCacheTest.java
@@ -118,7 +118,7 @@ public class SqlPlanCacheTest extends SqlTestSupport {
         sqlService.execute("SELECT * FROM map ORDER BY id");
         assertThat(planCache(instance()).size()).isEqualTo(1);
 
-        mapContainer(map).getIndexes().destroyIndexes();
+        mapContainer(map).getGlobalIndexRegistry().destroyIndexes();
         map.addIndex(new IndexConfig(IndexType.HASH, "__key.id").setName(indexName));
 
         assertTrueEventually(() -> assertThat(planCache(instance()).size()).isZero());

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/index/IndexFilterIteratorTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/index/IndexFilterIteratorTestSupport.java
@@ -55,7 +55,7 @@ public abstract class IndexFilterIteratorTestSupport extends IndexFilterTestSupp
 
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(MAP_NAME);
 
-        return mapContainer.getIndexes().getIndex(INDEX_NAME);
+        return mapContainer.getGlobalIndexRegistry().getIndex(INDEX_NAME);
     }
 
     protected static <T> void checkIterator(IndexType indexType, boolean expectedDescending, Iterator<QueryableEntry> iterator, T... expectedKeys) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/GetMapConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/GetMapConfigOperation.java
@@ -22,7 +22,7 @@ import com.hazelcast.internal.config.MapConfigReadOnly;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.spi.impl.operationservice.AbstractLocalOperation;
 
@@ -65,9 +65,9 @@ public class GetMapConfigOperation extends AbstractLocalOperation {
     }
 
     private List<IndexConfig> getIndexConfigsFromContainer(MapContainer mapContainer) {
-        Indexes indexes = mapContainer.getIndexes();
-        if (indexes != null) {
-            return Arrays.stream(indexes.getIndexes())
+        IndexRegistry indexRegistry = mapContainer.getGlobalIndexRegistry();
+        if (indexRegistry != null) {
+            return Arrays.stream(indexRegistry.getIndexes())
                     .map(InternalIndex::getConfig)
                     .collect(Collectors.toList());
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/IndexesStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/IndexesStats.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.internal.monitor.impl;
 
+import com.hazelcast.query.impl.IndexRegistry;
+
 /**
- * Provides internal statistics for {@link com.hazelcast.query.impl.Indexes
+ * Provides internal statistics for {@link IndexRegistry
  * Indexes}.
  */
 public interface IndexesStats {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -39,7 +39,7 @@ import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nearcache.NearCacheStats;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.spi.impl.NodeEngine;
 
@@ -354,32 +354,33 @@ public class LocalMapStatsProvider {
         if (mapContainer == null) {
             return;
         }
-        Indexes globalIndexes = mapContainer.getIndexes();
-
+        IndexRegistry globalIndexRegistry = mapContainer.getGlobalIndexRegistry();
         Map<String, OnDemandIndexStats> freshStats = null;
-        if (globalIndexes != null) {
-            assert globalIndexes.isGlobal();
-            localMapStats.setQueryCount(globalIndexes.getIndexesStats().getQueryCount());
-            localMapStats.setIndexedQueryCount(globalIndexes.getIndexesStats().getIndexedQueryCount());
-            freshStats = aggregateFreshIndexStats(globalIndexes.getIndexes(), null);
+        if (globalIndexRegistry != null) {
+            assert globalIndexRegistry.isGlobal();
+            localMapStats.setQueryCount(globalIndexRegistry.getIndexesStats().getQueryCount());
+            localMapStats.setIndexedQueryCount(globalIndexRegistry.getIndexesStats().getIndexedQueryCount());
+            freshStats = aggregateFreshIndexStats(globalIndexRegistry.getIndexes(), null);
             finalizeFreshIndexStats(freshStats);
         } else {
             long queryCount = 0;
             long indexedQueryCount = 0;
-            PartitionContainer[] partitionContainers = mapServiceContext.getPartitionContainers();
-            for (int i = 0; i < partitionContainers.length; i++) {
-                PartitionContainer partitionContainer = partitionContainers[i];
-                IPartition partition = partitionService.getPartition(partitionContainer.getPartitionId());
+
+            int partitionCount = partitionService.getPartitionCount();
+            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+                IPartition partition = partitionService.getPartition(partitionId);
                 if (!partition.isLocal()) {
                     continue;
                 }
 
-                Indexes partitionIndexes = partitionContainer.getIndexes().get(mapName);
-                if (partitionIndexes == null) {
+                IndexRegistry partitionedIndexRegistry
+                        = mapContainer.getOrNullPartitionedIndexRegistry(partitionId);
+                if (partitionedIndexRegistry == null) {
                     continue;
                 }
-                assert !partitionIndexes.isGlobal();
-                IndexesStats indexesStats = partitionIndexes.getIndexesStats();
+
+                assert !partitionedIndexRegistry.isGlobal();
+                IndexesStats indexesStats = partitionedIndexRegistry.getIndexesStats();
 
                 // Partitions may have different query stats due to migrations
                 // (partition stats is not preserved while migrating) and/or
@@ -388,7 +389,7 @@ public class LocalMapStatsProvider {
                 queryCount = Math.max(queryCount, indexesStats.getQueryCount());
                 indexedQueryCount = Math.max(indexedQueryCount, indexesStats.getIndexedQueryCount());
 
-                freshStats = aggregateFreshIndexStats(partitionIndexes.getIndexes(), freshStats);
+                freshStats = aggregateFreshIndexStats(partitionedIndexRegistry.getIndexes(), freshStats);
             }
 
             localMapStats.setQueryCount(queryCount);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -47,8 +47,8 @@ import com.hazelcast.map.impl.nearcache.invalidation.InvalidationListener;
 import com.hazelcast.map.impl.query.QueryEntryFactory;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.partition.PartitioningStrategy;
-import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
+import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.spi.eviction.EvictionPolicyComparator;
@@ -59,8 +59,11 @@ import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.wan.impl.DelegatingWanScheme;
 import com.hazelcast.wan.impl.WanReplicationService;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -84,16 +87,17 @@ import static java.lang.System.getProperty;
  */
 @SuppressWarnings({"WeakerAccess", "checkstyle:classfanoutcomplexity"})
 public class MapContainer {
+    static final int GLOBAL_INDEX_NOOP_PARTITION_ID = -1;
 
     protected final String name;
     protected final String splitBrainProtectionName;
     // on-heap indexes are global, meaning there is only one index per map,
     // stored in the mapContainer, so if globalIndexes is null it means that
     // global index is not in use
-    protected final Indexes globalIndexes;
     protected final Extractors extractors;
     protected final MapStoreContext mapStoreContext;
     protected final ObjectNamespace objectNamespace;
+    protected final IndexRegistry globalIndexRegistry;
     protected final MapServiceContext mapServiceContext;
     protected final QueryEntryFactory queryEntryFactory;
     protected final EventJournalConfig eventJournalConfig;
@@ -101,6 +105,7 @@ public class MapContainer {
     protected final InternalSerializationService serializationService;
     protected final Function<Object, Data> toDataFunction = new ObjectToData();
     protected final InterceptorRegistry interceptorRegistry = new InterceptorRegistry();
+    protected final ConcurrentMap<Integer, IndexRegistry> partitionedIndexRegistry = new ConcurrentHashMap<>();
 
     /**
      * Holds number of registered {@link InvalidationListener} from clients.
@@ -140,7 +145,8 @@ public class MapContainer {
                 .build();
         this.queryEntryFactory = new QueryEntryFactory(mapConfig.getCacheDeserializedValues(),
                 serializationService, extractors);
-        this.globalIndexes = shouldUseGlobalIndex() ? createIndexes(true, -1) : null;
+        this.globalIndexRegistry = shouldUseGlobalIndex()
+                ? createIndexRegistry(true, GLOBAL_INDEX_NOOP_PARTITION_ID) : null;
         this.mapStoreContext = createMapStoreContext(this);
         this.invalidationListenerCounter = mapServiceContext.getEventListenerCounter()
                 .getOrCreateCounter(name);
@@ -153,18 +159,19 @@ public class MapContainer {
     }
 
     /**
-     * @param global set {@code true} to create global indexes, otherwise set
-     *               {@code false} to have partitioned indexes
-     * @param partitionId  the partition ID the index is created on. {@code -1}
-     *                     for global indexes.
-     * @return a new Indexes object
+     * @param global      set {@code true} to create global indexes, otherwise set
+     *                    {@code false} to have partitioned indexes
+     * @param partitionId the partition ID the index is created on. {@code -1}
+     *                    for global indexes.
+     * @return a new IndexRegistry object
      */
-    public Indexes createIndexes(boolean global, int partitionId) {
+    public IndexRegistry createIndexRegistry(boolean global, int partitionId) {
         int partitionCount = mapServiceContext.getNodeEngine().getPartitionService().getPartitionCount();
 
         Node node = ((NodeEngineImpl) mapServiceContext.getNodeEngine()).getNode();
-        return Indexes.newBuilder(node, getName(), serializationService, mapServiceContext.getIndexCopyBehavior(),
-                mapConfig.getInMemoryFormat())
+        IndexRegistry newIndexRegistry = IndexRegistry.newBuilder(node, getName(),
+                        serializationService, mapServiceContext.getIndexCopyBehavior(),
+                        mapConfig.getInMemoryFormat())
                 .global(global)
                 .extractors(extractors)
                 .statsEnabled(mapConfig.isStatisticsEnabled())
@@ -174,6 +181,31 @@ public class MapContainer {
                 .partitionId(partitionId)
                 .resultFilterFactory(new IndexResultFilterFactory())
                 .build();
+
+        // if global index, return registry
+        if (partitionId == GLOBAL_INDEX_NOOP_PARTITION_ID) {
+            return newIndexRegistry;
+        } else {
+            // if partitioned index, first register it to
+            // partitionedIndexRegistry then return registry
+            IndexRegistry currentIndexRegistry
+                    = partitionedIndexRegistry.putIfAbsent(partitionId, newIndexRegistry);
+            return currentIndexRegistry == null ? newIndexRegistry : currentIndexRegistry;
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------------------------
+    // IMPORTANT: never use directly! use MapContainer.getIndex() instead.
+    // There are cases where a global index is used. In this case, the global-index is stored in the MapContainer.
+    // By using this method in the context of global index an exception will be thrown.
+    // -------------------------------------------------------------------------------------------------------------
+    IndexRegistry getOrCreatePartitionedIndexRegistry(int partitionId) {
+        if (isGlobalIndexEnabled()) {
+            throw new IllegalStateException("Can't use a partitioned-index in the context of a global-index.");
+        }
+
+        IndexRegistry existing = partitionedIndexRegistry.get(partitionId);
+        return existing != null ? existing : createIndexRegistry(false, partitionId);
     }
 
     public AtomicLong getLastInvalidMergePolicyCheckTime() {
@@ -184,8 +216,8 @@ public class MapContainer {
 
         @Override
         public Predicate<QueryableEntry> get() {
-            return new Predicate<QueryableEntry>() {
-                private long nowInMillis = Clock.currentTimeMillis();
+            return new Predicate<>() {
+                private final long nowInMillis = Clock.currentTimeMillis();
 
                 @Override
                 public boolean test(QueryableEntry queryableEntry) {
@@ -204,7 +236,7 @@ public class MapContainer {
         IPartitionService partitionService = mapServiceContext.getNodeEngine().getPartitionService();
         int partitionId = partitionService.getPartitionId(keyData);
 
-        if (!getIndexes(partitionId).isGlobal()) {
+        if (!getOrCreateIndexRegistry(partitionId).isGlobal()) {
             ThreadUtil.assertRunningOnPartitionThread();
         }
 
@@ -317,24 +349,48 @@ public class MapContainer {
     }
 
     /**
-     * @return the global index, if the global index is in use or null.
+     * Used to get index registry of one
+     * of global or partitioned indexes.
+     *
+     * @param partitionId partitionId
+     * @return by default always returns global-index
+     * registry otherwise return partitioned-index registry
      */
-    public Indexes getIndexes() {
-        return globalIndexes;
+    public IndexRegistry getOrCreateIndexRegistry(int partitionId) {
+        if (globalIndexRegistry != null) {
+            return globalIndexRegistry;
+        }
+
+        return getOrCreatePartitionedIndexRegistry(partitionId);
     }
 
     /**
-     * @param partitionId partitionId
+     * @return the global index, if the global index is in use or null.
      */
-    public Indexes getIndexes(int partitionId) {
-        if (globalIndexes != null) {
-            return globalIndexes;
+    public IndexRegistry getGlobalIndexRegistry() {
+        return globalIndexRegistry;
+    }
+
+    @Nullable
+    public IndexRegistry getOrNullPartitionedIndexRegistry(int partitionId) {
+        return partitionedIndexRegistry.get(partitionId);
+    }
+
+    // Only used for testing
+    public ConcurrentMap<Integer, IndexRegistry> getPartitionedIndexRegistry() {
+        return partitionedIndexRegistry;
+    }
+
+    // Only used for testing
+    public boolean isEmptyIndexRegistry() {
+        if (globalIndexRegistry != null) {
+            return globalIndexRegistry.getIndexes().length == 0;
         }
-        return mapServiceContext.getPartitionContainer(partitionId).getIndexes(name);
+        return partitionedIndexRegistry.isEmpty();
     }
 
     public boolean isGlobalIndexEnabled() {
-        return globalIndexes != null;
+        return globalIndexRegistry != null;
     }
 
     public DelegatingWanScheme getWanReplicationDelegate() {
@@ -448,7 +504,7 @@ public class MapContainer {
     }
 
     public boolean shouldCloneOnEntryProcessing(int partitionId) {
-        return getIndexes(partitionId).haveAtLeastOneIndex()
+        return getOrCreateIndexRegistry(partitionId).haveAtLeastOneIndex()
                 && OBJECT.equals(mapConfig.getInMemoryFormat());
     }
 
@@ -457,16 +513,32 @@ public class MapContainer {
     }
 
     public Map<String, IndexConfig> getIndexDefinitions() {
+        return isGlobalIndexEnabled()
+                ? getGlobalIndexDefinitions()
+                : getPartitionedIndexDefinitions();
+    }
+
+    private Map<String, IndexConfig> getGlobalIndexDefinitions() {
         Map<String, IndexConfig> definitions = new HashMap<>();
-        if (isGlobalIndexEnabled()) {
-            for (Index index : globalIndexes.getIndexes()) {
-                definitions.put(index.getName(), index.getConfig());
+        InternalIndex[] indexes = globalIndexRegistry.getIndexes();
+        for (int i = 0; i < indexes.length; i++) {
+            definitions.put(indexes[i].getName(), indexes[i].getConfig());
+        }
+        return definitions;
+    }
+
+    private Map<String, IndexConfig> getPartitionedIndexDefinitions() {
+        Map<String, IndexConfig> definitions = new HashMap<>();
+        int partitionCount = mapServiceContext.getNodeEngine().getPartitionService().getPartitionCount();
+        for (int i = 0; i < partitionCount; i++) {
+            IndexRegistry indexRegistry = getOrNullPartitionedIndexRegistry(i);
+            if (indexRegistry == null) {
+                continue;
             }
-        } else {
-            for (PartitionContainer container : mapServiceContext.getPartitionContainers()) {
-                for (Index index : container.getIndexes(name).getIndexes()) {
-                    definitions.put(index.getName(), index.getConfig());
-                }
+
+            InternalIndex[] indexes = indexRegistry.getIndexes();
+            for (int j = 0; j < indexes.length; j++) {
+                definitions.put(indexes[j].getName(), indexes[j].getConfig());
             }
         }
         return definitions;
@@ -482,6 +554,7 @@ public class MapContainer {
             SerializationService ss = mapStoreContext.getSerializationService();
             return ss.toData(input, partitioningStrategy);
         }
+
     }
 
     public boolean isUseCachedDeserializedValuesEnabled(int partitionId) {
@@ -492,7 +565,7 @@ public class MapContainer {
                 return true;
             default:
                 //if index exists then cached value is already set -> let's use it
-                return getIndexes(partitionId).haveAtLeastOneIndex();
+                return getOrCreateIndexRegistry(partitionId).haveAtLeastOneIndex();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -38,7 +38,7 @@ import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -95,10 +95,10 @@ class MapMigrationAwareService
             // during promotion finalization phase.
 
             // 1. Defensively clear possible stale leftovers from the previous failed promotion attempt.
-            clearNonGlobalIndexes(event);
+            clearPartitionedIndexes(event);
 
             // 2. Populate non-global partitioned indexes.
-            populateIndexes(event, TargetIndexes.NON_GLOBAL, "beforeMigration");
+            populateIndexes(event, TargetIndexes.PARTITIONED, "beforeMigration");
         }
 
         flushAndRemoveQueryCaches(event);
@@ -232,24 +232,27 @@ class MapMigrationAwareService
         }
     }
 
-    private void clearNonGlobalIndexes(PartitionMigrationEvent event) {
-        final PartitionContainer container = mapServiceContext.getPartitionContainer(event.getPartitionId());
-        for (RecordStore recordStore : container.getMaps().values()) {
-            final MapContainer mapContainer = recordStore.getMapContainer();
+    private void clearPartitionedIndexes(PartitionMigrationEvent event) {
+        PartitionContainer container = mapServiceContext.getPartitionContainer(event.getPartitionId());
 
-            final Indexes indexes = mapContainer.getIndexes(event.getPartitionId());
-            if (!indexes.haveAtLeastOneIndex() || indexes.isGlobal()) {
-                // no indexes to work with
+        for (RecordStore recordStore : container.getMaps().values()) {
+            MapContainer mapContainer = recordStore.getMapContainer();
+            IndexRegistry indexRegistry = mapContainer.getOrNullPartitionedIndexRegistry(event.getPartitionId());
+            if (indexRegistry == null) {
                 continue;
             }
 
             recordStore.beforeOperation();
             try {
-                indexes.clearAll();
+                indexRegistry.clearAll();
             } finally {
                 recordStore.afterOperation();
             }
         }
+    }
+
+    private RecordStore getOrNullRecordStore(PartitionMigrationEvent event, String mapName) {
+        return mapServiceContext.getPartitionContainer(event.getPartitionId()).getExistingRecordStore(mapName);
     }
 
     private void removeRecordStoresHavingLesserBackupCountThan(int partitionId, int thresholdReplicaIndex) {
@@ -313,28 +316,28 @@ class MapMigrationAwareService
         for (RecordStore<Record> recordStore : container.getMaps().values()) {
             MapContainer mapContainer = recordStore.getMapContainer();
 
-            Indexes indexes = mapContainer.getIndexes(event.getPartitionId());
+            IndexRegistry indexRegistry = mapContainer.getOrCreateIndexRegistry(event.getPartitionId());
             recordStore.beforeOperation();
             try {
-                indexes.createIndexesFromRecordedDefinitions();
+                indexRegistry.createIndexesFromRecordedDefinitions();
             } finally {
                 recordStore.afterOperation();
             }
-            if (!indexes.haveAtLeastOneIndex()) {
-                // no indexes to work with
+            if (!indexRegistry.haveAtLeastOneIndex()) {
+                // no indexRegistry to work with
                 continue;
             }
 
-            if (indexes.isGlobal() && targetIndexes == TargetIndexes.NON_GLOBAL) {
+            if (indexRegistry.isGlobal() && targetIndexes == TargetIndexes.PARTITIONED) {
                 continue;
             }
-            if (!indexes.isGlobal() && targetIndexes == TargetIndexes.GLOBAL) {
+            if (!indexRegistry.isGlobal() && targetIndexes == TargetIndexes.GLOBAL) {
                 continue;
             }
 
-            InternalIndex[] indexesSnapshot = indexes.getIndexes();
+            InternalIndex[] indexesSnapshot = indexRegistry.getIndexes();
 
-            Indexes.beginPartitionUpdate(indexesSnapshot);
+            IndexRegistry.beginPartitionUpdate(indexesSnapshot);
 
             CacheDeserializedValues cacheDeserializedValues = mapContainer.getMapConfig().getCacheDeserializedValues();
             CachedQueryEntry<?, ?> cachedEntry = cacheDeserializedValues == NEVER ? new CachedQueryEntry<>(serializationService,
@@ -347,15 +350,15 @@ class MapMigrationAwareService
                         QueryableEntry queryEntry = mapContainer.newQueryEntry(key, value);
                         queryEntry.setRecord(record);
                         CachedQueryEntry<?, ?> newEntry =
-                            cachedEntry == null ? (CachedQueryEntry<?, ?>) queryEntry : cachedEntry.init(key, value);
-                        indexes.putEntry(newEntry, null, queryEntry, Index.OperationSource.SYSTEM);
+                                cachedEntry == null ? (CachedQueryEntry<?, ?>) queryEntry : cachedEntry.init(key, value);
+                        indexRegistry.putEntry(newEntry, null, queryEntry, Index.OperationSource.SYSTEM);
                     }
                 }, false);
             } finally {
                 recordStore.afterOperation();
             }
 
-            Indexes.markPartitionAsIndexed(event.getPartitionId(), indexesSnapshot);
+            IndexRegistry.markPartitionAsIndexed(event.getPartitionId(), indexesSnapshot);
         }
 
         if (logger.isFinestEnabled()) {
@@ -375,15 +378,15 @@ class MapMigrationAwareService
         PartitionContainer container = mapServiceContext.getPartitionContainer(event.getPartitionId());
         for (RecordStore<Record> recordStore : container.getMaps().values()) {
             MapContainer mapContainer = recordStore.getMapContainer();
-            Indexes indexes = mapContainer.getIndexes(event.getPartitionId());
-            if (!indexes.haveAtLeastOneIndex()) {
-                // no indexes to work with
+            IndexRegistry indexRegistry = mapContainer.getOrCreateIndexRegistry(event.getPartitionId());
+            if (!indexRegistry.haveAtLeastOneIndex()) {
+                // no indexRegistry to work with
                 continue;
             }
 
-            InternalIndex[] indexesSnapshot = indexes.getIndexes();
+            InternalIndex[] indexesSnapshot = indexRegistry.getIndexes();
 
-            Indexes.beginPartitionUpdate(indexesSnapshot);
+            IndexRegistry.beginPartitionUpdate(indexesSnapshot);
 
             CachedQueryEntry<?, ?> entry = new CachedQueryEntry<>(serializationService, mapContainer.getExtractors());
             recordStore.beforeOperation();
@@ -391,13 +394,13 @@ class MapMigrationAwareService
                 recordStore.forEach((key, record) -> {
                     Object value = Records.getValueOrCachedValue(record, serializationService);
                     entry.init(key, value);
-                    indexes.removeEntry(entry, Index.OperationSource.SYSTEM);
+                    indexRegistry.removeEntry(entry, Index.OperationSource.SYSTEM);
                 }, false);
             } finally {
                 recordStore.afterOperation();
             }
 
-            Indexes.markPartitionAsUnindexed(event.getPartitionId(), indexesSnapshot);
+            IndexRegistry.markPartitionAsUnindexed(event.getPartitionId(), indexesSnapshot);
         }
 
         if (logger.isFinestEnabled()) {
@@ -406,7 +409,7 @@ class MapMigrationAwareService
     }
 
     private enum TargetIndexes {
-        GLOBAL, NON_GLOBAL
+        GLOBAL, PARTITIONED
     }
 
     public static boolean isLocalPromotion(PartitionMigrationEvent event) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -368,13 +368,13 @@ class MapServiceContextImpl implements MapServiceContext {
 
         Iterator<RecordStore> partitionIterator = container.getMaps().values().iterator();
         while (partitionIterator.hasNext()) {
-            RecordStore partition = partitionIterator.next();
-            if (predicate.test(partition)) {
-                partition.beforeOperation();
+            RecordStore recordStore = partitionIterator.next();
+            if (predicate.test(recordStore)) {
+                recordStore.beforeOperation();
                 try {
-                    partition.clearPartition(onShutdown, onRecordStoreDestroy);
+                    recordStore.clearPartition(onShutdown, onRecordStoreDestroy);
                 } finally {
-                    partition.afterOperation();
+                    recordStore.afterOperation();
                 }
                 partitionIterator.remove();
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.IndexConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 import com.hazelcast.map.impl.recordstore.RecordStore;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.spi.impl.merge.AbstractSplitBrainHandlerService;
 import com.hazelcast.spi.merge.DiscardMergePolicy;
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 
 import static com.hazelcast.internal.util.ThreadUtil.assertRunningOnPartitionThread;
+import static com.hazelcast.map.impl.MapContainer.GLOBAL_INDEX_NOOP_PARTITION_ID;
 
 class MapSplitBrainHandlerService extends AbstractSplitBrainHandlerService<RecordStore> {
 
@@ -64,17 +65,15 @@ class MapSplitBrainHandlerService extends AbstractSplitBrainHandlerService<Recor
     protected void onStoreCollection(RecordStore recordStore) {
         assertRunningOnPartitionThread();
 
-        DefaultRecordStore defaultRecordStore = (DefaultRecordStore) recordStore;
-        defaultRecordStore.getMapDataStore().reset();
-        defaultRecordStore.getIndexingObserver().onDestroy(false, true);
+        resetMapDataStore(recordStore);
 
-        // Removal of old mapContainer is required not to leak old
-        // state into merged cluster. An example old state that we
-        // don't want to leak into merged cluster is index state. In
-        // merged cluster, there will be a fresh mapContainer object.
-        PartitionContainer partitionContainer
-                = mapServiceContext.getPartitionContainer(recordStore.getPartitionId());
-        MapContainer mapContainer = recordStore.getMapContainer();
+        // Removal of old mapContainer is required not to leak
+        // old state into merged cluster. An example old state
+        // that we don't want to leak into merged cluster is
+        // index state. In merged cluster, there will be a
+        // fresh mapContainer object. So not to leak HD memory
+        // for example, we need to destroy old index objects.
+        destroyPartitionedIndexes(recordStore);
 
         // `onStoreCollection` method is called after collection
         // of each record-store. Since same map-container is shared
@@ -85,24 +84,53 @@ class MapSplitBrainHandlerService extends AbstractSplitBrainHandlerService<Recor
         //
         // This one-time logic also helps us to add shared
         // global indexes to new-map-container only once.
+        MapContainer mapContainer = recordStore.getMapContainer();
+        PartitionContainer partitionContainer
+                = mapServiceContext.getPartitionContainer(recordStore.getPartitionId());
         if (partitionContainer.destroyMapContainer(mapContainer)) {
             if (mapContainer.shouldUseGlobalIndex()) {
                 // remove global indexes from old-map-container and add them to new one
-                addIndexConfigToNewMapContainer(mapContainer.name, -1,
-                        mapContainer.getIndexes());
+                addIndexConfigToNewMapContainer(mapContainer.getName(), GLOBAL_INDEX_NOOP_PARTITION_ID,
+                        mapContainer.getGlobalIndexRegistry());
             }
         }
 
-        // remove partitioned indexes from old-map-container and add them to new one
+        // remove partitioned indexes from old-map-container
+        // and add index definitions to new one
         if (!mapContainer.shouldUseGlobalIndex()) {
-            Indexes indexes = partitionContainer.getIndexes().remove(mapContainer.name);
-            addIndexConfigToNewMapContainer(mapContainer.name, recordStore.getPartitionId(),
-                    indexes);
+            IndexRegistry partitionedIndexRegistry = mapContainer
+                    .getOrNullPartitionedIndexRegistry(recordStore.getPartitionId());
+            if (partitionedIndexRegistry != null) {
+                addIndexConfigToNewMapContainer(mapContainer.getName(),
+                        recordStore.getPartitionId(), partitionedIndexRegistry);
+            }
+        }
+    }
+
+    private static void resetMapDataStore(RecordStore recordStore) {
+        DefaultRecordStore defaultRecordStore = ((DefaultRecordStore) recordStore);
+        defaultRecordStore.getMapDataStore().reset();
+    }
+
+    private static void destroyPartitionedIndexes(RecordStore recordStore) {
+        MapContainer mapContainer = recordStore.getMapContainer();
+        recordStore.beforeOperation();
+        try {
+            IndexRegistry partitionedIndexRegistry
+                    = mapContainer.getOrNullPartitionedIndexRegistry(recordStore.getPartitionId());
+            if (partitionedIndexRegistry != null) {
+                InternalIndex[] indexes = partitionedIndexRegistry.getIndexes();
+                for (int i = 0; i < indexes.length; i++) {
+                    indexes[i].destroy();
+                }
+            }
+        } finally {
+            recordStore.afterOperation();
         }
     }
 
     private void addIndexConfigToNewMapContainer(String mapName, int partitionId,
-                                                 Indexes indexes) {
+                                                 IndexRegistry indexes) {
         if (indexes == null) {
             return;
         }
@@ -116,7 +144,7 @@ class MapSplitBrainHandlerService extends AbstractSplitBrainHandlerService<Recor
         // create new map-container here.
         MapContainer newMapContainer = mapServiceContext.getMapContainer(mapName);
         for (IndexConfig indexConfig : indexConfigs) {
-            newMapContainer.getIndexes(partitionId).addOrGetIndex(indexConfig);
+            newMapContainer.getOrCreateIndexRegistry(partitionId).recordIndexDefinition(indexConfig);
         }
     }
 
@@ -129,10 +157,15 @@ class MapSplitBrainHandlerService extends AbstractSplitBrainHandlerService<Recor
                     store.getName(), store.getPartitionId(), store.size()));
         }
 
-        if (store.getMapContainer().getMapConfig().getTieredStoreConfig().isEnabled()) {
-            ((DefaultRecordStore) store).destroyStorageImmediate(false, true);
-        } else {
-            ((DefaultRecordStore) store).destroyStorageAfterClear(false, true);
+        store.beforeOperation();
+        try {
+            if (store.getMapContainer().getMapConfig().getTieredStoreConfig().isEnabled()) {
+                ((DefaultRecordStore) store).destroyStorageImmediate(false, true);
+            } else {
+                ((DefaultRecordStore) store).destroyStorageAfterClear(false, true);
+            }
+        } finally {
+            store.afterOperation();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -29,7 +29,6 @@ import com.hazelcast.internal.util.ContextMutexFactory;
 import com.hazelcast.internal.util.MapUtil;
 import com.hazelcast.map.impl.operation.MapClearExpiredOperation;
 import com.hazelcast.map.impl.recordstore.RecordStore;
-import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.OperationService;
@@ -39,7 +38,6 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
 
@@ -52,7 +50,6 @@ public class PartitionContainer {
     private final MapService mapService;
     private final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
     private final ConcurrentMap<String, RecordStore> maps;
-    private final ConcurrentMap<String, Indexes> indexes = new ConcurrentHashMap<>();
     private final ConstructorFunction<String, RecordStore> recordStoreConstructor
             = name -> {
         RecordStore recordStore = createRecordStore(name);
@@ -107,8 +104,7 @@ public class PartitionContainer {
         int partitionId = getPartitionId();
 
         if (!mapContainer.isGlobalIndexEnabled()) {
-            Indexes indexesForMap = mapContainer.createIndexes(false, partitionId);
-            indexes.putIfAbsent(name, indexesForMap);
+            mapContainer.createIndexRegistry(false, partitionId);
         }
         RecordStore recordStore = serviceContext.createRecordStore(mapContainer, partitionId, keyLoader);
         recordStore.init();
@@ -117,10 +113,6 @@ public class PartitionContainer {
 
     public ConcurrentMap<String, RecordStore> getMaps() {
         return maps;
-    }
-
-    public ConcurrentMap<String, Indexes> getIndexes() {
-        return indexes;
     }
 
     public Collection<RecordStore> getAllRecordStores() {
@@ -192,9 +184,6 @@ public class PartitionContainer {
             clearLockStore(name);
         }
 
-        // getting rid of Indexes object in case it has been initialized
-        indexes.remove(name);
-
         destroyMapContainer(mapContainer);
         mapService.mapServiceContext.removePartitioningStrategyFromCache(mapContainer.getName());
     }
@@ -263,29 +252,5 @@ public class PartitionContainer {
 
     protected void cleanUpMap(String mapName) {
         // overridden in enterprise
-    }
-
-    // -------------------------------------------------------------------------------------------------------------
-    // IMPORTANT: never use directly! use MapContainer.getIndex() instead.
-    // There are cases where a global index is used. In this case, the global-index is stored in the MapContainer.
-    // By using this method in the context of global index an exception will be thrown.
-    // -------------------------------------------------------------------------------------------------------------
-    Indexes getIndexes(String name) {
-        Indexes ixs = indexes.get(name);
-        if (ixs == null) {
-            MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-            MapContainer mapContainer = mapServiceContext.getMapContainer(name);
-            if (mapContainer.isGlobalIndexEnabled()) {
-                throw new IllegalStateException("Can't use a partitioned-index in the context of a global-index.");
-            }
-            int partitionId = getPartitionId();
-
-            Indexes indexesForMap = mapContainer.createIndexes(false, partitionId);
-            ixs = indexes.putIfAbsent(name, indexesForMap);
-            if (ixs == null) {
-                ixs = indexesForMap;
-            }
-        }
-        return ixs;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexBackupOperation.java
@@ -21,7 +21,7 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.spi.impl.operationservice.BackupOperation;
 
 import java.io.IOException;
@@ -47,8 +47,8 @@ public class AddIndexBackupOperation extends MapOperation implements BackupOpera
     public void runInternal() {
         int partitionId = getPartitionId();
 
-        Indexes indexes = mapContainer.getIndexes(partitionId);
-        indexes.recordIndexDefinition(config);
+        IndexRegistry indexRegistry = mapContainer.getOrCreateIndexRegistry(partitionId);
+        indexRegistry.recordIndexDefinition(config);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.IndexUtils;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
@@ -85,8 +85,8 @@ public class AddIndexOperation extends MapOperation
     public void runInternal() {
         int partitionId = getPartitionId();
 
-        Indexes indexes = mapContainer.getIndexes(partitionId);
-        InternalIndex index = indexes.addOrGetIndex(config);
+        IndexRegistry indexRegistry = mapContainer.getOrCreateIndexRegistry(partitionId);
+        InternalIndex index = indexRegistry.addOrGetIndex(config);
         if (index.hasPartitionIndexed(partitionId)) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapChunkContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapChunkContext.java
@@ -32,7 +32,7 @@ import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.impl.recordstore.expiry.ExpiryMetadata;
 import com.hazelcast.map.impl.recordstore.expiry.ExpirySystem;
 import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.MapIndexInfo;
 
 import java.util.HashSet;
@@ -146,14 +146,14 @@ public class MapChunkContext {
         Set<IndexConfig> indexConfigs = new HashSet<>();
         if (mapContainer.isGlobalIndexEnabled()) {
             // global-index
-            final Indexes indexes = mapContainer.getIndexes();
+            final IndexRegistry indexes = mapContainer.getGlobalIndexRegistry();
             for (Index index : indexes.getIndexes()) {
                 indexConfigs.add(index.getConfig());
             }
             indexConfigs.addAll(indexes.getIndexDefinitions());
         } else {
             // partitioned-index
-            final Indexes indexes = mapContainer.getIndexes(partitionId);
+            final IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
             if (indexes != null && indexes.haveAtLeastOneIndexOrDefinition()) {
                 for (Index index : indexes.getIndexes()) {
                     indexConfigs.add(index.getConfig());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchIndexOperation.java
@@ -132,7 +132,7 @@ public class MapFetchIndexOperation extends MapOperation implements ReadonlyOper
                     + "\" is set to \"true\")");
         }
 
-        InternalIndex index = mapContainer.getIndexes().getIndex(indexName);
+        InternalIndex index = mapContainer.getGlobalIndexRegistry().getIndex(indexName);
         if (index == null) {
             throw QueryException.error(SqlErrorCode.INDEX_INVALID, "Index \"" + indexName + "\" does not exist");
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -47,7 +47,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.MapIndexInfo;
 
@@ -140,14 +140,14 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
             Set<IndexConfig> indexConfigs = new HashSet<>();
             if (mapContainer.isGlobalIndexEnabled()) {
                 // global-index
-                final Indexes indexes = mapContainer.getIndexes();
+                final IndexRegistry indexes = mapContainer.getGlobalIndexRegistry();
                 for (Index index : indexes.getIndexes()) {
                     indexConfigs.add(index.getConfig());
                 }
                 indexConfigs.addAll(indexes.getIndexDefinitions());
             } else {
                 // partitioned-index
-                final Indexes indexes = mapContainer.getIndexes(container.getPartitionId());
+                final IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(container.getPartitionId());
                 if (indexes != null && indexes.haveAtLeastOneIndexOrDefinition()) {
                     for (Index index : indexes.getIndexes()) {
                         indexConfigs.add(index.getConfig());
@@ -182,11 +182,11 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
                     PartitionContainer partitionContainer = recordStore.getMapContainer().getMapServiceContext()
                             .getPartitionContainer(operation.getPartitionId());
                     for (Map.Entry<String, IndexConfig> indexDefinition : mapContainer.getIndexDefinitions().entrySet()) {
-                        Indexes indexes = mapContainer.getIndexes(partitionContainer.getPartitionId());
+                        IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionContainer.getPartitionId());
                         indexes.addOrGetIndex(indexDefinition.getValue());
                     }
 
-                    final Indexes indexes = mapContainer.getIndexes(partitionContainer.getPartitionId());
+                    final IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionContainer.getPartitionId());
                     final boolean populateIndexes = indexesMustBePopulated(indexes, operation);
 
                     InternalIndex[] indexesSnapshot = null;
@@ -195,7 +195,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
                         // defensively clear possible stale leftovers in non-global indexes from
                         // the previous failed promotion attempt
                         indexesSnapshot = indexes.getIndexes();
-                        Indexes.beginPartitionUpdate(indexesSnapshot);
+                        IndexRegistry.beginPartitionUpdate(indexesSnapshot);
                         indexes.clearAll();
                     }
 
@@ -205,7 +205,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
 
 
                     if (populateIndexes) {
-                        Indexes.markPartitionAsIndexed(partitionContainer.getPartitionId(), indexesSnapshot);
+                        IndexRegistry.markPartitionAsIndexed(partitionContainer.getPartitionId(), indexesSnapshot);
                     }
                 } finally {
                     recordStore.afterOperation();
@@ -308,7 +308,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
         if (mapContainer.isGlobalIndexEnabled()) {
             // creating global indexes on partition thread in case they do not exist
             for (IndexConfig indexConfig : indexConfigs) {
-                Indexes indexes = mapContainer.getIndexes();
+                IndexRegistry indexes = mapContainer.getGlobalIndexRegistry();
 
                 // optimisation not to synchronize each partition thread on the addOrGetIndex method
                 if (indexes.getIndex(indexConfig.getName()) == null) {
@@ -316,7 +316,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
                 }
             }
         } else {
-            Indexes indexes = mapContainer.getIndexes(operation.getPartitionId());
+            IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(operation.getPartitionId());
             indexes.createIndexesFromRecordedDefinitions();
             for (IndexConfig indexConfig : indexConfigs) {
                 indexes.addOrGetIndex(indexConfig);
@@ -462,7 +462,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
         return MapDataSerializerHook.MAP_REPLICATION_STATE_HOLDER;
     }
 
-    private static boolean indexesMustBePopulated(Indexes indexes, MapReplicationOperation operation) {
+    private static boolean indexesMustBePopulated(IndexRegistry indexes, MapReplicationOperation operation) {
         if (!indexes.haveAtLeastOneIndex()) {
             // no indexes to populate
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -28,7 +28,7 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.MapMergeResponse;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
@@ -191,7 +191,7 @@ public class MergeOperation extends MapOperation
 
     public Queue<InternalIndex> beginIndexMarking() {
         int partitionId = getPartitionId();
-        Indexes indexes = mapContainer.getIndexes(partitionId);
+        IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
         InternalIndex[] indexesSnapshot = indexes.getIndexes();
 
         Queue<InternalIndex> notIndexedPartitions = new LinkedList<>();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -31,7 +31,7 @@ import com.hazelcast.map.impl.recordstore.StaticParams;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
 import com.hazelcast.spi.impl.operationservice.BackupAwareOperation;
@@ -151,7 +151,7 @@ public class PartitionWideEntryOperation extends MapOperation
         }
 
         // we use the partitioned-index to operate on the selected keys only
-        Indexes indexes = mapContainer.getIndexes(getPartitionId());
+        IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(getPartitionId());
         Iterable<QueryableEntry> entries = indexes.query(queryOptimizer.optimize(predicate, indexes), 1);
         if (entries == null) {
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PartitionWideEntryOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/PartitionWideEntryOpSteps.java
@@ -28,7 +28,7 @@ import com.hazelcast.map.impl.operation.steps.engine.State;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
 
@@ -80,7 +80,7 @@ public enum PartitionWideEntryOpSteps implements IMapOpStep {
             }
 
             // we use the partitioned-index to operate on the selected keys only
-            Indexes indexes = mapContainer.getIndexes(partitionId);
+            IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
             Iterable<QueryableEntry> entries = indexes.query(queryOptimizer.optimize(predicate, indexes), 1);
             if (entries == null) {
                 return false;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
@@ -20,7 +20,7 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.spi.impl.operationservice.PartitionAwareOperation;
 import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
 
@@ -47,7 +47,7 @@ public class QueryPartitionOperation extends MapOperation
 
         // we have to increment query count here manually since we are not even
         // trying to use indexes
-        Indexes indexes = mapContainer.getIndexes();
+        IndexRegistry indexes = mapContainer.getGlobalIndexRegistry();
         if (indexes != null) {
             indexes.getIndexesStats().incrementQueryCount();
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -30,7 +30,7 @@ import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryableEntriesSegment;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
@@ -96,7 +96,7 @@ public class QueryRunner {
                                                                IterationPointer[] pointers,
                                                                int fetchSize) {
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
-        Predicate predicate = queryOptimizer.optimize(query.getPredicate(), mapContainer.getIndexes(partitionId));
+        Predicate predicate = queryOptimizer.optimize(query.getPredicate(), mapContainer.getOrCreateIndexRegistry(partitionId));
         QueryableEntriesSegment entries = partitionScanExecutor
                 .execute(query.getMapName(), predicate, partitionId, pointers, fetchSize);
 
@@ -133,9 +133,9 @@ public class QueryRunner {
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
 
         // to optimize the query we need to get any index instance
-        Indexes indexes = mapContainer.getIndexes();
+        IndexRegistry indexes = mapContainer.getGlobalIndexRegistry();
         if (indexes == null) {
-            indexes = mapContainer.getIndexes(ownedPartitions.iterator().next());
+            indexes = mapContainer.getOrCreateIndexRegistry(ownedPartitions.iterator().next());
         }
         // first we optimize the query
         Predicate predicate = queryOptimizer.optimize(query.getPredicate(), indexes);
@@ -195,9 +195,9 @@ public class QueryRunner {
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
 
         // to optimize the query we need to get any index instance
-        Indexes indexes = mapContainer.getIndexes();
+        IndexRegistry indexes = mapContainer.getGlobalIndexRegistry();
         if (indexes == null) {
-            indexes = mapContainer.getIndexes(ownedPartitions.iterator().next());
+            indexes = mapContainer.getOrCreateIndexRegistry(ownedPartitions.iterator().next());
         }
         // first we optimize the query
         Predicate predicate = queryOptimizer.optimize(query.getPredicate(), indexes);
@@ -225,10 +225,10 @@ public class QueryRunner {
         PartitionIdSet partitions = singletonPartitionIdSet(partitionCount, partitionId);
 
         // first we optimize the query
-        Predicate predicate = queryOptimizer.optimize(query.getPredicate(), mapContainer.getIndexes(partitionId));
+        Predicate predicate = queryOptimizer.optimize(query.getPredicate(), mapContainer.getOrCreateIndexRegistry(partitionId));
 
         Iterable<QueryableEntry> entries = null;
-        Indexes indexes = mapContainer.getIndexes(partitionId);
+        IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
         if (indexes != null && !indexes.isGlobal()) {
             entries = indexes.query(predicate, partitions.size());
         }
@@ -270,7 +270,7 @@ public class QueryRunner {
             return null;
         }
 
-        Indexes indexes = mapContainer.getIndexes();
+        IndexRegistry indexes = mapContainer.getGlobalIndexRegistry();
         if (indexes == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -33,7 +33,7 @@ import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.IndexUtils;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.TruePredicate;
@@ -48,7 +48,7 @@ import java.util.function.BiConsumer;
 
 import static com.hazelcast.core.EntryEventType.EVICTED;
 import static com.hazelcast.query.impl.IndexCopyBehavior.COPY_ON_READ;
-import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+import static com.hazelcast.query.impl.IndexRegistry.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -65,7 +65,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
     protected final String cacheId;
     protected final String cacheName;
     protected final IMap delegate;
-    protected final Indexes indexes;
+    protected final IndexRegistry indexRegistry;
     protected final QueryCacheContext context;
     protected final QueryCacheConfig queryCacheConfig;
     protected final QueryCacheRecordStore recordStore;
@@ -89,22 +89,22 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
         // We are not using injected index provider since we're not supporting off-heap indexes in CQC due
         // to threading incompatibility. If we injected the IndexProvider from the MapServiceContext
         // the EE side would create HD indexes which is undesired.
-        this.indexes = Indexes.newBuilder(null, mapName, ss, COPY_ON_READ, queryCacheConfig.getInMemoryFormat())
+        this.indexRegistry = IndexRegistry.newBuilder(null, mapName, ss, COPY_ON_READ, queryCacheConfig.getInMemoryFormat())
                 .partitionCount(context.getPartitionCount())
                 .build();
 
         this.includeValue = isIncludeValue();
         this.partitioningStrategy = getPartitioningStrategy();
         this.extractors = Extractors.newBuilder(ss).build();
-        this.recordStore = new DefaultQueryCacheRecordStore(ss, indexes,
+        this.recordStore = new DefaultQueryCacheRecordStore(ss, indexRegistry,
                 queryCacheConfig, getEvictionListener(), extractors);
 
-        assert indexes.isGlobal();
+        assert indexRegistry.isGlobal();
 
         for (IndexConfig indexConfig : queryCacheConfig.getIndexConfigs()) {
             IndexConfig indexConfig0 = getNormalizedIndexConfig(indexConfig);
 
-            indexes.addOrGetIndex(indexConfig0);
+            indexRegistry.addOrGetIndex(indexConfig0);
         }
     }
 
@@ -216,7 +216,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
     }
 
     private boolean tryQueryOverIndexes(Predicate predicate, BiConsumer biConsumer) {
-        Iterable<QueryableEntry> query = indexes.query(predicate, SKIP_PARTITIONS_COUNT_CHECK);
+        Iterable<QueryableEntry> query = indexRegistry.query(predicate, SKIP_PARTITIONS_COUNT_CHECK);
         if (query == null) {
             return false;
         }
@@ -298,7 +298,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
 
     @Override
     public void clear() {
-        indexes.destroyIndexes();
+        indexRegistry.destroyIndexes();
         recordStore.clear();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -429,11 +429,11 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
     public void addIndex(IndexConfig config) {
         checkNotNull(config, "Index config cannot be null.");
 
-        assert indexes.isGlobal();
+        assert indexRegistry.isGlobal();
 
         IndexConfig config0 = getNormalizedIndexConfig(config);
 
-        indexes.addOrGetIndex(config0);
+        indexRegistry.addOrGetIndex(config0);
 
         InternalSerializationService serializationService = context.getSerializationService();
 
@@ -447,7 +447,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
             Data keyData = toData(queryCacheKey);
             QueryEntry queryable = new QueryEntry(serializationService, keyData, value, extractors);
             newEntry.init(keyData, value);
-            indexes.putEntry(newEntry, null, queryable, Index.OperationSource.USER);
+            indexRegistry.putEntry(newEntry, null, queryable, Index.OperationSource.USER);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRecordStore.java
@@ -30,7 +30,7 @@ import com.hazelcast.map.impl.querycache.subscriber.record.QueryCacheRecord;
 import com.hazelcast.map.impl.querycache.subscriber.record.QueryCacheRecordFactory;
 import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.getters.Extractors;
 
@@ -49,7 +49,7 @@ class DefaultQueryCacheRecordStore implements QueryCacheRecordStore {
 
     private static final int DEFAULT_CACHE_CAPACITY = 1000;
 
-    private final Indexes indexes;
+    private final IndexRegistry indexRegistry;
     private final QueryCacheRecordHashMap cache;
     private final EvictionOperator evictionOperator;
     private final QueryCacheRecordFactory recordFactory;
@@ -59,13 +59,13 @@ class DefaultQueryCacheRecordStore implements QueryCacheRecordStore {
     private final boolean serializeKeys;
 
     DefaultQueryCacheRecordStore(InternalSerializationService ss,
-                                 Indexes indexes,
+                                 IndexRegistry indexRegistry,
                                  QueryCacheConfig config, EvictionListener listener,
                                  Extractors extractors) {
         this.cache = new QueryCacheRecordHashMap(ss, DEFAULT_CACHE_CAPACITY);
         this.ss = ss;
         this.recordFactory = getRecordFactory(config.getInMemoryFormat());
-        this.indexes = indexes;
+        this.indexRegistry = indexRegistry;
         this.evictionOperator = new EvictionOperator(cache, config, listener, ss.getClassLoader());
         this.extractors = extractors;
         EvictionConfig evictionConfig = config.getEvictionConfig();
@@ -152,25 +152,25 @@ class DefaultQueryCacheRecordStore implements QueryCacheRecordStore {
      */
     private void saveIndex(Data keyData, QueryCacheRecord currentRecord, QueryCacheRecord oldRecord,
                            CachedQueryEntry newEntry, CachedQueryEntry oldEntry) {
-        if (indexes.haveAtLeastOneIndex()) {
+        if (indexRegistry.haveAtLeastOneIndex()) {
             Object currentValue = currentRecord.getValue();
             QueryEntry queryEntry = new QueryEntry(ss, keyData, currentValue, extractors);
             Object oldValue = oldRecord == null ? null : oldRecord.getValue();
             newEntry.init(keyData, currentValue);
             oldEntry.init(keyData, oldValue);
-            indexes.putEntry(newEntry, oldEntry, queryEntry, Index.OperationSource.USER);
+            indexRegistry.putEntry(newEntry, oldEntry, queryEntry, Index.OperationSource.USER);
         }
     }
 
     private void saveIndex(Object queryCacheKey, QueryCacheRecord currentRecord, QueryCacheRecord oldRecord) {
-        if (indexes.haveAtLeastOneIndex()) {
+        if (indexRegistry.haveAtLeastOneIndex()) {
             Data keyData = ss.toData(queryCacheKey);
             Object currentValue = currentRecord.getValue();
             QueryEntry queryEntry = new QueryEntry(ss, keyData, currentValue, extractors);
             Object oldValue = oldRecord == null ? null : oldRecord.getValue();
             CachedQueryEntry newEntry = new CachedQueryEntry(ss, keyData, currentValue, extractors);
             CachedQueryEntry oldEntry = new CachedQueryEntry(ss, keyData, oldValue, extractors);
-            indexes.putEntry(newEntry, oldEntry, queryEntry, Index.OperationSource.USER);
+            indexRegistry.putEntry(newEntry, oldEntry, queryEntry, Index.OperationSource.USER);
         }
     }
 
@@ -190,8 +190,8 @@ class DefaultQueryCacheRecordStore implements QueryCacheRecordStore {
     }
 
     private void removeIndex(Object queryCacheKey, Object value) {
-        if (indexes.haveAtLeastOneIndex()) {
-            indexes.removeEntry(ss.toData(queryCacheKey), value, Index.OperationSource.USER);
+        if (indexRegistry.haveAtLeastOneIndex()) {
+            indexRegistry.removeEntry(ss.toData(queryCacheKey), value, Index.OperationSource.USER);
         }
     }
 
@@ -228,7 +228,7 @@ class DefaultQueryCacheRecordStore implements QueryCacheRecordStore {
     public int clear() {
         int removedEntryCount = cache.size();
         cache.clear();
-        indexes.clearAll();
+        indexRegistry.clearAll();
         return removedEntryCount;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1078,8 +1078,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     @SuppressWarnings("unchecked")
     public MapMergeResponse merge(MapMergeTypes<Object, Object> mergingEntry,
-                               SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy,
-                               CallerProvenance provenance) {
+                                  SplitBrainMergePolicy<Object, MapMergeTypes<Object, Object>, Object> mergePolicy,
+                                  CallerProvenance provenance) {
         checkIfLoaded();
         long now = getNow();
 
@@ -1547,7 +1547,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         return nativeMemoryConfig != null && nativeMemoryConfig.getAllocatorType() == POOLED;
     }
 
-    public void destroyStorageImmediate(boolean isDuringShutdown, boolean internal) {
+    public void destroyStorageImmediate(boolean isDuringShutdown,
+                                        boolean internal) {
         mutationObserver.onDestroy(isDuringShutdown, internal);
         expirySystem.destroy();
         destroyMetadataStore();
@@ -1557,7 +1558,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     /**
      * Calls also {@link #clearStorage(boolean)} to release allocated HD memory
-     * of key+value pairs because {@link #destroyStorageImmediate(boolean, boolean)}
+     * of key+value pairs because
      * only releases internal resources of backing data structure.
      *
      * @param isDuringShutdown {@link Storage#clear(boolean)}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/IndexingMutationObserver.java
@@ -22,7 +22,7 @@ import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -111,7 +111,7 @@ public class IndexingMutationObserver<R extends Record> implements MutationObser
      * Only indexed data will be removed, index info will stay.
      */
     private void clearGlobalIndexes(boolean destroy) {
-        Indexes indexes = mapContainer.getIndexes(partitionId);
+        IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
         if (!indexes.isGlobal()) {
             return;
         }
@@ -132,7 +132,7 @@ public class IndexingMutationObserver<R extends Record> implements MutationObser
      * Only indexed data will be removed, index info will stay.
      */
     private void clearPartitionedIndexes(boolean destroy) {
-        Indexes indexes = mapContainer.getIndexes(partitionId);
+        IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
         if (indexes.isGlobal()) {
             return;
         }
@@ -149,24 +149,24 @@ public class IndexingMutationObserver<R extends Record> implements MutationObser
      * Clears local data of this partition from global index by doing
      * partition full-scan.
      */
-    private void fullScanLocalDataToClear(Indexes indexes) {
-        InternalIndex[] indexesSnapshot = indexes.getIndexes();
+    private void fullScanLocalDataToClear(IndexRegistry indexRegistry) {
+        InternalIndex[] indexesSnapshot = indexRegistry.getIndexes();
 
-        Indexes.beginPartitionUpdate(indexesSnapshot);
+        IndexRegistry.beginPartitionUpdate(indexesSnapshot);
 
         CachedQueryEntry<?, ?> entry = new CachedQueryEntry<>(ss, mapContainer.getExtractors());
         recordStore.forEach((BiConsumer<Data, Record>) (dataKey, record) -> {
             Object value = getValueOrCachedValue(record, ss);
             entry.init(dataKey, value);
-            indexes.removeEntry(entry, Index.OperationSource.SYSTEM);
+            indexRegistry.removeEntry(entry, Index.OperationSource.SYSTEM);
         }, false);
 
-        Indexes.markPartitionAsUnindexed(partitionId, indexesSnapshot);
+        IndexRegistry.markPartitionAsUnindexed(partitionId, indexesSnapshot);
     }
 
     private void saveIndex(Data dataKey, Record record, Object oldValue,
                            Index.OperationSource operationSource) {
-        Indexes indexes = mapContainer.getIndexes(partitionId);
+        IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
         if (!indexes.haveAtLeastOneIndex()) {
             return;
         }
@@ -180,7 +180,7 @@ public class IndexingMutationObserver<R extends Record> implements MutationObser
 
     private void removeIndex(Data dataKey, Record record,
                              Index.OperationSource operationSource) {
-        Indexes indexes = mapContainer.getIndexes(partitionId);
+        IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
         if (!indexes.haveAtLeastOneIndex()) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
@@ -52,7 +52,7 @@ public class AttributeIndexRegistry {
      * there is no more than one writer at any given time.
      *
      * @param index the index to register.
-     * @see Indexes#addOrGetIndex
+     * @see IndexRegistry#addOrGetIndex
      */
     public void register(InternalIndex index) {
         String[] components = index.getComponents();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/ConverterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/ConverterCache.java
@@ -25,7 +25,7 @@ import static com.hazelcast.query.impl.TypeConverters.NULL_CONVERTER;
 
 /**
  * Maintains a cache of {@link TypeConverter} instances corresponding to
- * attributes of a single {@link Indexes} instance.
+ * attributes of a single {@link IndexRegistry} instance.
  */
 public final class ConverterCache {
 
@@ -33,17 +33,17 @@ public final class ConverterCache {
     // information attached or having a null/transient converter.
     private static final int FULLY_UNRESOLVED = -1;
 
-    private final Indexes indexes;
+    private final IndexRegistry indexRegistry;
 
     private final Map<String, TypeConverter> cache = new ConcurrentHashMap<String, TypeConverter>();
 
     /**
      * Constructs a new converters cache for the given indexes.
      *
-     * @param indexes the indexes to construct a cache for.
+     * @param indexRegistry the indexes to construct a cache for.
      */
-    public ConverterCache(Indexes indexes) {
-        this.indexes = indexes;
+    public ConverterCache(IndexRegistry indexRegistry) {
+        this.indexRegistry = indexRegistry;
     }
 
     /**
@@ -60,7 +60,7 @@ public final class ConverterCache {
 
     /**
      * Invalidates this cache after the addition of the given index to the
-     * {@link Indexes} for which this cache was constructed for.
+     * {@link IndexRegistry} for which this cache was constructed for.
      *
      * @param index the index added.
      */
@@ -94,7 +94,7 @@ public final class ConverterCache {
         // and saved into the cache, so on the next invocation we don't need to
         // rescan the indexes.
 
-        InternalIndex[] indexesSnapshot = indexes.getIndexes();
+        InternalIndex[] indexesSnapshot = indexRegistry.getIndexes();
         if (indexesSnapshot.length == 0) {
             // no indexes at all
             return null;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProvider.java
@@ -29,7 +29,7 @@ public class GlobalQueryContextProvider implements QueryContextProvider {
     };
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
+    public QueryContext obtainContextFor(IndexRegistry indexes, int ownedPartitionCount) {
         QueryContext queryContext = QUERY_CONTEXT.get();
         queryContext.attachTo(indexes, ownedPartitionCount);
         return queryContext;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProviderWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextProviderWithStats.java
@@ -29,7 +29,7 @@ public class GlobalQueryContextProviderWithStats implements QueryContextProvider
     };
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
+    public QueryContext obtainContextFor(IndexRegistry indexes, int ownedPartitionCount) {
         GlobalQueryContextWithStats queryContext = QUERY_CONTEXT.get();
         queryContext.attachTo(indexes, ownedPartitionCount);
         return queryContext;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -38,7 +38,7 @@ public class GlobalQueryContextWithStats extends QueryContext {
     private final HashSet<QueryTrackingIndex> trackedIndexes = new HashSet<>(8);
 
     @Override
-    void attachTo(Indexes indexes, int ownedPartitionCount) {
+    void attachTo(IndexRegistry indexes, int ownedPartitionCount) {
         super.attachTo(indexes, ownedPartitionCount);
         for (QueryTrackingIndex trackedIndex : trackedIndexes) {
             trackedIndex.resetPerQueryStats();
@@ -55,7 +55,7 @@ public class GlobalQueryContextWithStats extends QueryContext {
 
     @Override
     public Index matchIndex(String pattern, IndexMatchHint matchHint) {
-        InternalIndex delegate = indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
+        InternalIndex delegate = indexRegistry.matchIndex(pattern, matchHint, ownedPartitionCount);
         if (delegate == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexProvider.java
@@ -23,7 +23,7 @@ import com.hazelcast.internal.monitor.impl.PerIndexStats;
 import com.hazelcast.query.impl.getters.Extractors;
 
 /**
- * Provides storage-specific indexes to {@link com.hazelcast.query.impl.Indexes
+ * Provides storage-specific indexes to {@link IndexRegistry
  * Indexes}.
  */
 public interface IndexProvider {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexRegistry.java
@@ -51,7 +51,7 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
  * Contains all indexes for a data-structure, e.g. an IMap.
  */
 @SuppressWarnings("rawtypes")
-public class Indexes {
+public class IndexRegistry {
 
     /**
      * The partitions count check detects a race condition when a
@@ -90,26 +90,26 @@ public class Indexes {
     private volatile InternalIndex[] compositeIndexes = EMPTY_INDEXES;
 
     @SuppressWarnings("checkstyle:ParameterNumber")
-    private Indexes(Node node,
-                    String mapName,
-                    InternalSerializationService ss,
-                    IndexCopyBehavior indexCopyBehavior,
-                    Extractors extractors,
-                    IndexProvider indexProvider,
-                    boolean usesCachedQueryableEntries,
-                    boolean statisticsEnabled,
-                    boolean global,
-                    InMemoryFormat inMemoryFormat,
-                    int partitionCount,
-                    int partitionId,
-                    Supplier<java.util.function.Predicate<QueryableEntry>> resultFilterFactory) {
+    private IndexRegistry(Node node,
+                          String mapName,
+                          InternalSerializationService ss,
+                          IndexCopyBehavior indexCopyBehavior,
+                          Extractors extractors,
+                          IndexProvider indexProvider,
+                          boolean usesCachedQueryableEntries,
+                          boolean statisticsEnabled,
+                          boolean global,
+                          InMemoryFormat inMemoryFormat,
+                          int partitionCount,
+                          int partitionId,
+                          Supplier<java.util.function.Predicate<QueryableEntry>> resultFilterFactory) {
         this.node = node;
         this.mapName = mapName;
         this.global = global;
         this.indexCopyBehavior = indexCopyBehavior;
         this.ss = ss;
         this.usesCachedQueryableEntries = usesCachedQueryableEntries;
-        this.stats = createStats(node, mapName, global, inMemoryFormat, statisticsEnabled);
+        this.stats = createStats(global, inMemoryFormat, statisticsEnabled);
         this.extractors = extractors == null ? Extractors.newBuilder(ss).build() : extractors;
         this.indexProvider = indexProvider == null ? new DefaultIndexProvider() : indexProvider;
         this.queryContextProvider = createQueryContextProvider(this, global, statisticsEnabled);
@@ -240,14 +240,6 @@ public class Indexes {
         });
     }
 
-    /**
-     * Returns all the indexes known to this indexes instance.
-     */
-    @SuppressFBWarnings("EI_EXPOSE_REP")
-    public InternalIndex[] getIndexes() {
-        return indexes;
-    }
-
     public void getStepAwareStorages(Consumer<Step> stepCollector) {
         for (int i = 0; i < indexes.length; i++) {
             indexes[i].getStepAwareStorage().addAsHeadStep(stepCollector);
@@ -274,7 +266,7 @@ public class Indexes {
      * Destroys and then removes all the indexes from this indexes instance.
      */
     public void destroyIndexes() {
-        InternalIndex[] indexesSnapshot = getIndexes();
+        InternalIndex[] indexesCopy = indexes;
 
         indexes = EMPTY_INDEXES;
         compositeIndexes = EMPTY_INDEXES;
@@ -283,18 +275,19 @@ public class Indexes {
         evaluateOnlyAttributeIndexRegistry.clear();
         converterCache.clear();
 
-        for (InternalIndex index : indexesSnapshot) {
+        for (InternalIndex index : indexesCopy) {
             index.destroy();
         }
+        CACHED_ENTRIES.remove();
     }
 
     /**
      * Clears contents of indexes managed by this instance.
      */
     public void clearAll() {
-        InternalIndex[] indexesSnapshot = getIndexes();
+        InternalIndex[] indexesCopy = indexes;
 
-        for (InternalIndex index : indexesSnapshot) {
+        for (InternalIndex index : indexesCopy) {
             index.clear();
         }
     }
@@ -374,12 +367,12 @@ public class Indexes {
      */
     public void putEntry(CachedQueryEntry newEntry, CachedQueryEntry oldEntry, QueryableEntry entryToStore,
                          Index.OperationSource operationSource) {
-        InternalIndex[] indexes = getIndexes();
         Throwable exception = null;
-        for (InternalIndex index : indexes) {
+        InternalIndex[] indexesCopy = indexes;
+        for (InternalIndex index : indexesCopy) {
             try {
                 index.putEntry(newEntry, oldEntry, entryToStore, operationSource);
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 if (exception == null) {
                     exception = t;
                 }
@@ -387,7 +380,7 @@ public class Indexes {
         }
 
         if (exception != null) {
-            rethrow(exception);
+            throw rethrow(exception);
         }
     }
 
@@ -416,8 +409,8 @@ public class Indexes {
      * @param operationSource the operation source.
      */
     public void removeEntry(CachedQueryEntry entry, Index.OperationSource operationSource) {
-        InternalIndex[] indexes = getIndexes();
-        for (InternalIndex index : indexes) {
+        InternalIndex[] indexesCopy = indexes;
+        for (InternalIndex index : indexesCopy) {
             index.removeEntry(entry, operationSource);
         }
     }
@@ -444,6 +437,14 @@ public class Indexes {
      */
     public InternalIndex getIndex(String name) {
         return indexesByName.get(name);
+    }
+
+    /**
+     * Returns all the indexes known to this indexes instance.
+     */
+    @SuppressFBWarnings("EI_EXPOSE_REP")
+    public InternalIndex[] getIndexes() {
+        return indexes;
     }
 
     /**
@@ -572,15 +573,18 @@ public class Indexes {
         return stats;
     }
 
-    private static QueryContextProvider createQueryContextProvider(Indexes indexes, boolean global, boolean statisticsEnabled) {
+    private static QueryContextProvider createQueryContextProvider(IndexRegistry indexes,
+                                                                   boolean global, boolean statisticsEnabled) {
         if (statisticsEnabled) {
-            return global ? new GlobalQueryContextProviderWithStats() : new PartitionQueryContextProviderWithStats(indexes);
+            return global ? new GlobalQueryContextProviderWithStats()
+                    : new PartitionQueryContextProviderWithStats(indexes);
         } else {
-            return global ? new GlobalQueryContextProvider() : new PartitionQueryContextProvider(indexes);
+            return global ? new GlobalQueryContextProvider()
+                    : new PartitionQueryContextProvider(indexes);
         }
     }
 
-    private static IndexesStats createStats(Node node, String mapName, boolean global, InMemoryFormat inMemoryFormat,
+    private static IndexesStats createStats(boolean global, InMemoryFormat inMemoryFormat,
                                             boolean statisticsEnabled) {
         if (statisticsEnabled) {
             if (global) {
@@ -701,8 +705,8 @@ public class Indexes {
         /**
          * @return a new instance of Indexes
          */
-        public Indexes build() {
-            return new Indexes(node, mapName, serializationService, indexCopyBehavior, extractors,
+        public IndexRegistry build() {
+            return new IndexRegistry(node, mapName, serializationService, indexCopyBehavior, extractors,
                     indexProvider, usesCachedQueryableEntries, statsEnabled, global,
                     inMemoryFormat, partitionCount, partitionId, resultFilterFactory);
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProvider.java
@@ -28,13 +28,13 @@ public class PartitionQueryContextProvider implements QueryContextProvider {
      *
      * @param indexes the indexes to construct the new query context for.
      */
-    public PartitionQueryContextProvider(Indexes indexes) {
+    public PartitionQueryContextProvider(IndexRegistry indexes) {
         queryContext = new QueryContext(indexes, 1);
     }
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
-        assert indexes == queryContext.indexes;
+    public QueryContext obtainContextFor(IndexRegistry indexes, int ownedPartitionCount) {
+        assert indexes == queryContext.indexRegistry;
         assert queryContext.ownedPartitionCount == 1 && ownedPartitionCount == 1;
         return queryContext;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProviderWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextProviderWithStats.java
@@ -29,12 +29,12 @@ public class PartitionQueryContextProviderWithStats implements QueryContextProvi
      *
      * @param indexes the indexes to construct the new query context for.
      */
-    public PartitionQueryContextProviderWithStats(Indexes indexes) {
+    public PartitionQueryContextProviderWithStats(IndexRegistry indexes) {
         queryContext = new PartitionQueryContextWithStats(indexes);
     }
 
     @Override
-    public QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount) {
+    public QueryContext obtainContextFor(IndexRegistry indexes, int ownedPartitionCount) {
         assert queryContext.ownedPartitionCount == 1 && ownedPartitionCount == 1;
         queryContext.attachTo(indexes, ownedPartitionCount);
         return queryContext;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PartitionQueryContextWithStats.java
@@ -33,13 +33,13 @@ public class PartitionQueryContextWithStats extends QueryContext {
      *
      * @param indexes the indexes to construct the new query context for.
      */
-    public PartitionQueryContextWithStats(Indexes indexes) {
+    public PartitionQueryContextWithStats(IndexRegistry indexes) {
         super(indexes, 1);
     }
 
     @Override
-    void attachTo(Indexes indexes, int ownedPartitionCount) {
-        assert indexes == this.indexes;
+    void attachTo(IndexRegistry indexes, int ownedPartitionCount) {
+        assert indexes == this.indexRegistry;
         assert ownedPartitionCount == 1 && this.ownedPartitionCount == 1;
         for (PerIndexStats stats : trackedStats) {
             stats.resetPerQueryStats();
@@ -56,7 +56,7 @@ public class PartitionQueryContextWithStats extends QueryContext {
 
     @Override
     public Index matchIndex(String pattern, IndexMatchHint matchHint) {
-        InternalIndex index = indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
+        InternalIndex index = indexRegistry.matchIndex(pattern, matchHint, ownedPartitionCount);
         if (index == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/PredicateBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/PredicateBuilderImpl.java
@@ -46,7 +46,7 @@ public class PredicateBuilderImpl
     private String attribute;
 
     @Override
-    public Predicate accept(Visitor visitor, Indexes indexes) {
+    public Predicate accept(Visitor visitor, IndexRegistry indexes) {
         Predicate predicate = lsPredicates.get(0);
         if (predicate instanceof VisitablePredicate) {
             Predicate newPredicate = ((VisitablePredicate) predicate).accept(visitor, indexes);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
@@ -21,16 +21,16 @@ package com.hazelcast.query.impl;
  */
 public class QueryContext {
 
-    protected Indexes indexes;
+    protected IndexRegistry indexRegistry;
     protected int ownedPartitionCount = -1;
 
     /**
      * Creates a new query context with the given available indexes.
      *
-     * @param indexes the indexes available for the query context.
+     * @param indexRegistry the indexes available for the query context.
      */
-    public QueryContext(Indexes indexes, int ownedPartitionCount) {
-        this.indexes = indexes;
+    public QueryContext(IndexRegistry indexRegistry, int ownedPartitionCount) {
+        this.indexRegistry = indexRegistry;
         this.ownedPartitionCount = ownedPartitionCount;
     }
 
@@ -63,8 +63,8 @@ public class QueryContext {
      *                            Negative value indicates that the value is not defined.
      *
      */
-    void attachTo(Indexes indexes, int ownedPartitionCount) {
-        this.indexes = indexes;
+    void attachTo(IndexRegistry indexes, int ownedPartitionCount) {
+        this.indexRegistry = indexes;
         this.ownedPartitionCount = ownedPartitionCount;
     }
 
@@ -97,7 +97,7 @@ public class QueryContext {
      * @see QueryContext.IndexMatchHint
      */
     public Index matchIndex(String pattern, IndexMatchHint matchHint) {
-        return indexes.matchIndex(pattern, matchHint, ownedPartitionCount);
+        return indexRegistry.matchIndex(pattern, matchHint, ownedPartitionCount);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContextProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContextProvider.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl;
 
 /**
- * Provides query contexts for {@link Indexes} to execute queries.
+ * Provides query contexts for {@link IndexRegistry} to execute queries.
  */
 public interface QueryContextProvider {
 
@@ -32,6 +32,6 @@ public interface QueryContextProvider {
      *                            Negative value indicates that the value is not defined.
      * @return the obtained query context.
      */
-    QueryContext obtainContextFor(Indexes indexes, int ownedPartitionCount);
+    QueryContext obtainContextFor(IndexRegistry indexes, int ownedPartitionCount);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractVisitor.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 /**
  * Base class for all visitors. It returns the original predicate without touching.
@@ -26,37 +26,37 @@ import com.hazelcast.query.impl.Indexes;
 public abstract class AbstractVisitor implements Visitor {
 
     @Override
-    public Predicate visit(EqualPredicate predicate, Indexes indexes) {
+    public Predicate visit(EqualPredicate predicate, IndexRegistry indexes) {
         return predicate;
     }
 
     @Override
-    public Predicate visit(NotEqualPredicate predicate, Indexes indexes) {
+    public Predicate visit(NotEqualPredicate predicate, IndexRegistry indexes) {
         return predicate;
     }
 
     @Override
-    public Predicate visit(AndPredicate predicate, Indexes indexes) {
+    public Predicate visit(AndPredicate predicate, IndexRegistry indexes) {
         return predicate;
     }
 
     @Override
-    public Predicate visit(OrPredicate predicate, Indexes indexes) {
+    public Predicate visit(OrPredicate predicate, IndexRegistry indexes) {
         return predicate;
     }
 
     @Override
-    public Predicate visit(NotPredicate predicate, Indexes indexes) {
+    public Predicate visit(NotPredicate predicate, IndexRegistry indexes) {
         return predicate;
     }
 
     @Override
-    public Predicate visit(InPredicate predicate, Indexes indexes) {
+    public Predicate visit(InPredicate predicate, IndexRegistry indexes) {
         return predicate;
     }
 
     @Override
-    public Predicate visit(BetweenPredicate predicate, Indexes indexes) {
+    public Predicate visit(BetweenPredicate predicate, IndexRegistry indexes) {
         return predicate;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
@@ -22,7 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.AndResultSet;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
-import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+import static com.hazelcast.query.impl.IndexRegistry.SKIP_PARTITIONS_COUNT_CHECK;
 import static com.hazelcast.query.impl.predicates.PredicateUtils.estimatedSizeOf;
 
 /**
@@ -57,7 +57,7 @@ public final class AndPredicate
     }
 
     @Override
-    public Predicate accept(Visitor visitor, Indexes indexes) {
+    public Predicate accept(Visitor visitor, IndexRegistry indexes) {
         Predicate[] result = VisitorUtils.acceptVisitor(predicates, visitor, indexes);
         if (result != predicates) {
             //inner predicates were modified by a visitor

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -22,7 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -138,7 +138,7 @@ public class BetweenPredicate extends AbstractIndexAwarePredicate implements Vis
     }
 
     @Override
-    public Predicate accept(Visitor visitor, Indexes indexes) {
+    public Predicate accept(Visitor visitor, IndexRegistry indexes) {
         return visitor.visit(this, indexes);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeIndexVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeIndexVisitor.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.CompositeValue;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -40,7 +40,7 @@ public class CompositeIndexVisitor extends AbstractVisitor {
 
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:methodlength", "checkstyle:npathcomplexity"})
     @Override
-    public Predicate visit(AndPredicate andPredicate, Indexes indexes) {
+    public Predicate visit(AndPredicate andPredicate, IndexRegistry indexes) {
         int originalSize = andPredicate.predicates.length;
         if (originalSize < 2) {
             // can't optimize further

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EmptyOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EmptyOptimizer.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 /**
  * Optimizer which just returns the original predicate.
@@ -26,7 +26,7 @@ import com.hazelcast.query.impl.Indexes;
  */
 public class EmptyOptimizer implements QueryOptimizer {
     @Override
-    public <K, V> Predicate<K, V> optimize(Predicate<K, V> predicate, Indexes indexes) {
+    public <K, V> Predicate<K, V> optimize(Predicate<K, V> predicate, IndexRegistry indexes) {
         return predicate;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -22,7 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -56,7 +56,7 @@ public class EqualPredicate extends AbstractIndexAwarePredicate
     }
 
     @Override
-    public Predicate accept(Visitor visitor, Indexes indexes) {
+    public Predicate accept(Visitor visitor, IndexRegistry indexes) {
         return visitor.visit(this, indexes);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluateVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EvaluateVisitor.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryContext.IndexMatchHint;
 
 import java.util.ArrayList;
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+import static com.hazelcast.query.impl.IndexRegistry.SKIP_PARTITIONS_COUNT_CHECK;
 
 /**
  * Tries to divide the predicate tree into isolated subtrees every of which can
@@ -39,7 +39,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
     @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
     @Override
-    public Predicate visit(AndPredicate andPredicate, Indexes indexes) {
+    public Predicate visit(AndPredicate andPredicate, IndexRegistry indexes) {
         Predicate[] predicates = andPredicate.predicates;
 
         // Try to group evaluable predicates by their indexes.
@@ -118,7 +118,7 @@ public class EvaluateVisitor extends AbstractVisitor {
 
     @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
     @Override
-    public Predicate visit(OrPredicate orPredicate, Indexes indexes) {
+    public Predicate visit(OrPredicate orPredicate, IndexRegistry indexes) {
         Predicate[] predicates = orPredicate.predicates;
 
         // Try to group evaluable predicates by their indexes.
@@ -196,7 +196,7 @@ public class EvaluateVisitor extends AbstractVisitor {
     }
 
     @Override
-    public Predicate visit(NotPredicate notPredicate, Indexes indexes) {
+    public Predicate visit(NotPredicate notPredicate, IndexRegistry indexes) {
         Predicate subPredicate = notPredicate.getPredicate();
         if (!(subPredicate instanceof EvaluatePredicate)) {
             return notPredicate;
@@ -214,7 +214,7 @@ public class EvaluateVisitor extends AbstractVisitor {
     }
 
     @Override
-    public Predicate visit(EqualPredicate predicate, Indexes indexes) {
+    public Predicate visit(EqualPredicate predicate, IndexRegistry indexes) {
         Index index = indexes.matchIndex(predicate.attributeName, predicate.getClass(), IndexMatchHint.PREFER_UNORDERED,
                 SKIP_PARTITIONS_COUNT_CHECK);
         if (index == null) {
@@ -230,7 +230,7 @@ public class EvaluateVisitor extends AbstractVisitor {
     }
 
     @Override
-    public Predicate visit(NotEqualPredicate predicate, Indexes indexes) {
+    public Predicate visit(NotEqualPredicate predicate, IndexRegistry indexes) {
         Index index = indexes.matchIndex(predicate.attributeName, predicate.getClass(), IndexMatchHint.PREFER_UNORDERED,
                 SKIP_PARTITIONS_COUNT_CHECK);
         if (index == null) {
@@ -246,7 +246,7 @@ public class EvaluateVisitor extends AbstractVisitor {
     }
 
     @Override
-    public Predicate visit(InPredicate predicate, Indexes indexes) {
+    public Predicate visit(InPredicate predicate, IndexRegistry indexes) {
         Index index = indexes.matchIndex(predicate.attributeName, predicate.getClass(), IndexMatchHint.PREFER_UNORDERED,
                 SKIP_PARTITIONS_COUNT_CHECK);
         if (index == null) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FlatteningVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FlatteningVisitor.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,7 +42,7 @@ import static com.hazelcast.internal.util.collection.ArrayUtils.createCopy;
 public class FlatteningVisitor extends AbstractVisitor {
 
     @Override
-    public Predicate visit(AndPredicate andPredicate, Indexes indexes) {
+    public Predicate visit(AndPredicate andPredicate, IndexRegistry indexes) {
         Predicate[] originalPredicates = andPredicate.predicates;
         List<Predicate> toBeAdded = null;
         boolean modified = false;
@@ -66,7 +66,7 @@ public class FlatteningVisitor extends AbstractVisitor {
     }
 
     @Override
-    public Predicate visit(OrPredicate orPredicate, Indexes indexes) {
+    public Predicate visit(OrPredicate orPredicate, IndexRegistry indexes) {
         Predicate[] originalPredicates = orPredicate.predicates;
         List<Predicate> toBeAdded = null;
         boolean modified = false;
@@ -120,7 +120,7 @@ public class FlatteningVisitor extends AbstractVisitor {
     }
 
     @Override
-    public Predicate visit(NotPredicate predicate, Indexes indexes) {
+    public Predicate visit(NotPredicate predicate, IndexRegistry indexes) {
         Predicate inner = predicate.predicate;
         if (inner instanceof NegatablePredicate) {
             return ((NegatablePredicate) inner).negate();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -22,7 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -64,7 +64,7 @@ public class InPredicate extends AbstractIndexAwarePredicate implements Visitabl
     }
 
     @Override
-    public Predicate accept(Visitor visitor, Indexes indexes) {
+    public Predicate accept(Visitor visitor, IndexRegistry indexes) {
         return visitor.visit(this, indexes);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Comparables;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 import java.io.IOException;
 import java.util.Map;
@@ -52,7 +52,7 @@ public class NotEqualPredicate extends AbstractPredicate implements NegatablePre
     }
 
     @Override
-    public Predicate accept(Visitor visitor, Indexes indexes) {
+    public Predicate accept(Visitor visitor, IndexRegistry indexes) {
         return visitor.visit(this, indexes);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 import java.io.IOException;
 import java.util.Map;
@@ -71,7 +71,7 @@ public final class NotPredicate
     }
 
     @Override
-    public Predicate accept(Visitor visitor, Indexes indexes) {
+    public Predicate accept(Visitor visitor, IndexRegistry indexes) {
         Predicate target = predicate;
         if (predicate instanceof VisitablePredicate) {
             target = ((VisitablePredicate) predicate).accept(visitor, indexes);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.OrResultSet;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
-import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+import static com.hazelcast.query.impl.IndexRegistry.SKIP_PARTITIONS_COUNT_CHECK;
 
 /**
  * Or Predicate
@@ -140,7 +140,7 @@ public final class OrPredicate
     }
 
     @Override
-    public Predicate accept(Visitor visitor, Indexes indexes) {
+    public Predicate accept(Visitor visitor, IndexRegistry indexes) {
         Predicate[] result = VisitorUtils.acceptVisitor(predicates, visitor, indexes);
         if (result != predicates) {
             return visitor.visit(new OrPredicate(result), indexes);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrToInVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrToInVisitor.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.internal.util.collection.InternalListMultiMap;
 
 import java.util.List;
@@ -48,7 +48,7 @@ public class OrToInVisitor extends AbstractVisitor {
     private static final int MINIMUM_NUMBER_OF_OR_TO_REPLACE = 5;
 
     @Override
-    public Predicate visit(OrPredicate orPredicate, Indexes indexes) {
+    public Predicate visit(OrPredicate orPredicate, IndexRegistry indexes) {
         Predicate[] originalInnerPredicates = orPredicate.predicates;
         if (originalInnerPredicates == null || originalInnerPredicates.length < MINIMUM_NUMBER_OF_OR_TO_REPLACE) {
             return orPredicate;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
@@ -24,7 +24,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -158,7 +158,7 @@ public class PagingPredicateImpl<K, V>
     }
 
     @Override
-    public Predicate accept(Visitor visitor, Indexes indexes) {
+    public Predicate accept(Visitor visitor, IndexRegistry indexes) {
         if (predicate instanceof VisitablePredicate) {
             Predicate transformed = ((VisitablePredicate) predicate).accept(visitor, indexes);
             return transformed == predicate ? this : new PagingPredicateImpl(this, transformed);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/QueryOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/QueryOptimizer.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 /**
  * Optimizes predicate for faster execution.
@@ -25,5 +25,5 @@ import com.hazelcast.query.impl.Indexes;
  * if no optimization has been performed.
 */
 public interface QueryOptimizer {
-    <K, V> Predicate<K, V> optimize(Predicate<K, V> predicate, Indexes indexes);
+    <K, V> Predicate<K, V> optimize(Predicate<K, V> predicate, IndexRegistry indexes);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RangeVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RangeVisitor.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.TypeConverter;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.impl.Comparables;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.TypeConverters;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -45,7 +45,7 @@ import static com.hazelcast.query.impl.predicates.PredicateUtils.isNull;
 public class RangeVisitor extends AbstractVisitor {
 
     @Override
-    public Predicate visit(AndPredicate predicate, Indexes indexes) {
+    public Predicate visit(AndPredicate predicate, IndexRegistry indexes) {
         Predicate[] predicates = predicate.predicates;
         Ranges ranges = null;
 
@@ -60,7 +60,7 @@ public class RangeVisitor extends AbstractVisitor {
     }
 
     @Override
-    public Predicate visit(BetweenPredicate predicate, Indexes indexes) {
+    public Predicate visit(BetweenPredicate predicate, IndexRegistry indexes) {
         TypeConverter converter = indexes.getConverter(predicate.attributeName);
         if (converter == null) {
             return predicate;
@@ -82,7 +82,7 @@ public class RangeVisitor extends AbstractVisitor {
         }
     }
 
-    private static Ranges intersect(Predicate[] predicates, int predicateIndex, Ranges ranges, Indexes indexes) {
+    private static Ranges intersect(Predicate[] predicates, int predicateIndex, Ranges ranges, IndexRegistry indexes) {
         Predicate predicate = predicates[predicateIndex];
 
         if (predicate instanceof FalsePredicate) {
@@ -120,7 +120,7 @@ public class RangeVisitor extends AbstractVisitor {
         return !rangePredicate.getAttribute().contains("[any]");
     }
 
-    private static Range intersect(RangePredicate predicate, Range range, Indexes indexes) {
+    private static Range intersect(RangePredicate predicate, Range range, IndexRegistry indexes) {
         if (range == null) {
             TypeConverter converter = indexes.getConverter(predicate.getAttribute());
             if (converter == null) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RuleBasedQueryOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RuleBasedQueryOptimizer.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 /**
  * Rule based optimizer. It chains {@link Visitor}s to rewrite query.
@@ -31,7 +31,7 @@ public final class RuleBasedQueryOptimizer implements QueryOptimizer {
     private final Visitor evaluateVisitor = new EvaluateVisitor();
 
     @SuppressWarnings("unchecked")
-    public <K, V> Predicate<K, V> optimize(Predicate<K, V> predicate, Indexes indexes) {
+    public <K, V> Predicate<K, V> optimize(Predicate<K, V> predicate, IndexRegistry indexes) {
         Predicate optimized = predicate;
         if (optimized instanceof VisitablePredicate) {
             optimized = ((VisitablePredicate) optimized).accept(flatteningVisitor, indexes);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -386,7 +386,7 @@ public class SqlPredicate
     }
 
     @Override
-    public Predicate accept(Visitor visitor, Indexes indexes) {
+    public Predicate accept(Visitor visitor, IndexRegistry indexes) {
         Predicate target = predicate;
         if (predicate instanceof VisitablePredicate) {
             target = ((VisitablePredicate) predicate).accept(visitor, indexes);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/VisitablePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/VisitablePredicate.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 /**
  * Predicates which can be visited by optimizer.
@@ -35,5 +35,5 @@ public interface VisitablePredicate {
      * @param indexes indexes
      * @return itself or its changed copy
      */
-    Predicate accept(Visitor visitor, Indexes indexes);
+    Predicate accept(Visitor visitor, IndexRegistry indexes);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/Visitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/Visitor.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 /**
  * Visitor can inspect internal state of a node,
@@ -28,18 +28,18 @@ import com.hazelcast.query.impl.Indexes;
  */
 public interface Visitor {
 
-    Predicate visit(EqualPredicate predicate, Indexes indexes);
+    Predicate visit(EqualPredicate predicate, IndexRegistry indexes);
 
-    Predicate visit(NotEqualPredicate predicate, Indexes indexes);
+    Predicate visit(NotEqualPredicate predicate, IndexRegistry indexes);
 
-    Predicate visit(AndPredicate predicate, Indexes indexes);
+    Predicate visit(AndPredicate predicate, IndexRegistry indexes);
 
-    Predicate visit(OrPredicate predicate, Indexes indexes);
+    Predicate visit(OrPredicate predicate, IndexRegistry indexes);
 
-    Predicate visit(NotPredicate predicate, Indexes indexes);
+    Predicate visit(NotPredicate predicate, IndexRegistry indexes);
 
-    Predicate visit(InPredicate predicate, Indexes indexes);
+    Predicate visit(InPredicate predicate, IndexRegistry indexes);
 
-    Predicate visit(BetweenPredicate predicate, Indexes indexes);
+    Predicate visit(BetweenPredicate predicate, IndexRegistry indexes);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/VisitorUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/VisitorUtils.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 import static com.hazelcast.internal.util.collection.ArrayUtils.createCopy;
 
@@ -36,7 +36,7 @@ public final class VisitorUtils {
      * @param visitor
      * @return
      */
-    public static Predicate[] acceptVisitor(Predicate[] predicates, Visitor visitor, Indexes indexes) {
+    public static Predicate[] acceptVisitor(Predicate[] predicates, Visitor visitor, IndexRegistry indexes) {
         Predicate[] target = predicates;
         boolean copyCreated = false;
         for (int i = 0; i < predicates.length; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
@@ -29,7 +29,7 @@ import com.hazelcast.map.LocalIndexStatsTest;
 import com.hazelcast.map.LocalMapStats;
 import com.hazelcast.query.LocalIndexStats;
 import com.hazelcast.query.Predicates;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -136,7 +136,7 @@ public class ClientIndexStatsTest extends LocalIndexStatsTest {
         LocalMapStats stats1 = map1.getLocalMapStats();
         LocalMapStats stats2 = map2.getLocalMapStats();
 
-        List<Indexes> allIndexes = new ArrayList<Indexes>();
+        List<IndexRegistry> allIndexes = new ArrayList<IndexRegistry>();
         allIndexes.addAll(getAllIndexes(map1));
         allIndexes.addAll(getAllIndexes(map2));
 
@@ -165,7 +165,7 @@ public class ClientIndexStatsTest extends LocalIndexStatsTest {
 
             long totalHitCount = 0;
             double totalNormalizedHitCardinality = 0.0;
-            for (Indexes indexes : allIndexes) {
+            for (IndexRegistry indexes : allIndexes) {
                 PerIndexStats perIndexStats = indexes.getIndex(indexEntry.getKey()).getPerIndexStats();
                 totalHitCount += perIndexStats.getHitCount();
                 totalNormalizedHitCardinality += perIndexStats.getTotalNormalizedHitCardinality();

--- a/hazelcast/src/test/java/com/hazelcast/client/map/impl/query/ClientBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/impl/query/ClientBitmapIndexTest.java
@@ -28,7 +28,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.IndexUtils;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastParametrizedRunner;
@@ -142,7 +142,7 @@ public class ClientBitmapIndexTest extends HazelcastTestSupport {
 
         // add the index dynamically to verify client protocol support
         persons.addIndex(indexConfig);
-        List<Indexes> allIndexes = getAllIndexes(personsOnMember);
+        List<IndexRegistry> allIndexes = getAllIndexes(personsOnMember);
         assertEquals(1, allIndexes.size());
         InternalIndex[] indexes = allIndexes.get(0).getIndexes();
         assertEquals(1, indexes.length);

--- a/hazelcast/src/test/java/com/hazelcast/json/MapIndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapIndexJsonTest.java
@@ -32,7 +32,7 @@ import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastParametrizedRunner;
@@ -275,7 +275,7 @@ public class MapIndexJsonTest extends HazelcastTestSupport {
 
         List<Index> result = new ArrayList<>();
         for (int partitionId : mapServiceContext.getCachedOwnedPartitions()) {
-            Indexes indexes = mapContainer.getIndexes(partitionId);
+            IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
             result.add(indexes.getIndex(attribute));
         }
         return result;

--- a/hazelcast/src/test/java/com/hazelcast/map/IndexStatsChangingNumberOfMembersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/IndexStatsChangingNumberOfMembersTest.java
@@ -27,7 +27,7 @@ import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.partition.Partition;
 import com.hazelcast.query.LocalIndexStats;
 import com.hazelcast.query.Predicates;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
@@ -406,14 +406,14 @@ public class IndexStatsChangingNumberOfMembersTest extends HazelcastTestSupport 
     }
 
     protected double calculateOverallSelectivity(long initialHits, double initialTotalSelectivityCount, IMap<?, ?>... maps) {
-        List<Indexes> allIndexes = new ArrayList<>();
+        List<IndexRegistry> allIndexes = new ArrayList<>();
         for (IMap<?, ?> map : maps) {
             allIndexes.addAll(getAllIndexes(map));
         }
 
         long totalHitCount = 0;
         double totalNormalizedHitCardinality = 0.0;
-        for (Indexes indexes : allIndexes) {
+        for (IndexRegistry indexes : allIndexes) {
             PerIndexStats perIndexStats = indexes.getIndex("this").getPerIndexStats();
             totalHitCount += perIndexStats.getHitCount();
             totalNormalizedHitCardinality += perIndexStats.getTotalNormalizedHitCardinality();
@@ -441,7 +441,7 @@ public class IndexStatsChangingNumberOfMembersTest extends HazelcastTestSupport 
         assertTrueEventually(() -> {
             for (HazelcastInstance instance : instances) {
                 InternalIndex index = ((MapProxyImpl<?, ?>) instance.getMap(mapName)).getService().getMapServiceContext()
-                        .getMapContainer(mapName).getIndexes().getIndex(INDEX_NAME);
+                        .getMapContainer(mapName).getGlobalIndexRegistry().getIndex(INDEX_NAME);
 
                 assertNotNull(index);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
@@ -36,7 +36,7 @@ import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.query.Predicates;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.Operation;
@@ -52,10 +52,10 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import static com.hazelcast.test.Accessors.getNode;
 import static com.hazelcast.test.Accessors.getNodeEngineImpl;
@@ -64,6 +64,7 @@ import static java.util.Arrays.copyOfRange;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -169,21 +170,21 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
         if (!globalIndex()) {
             return;
         }
-        assertTrueEventually(() -> assertEquals(2, mapContainer.getIndexes().getIndexes().length));
+        assertTrueEventually(() -> assertEquals(2, mapContainer.getGlobalIndexRegistry().getIndexes().length));
 
         assertNotNull("There should be a global index for attribute 'author'",
-                mapContainer.getIndexes().getIndex("author"));
+                mapContainer.getGlobalIndexRegistry().getIndex("author"));
         assertNotNull("There should be a global index for attribute 'year'",
-                mapContainer.getIndexes().getIndex("year"));
+                mapContainer.getGlobalIndexRegistry().getIndex("year"));
         final String authorOwned = findAuthorOwnedBy(instance);
         final Integer yearOwned = findYearOwnedBy(instance);
         assertTrueEventually(() -> assertTrue("Author index should contain records.",
-                mapContainer.getIndexes()
+                mapContainer.getGlobalIndexRegistry()
                         .getIndex("author")
                         .getRecords(authorOwned).size() > 0));
 
         assertTrueEventually(() -> assertTrue("Year index should contain records",
-                mapContainer.getIndexes().getIndex("year").getRecords(yearOwned).size() > 0));
+                mapContainer.getGlobalIndexRegistry().getIndex("year").getRecords(yearOwned).size() > 0));
     }
 
     private int numberOfPartitionQueryResults(HazelcastInstance instance, int partitionId, String attribute, Comparable value) {
@@ -198,22 +199,41 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
 
     private void assertAllPartitionContainersAreEmpty(HazelcastInstance instance) {
         MapServiceContext context = getMapServiceContext(instance);
-        int partitionCount = getPartitionCount(instance);
+        Map<String, MapContainer> mapContainers = context.getMapContainers();
 
+        // check if there is no map-container exists than INTERNAL_JET_OBJECTS_PREFIX.
+        for (MapContainer mapContainer : mapContainers.values()) {
+            if (mapContainer.getName().startsWith(JobRepository.INTERNAL_JET_OBJECTS_PREFIX)) {
+                continue;
+            }
+
+            fail("No such map container must exists: " + mapContainer.getName());
+        }
+
+        // check if there is no record-store exists than INTERNAL_JET_OBJECTS_PREFIX.
+        int partitionCount = getPartitionCount(instance);
         for (int i = 0; i < partitionCount; i++) {
             PartitionContainer container = context.getPartitionContainer(i);
-
-            Map<String, ?> maps = container.getMaps().entrySet().stream()
-                    .filter(e -> !e.getKey().startsWith(JobRepository.INTERNAL_JET_OBJECTS_PREFIX))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            assertTrue("record stores not empty", maps.isEmpty());
-
-            Map<String, Indexes> indexes = container.getIndexes()
-                    .entrySet().stream()
-                    .filter(e -> !e.getKey().startsWith(JobRepository.INTERNAL_JET_OBJECTS_PREFIX))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            assertTrue("indexes not empty", indexes.isEmpty());
+            Collection<RecordStore> allRecordStores = container.getAllRecordStores();
+            for (RecordStore recordStore : allRecordStores) {
+                if (recordStore.getName().startsWith(JobRepository.INTERNAL_JET_OBJECTS_PREFIX)) {
+                    continue;
+                }
+                fail("No such record-store must exists: " + recordStore.getName());
+            }
         }
+
+        // check if there is no index exist than INTERNAL_JET_OBJECTS_PREFIX.
+        for (MapContainer mapContainer : mapContainers.values()) {
+            if (mapContainer.getName().startsWith(JobRepository.INTERNAL_JET_OBJECTS_PREFIX)) {
+                continue;
+            }
+
+            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+                assertTrue("indexes not empty", mapContainer.isEmptyIndexRegistry());
+            }
+        }
+
     }
 
     private void assertAllPartitionContainersAreInitialized(HazelcastInstance instance) {
@@ -238,12 +258,12 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
 
             if (!globalIndex()) {
                 // also assert contents of partition indexes when NATIVE memory format
-                ConcurrentMap<String, Indexes> indexes = container.getIndexes();
-                final Indexes index = indexes.get(mapName);
+                IndexRegistry indexes = context.getExistingMapContainer(mapName)
+                        .getPartitionedIndexRegistry().get(i);
                 assertNotNull("indexes is null", indexes);
-                assertEquals(2, index.getIndexes().length);
-                assertNotNull("There should be a partition index for attribute 'author'", index.getIndex("author"));
-                assertNotNull("There should be a partition index for attribute 'year'", index.getIndex("year"));
+                assertEquals(2, indexes.getIndexes().length);
+                assertNotNull("There should be a partition index for attribute 'author'", indexes.getIndex("author"));
+                assertNotNull("There should be a partition index for attribute 'year'", indexes.getIndex("year"));
 
                 authorRecordsCounter.getAndAdd(numberOfPartitionQueryResults(instance, i, "author", authorOwned));
                 yearRecordsCounter.getAndAdd(numberOfPartitionQueryResults(instance, i, "year", yearOwned));

--- a/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateOptimizationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateOptimizationTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.map;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.predicates.InPredicate;
 import com.hazelcast.query.impl.predicates.PagingPredicateImpl;
 import com.hazelcast.query.impl.predicates.RuleBasedQueryOptimizer;
@@ -40,7 +40,7 @@ public class PagingPredicateOptimizationTest extends HazelcastTestSupport {
     @Test
     public void testInnerPredicateOptimization() {
         RuleBasedQueryOptimizer optimizer = new RuleBasedQueryOptimizer();
-        Indexes indexes = mock(Indexes.class);
+        IndexRegistry indexes = mock(IndexRegistry.class);
 
         Predicate[] orPredicates = new Predicate[10];
         for (int i = 0; i < orPredicates.length; ++i) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
@@ -58,7 +58,7 @@ public class RecordStoreTest extends HazelcastTestSupport {
         MapServiceContext mapServiceContext = getMapServiceContext((MapProxyImpl) map);
         MapContainer mapContainer = mapServiceContext.getMapContainer(map.getName());
         for (int partitionId : mapServiceContext.getCachedOwnedPartitions()) {
-            mapContainer.getIndexes(partitionId).destroyIndexes();
+            mapContainer.getOrCreateIndexRegistry(partitionId).destroyIndexes();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
@@ -151,7 +151,7 @@ public class PostJoinMapOperationTest extends HazelcastTestSupport {
         MapService mapService = getNodeEngineImpl(hz2).getService(MapService.SERVICE_NAME);
         MapContainer mapContainerOnNode2 = mapService.getMapServiceContext().getMapContainer("map");
 
-        assertEquals(1, mapContainerOnNode2.getIndexes().getIndexes().length);
+        assertEquals(1, mapContainerOnNode2.getGlobalIndexRegistry().getIndexes().length);
         assertEquals(1, mapContainerOnNode2.getInterceptorRegistry().getInterceptors().size());
         assertEquals(Person.class,
                 mapContainerOnNode2.getInterceptorRegistry().getInterceptors().get(0).interceptGet("anything").getClass());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
@@ -26,7 +26,7 @@ import com.hazelcast.query.Predicates;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.Extractable;
 import com.hazelcast.query.impl.IndexUtils;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.IndexAwarePredicate;
@@ -334,7 +334,7 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Predicate accept(Visitor visitor, Indexes indexes) {
+        public Predicate accept(Visitor visitor, IndexRegistry indexes) {
             Predicate delegate = this.delegate;
             if (delegate instanceof VisitablePredicate) {
                 this.delegate = ((VisitablePredicate) delegate).accept(visitor, indexes);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/IndexCreateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/IndexCreateTest.java
@@ -29,7 +29,7 @@ import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.query.impl.IndexUtils;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastParametrizedRunner;
@@ -188,7 +188,7 @@ public class IndexCreateTest extends HazelcastTestSupport {
             MapServiceContext mapServiceContext = service.getMapServiceContext();
             MapContainer mapContainer = mapServiceContext.getMapContainer(MAP_NAME);
 
-            Indexes indexes = mapContainer.getIndexes();
+            IndexRegistry indexes = mapContainer.getGlobalIndexRegistry();
 
             assertEquals(indexConfigs.length, indexes.getIndexes().length);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/SingleValueBitmapIndexTest.java
@@ -31,7 +31,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.partition.Partition;
 import com.hazelcast.query.LocalIndexStats;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -224,13 +224,13 @@ public class SingleValueBitmapIndexTest extends HazelcastTestSupport {
             HazelcastInstanceImpl instanceImpl = (HazelcastInstanceImpl) instance;
             MapService mapService = instanceImpl.node.getNodeEngine().getService(MapService.SERVICE_NAME);
 
-            Indexes indexes = mapService.getMapServiceContext().getMapContainer(persons.getName()).getIndexes();
+            IndexRegistry indexes = mapService.getMapServiceContext().getMapContainer(persons.getName()).getGlobalIndexRegistry();
             indexes.clearAll();
 
             for (Partition partition : instanceImpl.getPartitionService().getPartitions()) {
                 if (partition.getOwner().localMember()) {
-                    Indexes.beginPartitionUpdate(indexes.getIndexes());
-                    Indexes.markPartitionAsIndexed(partition.getPartitionId(), indexes.getIndexes());
+                    IndexRegistry.beginPartitionUpdate(indexes.getIndexes());
+                    IndexRegistry.markPartitionAsIndexed(partition.getPartitionId(), indexes.getIndexes());
                 }
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheIndexConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheIndexConfigTest.java
@@ -55,8 +55,8 @@ public class QueryCacheIndexConfigTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = instance.getMap("map");
         final DefaultQueryCache<Object, Object> cache = (DefaultQueryCache<Object, Object>) map.getQueryCache("query-cache");
 
-        assertNotNull(cache.indexes.getIndex(indexConfig.getName()));
-        assertTrue(cache.indexes.getIndex(indexConfig.getName()).isOrdered());
+        assertNotNull(cache.indexRegistry.getIndex(indexConfig.getName()));
+        assertTrue(cache.indexRegistry.getIndex(indexConfig.getName()).isOrdered());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapInternalStateSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapInternalStateSplitBrainTest.java
@@ -205,7 +205,7 @@ public class MapInternalStateSplitBrainTest extends SplitBrainTestSupport {
                         .getProperties().getBoolean(ClusterProperty.GLOBAL_HD_INDEX_ENABLED);
 
                 if (globalIndex) {
-                    InternalIndex[] indexes = container.getIndexes().getIndexes();
+                    InternalIndex[] indexes = container.getGlobalIndexRegistry().getIndexes();
                     for (InternalIndex index : indexes) {
                         stampByMap.computeIfAbsent(mapName,
                                 s -> new ArrayList<>()).add(index.getPartitionStamp());
@@ -213,7 +213,7 @@ public class MapInternalStateSplitBrainTest extends SplitBrainTestSupport {
                 } else {
                     int partitionCount = container.getMapServiceContext().getNodeEngine().getPartitionService().getPartitionCount();
                     for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
-                        InternalIndex[] indexes = container.getIndexes(partitionId).getIndexes();
+                        InternalIndex[] indexes = container.getOrCreateIndexRegistry(partitionId).getIndexes();
                         for (InternalIndex index : indexes) {
                             stampByMap.computeIfAbsent(mapName,
                                     s -> new ArrayList<>()).add(index.getPartitionStamp());
@@ -236,7 +236,7 @@ public class MapInternalStateSplitBrainTest extends SplitBrainTestSupport {
                 boolean globalIndex = container.getMapServiceContext().getNodeEngine()
                         .getProperties().getBoolean(ClusterProperty.GLOBAL_HD_INDEX_ENABLED);
                 if (globalIndex) {
-                    InternalIndex[] indexes = container.getIndexes().getIndexes();
+                    InternalIndex[] indexes = container.getGlobalIndexRegistry().getIndexes();
                     for (InternalIndex index : indexes) {
                         stampByMap.computeIfAbsent(instance.getCluster().getLocalMember().getUuid(),
                                 s -> new ArrayList<>()).add(index.getPartitionStamp());
@@ -244,7 +244,7 @@ public class MapInternalStateSplitBrainTest extends SplitBrainTestSupport {
                 } else {
                     int partitionCount = container.getMapServiceContext().getNodeEngine().getPartitionService().getPartitionCount();
                     for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
-                        InternalIndex[] indexes = container.getIndexes(partitionId).getIndexes();
+                        InternalIndex[] indexes = container.getOrCreateIndexRegistry(partitionId).getIndexes();
                         for (InternalIndex index : indexes) {
                             stampByMap.computeIfAbsent(instance.getCluster().getLocalMember().getUuid(),
                                     s -> new ArrayList<>()).add(index.getPartitionStamp());

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainStressTest.java
@@ -108,9 +108,9 @@ public class MapSplitBrainStressTest extends SplitBrainTestSupport {
                 String mapName = MAP_NAME_PREFIX + "_" + (mapIndex + 1);
                 mapNames.put(mapIndex, mapName);
 
-                IMap<Integer, Integer> mapOnFirstBrain = instances[0].getMap(mapName);
+                IMap<Integer, MyPerson> mapOnFirstBrain = instances[0].getMap(mapName);
                 for (int key = 0; key < ENTRY_COUNT; key++) {
-                    mapOnFirstBrain.put(key, key);
+                    mapOnFirstBrain.put(key, new MyPerson(key));
                 }
             }
         }
@@ -141,17 +141,17 @@ public class MapSplitBrainStressTest extends SplitBrainTestSupport {
 
         for (int mapIndex = 0; mapIndex < MAP_COUNT; mapIndex++) {
             String mapName = mapNames.get(mapIndex);
-            IMap<Integer, Integer> map = instances[0].getMap(mapName);
+            IMap<Integer, MyPerson> map = instances[0].getMap(mapName);
             int finalMapIndex = mapIndex;
             assertTrueEventually(() -> assertEquals(format("expected %d entries in map %d/%d (iteration %d)",
                             ENTRY_COUNT, finalMapIndex, MAP_COUNT, iteration),
                     ENTRY_COUNT, map.size()));
 
             for (int key = 0; key < ENTRY_COUNT; key++) {
-                int value = map.get(key);
+                MyPerson myPerson = map.get(key);
                 assertEquals(format("expected value %d for key %d in map %d/%d (iteration %d)",
-                                value, key, mapIndex, MAP_COUNT, iteration),
-                        key, value);
+                                myPerson.personId, key, mapIndex, MAP_COUNT, iteration),
+                        key, myPerson.personId);
             }
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MyPerson.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MyPerson.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.merge;
+
+import java.io.Serializable;
+import java.util.Random;
+
+public class MyPerson implements Serializable {
+
+    private static Random random = new Random();
+
+    long personId;
+
+    long age;
+
+    String firstName;
+
+    String lastName;
+
+    double salary;
+
+    long count = 0;
+
+    public MyPerson() {
+
+    }
+
+    public MyPerson(long personId) {
+        this.personId = personId;
+        this.age = personId;
+        this.firstName = "" + personId;
+        this.lastName = "" + personId;
+        this.salary = random.nextDouble();
+    }
+
+    public long getPersonId() {
+        return personId;
+    }
+
+    public void setPersonId(long personId) {
+        this.personId = personId;
+    }
+
+    public long getAge() {
+        return age;
+    }
+
+    public void setAge(long age) {
+        this.age = age;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public double getSalary() {
+        return salary;
+    }
+
+    public void setSalary(double salary) {
+        this.salary = salary;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o || personId == ((MyPerson) o).getPersonId();
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) personId;
+    }
+
+    @Override
+    public String toString() {
+        return "MyPerson{"
+                + "personId=" + personId
+                + ", age=" + age
+                + ", firstName='" + firstName + '\''
+                + ", lastName='" + lastName + '\''
+                + ", salary=" + salary
+                + ", count=" + count
+                + '}';
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/ConverterResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/ConverterResolutionTest.java
@@ -43,13 +43,13 @@ public class ConverterResolutionTest {
 
     private InternalSerializationService serializationService;
     private Extractors extractors;
-    private Indexes indexes;
+    private IndexRegistry indexes;
 
     @Before
     public void before() {
         serializationService = new DefaultSerializationServiceBuilder().build();
         extractors = Extractors.newBuilder(serializationService).build();
-        indexes = Indexes.newBuilder(null, "test", serializationService,
+        indexes = IndexRegistry.newBuilder(null, "test", serializationService,
                 IndexCopyBehavior.COPY_ON_READ, DEFAULT_IN_MEMORY_FORMAT).extractors(extractors).build();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
@@ -225,7 +225,7 @@ public class IndexIntegrationTest extends HazelcastTestSupport {
 
         List<Index> result = new ArrayList<>();
         for (int partitionId : mapServiceContext.getCachedOwnedPartitions()) {
-            Indexes indexes = mapContainer.getIndexes(partitionId);
+            IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
 
             for (InternalIndex index : indexes.getIndexes()) {
                 for (String component : index.getComponents()) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
@@ -41,7 +41,7 @@ import java.util.Collection;
 
 import static com.hazelcast.config.MapConfig.DEFAULT_IN_MEMORY_FORMAT;
 import static com.hazelcast.internal.util.IterableUtil.size;
-import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+import static com.hazelcast.query.impl.IndexRegistry.SKIP_PARTITIONS_COUNT_CHECK;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParametrizedRunner.class)
@@ -66,7 +66,7 @@ public class IndexJsonTest {
     @Test
     public void testJsonIndex() {
         InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
-        Indexes indexes = Indexes.newBuilder(null, "test", ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).extractors(Extractors.newBuilder(ss).build()).indexProvider(
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test", ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).extractors(Extractors.newBuilder(ss).build()).indexProvider(
                 new DefaultIndexProvider()).usesCachedQueryableEntries(true).statsEnabled(true).global(true).build();
         Index numberIndex = indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "age"));
         Index boolIndex = indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "active"));

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -66,7 +66,7 @@ import java.util.Set;
 import static com.hazelcast.config.MapConfig.DEFAULT_IN_MEMORY_FORMAT;
 import static com.hazelcast.instance.impl.TestUtil.toData;
 import static com.hazelcast.internal.util.IterableUtil.size;
-import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+import static com.hazelcast.query.impl.IndexRegistry.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -127,7 +127,7 @@ public class IndexTest {
         IndexConfig config = IndexUtils.createTestIndexConfig(IndexType.HASH, "favoriteCity");
 
         String mapName = mapContainer.getName();
-        Indexes is = Indexes.newBuilder(null, mapName, ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry is = IndexRegistry.newBuilder(null, mapName, ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         is.addOrGetIndex(config);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
@@ -143,7 +143,7 @@ public class IndexTest {
         IndexConfig config = IndexUtils.createTestIndexConfig(IndexType.HASH, "favoriteCity");
 
         String mapName = mapContainer.getName();
-        Indexes is = Indexes.newBuilder(null, mapName, ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry is = IndexRegistry.newBuilder(null, mapName, ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         is.addOrGetIndex(config);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
@@ -163,7 +163,7 @@ public class IndexTest {
     @Test
     public void testIndex() throws QueryException {
         String mapName = mapContainer.getName();
-        Indexes indexes = Indexes.newBuilder(null, mapName, ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, mapName, ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         Index dIndex = indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "d"));
         Index boolIndex = indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "bool"));
         Index strIndex = indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "str"));
@@ -228,7 +228,7 @@ public class IndexTest {
     public void testIndexWithNull() throws QueryException {
         String mapName = mapContainer.getName();
 
-        Indexes is = Indexes.newBuilder(null, mapName, ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry is = IndexRegistry.newBuilder(null, mapName, ss, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         Index strIndex = is.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.SORTED, "str"));
 
         Data value = ss.toData(new MainPortable(false, 1, null));

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -48,7 +48,7 @@ import java.util.Set;
 import static com.hazelcast.config.MapConfig.DEFAULT_IN_MEMORY_FORMAT;
 import static com.hazelcast.instance.impl.TestUtil.toData;
 import static com.hazelcast.internal.util.IterableUtil.size;
-import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+import static com.hazelcast.query.impl.IndexRegistry.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -76,7 +76,7 @@ public class IndexesTest {
 
     @Test
     public void testAndWithSingleEntry() {
-        Indexes indexes = Indexes.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "name"));
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.SORTED, "age"));
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.SORTED, "salary"));
@@ -98,7 +98,7 @@ public class IndexesTest {
 
     @Test
     public void testIndex() {
-        Indexes indexes = Indexes.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "name"));
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.SORTED, "age"));
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.SORTED, "salary"));
@@ -116,7 +116,7 @@ public class IndexesTest {
 
     @Test
     public void testIndex2() {
-        Indexes indexes = Indexes.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "name"));
         indexes.putEntry(new QueryEntry(serializationService, toData(1), new Value("abc"), newExtractor()), null,
                 Index.OperationSource.USER);
@@ -150,7 +150,7 @@ public class IndexesTest {
      */
     @Test
     public void shouldNotThrowException_withNullValues_whenIndexAddedForValueField() {
-        Indexes indexes = Indexes.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "name"));
 
         shouldReturnNull_whenQueryingOnKeys(indexes);
@@ -158,12 +158,12 @@ public class IndexesTest {
 
     @Test
     public void shouldNotThrowException_withNullValues_whenNoIndexAdded() {
-        Indexes indexes = Indexes.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
 
         shouldReturnNull_whenQueryingOnKeys(indexes);
     }
 
-    private void shouldReturnNull_whenQueryingOnKeys(Indexes indexes) {
+    private void shouldReturnNull_whenQueryingOnKeys(IndexRegistry indexes) {
         for (int i = 0; i < 50; i++) {
             // passing null value to QueryEntry
             indexes.putEntry(new QueryEntry(serializationService, toData(i), null, newExtractor()), null,
@@ -176,7 +176,7 @@ public class IndexesTest {
 
     @Test
     public void shouldNotThrowException_withNullValue_whenIndexAddedForKeyField() {
-        Indexes indexes = Indexes.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
         indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "__key"));
 
         for (int i = 0; i < 100; i++) {
@@ -190,7 +190,7 @@ public class IndexesTest {
 
     @Test
     public void testNoDuplicateIndexes() {
-        Indexes indexes = Indexes.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
 
         IndexConfig config1 = IndexUtils.createTestIndexConfig(IndexType.HASH, "a");
 
@@ -207,7 +207,7 @@ public class IndexesTest {
 
     @Test
     public void testEvaluateOnlyIndexesMatching() {
-        Indexes indexes = Indexes.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test", serializationService, copyBehavior, DEFAULT_IN_MEMORY_FORMAT).build();
 
         Index hashIndex = indexes.addOrGetIndex(IndexUtils.createTestIndexConfig(IndexType.HASH, "a"));
         Index matched = indexes.matchIndex("a", IndexMatchHint.NONE, SKIP_PARTITIONS_COUNT_CHECK);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
@@ -206,7 +206,7 @@ public class JsonIndexIntegrationTest extends HazelcastTestSupport {
 
         List<Index> result = new ArrayList<Index>();
         for (int partitionId : mapServiceContext.getCachedOwnedPartitions()) {
-            Indexes indexes = mapContainer.getIndexes(partitionId);
+            IndexRegistry indexes = mapContainer.getOrCreateIndexRegistry(partitionId);
 
             for (InternalIndex index : indexes.getIndexes()) {
                 for (String component : index.getComponents()) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/PartitionIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/PartitionIndexingTest.java
@@ -201,7 +201,7 @@ public class PartitionIndexingTest extends HazelcastTestSupport {
         Map<String, BitSet> indexToPartitions = new HashMap<String, BitSet>();
 
         for (IMap map : maps) {
-            for (Indexes indexes : getAllIndexes(map)) {
+            for (IndexRegistry indexes : getAllIndexes(map)) {
                 for (InternalIndex index : indexes.getIndexes()) {
                     String indexName = index.getName();
                     BitSet indexPartitions = indexToPartitions.get(indexName);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AbstractVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AbstractVisitorTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -47,7 +47,7 @@ public class AbstractVisitorTest {
         for (Method method : methods) {
             Class<?> predicateType = method.getParameterTypes()[0];
             Predicate predicate = (Predicate) predicateType.newInstance();
-            Indexes indexes = mock(Indexes.class);
+            IndexRegistry indexes = mock(IndexRegistry.class);
             Object result = method.invoke(visitor, predicate, indexes);
 
             assertSame("Method " + method + " does not return identity of the original predicate."

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AndPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AndPredicateTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -75,7 +75,7 @@ public class AndPredicateTest {
     @Test
     public void accept_whenEmptyPredicate_thenReturnItself() {
         Visitor mockVisitor = createPassthroughVisitor();
-        Indexes mockIndexes = mock(Indexes.class);
+        IndexRegistry mockIndexes = mock(IndexRegistry.class);
 
         AndPredicate andPredicate = new AndPredicate(new Predicate[0]);
         AndPredicate result = (AndPredicate) andPredicate.accept(mockVisitor, mockIndexes);
@@ -86,7 +86,7 @@ public class AndPredicateTest {
     @Test
     public void accept_whenInnerPredicateChangedOnAccept_thenReturnAndNewAndPredicate() {
         Visitor mockVisitor = createPassthroughVisitor();
-        Indexes mockIndexes = mock(Indexes.class);
+        IndexRegistry mockIndexes = mock(IndexRegistry.class);
 
         Predicate transformed = mock(Predicate.class);
         Predicate innerPredicate = createMockVisitablePredicate(transformed);
@@ -106,7 +106,7 @@ public class AndPredicateTest {
     public void accept_whenVisitorReturnsNewInstance_thenReturnTheNewInstance() {
         Predicate delegate = mock(Predicate.class);
         Visitor mockVisitor = createDelegatingVisitor(delegate);
-        Indexes mockIndexes = mock(Indexes.class);
+        IndexRegistry mockIndexes = mock(IndexRegistry.class);
         Predicate innerPredicate = mock(Predicate.class);
         Predicate[] innerPredicates = new Predicate[1];
         innerPredicates[0] = innerPredicate;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AttributeCanonicalizationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AttributeCanonicalizationTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.IndexType;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.IndexUtils;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -65,7 +65,7 @@ public class AttributeCanonicalizationTest {
 
     @Test
     public void testIndexes() {
-        Indexes indexes = Indexes.newBuilder(null, "test",
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test",
                 new DefaultSerializationServiceBuilder().build(), IndexCopyBehavior.NEVER, DEFAULT_IN_MEMORY_FORMAT).build();
 
         checkIndex(indexes, "foo", "foo");
@@ -80,7 +80,7 @@ public class AttributeCanonicalizationTest {
 
     @Test
     public void testCompositeIndexes() {
-        Indexes indexes = Indexes.newBuilder(null, "test2",
+        IndexRegistry indexes = IndexRegistry.newBuilder(null, "test2",
                 new DefaultSerializationServiceBuilder().build(), IndexCopyBehavior.NEVER, DEFAULT_IN_MEMORY_FORMAT).build();
 
         checkIndex(indexes, new String[]{"foo", "bar"}, new String[]{"foo", "bar"});
@@ -92,16 +92,16 @@ public class AttributeCanonicalizationTest {
         checkIndex(indexes, new String[]{"foo", "this.bar", "__key.baz"}, new String[]{"foo", "bar", "__key.baz"});
     }
 
-    private void checkIndex(Indexes indexes, String attribute, String expAttribute) {
+    private void checkIndex(IndexRegistry indexes, String attribute, String expAttribute) {
         checkIndex(indexes, new String[]{attribute}, new String[]{expAttribute});
     }
 
-    private void checkIndex(Indexes indexes, String[] attributes, String[] expAttributes) {
+    private void checkIndex(IndexRegistry indexes, String[] attributes, String[] expAttributes) {
         checkIndex(indexes, IndexType.HASH, attributes, expAttributes);
         checkIndex(indexes, IndexType.SORTED, attributes, expAttributes);
     }
 
-    private void checkIndex(Indexes indexes, IndexType indexType, String[] attributes, String[] expAttributes) {
+    private void checkIndex(IndexRegistry indexes, IndexType indexType, String[] attributes, String[] expAttributes) {
         IndexConfig config = new IndexConfig().setType(indexType);
 
         for (String attribute : attributes) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/CompositeIndexVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/CompositeIndexVisitorTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.CompositeValue;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -50,7 +50,7 @@ public class CompositeIndexVisitorTest extends VisitorTestSupport {
     private static final Comparable P_INF = POSITIVE_INFINITY;
 
     private CompositeIndexVisitor visitor;
-    private Indexes indexes;
+    private IndexRegistry indexes;
 
     private InternalIndex o123;
     private InternalIndex u321;
@@ -58,7 +58,7 @@ public class CompositeIndexVisitorTest extends VisitorTestSupport {
 
     @Before
     public void before() {
-        indexes = mock(Indexes.class);
+        indexes = mock(IndexRegistry.class);
 
         o123 = mock(InternalIndex.class);
         when(o123.isOrdered()).thenReturn(true);
@@ -146,7 +146,7 @@ public class CompositeIndexVisitorTest extends VisitorTestSupport {
     }
 
     @Override
-    protected Indexes getIndexes() {
+    protected IndexRegistry getIndexes() {
         return indexes;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EmptyOptimizerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EmptyOptimizerTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -36,7 +36,7 @@ public class EmptyOptimizerTest {
     public void optimize_returnsOriginalPredicate() {
         EmptyOptimizer emptyOptimizer = new EmptyOptimizer();
         Predicate predicate = mock(Predicate.class);
-        Indexes indexes = mock(Indexes.class);
+        IndexRegistry indexes = mock(IndexRegistry.class);
 
         Predicate result = emptyOptimizer.optimize(predicate, indexes);
         assertSame(predicate, result);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EvaluateVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EvaluateVisitorTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.QueryContext.IndexMatchHint;
 import com.hazelcast.query.impl.TypeConverters;
@@ -44,7 +44,7 @@ import static com.hazelcast.query.Predicates.like;
 import static com.hazelcast.query.Predicates.not;
 import static com.hazelcast.query.Predicates.notEqual;
 import static com.hazelcast.query.Predicates.or;
-import static com.hazelcast.query.impl.Indexes.SKIP_PARTITIONS_COUNT_CHECK;
+import static com.hazelcast.query.impl.IndexRegistry.SKIP_PARTITIONS_COUNT_CHECK;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -70,12 +70,12 @@ public class EvaluateVisitorTest {
     }
 
     private EvaluateVisitor visitor = new EvaluateVisitor();
-    private Indexes indexes;
+    private IndexRegistry indexes;
 
     @SuppressWarnings("SuspiciousMethodCalls")
     @Before
     public void before() {
-        indexes = mock(Indexes.class);
+        indexes = mock(IndexRegistry.class);
 
         InternalIndex bitmapA = mock(InternalIndex.class);
         when(bitmapA.getConverter()).thenReturn(TypeConverters.INTEGER_CONVERTER);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/FlatteningVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/FlatteningVisitorTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -40,11 +40,11 @@ import static org.mockito.Mockito.withSettings;
 public class FlatteningVisitorTest {
 
     private FlatteningVisitor visitor;
-    private Indexes indexes;
+    private IndexRegistry indexes;
 
     @Before
     public void setUp() {
-        indexes = mock(Indexes.class);
+        indexes = mock(IndexRegistry.class);
         visitor = new FlatteningVisitor();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotPredicateTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -89,7 +89,7 @@ public class NotPredicateTest {
     @Test
     public void accept_whenNullPredicate_thenReturnItself() {
         Visitor mockVisitor = createPassthroughVisitor();
-        Indexes mockIndexes = mock(Indexes.class);
+        IndexRegistry mockIndexes = mock(IndexRegistry.class);
 
         NotPredicate notPredicate = new NotPredicate(null);
         NotPredicate result = (NotPredicate) notPredicate.accept(mockVisitor, mockIndexes);
@@ -100,7 +100,7 @@ public class NotPredicateTest {
     @Test
     public void accept_whenPredicateChangedOnAccept_thenReturnAndNewNotPredicate() {
         Visitor mockVisitor = createPassthroughVisitor();
-        Indexes mockIndexes = mock(Indexes.class);
+        IndexRegistry mockIndexes = mock(IndexRegistry.class);
 
         Predicate transformed = mock(Predicate.class);
         Predicate predicate = createMockVisitablePredicate(transformed);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrToInVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrToInVisitorTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -38,11 +38,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OrToInVisitorTest {
 
     private OrToInVisitor visitor;
-    private Indexes indexes;
+    private IndexRegistry indexes;
 
     @Before
     public void setUp() {
-        indexes = mock(Indexes.class);
+        indexes = mock(IndexRegistry.class);
         visitor = new OrToInVisitor();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicateTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicateTestUtils.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.getters.Extractors;
 import org.mockito.internal.stubbing.answers.ReturnsArgumentAt;
@@ -57,30 +57,30 @@ public final class PredicateTestUtils {
 
     static Predicate createMockVisitablePredicate() {
         VisitablePredicate visitablePredicate = mock(VisitablePredicate.class, withSettings().extraInterfaces(Predicate.class));
-        when(visitablePredicate.accept((Visitor) any(), (Indexes) any())).thenReturn((Predicate) visitablePredicate);
+        when(visitablePredicate.accept((Visitor) any(), (IndexRegistry) any())).thenReturn((Predicate) visitablePredicate);
         return (Predicate) visitablePredicate;
     }
 
     static Predicate createMockVisitablePredicate(Predicate transformed) {
         VisitablePredicate visitablePredicate = mock(VisitablePredicate.class, withSettings().extraInterfaces(Predicate.class));
-        when(visitablePredicate.accept((Visitor) any(), (Indexes) any())).thenReturn(transformed);
+        when(visitablePredicate.accept((Visitor) any(), (IndexRegistry) any())).thenReturn(transformed);
         return (Predicate) visitablePredicate;
     }
 
     static Visitor createPassthroughVisitor() {
         Visitor visitor = mock(Visitor.class);
-        when(visitor.visit((AndPredicate) any(), (Indexes) any())).thenAnswer(new ReturnsArgumentAt(0));
-        when(visitor.visit((OrPredicate) any(), (Indexes) any())).thenAnswer(new ReturnsArgumentAt(0));
-        when(visitor.visit((NotPredicate) any(), (Indexes) any())).thenAnswer(new ReturnsArgumentAt(0));
+        when(visitor.visit((AndPredicate) any(), (IndexRegistry) any())).thenAnswer(new ReturnsArgumentAt(0));
+        when(visitor.visit((OrPredicate) any(), (IndexRegistry) any())).thenAnswer(new ReturnsArgumentAt(0));
+        when(visitor.visit((NotPredicate) any(), (IndexRegistry) any())).thenAnswer(new ReturnsArgumentAt(0));
 
         return visitor;
     }
 
     static Visitor createDelegatingVisitor(Predicate delegate) {
         Visitor visitor = mock(Visitor.class);
-        when(visitor.visit((AndPredicate) any(), (Indexes) any())).thenReturn(delegate);
-        when(visitor.visit((OrPredicate) any(), (Indexes) any())).thenReturn(delegate);
-        when(visitor.visit((NotPredicate) any(), (Indexes) any())).thenReturn(delegate);
+        when(visitor.visit((AndPredicate) any(), (IndexRegistry) any())).thenReturn(delegate);
+        when(visitor.visit((OrPredicate) any(), (IndexRegistry) any())).thenReturn(delegate);
+        when(visitor.visit((NotPredicate) any(), (IndexRegistry) any())).thenReturn(delegate);
 
         return visitor;
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/RangeVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/RangeVisitorTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -46,11 +46,11 @@ import static org.mockito.Mockito.when;
 public class RangeVisitorTest extends VisitorTestSupport {
 
     private RangeVisitor visitor;
-    private Indexes indexes;
+    private IndexRegistry indexes;
 
     @Before
     public void before() {
-        indexes = mock(Indexes.class);
+        indexes = mock(IndexRegistry.class);
         when(indexes.getConverter("age")).thenReturn(INTEGER_CONVERTER);
         when(indexes.getConverter("name")).thenReturn(STRING_CONVERTER);
         when(indexes.getConverter("noConverter")).thenReturn(null);
@@ -157,7 +157,7 @@ public class RangeVisitorTest extends VisitorTestSupport {
     }
 
     @Override
-    protected Indexes getIndexes() {
+    protected IndexRegistry getIndexes() {
         return indexes;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorTestSupport.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -46,7 +46,7 @@ public abstract class VisitorTestSupport {
     /**
      * @return the indexes available to the visitor being tested.
      */
-    protected abstract Indexes getIndexes();
+    protected abstract IndexRegistry getIndexes();
 
     protected static void assertEqualPredicate(EqualPredicate expected, Predicate actual) {
         assertTrue(actual instanceof EqualPredicate);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorUtilsTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -35,11 +35,11 @@ import static org.mockito.Mockito.mock;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class VisitorUtilsTest extends HazelcastTestSupport {
 
-    private Indexes mockIndexes;
+    private IndexRegistry mockIndexes;
 
     @Before
     public void setUp() {
-        mockIndexes = mock(Indexes.class);
+        mockIndexes = mock(IndexRegistry.class);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/Accessors.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/Accessors.java
@@ -38,9 +38,8 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
-import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
-import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
@@ -165,7 +164,7 @@ public class Accessors {
     }
 
     /**
-     * Obtains a list of {@link Indexes} for the given map local to the node
+     * Obtains a list of {@link IndexRegistry} for the given map local to the node
      * associated with it.
      * <p>
      * There may be more than one indexes instance associated with a map if its
@@ -174,7 +173,7 @@ public class Accessors {
      * @param map the map to obtain the indexes for.
      * @return the obtained indexes list.
      */
-    public static List<Indexes> getAllIndexes(IMap map) {
+    public static List<IndexRegistry> getAllIndexes(IMap map) {
         MapProxyImpl mapProxy = (MapProxyImpl) map;
         String mapName = mapProxy.getName();
         NodeEngine nodeEngine = mapProxy.getNodeEngine();
@@ -183,20 +182,21 @@ public class Accessors {
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
 
-        Indexes maybeGlobalIndexes = mapContainer.getIndexes();
+        IndexRegistry maybeGlobalIndexes = mapContainer.getGlobalIndexRegistry();
         if (maybeGlobalIndexes != null) {
             return Collections.singletonList(maybeGlobalIndexes);
         }
 
-        PartitionContainer[] partitionContainers = mapServiceContext.getPartitionContainers();
-        List<Indexes> allIndexes = new ArrayList<>();
-        for (PartitionContainer partitionContainer : partitionContainers) {
-            IPartition partition = partitionService.getPartition(partitionContainer.getPartitionId());
+        List<IndexRegistry> allIndexes = new ArrayList<>();
+
+        int partitionCount = partitionService.getPartitionCount();
+        for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+            IPartition partition = partitionService.getPartition(partitionId);
             if (!partition.isLocal()) {
                 continue;
             }
 
-            Indexes partitionIndexes = partitionContainer.getIndexes().get(mapName);
+            IndexRegistry partitionIndexes = mapContainer.getOrNullPartitionedIndexRegistry(partitionId);
             if (partitionIndexes == null) {
                 continue;
             }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/6511

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/6545

**Modifications:**
- Moved partitionedIndexes into `MapContainer`, to better manage its lifecycle.
- Add before/after operations for thread registrations
- Destroy indexes 1 time on heal
- Renamed `Indexes` as `IndexRegistry` to make indexing code more readable/understandable
- Renamed 2 types of indexes as `global` and `partitioned`, used these words consistently all over the code-base instead of current chaotic naming.