### PR TITLE
Fix duplicate results and failures of queries with indexes and query parameters and improve index scan generation [HZ-3014] [HZ-3013]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
@@ -169,6 +169,17 @@ public final class QueryUtil {
                 to = toValue;
             }
 
+            if (from != null && to != null) {
+                int cmp = ((Comparable) from).compareTo(to);
+                if (cmp > 0 || (cmp == 0 && (!rangeFilter.isFromInclusive() || !rangeFilter.isToInclusive()))) {
+                    // Range scan with from > to would produce empty result.
+                    // Range scan which reduces to point lookup (from = to) produces result only
+                    // if both ends are inclusive. Otherwise, result would be empty.
+                    // Do not create iteration pointer for such scans (as they would be invalid).
+                    return;
+                }
+            }
+
             result.add(IndexIterationPointer.create(
                     from, rangeFilter.isFromInclusive(), to, rangeFilter.isToInclusive(), descending, null));
         } else if (indexFilter instanceof IndexEqualsFilter) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
@@ -116,8 +116,9 @@ public final class QueryUtil {
             boolean descending,
             ExpressionEvalContext evalContext
     ) {
-        ArrayList<IndexIterationPointer> result = new ArrayList<>();
+        List<IndexIterationPointer> result = new ArrayList<>();
         createFromIndexFilterInt(indexFilter, compositeIndex, descending, evalContext, result);
+        result = IndexIterationPointer.normalizePointers(result, descending);
         return result.toArray(new IndexIterationPointer[0]);
     }
 
@@ -173,6 +174,8 @@ public final class QueryUtil {
         } else if (indexFilter instanceof IndexEqualsFilter) {
             IndexEqualsFilter equalsFilter = (IndexEqualsFilter) indexFilter;
             Comparable<?> value = equalsFilter.getComparable(evalContext);
+            // Note: this branch is also used for IS NULL, but null value in IndexEqualsFilter
+            // is mapped to NULL by getComparable, so we can easily use it in the same way as ordinary values.
             result.add(IndexIterationPointer.create(value, true, value, true, descending, null));
         } else if (indexFilter instanceof IndexCompositeFilter) {
             IndexCompositeFilter inFilter = (IndexCompositeFilter) indexFilter;

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
@@ -141,13 +141,26 @@ public final class QueryUtil {
             // based on null end (before conversion) meaning different things.
             // The above affects only `from` because NULLs are smaller than any other value and only DESC sort order
             // for which `to` is updated during the scan.
-            result.add(IndexIterationPointer.create(!compositeIndex && descending ? NULL : null, true,
-                    null, true, descending, null));
+            if (!compositeIndex && descending) {
+                result.add(IndexIterationPointer.ALL_ALT_DESC);
+            } else {
+                result.add(descending ? IndexIterationPointer.ALL_DESC : IndexIterationPointer.ALL);
+            }
         }
         if (indexFilter instanceof IndexRangeFilter) {
             IndexRangeFilter rangeFilter = (IndexRangeFilter) indexFilter;
 
-            Comparable<?> from = null;
+            if (rangeFilter.getFrom() == null && rangeFilter.getTo() == null) {
+                // IS NOT NULL range
+                assert !compositeIndex : "IS NOT NULL range should not be generated for composite index";
+                result.add(descending ? IndexIterationPointer.IS_NOT_NULL_DESC : IndexIterationPointer.IS_NOT_NULL);
+                return;
+            }
+
+            // Range filter for non-composite index never includes NULLs.
+            // Composite index should have both ends specified, and they might cover also NULL values for components
+            // but from/to will never be NULL but CompositeValue.
+            Comparable<?> from = compositeIndex ? null : NULL;
             if (rangeFilter.getFrom() != null) {
                 Comparable<?> fromValue = rangeFilter.getFrom().getValue(evalContext);
                 // If the index filter has expression like a > NULL, we need to
@@ -169,7 +182,7 @@ public final class QueryUtil {
                 to = toValue;
             }
 
-            if (from != null && to != null) {
+            if (to != null) {
                 int cmp = ((Comparable) from).compareTo(to);
                 if (cmp > 0 || (cmp == 0 && (!rangeFilter.isFromInclusive() || !rangeFilter.isToInclusive()))) {
                     // Range scan with from > to would produce empty result.

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
@@ -182,7 +182,7 @@ public final class QueryUtil {
                 to = toValue;
             }
 
-            if (to != null) {
+            if (from != null && to != null) {
                 int cmp = ((Comparable) from).compareTo(to);
                 if (cmp > 0 || (cmp == 0 && (!rangeFilter.isFromInclusive() || !rangeFilter.isToInclusive()))) {
                     // Range scan with from > to would produce empty result.

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexComponentFilterResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexComponentFilterResolver.java
@@ -122,6 +122,7 @@ final class IndexComponentFilterResolver {
         boolean fromInclusive = false;
         IndexFilterValue to = null;
         boolean toInclusive = false;
+        boolean found = false;
         List<RexNode> expressions = new ArrayList<>(2);
 
         for (IndexComponentCandidate candidate : candidates) {
@@ -129,8 +130,14 @@ final class IndexComponentFilterResolver {
                 continue;
             }
 
+            found = true;
             IndexRangeFilter candidateFilter = (IndexRangeFilter) candidate.getFilter();
 
+            // Use first matching candidate to define range.
+            // We do not expect many candidates with literal values as they should be simplified by Calcite.
+            // When there are both literals and dynamic parameters, we choose one of them.
+            // Maybe we could be preferring literals, but in general it is not possible to know upfront
+            // which one would be better.
             if (from == null && candidateFilter.getFrom() != null) {
                 from = candidateFilter.getFrom();
                 fromInclusive = candidateFilter.isFromInclusive();
@@ -142,9 +149,14 @@ final class IndexComponentFilterResolver {
                 toInclusive = candidateFilter.isToInclusive();
                 expressions.add(candidate.getExpression());
             }
+
+            if (from == null && to == null && candidateFilter.getFrom() == null && candidateFilter.getTo() == null) {
+                // IS NOT NULL filter
+                expressions.add(candidate.getExpression());
+            }
         }
 
-        if (from != null || to != null) {
+        if (found) {
             IndexRangeFilter filter = new IndexRangeFilter(from, fromInclusive, to, toInclusive);
             return new IndexComponentFilter(filter, expressions, converterType);
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
@@ -578,8 +578,6 @@ public final class IndexResolver {
 
         int columnIndex = ((RexInputRef) operand).getIndex();
 
-        QueryDataType type = HazelcastTypeUtils.toHazelcastType(operand.getType());
-
         // Create a range scan for entire range (-inf..+inf), range scan does not include nulls
         IndexFilter filter = new IndexRangeFilter(null, false, null, false);
 
@@ -684,7 +682,7 @@ public final class IndexResolver {
         );
     }
 
-    @SuppressWarnings({"ConstantConditions", "UnstableApiUsage"})
+    @SuppressWarnings({"ConstantConditions"})
     private static IndexComponentCandidate prepareSingleColumnSearchCandidateComparison(
             RexNode exp,
             RexNode operand1,

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/index/IndexResolver.java
@@ -351,7 +351,7 @@ public final class IndexResolver {
      * @param exp expression
      * @return candidate or {@code null} if the expression cannot be used by any index implementation
      */
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:ReturnCount"})
     private static IndexComponentCandidate prepareSingleColumnCandidate(
             RexNode exp,
             QueryParameterMetadata parameterMetadata
@@ -396,6 +396,13 @@ public final class IndexResolver {
                 // Handle SELECT * FROM WHERE column IS NULL.
                 // Internally it is converted into EQUALS(NULL) filter
                 return prepareSingleColumnCandidateIsNull(
+                        exp,
+                        removeCastIfPossible(((RexCall) exp).getOperands().get(0))
+                );
+
+            case IS_NOT_NULL:
+                // Handle SELECT * FROM WHERE column IS NOT NULL.
+                return prepareSingleColumnCandidateIsNotNull(
                         exp,
                         removeCastIfPossible(((RexCall) exp).getOperands().get(0))
                 );
@@ -546,6 +553,35 @@ public final class IndexResolver {
         );
 
         IndexFilter filter = new IndexEqualsFilter(filterValue);
+
+        return new IndexComponentCandidate(
+                exp,
+                columnIndex,
+                filter
+        );
+    }
+
+    /**
+     * Try creating a candidate filter for the "IS NOT NULL" expression.
+     * <p>
+     * Returns the filter RANGE(-inf..+inf) with "allowNulls-false".
+     *
+     * @param exp     original expression, e.g. {col IS NOT NULL}
+     * @param operand operand, e.g. {col}; CAST must be unwrapped before the method is invoked
+     * @return candidate or {@code null}
+     */
+    private static IndexComponentCandidate prepareSingleColumnCandidateIsNotNull(RexNode exp, RexNode operand) {
+        if (operand.getKind() != SqlKind.INPUT_REF) {
+            // The operand is not a column, e.g. {'literal' IS NOT NULL}, index cannot be used
+            return null;
+        }
+
+        int columnIndex = ((RexInputRef) operand).getIndex();
+
+        QueryDataType type = HazelcastTypeUtils.toHazelcastType(operand.getType());
+
+        // Create a range scan for entire range (-inf..+inf), range scan does not include nulls
+        IndexFilter filter = new IndexRangeFilter(null, false, null, false);
 
         return new IndexComponentCandidate(
                 exp,
@@ -783,11 +819,6 @@ public final class IndexResolver {
 
             IndexFilter candidateFilter = candidate.getFilter();
 
-            if (!(candidateFilter instanceof IndexEqualsFilter || candidateFilter instanceof IndexCompositeFilter)) {
-                // Support only equality for ORs
-                return null;
-            }
-
             // Make sure that all '=' expressions relate to a single column
             if (columnIndex == null) {
                 columnIndex = candidate.getColumnIndex();
@@ -796,7 +827,7 @@ public final class IndexResolver {
             }
 
             // Flatten. E.g. ((a=1 OR a=2) OR a=3) is parsed into IN(1, 2) and OR(3), that is then flatten into IN(1, 2, 3)
-            if (candidateFilter instanceof IndexEqualsFilter) {
+            if (candidateFilter instanceof IndexEqualsFilter || candidateFilter instanceof IndexRangeFilter) {
                 filters.add(candidateFilter);
             } else {
                 filters.addAll(((IndexCompositeFilter) candidateFilter).getFilters());

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/exec/scan/index/IndexRangeFilter.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/exec/scan/index/IndexRangeFilter.java
@@ -26,7 +26,8 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * Filter the is used for range requests. Could have either lower bound, upper bound or both.
+ * Filter the is used for range requests. Could have either lower bound, upper bound, both
+ * or none ({@code IS NOT NULL}).
  * <p>
  * For non-composite index: matches only NOT NULL values. If any of the bounds
  * is {@link com.hazelcast.query.impl.AbstractIndex#NULL}, matches nothing.
@@ -61,7 +62,6 @@ public class IndexRangeFilter implements IndexFilter, IdentifiedDataSerializable
     }
 
     public IndexRangeFilter(IndexFilterValue from, boolean fromInclusive, IndexFilterValue to, boolean toInclusive) {
-        assert from != null || to != null;
         assert from != null || !fromInclusive : "Unspecified from end must not be inclusive";
         assert to != null || !toInclusive : "Unspecified to end must not be inclusive";
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/SqlIndexAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/SqlIndexAbstractTest.java
@@ -179,7 +179,7 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
 
         // this query might not use index also due to selectivity of predicates
         check(query("field1>=? or field1<=?", f1.valueFrom(), f1.valueTo()),
-                false, //TODO: HZ-3014 c_sorted(),
+                c_sorted(),
                 isNotNull()
         );
     }
@@ -223,8 +223,7 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
 
         // WHERE f1 IS NOT NULL
         // index with additional condition is not used due to cost estimation, full scan is slightly cheaper
-        check(query("field1 IS NOT NULL"), false, // TODO: c_sorted() after HZ-3014
-                false, isNotNull());
+        check(query("field1 IS NOT NULL"), c_sorted(), false, isNotNull());
 
         // WHERE f1=literal
         check(query("field1=" + toLiteral(f1, f1.valueFrom())), c_notHashComposite(), eq(f1.valueFrom()));
@@ -426,7 +425,7 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
         // WHERE f1<? OR f1>? (range from -inf..val1 and val2..+inf)
         check(
                 query("field1<? OR field1>?", f1.valueFrom(), f1.valueTo()),
-                false, //TODO: HZ-3014 c_sorted(),
+                c_sorted(),
                 or(lt(f1.valueFrom()), gt(f1.valueTo()))
         );
 
@@ -511,11 +510,11 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
     }
 
     private void checkSecondColumn() {
-        // WHERE f1 IS (NOT) NULL
+        // WHERE f2 IS (NOT) NULL
         check(query("field2 IS NULL"), false, isNull_2());
         check(query("field2 IS NOT NULL"), false, isNotNull_2());
 
-        // WHERE f1<cmp>?
+        // WHERE f2<cmp>?
         check(query("field2=?", f2.valueFrom()), false, eq_2(f2.valueFrom()));
         check(query("field2!=?", f2.valueFrom()), false, neq_2(f2.valueFrom()));
         check(query("field2>?", f2.valueFrom()), false, gt_2(f2.valueFrom()));
@@ -581,6 +580,12 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
                 c_sorted() || c_notComposite(),
                 and(or(eq(f1.valueFrom()), eq(f1.valueTo())), and(gt_2(f2.valueFrom()), lt_2(f2.valueTo())))
         );
+        check(
+                // both field1 parameters have the same value
+                query("(field1=? OR field1=?) AND (field2>? AND field2<?)", f1.valueFrom(), f1.valueFrom(), f2.valueFrom(), f2.valueTo()),
+                c_sorted() || c_notComposite(),
+                and(or(eq(f1.valueFrom()), eq(f1.valueFrom())), and(gt_2(f2.valueFrom()), lt_2(f2.valueTo())))
+        );
 
         // RANGE + EQ
         check(
@@ -602,6 +607,37 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
                 c_sorted(),
                 and(and(gt(f1.valueFrom()), lt(f1.valueTo())), and(gt_2(f2.valueFrom()), lt_2(f2.valueTo())))
         );
+
+        // IS NOT NULL/IS NULL combinations
+        check(
+                query("field1 IS NULL AND field2 IS NULL"),
+                // lookup on all index types is possible
+                true,
+                and(isNull(), isNull_2())
+        );
+        check(
+                query("field1 IS NULL AND field2 IS NOT NULL"),
+                // NOT NULL is range scan so composite hash index cannot be used at all.
+                // Sorted index can be used at least for prefix (field1),
+                // condition on field2 should use composite index.
+                c_notHashComposite(),
+                and(isNull(), isNotNull_2())
+        );
+        check(
+                query("field1 IS NOT NULL AND field2 IS NULL"),
+                // basic query does not use sorted index due to poor selectivity of IS NOT NULL
+                // queries with ORDER BY will use sorted index due to high sort cost.
+                false,
+                and(isNotNull(), isNull_2())
+        );
+        check(
+                query("field1 IS NOT NULL AND field2 IS NOT NULL"),
+                // Note that with composite sorted index field2 will not be used in the lookup range
+                // because it is not possible to express such scan as bounded number of iteration pointers
+                // (and also it would not bring much value due to poor selectivity).
+                false,
+                and(isNotNull(), isNotNull_2())
+        );
     }
 
     private boolean c_always() {
@@ -614,6 +650,10 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
 
     private boolean c_sorted() {
         return indexType == IndexType.SORTED;
+    }
+
+    private boolean c_hash() {
+        return indexType == IndexType.HASH;
     }
 
     private boolean c_composite() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/iteration/IndexIterationPointer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/iteration/IndexIterationPointer.java
@@ -68,7 +68,7 @@ public class IndexIterationPointer implements IdentifiedDataSerializable {
 
     public static final IndexIterationPointer ALL = create(null, false, null, false, false, null);
     public static final IndexIterationPointer ALL_DESC = ALL.asDescending();
-    // alternative representation of ALL pointer
+    // alternative representation of ALL pointer (valid only for non-composite index)
     public static final IndexIterationPointer ALL_ALT = create(AbstractIndex.NULL, true, null, false, false, null);
     public static final IndexIterationPointer ALL_ALT_DESC = ALL_ALT.asDescending();
     public static final IndexIterationPointer IS_NULL = create(AbstractIndex.NULL, true, AbstractIndex.NULL, true, false, null);

--- a/hazelcast/src/main/java/com/hazelcast/internal/iteration/IndexIterationPointer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/iteration/IndexIterationPointer.java
@@ -18,18 +18,28 @@ package com.hazelcast.internal.iteration;
 
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.query.impl.AbstractIndex;
+import com.hazelcast.query.impl.OrderedIndexStore;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 
 /**
  * Index iteration range or point lookup.
  * <p>
- * The following types of pointers are supported:
+ * The following types of pointers are supported (see also predefined constants in the class):
  * <ul>
  *     <li>unconstrained pointer: (null, null) - scans null and not-null values</li>
  *     <li>single side constrained ranges: (null, X) and (X, null). Note that (null, X)
@@ -50,8 +60,32 @@ import java.io.IOException;
  *     they consist entirely of {@link com.hazelcast.query.impl.AbstractIndex#NULL} values.</li>
  *     </li>beware of distinction between Java null and NULL - it is not always obvious.</li>
  * </ol>
+ * <p>
+ * {@link IndexIterationPointer} set operation use the following ordering:
+ * {@code -Inf < NULL < non-null value < +Inf}.
  */
 public class IndexIterationPointer implements IdentifiedDataSerializable {
+
+    public static final IndexIterationPointer ALL = create(null, false, null, false, false, null);
+    public static final IndexIterationPointer ALL_DESC = ALL.asDescending();
+    // alternative representation of ALL pointer
+    public static final IndexIterationPointer ALL_ALT = create(AbstractIndex.NULL, true, null, false, false, null);
+    public static final IndexIterationPointer ALL_ALT_DESC = ALL_ALT.asDescending();
+    public static final IndexIterationPointer IS_NULL = create(AbstractIndex.NULL, true, AbstractIndex.NULL, true, false, null);
+    public static final IndexIterationPointer IS_NULL_DESC = IS_NULL.asDescending();
+    public static final IndexIterationPointer IS_NOT_NULL = create(AbstractIndex.NULL, false, null, false, false, null);
+    public static final IndexIterationPointer IS_NOT_NULL_DESC = IS_NOT_NULL.asDescending();
+
+    private static final Comparator<IndexIterationPointer> FROM_COMPARATOR =
+            Comparator.comparing(IndexIterationPointer::getFrom, OrderedIndexStore.SPECIAL_AWARE_COMPARATOR);
+    private static final Comparator<IndexIterationPointer> TO_COMPARATOR =
+            Comparator.comparing(IndexIterationPointer::getTo, OrderedIndexStore.SPECIAL_AWARE_COMPARATOR);
+    // Note that this ordering is not fully compatible with equals as it ignores inclusiveness.
+    // This is sufficient for the purpose of normalization.
+    // TODO: revisit in https://hazelcast.atlassian.net/browse/HZ-3093
+    //  maybe this is ok because IndexIterationPointer should not (?) contain NativeMemoryData
+    private static final Comparator<IndexIterationPointer> POINTER_COMPARATOR = FROM_COMPARATOR.thenComparing(TO_COMPARATOR);
+    private static final Comparator<IndexIterationPointer> POINTER_COMPARATOR_REVERSED = POINTER_COMPARATOR.reversed();
 
     private static final byte FLAG_DESCENDING = 1;
     private static final byte FLAG_FROM_INCLUSIVE = 1 << 1;
@@ -103,6 +137,17 @@ public class IndexIterationPointer implements IdentifiedDataSerializable {
                 to,
                 lastEntryKey
         );
+    }
+
+    public IndexIterationPointer asDescending() {
+        assert !isDescending() : "Pointer is already descending";
+        return create(getFrom(), isFromInclusive(), getTo(), isToInclusive(), true, lastEntryKeyData);
+    }
+
+    // visible for tests
+    boolean isAll() {
+        return (from == null || (from == AbstractIndex.NULL && isFromInclusive()))
+                &&  (to == null);
     }
 
     @Nullable
@@ -170,5 +215,178 @@ public class IndexIterationPointer implements IdentifiedDataSerializable {
                 + (isDescending() ? " DESC" : " ASC")
                 + ", lastEntryKeyData=" + lastEntryKeyData
                 + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IndexIterationPointer that = (IndexIterationPointer) o;
+        return flags == that.flags
+                && Objects.equals(getFrom(), that.getFrom())
+                && Objects.equals(getTo(), that.getTo())
+                && Objects.equals(getLastEntryKeyData(), that.getLastEntryKeyData());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(flags, getFrom(), getTo(), getLastEntryKeyData());
+    }
+
+    /**
+     * Checks if two pointers overlap or are adjacent which means that they can be combined into a single pointer.
+     * Requires that {@code left <= right} regardless of descending flags - leads to simpler checks
+     * @param left
+     * @param right
+     * @param comparator from/to value comparator, must be able to handle special values (NULL, null).
+     * @return if the pointers overlap or are adjacent
+     */
+    public static boolean overlapsOrdered(IndexIterationPointer left, IndexIterationPointer right, Comparator comparator) {
+        assert left.isDescending() == right.isDescending() : "Cannot compare pointer with different directions";
+        assert left.lastEntryKeyData == null && right.lastEntryKeyData == null : "Can merge only initial pointers";
+
+        // fast path for the same instance
+        if (left == right) {
+            return true;
+        }
+
+        assert comparator.compare(left.from, right.from) <= 0 : "Pointers must be ordered";
+
+        // if one of the ends is +/-inf respectively -> overlap
+        if (left.to == null || right.from == null) {
+            return true;
+        }
+
+        // if given end is equal the ranges overlap (or at least are adjacent)
+        // if at least one of the ranges is inclusive
+        boolean eqOverlaps = left.isToInclusive() || right.isFromInclusive();
+
+        // Check non-inf values, do not need to check the other way around because pointers are ordered
+        // Thanks to order we do not have to check `right.to`, we only need to check
+        // if `right.from` belongs to `left` pointer range.
+        // we must take into account inclusiveness so we do not merge < X and > X ranges
+        int rfCmpLt = comparator.compare(right.from, left.to);
+        return eqOverlaps ? rfCmpLt <= 0 : rfCmpLt < 0;
+    }
+
+    /**
+     * Calculates union of two iteration pointers. If the pointers are not
+     * overlapping it will contain also everything between them. Pointers can
+     * be passed in any order.
+     *
+     * @param left
+     * @param right
+     * @param comparator from/to value comparator, must be able to handle special values (NULL, null).
+     * @return
+     * @see #overlapsOrdered
+     */
+    public static IndexIterationPointer union(IndexIterationPointer left, IndexIterationPointer right, Comparator comparator) {
+        assert left.isDescending() == right.isDescending();
+        assert left.getLastEntryKeyData() == null && right.lastEntryKeyData == null : "Can merge only initial pointers";
+        Tuple2<Comparable<?>, Boolean> newFrom = min(left.getFrom(), left.isFromInclusive(),
+                right.getFrom(), right.isFromInclusive(),
+                comparator);
+        Tuple2<Comparable<?>, Boolean> newTo = max(left.getTo(), left.isToInclusive(),
+                right.getTo(), right.isToInclusive(),
+                comparator);
+
+        return IndexIterationPointer.create(newFrom.f0(), newFrom.f1(), newTo.f0(), newTo.f1(),
+                left.isDescending(), null);
+    }
+
+    // (value, inclusive); null means -inf
+    private static Tuple2<Comparable<?>, Boolean> min(Comparable<?> left, boolean leftInclusive,
+                                                      Comparable<?> right, boolean rightInclusive,
+                                                      Comparator comparator) {
+        // fast path for infinity
+        if (left == null || right == null) {
+            // -inf is not inclusive
+            return tuple2(null, false);
+        }
+        int result = comparator.compare(left, right);
+        if (result == 0) {
+            // both ends are equal, but might differ in inclusiveness,
+            // use one which covers bigger range
+            return tuple2(left, leftInclusive || rightInclusive);
+        } else if (result < 0) {
+            return tuple2(left, leftInclusive);
+        } else {
+            return tuple2(right, rightInclusive);
+        }
+    }
+
+    // (value, inclusive), null means +inf
+    private static Tuple2<Comparable<?>, Boolean> max(Comparable<?> left, boolean leftInclusive,
+                                                      Comparable<?> right, boolean rightInclusive,
+                                                      Comparator comparator) {
+        // fast path for infinity
+        if (left == null || right == null) {
+            // +inf is not inclusive
+            return tuple2(null, false);
+        }
+        int result = comparator.compare(left, right);
+        if (result == 0) {
+            // both ends are equal, but might differ in inclusiveness,
+            // use one which covers bigger range
+            return tuple2(left, leftInclusive || rightInclusive);
+        } else if (result < 0) {
+            return tuple2(right, rightInclusive);
+        } else {
+            return tuple2(left, leftInclusive);
+        }
+    }
+
+    /**
+     * Converts list of {@link IndexIterationPointer}s to ordered list of non-overlapping pointers.
+     *
+     * @param result List to be normalized. It may be modified in place
+     * @param descending
+     * @return Normalized list. It may be the same object as passed as argument or different.
+     */
+    @Nonnull
+    public static List<IndexIterationPointer> normalizePointers(@Nonnull List<IndexIterationPointer> result, boolean descending) {
+        if (result.size() <= 1) {
+            // single pointer, nothing to do
+            return result;
+        }
+
+        // without the same ordering of pointers order of results would be unspecified
+        assert result.stream().allMatch(r -> r.isDescending() == descending)
+                : "All iteration pointers must have the same direction";
+
+        // order of ranges is critical for preserving ordering of the results
+        Collections.sort(result, descending ? POINTER_COMPARATOR_REVERSED : POINTER_COMPARATOR);
+
+        // loop until we processed the last remaining pair
+        //
+        // do the normalization in place without extra shifts in the array
+        // we write normalized pointers from the beginning
+        int writeIdx = 0;
+        IndexIterationPointer currentMerged = result.get(0);
+        for (int nextPointerIdx = 1; nextPointerIdx < result.size(); nextPointerIdx++) {
+            // compare current pointer with next one and merge if they overlap
+            // otherwise go to next pointer
+            // pointers might be ordered in descending way but util methods expect ascending order of arguments
+            IndexIterationPointer next = result.get(nextPointerIdx);
+            if (!descending && overlapsOrdered(currentMerged, next, OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)) {
+                // merge overlapping ranges
+                currentMerged = union(currentMerged, next, OrderedIndexStore.SPECIAL_AWARE_COMPARATOR);
+            } else if (descending && overlapsOrdered(next, currentMerged, OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)) {
+                // merge overlapping ranges
+                currentMerged = union(next, currentMerged, OrderedIndexStore.SPECIAL_AWARE_COMPARATOR);
+            } else {
+                // write current pointer and advance
+                result.set(writeIdx++, currentMerged);
+                currentMerged = next;
+            }
+        }
+        // write last remaining pointer
+        result.set(writeIdx++, currentMerged);
+
+        return result.subList(0, writeIdx);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
@@ -49,7 +49,7 @@ public class OrderedIndexStore extends BaseSingleValueIndexStore {
     public static final Comparator<Data> DATA_COMPARATOR = new DataComparator();
     public static final Comparator<Data> DATA_COMPARATOR_REVERSED = new DataComparator().reversed();
 
-    private static final Comparator<Comparable> SPECIAL_AWARE_COMPARATOR = (left, right) -> {
+    public static final Comparator<Comparable> SPECIAL_AWARE_COMPARATOR = (left, right) -> {
         // compare to explicit instances of special Comparables to avoid infinite loop
         // NEGATIVE_INFINITY should not be used in the index or queries
         // - the same result can be achieved by inclusive NULL or null.

--- a/hazelcast/src/test/java/com/hazelcast/internal/iteration/IndexIterationPointerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/iteration/IndexIterationPointerTest.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.iteration;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import com.hazelcast.query.impl.OrderedIndexStore;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.collect.Range.atLeast;
+import static com.google.common.collect.Range.atMost;
+import static com.google.common.collect.Range.closedOpen;
+import static com.google.common.collect.Range.greaterThan;
+import static com.google.common.collect.Range.lessThan;
+import static com.google.common.collect.Range.singleton;
+import static com.hazelcast.internal.iteration.IndexIterationPointer.ALL;
+import static com.hazelcast.internal.iteration.IndexIterationPointer.ALL_ALT;
+import static com.hazelcast.internal.iteration.IndexIterationPointer.IS_NOT_NULL;
+import static com.hazelcast.internal.iteration.IndexIterationPointer.IS_NOT_NULL_DESC;
+import static com.hazelcast.internal.iteration.IndexIterationPointer.IS_NULL;
+import static com.hazelcast.internal.iteration.IndexIterationPointer.IS_NULL_DESC;
+import static com.hazelcast.internal.iteration.IndexIterationPointer.create;
+import static com.hazelcast.internal.iteration.IndexIterationPointer.normalizePointers;
+import static com.hazelcast.internal.iteration.IndexIterationPointer.overlapsOrdered;
+import static com.hazelcast.internal.iteration.IndexIterationPointer.union;
+import static com.hazelcast.query.impl.AbstractIndex.NULL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IndexIterationPointerTest {
+
+    // use Guava's nice Range DSL
+    // produces ranges that do not include NULL unless NULL is explicitly used as bound
+    public static <C extends Comparable> IndexIterationPointer pointer(com.google.common.collect.Range<C> r, boolean descending) {
+        return create(
+                r.hasLowerBound() ? r.lowerEndpoint() : NULL, r.hasLowerBound() && r.lowerBoundType() == BoundType.CLOSED,
+                r.hasUpperBound() ? r.upperEndpoint() : null, r.hasUpperBound() && r.upperBoundType() == BoundType.CLOSED,
+                descending, null
+        );
+    }
+
+    public static <C extends Comparable> IndexIterationPointer pointer(com.google.common.collect.Range<C> r) {
+        return pointer(r, false);
+    }
+
+    @Test
+    void createSingleton() {
+        IndexIterationPointer singleton = create(5, true, 5, true, false, null);
+        assertThat(singleton.getFrom()).isEqualTo(singleton.getTo()).isEqualTo(5);
+        assertTrue(singleton.isFromInclusive());
+        assertTrue(singleton.isToInclusive());
+        assertFalse(singleton.isDescending());
+    }
+
+    @Test
+    void createBadSingleton() {
+        assertThatThrownBy(() -> create(5, true, 5, false, false, null))
+                .isInstanceOf(AssertionError.class).hasMessageContaining("Point lookup limits must be all inclusive");
+        assertThatThrownBy(() -> create(5, false, 5, true, false, null))
+                .isInstanceOf(AssertionError.class).hasMessageContaining("Point lookup limits must be all inclusive");
+        assertThatThrownBy(() -> create(5, false, 5, false, false, null))
+                .isInstanceOf(AssertionError.class).hasMessageContaining("Point lookup limits must be all inclusive");
+    }
+
+    @Test
+    void overlapsOrderedSingleton() {
+        assertTrue(overlapsOrdered(pointer(singleton(5)), pointer(singleton(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR), "singleton value should overlap with itself");
+        assertFalse(overlapsOrdered(pointer(singleton(5)), pointer(singleton(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR), "singleton value should not overlap with different singleton");
+        assertFalse(overlapsOrdered(pointer(singleton(5), true), pointer(singleton(6), true),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR), "singleton value should not overlap with different singleton");
+    }
+
+    @Test
+    void overlapsOrderedRanges() {
+        // ranges unbounded on the same side
+        assertTrue(overlapsOrdered(pointer(lessThan(5)), pointer(lessThan(5)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+        assertTrue(overlapsOrdered(pointer(lessThan(5)), pointer(lessThan(6)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+
+        assertTrue(overlapsOrdered(pointer(greaterThan(5)), pointer(greaterThan(5)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+        assertTrue(overlapsOrdered(pointer(greaterThan(5)), pointer(greaterThan(6)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+
+        // adjacent ranges unbounded on different sides
+        assertFalse(overlapsOrdered(pointer(lessThan(5)), pointer(greaterThan(5)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR),
+                "Ranges with the same open end should not be adjacent");
+        assertTrue(overlapsOrdered(pointer(lessThan(5)), pointer(atLeast(5)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+        assertTrue(overlapsOrdered(pointer(atMost(5)), pointer(greaterThan(5)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+
+        // overlapping ranges unbounded on different sides
+        assertTrue(overlapsOrdered(pointer(lessThan(6)), pointer(greaterThan(5)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+        assertTrue(overlapsOrdered(pointer(lessThan(6)), pointer(atLeast(5)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+        assertTrue(overlapsOrdered(pointer(atMost(6)), pointer(greaterThan(5)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+        assertTrue(overlapsOrdered(pointer(atMost(6)), pointer(atLeast(5)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+
+        // non-overlapping ranges unbounded on different sides
+        assertFalse(overlapsOrdered(pointer(lessThan(5)), pointer(greaterThan(6)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+        assertFalse(overlapsOrdered(pointer(lessThan(5)), pointer(atLeast(6)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+        assertFalse(overlapsOrdered(pointer(atMost(5)), pointer(greaterThan(6)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+        assertFalse(overlapsOrdered(pointer(atMost(5)), pointer(atLeast(6)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR));
+    }
+
+    @Test
+    void overlapsOrderedSingletonValidation() {
+        assertThatThrownBy(() -> overlapsOrdered(pointer(singleton(6)), pointer(singleton(5)), OrderedIndexStore.SPECIAL_AWARE_COMPARATOR))
+                .isInstanceOf(AssertionError.class).hasMessageContaining("Pointers must be ordered");
+        assertThatThrownBy(() -> overlapsOrdered(pointer(singleton(6), true), pointer(singleton(5), true),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR))
+                .isInstanceOf(AssertionError.class).hasMessageContaining("Pointers must be ordered");
+    }
+
+    @Test
+    void createIsNull() {
+        IndexIterationPointer singleton = IS_NULL;
+        assertThat(singleton.getFrom()).isEqualTo(singleton.getTo()).isEqualTo(NULL);
+        assertTrue(singleton.isFromInclusive());
+        assertTrue(singleton.isToInclusive());
+        assertFalse(singleton.isDescending());
+    }
+
+    @Test
+    void overlapsIsNull() {
+        assertTrue(overlapsOrdered(IS_NULL, IS_NULL,
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR), "IS NULL should overlap with itself");
+        assertTrue(overlapsOrdered(IS_NULL_DESC, IS_NULL_DESC,
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR), "IS NULL should overlap with itself");
+
+        assertFalse(overlapsOrdered(IS_NULL, pointer(singleton(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR), "IS NULL should not overlap with singleton");
+        assertFalse(overlapsOrdered(IS_NULL_DESC, pointer(singleton(5), true),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR), "IS NULL should not overlap with singleton");
+
+        assertTrue(overlapsOrdered(IS_NULL, IS_NOT_NULL,
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR), "IS NULL should overlap with NOT NULL (they are adjacent)");
+        assertTrue(overlapsOrdered(IS_NULL_DESC, IS_NOT_NULL_DESC,
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR), "IS NULL should overlap with NOT NULL (they are adjacent)");
+    }
+
+    @Test
+    void isAll() {
+        assertFalse(pointer(singleton(5)).isAll());
+        assertFalse(IS_NULL.isAll());
+        assertFalse(IS_NOT_NULL.isAll());
+        assertTrue(ALL.isAll());
+        assertTrue(ALL_ALT.isAll());
+    }
+
+    @Test
+    void unionSpecialValues() {
+        // null/not null combinations
+        assertThat(union(IS_NULL, IS_NULL,
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(IS_NULL);
+        assertThat(union(IS_NOT_NULL, IS_NOT_NULL,
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(IS_NOT_NULL);
+        assertTrue(union(IS_NULL, IS_NOT_NULL,
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll());
+
+        // all + something = all
+        assertTrue(union(ALL, IS_NULL,
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll());
+        assertTrue(union(ALL, IS_NOT_NULL,
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll());
+        assertTrue(union(ALL, pointer(singleton(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll());
+        assertTrue(union(ALL, pointer(lessThan(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll());
+        assertTrue(union(ALL, pointer(atMost(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll());
+        assertTrue(union(ALL, pointer(atLeast(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll());
+        assertTrue(union(ALL, pointer(greaterThan(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll());
+        assertTrue(union(ALL, ALL,
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll());
+    }
+
+    @Test
+    void unionAdjacentSingletonRange() {
+        assertThat(union(pointer(singleton(5)), pointer(singleton(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(singleton(5)));
+
+        assertThat(union(pointer(singleton(5)), pointer(greaterThan(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(atLeast(5)));
+        // reverse order is also allowed
+        assertThat(union(pointer(greaterThan(5)), pointer(singleton(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(atLeast(5)));
+
+        assertThat(union(pointer(singleton(5)), pointer(lessThan(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(atMost(5)));
+        // reverse order is also allowed
+        assertThat(union(pointer(lessThan(5)), pointer(singleton(5)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(atMost(5)));
+    }
+
+    @Test
+    void unionRange() {
+        assertThat(union(pointer(lessThan(5)), pointer(lessThan(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(lessThan(6)));
+        assertThat(union(pointer(lessThan(5)), pointer(atMost(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(atMost(6)));
+        assertThat(union(pointer(atMost(5)), pointer(atMost(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(atMost(6)));
+        assertThat(union(pointer(atMost(5)), pointer(lessThan(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(lessThan(6)));
+
+        assertThat(union(pointer(greaterThan(5)), pointer(greaterThan(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(greaterThan(5)));
+        assertThat(union(pointer(greaterThan(5)), pointer(atLeast(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(greaterThan(5)));
+        assertThat(union(pointer(atLeast(5)), pointer(atLeast(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(atLeast(5)));
+        assertThat(union(pointer(atLeast(5)), pointer(greaterThan(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(pointer(atLeast(5)));
+    }
+
+    @Test
+    void unionRangeToAll() {
+        // union of { > X } and { < X + NULLs }
+        assertThat(union(pointer(greaterThan(5)), pointer(Range.closedOpen(NULL, 6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll()).isTrue();
+        assertThat(union(pointer(atLeast(5)), pointer(Range.closedOpen(NULL, 6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll()).isTrue();
+        assertThat(union(pointer(atLeast(5)), pointer(Range.closed(NULL, 6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll()).isTrue();
+        assertThat(union(pointer(greaterThan(5)), pointer(Range.closed(NULL, 6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR).isAll()).isTrue();
+
+        assertThat(union(pointer(greaterThan(5)), pointer(lessThan(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(IS_NOT_NULL);
+        assertThat(union(pointer(atLeast(5)), pointer(lessThan(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(IS_NOT_NULL);
+        assertThat(union(pointer(atLeast(5)), pointer(atMost(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(IS_NOT_NULL);
+        assertThat(union(pointer(greaterThan(5)), pointer(atMost(6)),
+                OrderedIndexStore.SPECIAL_AWARE_COMPARATOR)).isEqualTo(IS_NOT_NULL);
+    }
+
+    private static <T> List<T> arrayListOf(T... elements) {
+        return new ArrayList<>(List.of(elements));
+    }
+
+    @Test
+    void normalizePointersMerge() {
+        assertThat(normalizePointers(arrayListOf(
+                pointer(singleton(5)), pointer(singleton(5))), false))
+                .as("Should merge overlapping ranges")
+                .containsExactly(pointer(singleton(5)));
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(singleton(5)), pointer(singleton(6))), false))
+                .as("Should not merge non overlapping ranges")
+                .containsExactly(pointer(singleton(5)), pointer(singleton(6)));
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(singleton(6), true), pointer(singleton(5), true)), true))
+                .as("Should not merge non overlapping desc ranges")
+                .containsExactly(pointer(singleton(6), true), pointer(singleton(5), true));
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(lessThan(2)), pointer(lessThan(5))), false))
+                .as("Should merge ranges in correct order")
+                .containsExactly(pointer(lessThan(5)));
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(lessThan(5)), pointer(lessThan(2))), false))
+                .as("Should merge ranges in wrong order")
+                .containsExactly(pointer(lessThan(5)));
+    }
+
+    @Test
+    void normalizePointersOrder() {
+        assertThat(normalizePointers(arrayListOf(
+                pointer(singleton(6)), pointer(singleton(5))), false))
+                .as("Should order and not merge non overlapping ranges")
+                .containsExactly(pointer(singleton(5)), pointer(singleton(6)));
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(singleton(6)), pointer(lessThan(5))), false))
+                .as("Should order and not merge non overlapping ranges")
+                .containsExactly(pointer(lessThan(5)), pointer(singleton(6)));
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(greaterThan(6)), pointer(singleton(5))), false))
+                .as("Should order and not merge non overlapping ranges")
+                .containsExactly(pointer(singleton(5)), pointer(greaterThan(6)));
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(singleton(5), true), pointer(singleton(6), true)), true))
+                .as("Should order and not merge non overlapping desc ranges")
+                .containsExactly(pointer(singleton(6), true), pointer(singleton(5), true));
+    }
+
+    @Test
+    void normalizePointersMergeIsNullWithLessThan() {
+        // due to NULL ordering NULL and < X pointers can be merged
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(lessThan(6)), IS_NULL), false))
+                .as("IS NULL should be merged with less than")
+                .containsExactly(pointer(closedOpen(NULL, 6)));
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(greaterThan(6)), IS_NULL), false))
+                .as("IS NULL should not be merged with greater than")
+                .containsExactly(IS_NULL, pointer(greaterThan(6)));
+    }
+
+    @Test
+    void normalizePointersMany() {
+        // some cases for partial reduction of number of pointers
+        assertThat(normalizePointers(arrayListOf(
+                pointer(singleton(6)), pointer(singleton(5)), IS_NULL), false))
+                .containsExactly(IS_NULL, pointer(singleton(5)), pointer(singleton(6)));
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(singleton(6)), pointer(singleton(5)), IS_NOT_NULL), false))
+                .containsExactly(IS_NOT_NULL);
+
+        assertThat(normalizePointers(arrayListOf(
+                pointer(greaterThan(5)), pointer(singleton(6)), IS_NULL), false))
+                .containsExactly(IS_NULL, pointer(greaterThan(5)));
+
+    }
+}


### PR DESCRIPTION
In order to generate correct results for queries with query parameters normalisation of index iteration pointers set is performed to make it disjoint and ordered. This has to be done late, when query parameter values are known (during execution not optimisation), for literals this happens during query optimisation. This process uses special treatment of `NULL` value which can be compared and satisfies the following ordering: `-Inf < NULL < non null value < +Inf`. This ordering is compatible with SQL `ORDER BY x NULLS FIRST` and `ORDER BY x DESC NULLS LAST` - this is the only currently available NULL placement in ordered results.

After that some obsolete restrictions for index usage (e.g. disjunction of ranges) could be removed and `IS NOT NULL` predicates can also be correctly executed using index.

Fixes HZ-3013, HZ-3014

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases

