### PR TITLE
Call interceptor with old-value-clone[HZ-3186]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -258,6 +258,10 @@ public final class EntryOperator {
         return oldValue;
     }
 
+    public Object getOldValueClone() {
+        return oldValueClone;
+    }
+
     public Data getResult() {
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/EntryOpSteps.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/steps/EntryOpSteps.java
@@ -221,7 +221,7 @@ public enum EntryOpSteps implements IMapOpStep {
                         }
                         Object newValue = entryOperator.extractNewValue();
                         newValue = mapServiceContext.interceptPut(mapContainer.getInterceptorRegistry(),
-                                state.getOldValue(), newValue);
+                                entryOperator.getOldValueClone(), newValue);
                         state.setNewValue(newValue);
                         state.setTtl(entryOperator.getEntry().getNewTtl());
                         state.setChangeExpiryOnUpdate(entryOperator.getEntry().isChangeExpiryOnUpdate());

--- a/hazelcast/src/test/java/com/hazelcast/map/listener/EntryUpdatedListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/listener/EntryUpdatedListenerTest.java
@@ -16,33 +16,54 @@
 
 package com.hazelcast.map.listener;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.MapInterceptorAdaptor;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-@RunWith(HazelcastParallelClassRunner.class)
+import static java.util.Arrays.asList;
+
+@RunWith(HazelcastParametrizedRunner.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class EntryUpdatedListenerTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameters(name = "offload: {0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {true},
+                {false}
+        });
+    }
+
+    @Parameterized.Parameter
+    public boolean offload;
+
     /**
      * @see <a href="https://hazelcast.atlassian.net/browse/HZ-2837">HZ-2837 - Field level mutation being taken by listener as
      *      old value but not being considered by interceptor - Strange Behaviour</a>
      */
     @Test
     public void testOldValues() throws InterruptedException, ExecutionException {
-        final HazelcastInstance instance = createHazelcastInstanceFactory().newHazelcastInstance();
+        Config config = smallInstanceConfigWithoutJetAndMetrics();
+        config.setProperty(MapServiceContext.PROP_FORCE_OFFLOAD_ALL_OPERATIONS, String.valueOf(offload));
+        final HazelcastInstance instance = createHazelcastInstanceFactory().newHazelcastInstance(config);
 
         // Create a map
         final IMap<Object, AtomicInteger> map = instance.getMap(randomMapName());
@@ -107,7 +128,7 @@ public class EntryUpdatedListenerTest extends HazelcastTestSupport {
             final Consumer<EntryUpdatedListener<Object, AtomicInteger>> listenerSetter) {
         final CompletableFuture<Integer> oldValue = new CompletableFuture<>();
         listenerSetter
-                .accept((EntryUpdatedListener<Object, AtomicInteger>) event -> oldValue.complete(event.getOldValue().get()));
+                .accept(event -> oldValue.complete(event.getOldValue().get()));
         return oldValue;
     }
 }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/25535

Missing piece from https://github.com/hazelcast/hazelcast/pull/25478