### PR TITLE
Stop `com.hazelcast.config.XmlYamlConfigBuilderEqualsTest` from leaving `password.txt` artifact behind

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.config.replacer.EncryptionReplacer;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -25,10 +25,10 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.TreeSet;
@@ -81,8 +81,8 @@ public class XmlYamlConfigBuilderEqualsTest extends HazelcastTestSupport {
                 .replace("\r", "")
                 .replace("import:\n    - your-configuration-YAML-file", "");
 
-        // create file to the working directory needed for the EncryptionReplacer
-        createPasswordFile("password.txt", "h4z3lc4$t");
+        fullExampleXml = replacePasswordFileWithTemporaryFile(fullExampleXml);
+        fullExampleYaml = replacePasswordFileWithTemporaryFile(fullExampleYaml);
 
         Config xmlConfig = new InMemoryXmlConfig(fullExampleXml);
         Config yamlConfig = new InMemoryYamlConfig(fullExampleYaml);
@@ -106,9 +106,9 @@ public class XmlYamlConfigBuilderEqualsTest extends HazelcastTestSupport {
         fullExampleYaml = fullExampleYaml
                 .replace("\r", "")
                 .replace("import:\n    - your-configuration-YAML-file", "");
-
-        // create file to the working directory needed for the EncryptionReplacer
-        createPasswordFile("password.txt", "h4z3lc4$t");
+        
+        fullExampleXml = replacePasswordFileWithTemporaryFile(fullExampleXml);
+        fullExampleYaml = replacePasswordFileWithTemporaryFile(fullExampleYaml);
 
         Config xmlConfig = new InMemoryXmlConfig(fullExampleXml);
         Config yamlConfig = new InMemoryYamlConfig(fullExampleYaml);
@@ -134,20 +134,20 @@ public class XmlYamlConfigBuilderEqualsTest extends HazelcastTestSupport {
         }
     }
 
-    static File createPasswordFile(String passwordFileName, String passwordFileContent) throws IOException {
-        File workDir = new File(".");
-        File file = new File(workDir, passwordFileName);
-        file.deleteOnExit();
+    /**
+     * The supplied config files contain a {@value EncryptionReplacer#PROPERTY_PASSWORD_FILE} reference to a path of
+     * {@code password.txt}, which is resolved at load-time by {@link EncryptionReplacer} - if missing, an exception is thrown.
+     * <p>
+     * This file doesn't exist within the scope of the test, especially not in the working directory - so create a temporary
+     * file, and update the reference to use that instead.
+     */
+    private static String replacePasswordFileWithTemporaryFile(String str) throws IOException {
+        final Path file = Files.createTempFile("password", ".txt");
+        file.toFile().deleteOnExit();
 
-        if (passwordFileContent != null && passwordFileContent.length() > 0) {
-            PrintWriter out = new PrintWriter(file);
-            try {
-                out.print(passwordFileContent);
-            } finally {
-                IOUtil.closeResource(out);
-            }
-        }
-        return file;
+        Files.writeString(file, "h4z3lc4$t");
+
+        return str.replace("password.txt", file.toString());
     }
 
     private void assertXmlYamlFileEquals(String filenameBase) {

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
@@ -106,7 +106,7 @@ public class XmlYamlConfigBuilderEqualsTest extends HazelcastTestSupport {
         fullExampleYaml = fullExampleYaml
                 .replace("\r", "")
                 .replace("import:\n    - your-configuration-YAML-file", "");
-        
+
         fullExampleXml = replacePasswordFileWithTemporaryFile(fullExampleXml);
         fullExampleYaml = replacePasswordFileWithTemporaryFile(fullExampleYaml);
 


### PR DESCRIPTION
`com.hazelcast.config.XmlYamlConfigBuilderEqualsTest` creates `password.txt` in the working directory to allow the config files to be fully inflated without errors.

This file _should_ be cleaned up by `java.io.File.deleteOnExit()`, but it's not always.

I've refactored these tests to create the `passwordFile` in a temporary location, and pre-parse the config file to replace the `password.txt` reference with this new path to avoid this.

Fixes https://github.com/hazelcast/hazelcast/issues/16284

