### PR TITLE
Stop `com.hazelcast.internal.diagnostics.MetricsPluginTest` from leaving `diagnostics-xxx.log` artifacts behind

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
@@ -25,9 +25,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 
-import java.io.IOException;
-import java.nio.file.Files;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -39,23 +36,33 @@ import static com.hazelcast.test.Accessors.getNodeEngineImpl;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 
+import org.junit.After;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MetricsPluginTest extends AbstractDiagnosticsPluginTest {
 
     private MetricsPlugin plugin;
     private MetricsRegistry metricsRegistry;
+    private Diagnostics diagnostics;
 
     @Before
-    public void setup() throws IOException {
-        Config config = new Config().setProperty(Diagnostics.ENABLED.getName(), "true")
-                .setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1")
-                .setProperty(Diagnostics.DIRECTORY.getName(), Files.createTempDirectory(Diagnostics.DIRECTORY.getSystemProperty()).toString());
+    public void setup() {
+        Config config = new Config()
+                .setProperty(Diagnostics.ENABLED.getName(), "true")
+                .setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
         HazelcastInstance hz = createHazelcastInstance(config);
         NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(hz);
         metricsRegistry = nodeEngineImpl.getMetricsRegistry();
         plugin = new MetricsPlugin(nodeEngineImpl);
         plugin.onStart();
+
+        diagnostics = AbstractDiagnosticsPluginTest.getDiagnostics(hz);
+    }
+
+    @After
+    public void teardown() {
+        cleanupDiagnosticFiles(diagnostics);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
@@ -24,6 +24,10 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -43,10 +47,10 @@ public class MetricsPluginTest extends AbstractDiagnosticsPluginTest {
     private MetricsRegistry metricsRegistry;
 
     @Before
-    public void setup() {
-        Config config = new Config()
-                .setProperty(Diagnostics.ENABLED.getName(), "true")
-                .setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
+    public void setup() throws IOException {
+        Config config = new Config().setProperty(Diagnostics.ENABLED.getName(), "true")
+                .setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1")
+                .setProperty(Diagnostics.DIRECTORY.getName(), Files.createTempDirectory(Diagnostics.DIRECTORY.getSystemProperty()).toString());
         HazelcastInstance hz = createHazelcastInstance(config);
         NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(hz);
         metricsRegistry = nodeEngineImpl.getMetricsRegistry();


### PR DESCRIPTION
`com.hazelcast.internal.diagnostics.MetricsPluginTest.testRun()` is initializing a `com.hazelcast.internal.diagnostics.DiagnosticsLogFile` which defaults to writing `diagnostics-xxx.log` to the working directory.

`DiagnosticsLogTest` already handles this by running `AbstractDiagnosticsPluginTest.cleanupDiagnosticFiles(Diagnostics)` `@After`.

I've replicated this behaviour in `MetricsPluginTest`.

An alternative solution / addition would be to set the `Diagnostics.DIRECTORY` property to some temporary directory.

Fixes https://github.com/hazelcast/hazelcast/issues/16284