### PR TITLE
Reverted the incorrectly changed method names back to the original name

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveAllKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveAllKeysMessageTask.java
@@ -96,7 +96,7 @@ public class CacheRemoveAllKeysMessageTask
 
     @Override
     public String getMethodName() {
-        return SecurityInterceptorConstants.REMOVE_ALL_KEYS;
+        return SecurityInterceptorConstants.REMOVE_ALL;
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetGetAllMessageTask.java
@@ -73,7 +73,7 @@ public class SetGetAllMessageTask
 
     @Override
     public String getMethodName() {
-        return SecurityInterceptorConstants.GET_ALL;
+        return SecurityInterceptorConstants.ITERATOR;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityInterceptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityInterceptorConstants.java
@@ -56,7 +56,6 @@ public final class SecurityInterceptorConstants {
     public static final String PUT = "put";
     public static final String GET_AND_PUT = "getAndPut";
     public static final String REMOVE = "remove";
-    public static final String REMOVE_ALL_KEYS = "removeAllKeys";
     public static final String REMOVE_ALL = "removeAll";
     public static final String REPLACE = "replace";
     public static final String SET_EXPIRY_POLICY = "setExpiryPolicy";


### PR DESCRIPTION
Fixed the incorrectly changed method names at [merged PR](https://github.com/hazelcast/hazelcast/pull/25020) back to the original name.

Fixes the test failure at [this](https://github.com/hazelcast/hazelcast-enterprise/pull/6548) PR [run](https://jenkins.hazelcast.com/job/Hazelcast-EE-pr-builder/9256/#showFailuresLink).
