### PR TITLE
`CompactSerializationTest.testSerializerRegistration_withDuplicateClasses()` missing `@Test` annotation

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/compact/CompactSerializationTest.java
@@ -110,6 +110,7 @@ public class CompactSerializationTest {
                 .hasMessageContaining("Invalid field name");
     }
 
+    @Test
     public void testSerializerRegistration_withDuplicateClasses() {
         SerializationConfig config = new SerializationConfig();
         assertThatThrownBy(() -> {


### PR DESCRIPTION
In f4fe4ef0eb536b7fad568f1736fd66c69773db40 the `@Test` annotation was accidentally removed from this test so it no longer runs.