### PR TITLE
Add mockito jupiter extension dependency and use it in a few tests as example [HZ-3268]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/h2/H2UpsertQueryBuilderTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/h2/H2UpsertQueryBuilderTest.java
@@ -17,47 +17,37 @@
 package com.hazelcast.jet.sql.impl.connector.jdbc.h2;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcTable;
-import com.hazelcast.mock.MockUtil;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.dialect.H2SqlDialect;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
-public class H2UpsertQueryBuilderTest {
+@ExtendWith(MockitoExtension.class)
+class H2UpsertQueryBuilderTest {
 
     @Mock
     JdbcTable table;
 
     SqlDialect dialect = H2SqlDialect.DEFAULT;
 
-    private AutoCloseable openMocks;
-
-    @Before
+    @BeforeEach
     public void setUp() {
-        openMocks = openMocks(this);
-
-        when(table.getExternalName()).thenReturn(new String[]{"table1"});
         when(table.getExternalNameList()).thenReturn(Collections.singletonList("table1"));
         when(table.getPrimaryKeyList()).thenReturn(Arrays.asList("pk1", "pk2"));
         when(table.dbFieldNames()).thenReturn(Arrays.asList("field1", "field2"));
     }
 
-    @After
-    public void cleanUp() {
-        MockUtil.closeMocks(openMocks);
-    }
-
     @Test
-    public void appendMergeClause() {
+    void appendMergeClause() {
         H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(table, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendMergeClause(sb);
@@ -67,7 +57,7 @@ public class H2UpsertQueryBuilderTest {
     }
 
     @Test
-    public void appendKeyClause() {
+    void appendKeyClause() {
         H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(table, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendKeyClause(sb);
@@ -77,7 +67,7 @@ public class H2UpsertQueryBuilderTest {
     }
 
     @Test
-    public void appendValuesClause() {
+    void appendValuesClause() {
         H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(table, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendValuesClause(sb);
@@ -87,7 +77,7 @@ public class H2UpsertQueryBuilderTest {
     }
 
     @Test
-    public void testQuery() {
+    void testQuery() {
         H2UpsertQueryBuilder builder = new H2UpsertQueryBuilder(table, dialect);
 
         String query = builder.query();

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLUpsertQueryBuilderTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/MSSQLUpsertQueryBuilderTest.java
@@ -17,46 +17,38 @@
 package com.hazelcast.jet.sql.impl.connector.jdbc.mssql;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcTable;
-import com.hazelcast.mock.MockUtil;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.dialect.MssqlSqlDialect;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
-public class MSSQLUpsertQueryBuilderTest {
+@ExtendWith(MockitoExtension.class)
+class MSSQLUpsertQueryBuilderTest {
 
     @Mock
     JdbcTable jdbcTable;
 
     SqlDialect dialect = MssqlSqlDialect.DEFAULT;
-    private AutoCloseable openMocks;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        openMocks = openMocks(this);
-
-        when(jdbcTable.getExternalName()).thenReturn(new String[]{"table1"});
         when(jdbcTable.getExternalNameList()).thenReturn(singletonList("table1"));
         when(jdbcTable.dbFieldNames()).thenReturn(Arrays.asList("field1", "field2"));
         when(jdbcTable.getPrimaryKeyList()).thenReturn(Arrays.asList("pk1", "pk2"));
     }
 
-    @After
-    public void cleanUp() {
-        MockUtil.closeMocks(openMocks);
-    }
 
     @Test
-    public void appendMergeClause() {
+    void appendMergeClause() {
         MSSQLUpsertQueryBuilder builder = new MSSQLUpsertQueryBuilder(jdbcTable, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendMergeClause(sb);
@@ -65,7 +57,7 @@ public class MSSQLUpsertQueryBuilderTest {
     }
 
     @Test
-    public void appendValuesClause() {
+    void appendValuesClause() {
         MSSQLUpsertQueryBuilder builder = new MSSQLUpsertQueryBuilder(jdbcTable, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendValuesClause(sb);
@@ -75,7 +67,7 @@ public class MSSQLUpsertQueryBuilderTest {
     }
 
     @Test
-    public void appendMatchedClause() {
+    void appendMatchedClause() {
         MSSQLUpsertQueryBuilder builder = new MSSQLUpsertQueryBuilder(jdbcTable, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendMatchedClause(sb);
@@ -87,7 +79,7 @@ public class MSSQLUpsertQueryBuilderTest {
     }
 
     @Test
-    public void query() {
+    void query() {
         MSSQLUpsertQueryBuilder builder = new MSSQLUpsertQueryBuilder(jdbcTable, dialect);
         String result = builder.query();
         assertThat(result).isEqualTo(

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLUpsertQueryBuilderTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mysql/MySQLUpsertQueryBuilderTest.java
@@ -17,46 +17,37 @@
 package com.hazelcast.jet.sql.impl.connector.jdbc.mysql;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcTable;
-import com.hazelcast.mock.MockUtil;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.dialect.MysqlSqlDialect;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
-public class MySQLUpsertQueryBuilderTest {
+@ExtendWith(MockitoExtension.class)
+class MySQLUpsertQueryBuilderTest {
 
     @Mock
     JdbcTable jdbcTable;
 
     SqlDialect dialect = MysqlSqlDialect.DEFAULT;
 
-    private AutoCloseable openMocks;
-
-    @Before
+    @BeforeEach
     public void setUp() {
-        openMocks = openMocks(this);
-
-        when(jdbcTable.getExternalName()).thenReturn(new String[]{"table1"});
         when(jdbcTable.getExternalNameList()).thenReturn(singletonList("table1"));
         when(jdbcTable.dbFieldNames()).thenReturn(Arrays.asList("field1", "field2"));
     }
 
-    @After
-    public void cleanUp() {
-        MockUtil.closeMocks(openMocks);
-    }
 
     @Test
-    public void appendInsertClause() {
+    void appendInsertClause() {
         MySQLUpsertQueryBuilder builder = new MySQLUpsertQueryBuilder(jdbcTable, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendInsertClause(sb);
@@ -66,7 +57,7 @@ public class MySQLUpsertQueryBuilderTest {
     }
 
     @Test
-    public void appendValuesClause() {
+    void appendValuesClause() {
         MySQLUpsertQueryBuilder builder = new MySQLUpsertQueryBuilder(jdbcTable, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendValuesClause(sb);
@@ -76,7 +67,7 @@ public class MySQLUpsertQueryBuilderTest {
     }
 
     @Test
-    public void appendOnDuplicateClause() {
+    void appendOnDuplicateClause() {
         MySQLUpsertQueryBuilder builder = new MySQLUpsertQueryBuilder(jdbcTable, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendOnDuplicateClause(sb);
@@ -89,7 +80,7 @@ public class MySQLUpsertQueryBuilderTest {
     }
 
     @Test
-    public void query() {
+    void query() {
         MySQLUpsertQueryBuilder builder = new MySQLUpsertQueryBuilder(jdbcTable, dialect);
         String result = builder.query();
         assertThat(result).isEqualTo(

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresUpsertQueryBuilderTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/PostgresUpsertQueryBuilderTest.java
@@ -17,54 +17,38 @@
 package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
 
 import com.hazelcast.jet.sql.impl.connector.jdbc.JdbcTable;
-import com.hazelcast.mock.MockUtil;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
-public class PostgresUpsertQueryBuilderTest {
+@ExtendWith(MockitoExtension.class)
+class PostgresUpsertQueryBuilderTest {
 
     @Mock
     JdbcTable jdbcTable;
 
     SqlDialect dialect = PostgresqlSqlDialect.DEFAULT;
 
-    private AutoCloseable openMocks;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        openMocks = openMocks(this);
-
-        when(jdbcTable.getExternalName()).thenReturn(new String[]{"table1"});
         when(jdbcTable.getExternalNameList()).thenReturn(Collections.singletonList("table1"));
         when(jdbcTable.getPrimaryKeyList()).thenReturn(Arrays.asList("pk1", "pk2"));
         when(jdbcTable.dbFieldNames()).thenReturn(Arrays.asList("field1", "field2"));
     }
 
-    @After
-    public void cleanUp() {
-        MockUtil.closeMocks(openMocks);
-    }
-
     @Test
-    public void testAppendInsertClause() {
+    void testAppendInsertClause() {
         PostgresUpsertQueryBuilder builder = new PostgresUpsertQueryBuilder(jdbcTable, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendInsertClause(sb);
@@ -74,7 +58,7 @@ public class PostgresUpsertQueryBuilderTest {
     }
 
     @Test
-    public void testAppendValuesClause() {
+    void testAppendValuesClause() {
         PostgresUpsertQueryBuilder builder = new PostgresUpsertQueryBuilder(jdbcTable, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendValuesClause(sb);
@@ -84,7 +68,7 @@ public class PostgresUpsertQueryBuilderTest {
     }
 
     @Test
-    public void testAppendOnConflictClause() {
+    void testAppendOnConflictClause() {
         PostgresUpsertQueryBuilder builder = new PostgresUpsertQueryBuilder(jdbcTable, dialect);
         StringBuilder sb = new StringBuilder();
         builder.appendOnConflictClause(sb);
@@ -99,7 +83,7 @@ public class PostgresUpsertQueryBuilderTest {
     }
 
     @Test
-    public void testQuery() {
+    void testQuery() {
         PostgresUpsertQueryBuilder builder = new PostgresUpsertQueryBuilder(jdbcTable, dialect);
         String result = builder.query();
         String expected = "INSERT INTO \"table1\" (\"field1\",\"field2\") VALUES (?,?) ON CONFLICT (\"pk1\",\"pk2\") " +

--- a/pom.xml
+++ b/pom.xml
@@ -2051,6 +2051,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
                 <version>${reflections.version}</version>
@@ -2127,6 +2133,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Jira : https://hazelcast.atlassian.net/browse/HZ-3268

MockitoExtension automatically closes mocks. This makes tests easier

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible