### PR TITLE
Fix race in GenericMapStoreIntegrationTest [HZ-3158]

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
@@ -262,7 +262,7 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
     }
 
     private void readExistingMapping() {
-        logger.fine("Reading existing mapping for map" + mapName);
+        logger.fine("Reading existing mapping for map " + mapName);
         try {
             // If mappingName does not exist, we get "... did you forget to CREATE MAPPING?" exception
             columnMetadataList = mappingHelper.loadColumnMetadataFromMapping(mappingName);


### PR DESCRIPTION
In #testInstanceShutdown we add another member and then we insert 1000 items to have items in each partition. It was possible that the items were inserted before the repartitioning started, leading to late initialization of GenericMapStore on the 3rd member.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
