### PR TITLE
Fix race in GenericMapStoreIntegrationTest [HZ-3158] [5.3.z]

### DIFF
--- a/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
+++ b/extensions/mapstore/src/main/java/com/hazelcast/mapstore/GenericMapLoader.java
@@ -265,7 +265,7 @@ public class GenericMapLoader<K> implements MapLoader<K, GenericRecord>, MapLoad
     }
 
     private void readExistingMapping() {
-        logger.fine("Reading existing mapping for map" + mapName);
+        logger.fine("Reading existing mapping for map " + mapName);
         try {
             // If mappingName does not exist, we get "... did you forget to CREATE MAPPING?" exception
             columnMetadataList = mappingHelper.loadColumnMetadataFromMapping(mappingName);

--- a/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
+++ b/extensions/mapstore/src/test/java/com/hazelcast/mapstore/GenericMapStoreIntegrationTest.java
@@ -421,7 +421,10 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
 
         // create another member
         HazelcastInstance hz3 = factory().newHazelcastInstance(memberConfig);
-        assertClusterSizeEventually(3, hz3);
+
+        HazelcastInstance[] instances = new HazelcastInstance[]{instances()[0], instances()[1], hz3};
+        assertClusterSizeEventually(3, instances);
+        waitAllForSafeState(instances);
 
         ExceptionRecorder recorder = new ExceptionRecorder(hz3, Level.WARNING);
         // fill the map with some values so each member gets some items
@@ -429,6 +432,8 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
         for (int i = 1; i < itemSize; i++) {
             map.put(i, new Person(i, "name-" + i));
         }
+        logger.info("Putting data into the IMap finished");
+
         // Ensure that all put operations are inserted into the DB. Otherwise, we may get
         // HazelcastSqlException: Hazelcast instance is not active! from the SqlService
         // when we shut down the hz3 instance
@@ -454,7 +459,8 @@ public class GenericMapStoreIntegrationTest extends JdbcSqlTestSupport {
         assertThat(p.getName()).isEqualTo("name-" + itemSize);
 
         for (Throwable throwable : recorder.exceptionsLogged()) {
-            assertThat(throwable).hasMessageNotContaining("is not active!");
+            assertThat(throwable).hasMessageNotContaining("HazelcastSqlException: The Jet SQL job failed: "
+                    + "Hazelcast instance is not active!");
         }
     }
 }


### PR DESCRIPTION
In #testInstanceShutdown we add another member and then we insert 1000 items to have items in each partition. It was possible that the items were inserted before the repartitioning started, leading to late initialization of GenericMapStore.

Backport of https://github.com/hazelcast/hazelcast/pull/25569

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
