### PR TITLE
Remove wiremock-jre8-standalone dependency and upgrade wiremock [HZ-3113]

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -40,7 +40,7 @@
         <pax.exam.version>2.6.0</pax.exam.version>
         <pax.runner.version>1.8.6</pax.runner.version>
         <javax.inject.version>1</javax.inject.version>
-        <wiremock.version>2.27.2</wiremock.version>
+        <wiremock.version>3.0.1</wiremock.version>
     </properties>
 
     <build>
@@ -697,12 +697,6 @@
             <version>2.1.12</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.35.1</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.activemq</groupId>
@@ -810,7 +804,7 @@
 
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-standalone</artifactId>
             <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>

--- a/hazelcast/src/test/java/childfirstclassloader/TestProcessor.java
+++ b/hazelcast/src/test/java/childfirstclassloader/TestProcessor.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.core.AbstractProcessor;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
-import org.apache.commons.io.IOUtils;
 import org.example.jet.impl.deployment.ResourceCollector;
 
 import javax.annotation.Nonnull;
@@ -72,7 +71,8 @@ public class TestProcessor extends AbstractProcessor {
         @Override
         public String getEx() throws Exception {
             try (InputStream is = ResourceReader.class.getClassLoader().getResourceAsStream("childfirstclassloader/resource_test.txt")) {
-                return IOUtils.toString(is, UTF_8);
+                assert is != null;
+                return new String(is.readAllBytes(), UTF_8);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/CompatibilitySerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/CompatibilitySerializationServiceTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -95,7 +94,7 @@ public class CompatibilitySerializationServiceTest {
         try (InputStream is = new FileInputStream(useBigEndian
                 ? "src/test/resources/testHz3Object"
                 : "src/test/resources/testHz3ObjectLittleEndian")) {
-            byte[] payload = IOUtils.toByteArray(is);
+            byte[] payload = is.readAllBytes();
             return new HeapData(payload);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ChildFirstClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ChildFirstClassLoaderTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.JarUtil;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -248,7 +247,7 @@ public class ChildFirstClassLoaderTest {
                 throw new IllegalArgumentException("Resource with name " + name +
                         " could not be found in classloader " + cl);
             }
-            return IOUtils.toString(is, UTF_8);
+            return new String(is.readAllBytes(), UTF_8);
         }
     }
 }


### PR DESCRIPTION
Upgrade wiremock dependency to wiremock-standalone:3.0.1

With the new dependency the apache commons library is not available anymore. Fix the tests that use apache commons IOUtils 

Jira : https://hazelcast.atlassian.net/browse/HZ-3113


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible


[HZ-3113]: https://hazelcast.atlassian.net/browse/HZ-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ