### PR TITLE
Replace `Probe` reflection implementation with Lmbda library

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -664,6 +664,10 @@
                     <artifactId>junit</artifactId>
                     <groupId>junit</groupId>
                 </exclusion>
+                <exclusion>
+                	<groupId>asm</groupId>
+                	<artifactId>asm</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -839,6 +843,12 @@
             <artifactId>maven-resolver-provider</artifactId>
             <version>3.9.4</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.LanternPowered</groupId>
+            <artifactId>Lmbda</artifactId>
+            <version>c9030d67cf17e2981913f6ddb282df9d9e90f2a4</version>
         </dependency>
 	</dependencies>
 </project>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -849,6 +849,7 @@
             <groupId>com.github.LanternPowered</groupId>
             <artifactId>Lmbda</artifactId>
             <version>c9030d67cf17e2981913f6ddb282df9d9e90f2a4</version>
+            <optional>true</optional>
         </dependency>
 	</dependencies>
 </project>

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -16,123 +16,29 @@
 
 package com.hazelcast.internal.metrics.impl;
 
-import static com.hazelcast.internal.metrics.impl.ProbeType.getType;
-import static java.lang.String.format;
-
-import com.hazelcast.internal.metrics.DoubleProbeFunction;
-import com.hazelcast.internal.metrics.LongProbeFunction;
-import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeFunction;
-import com.hazelcast.internal.util.counters.Counter;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.Semaphore;
+import java.lang.reflect.Modifier;
 
 /**
  * A FieldProbe is a {@link ProbeFunction} that reads out a field that is annotated with {@link Probe}.
  */
-abstract class FieldProbe implements ProbeFunction {
+abstract class FieldProbe<S> extends MethodHandleProbe<S> {
 
-    final CachedProbe probe;
-    final Field field;
-    final ProbeType type;
-    final SourceMetadata sourceMetadata;
-    final String probeName;
-
-    FieldProbe(Field field, Probe probe, ProbeType type, SourceMetadata sourceMetadata) {
-        this.field = field;
-        this.probe = new CachedProbe(probe);
-        this.type = type;
-        this.sourceMetadata = sourceMetadata;
-        this.probeName = probe.name();
-        assert probeName != null;
-        assert probeName.length() > 0;
-        field.setAccessible(true);
+    protected FieldProbe(MethodHandle getterMethod, boolean isStatic, Probe probe, ProbeType type,
+            SourceMetadata sourceMetadata) {
+        super(getterMethod, isStatic, probe, type, sourceMetadata);
     }
 
-    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
-        MetricDescriptor descriptor = metricsRegistry
-                .newMetricDescriptor()
-                .withPrefix(namePrefix)
-                .withMetric(getProbeName());
-        metricsRegistry.registerInternal(source, descriptor, probe.level(), this);
-    }
-
-    void register(MetricsRegistryImpl metricsRegistry, MetricDescriptor descriptor, Object source) {
-        metricsRegistry.registerStaticProbe(source, descriptor, getProbeName(), probe.level(), probe.unit(), this);
-    }
-
-    String getProbeName() {
-        return probeName;
-    }
-
-    static <S> FieldProbe createFieldProbe(Field field, Probe probe, SourceMetadata sourceMetadata) {
-        ProbeType type = getType(field.getType());
-        if (type == null) {
-            throw new IllegalArgumentException(format("@Probe field '%s' is of an unhandled type", field));
-        }
-
-        if (type.getMapsTo() == double.class) {
-            return new DoubleFieldProbe<S>(field, probe, type, sourceMetadata);
-        } else if (type.getMapsTo() == long.class) {
-            return new LongFieldProbe<S>(field, probe, type, sourceMetadata);
-        } else {
-            throw new IllegalArgumentException(type.toString());
-        }
-    }
-
-    static class LongFieldProbe<S> extends FieldProbe implements LongProbeFunction<S> {
-
-        LongFieldProbe(Field field, Probe probe, ProbeType type, SourceMetadata sourceMetadata) {
-            super(field, probe, type, sourceMetadata);
-        }
-
-        @Override
-        public long get(S source) throws Exception {
-            switch (type) {
-                case TYPE_LONG_PRIMITIVE:
-                    return field.getLong(source);
-                case TYPE_LONG_NUMBER:
-                    Number longNumber = (Number) field.get(source);
-                    return longNumber == null ? 0 : longNumber.longValue();
-                case TYPE_MAP:
-                    Map<?, ?> map = (Map<?, ?>) field.get(source);
-                    return map == null ? 0 : map.size();
-                case TYPE_COLLECTION:
-                    Collection<?> collection = (Collection<?>) field.get(source);
-                    return collection == null ? 0 : collection.size();
-                case TYPE_COUNTER:
-                    Counter counter = (Counter) field.get(source);
-                    return counter == null ? 0 : counter.get();
-                case TYPE_SEMAPHORE:
-                    Semaphore semaphore = (Semaphore) field.get(source);
-                    return semaphore == null ? 0 : semaphore.availablePermits();
-                default:
-                    throw new IllegalStateException("Unhandled type:" + type);
-            }
-        }
-    }
-
-    static class DoubleFieldProbe<S> extends FieldProbe implements DoubleProbeFunction<S> {
-
-        DoubleFieldProbe(Field field, Probe probe, ProbeType type, SourceMetadata sourceMetadata) {
-            super(field, probe, type, sourceMetadata);
-        }
-
-        @Override
-        public double get(S source) throws Exception {
-            switch (type) {
-                case TYPE_DOUBLE_PRIMITIVE:
-                    return field.getDouble(source);
-                case TYPE_DOUBLE_NUMBER:
-                    Number doubleNumber = (Number) field.get(source);
-                    return doubleNumber == null ? 0 : doubleNumber.doubleValue();
-                default:
-                    throw new IllegalStateException("Unhandled type:" + type);
-            }
+    static <S> MethodHandleProbe<S> createProbe(Field field, Probe probe, SourceMetadata sourceMetadata) {
+        try {
+            field.setAccessible(true);
+            return createProbe(LOOKUP.unreflectGetter(field), Modifier.isStatic(field.getModifiers()), probe, sourceMetadata);
+        } catch (final IllegalAccessException e) {
+            throw new ExceptionInInitializerError(e);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -33,7 +33,7 @@ abstract class FieldProbe<S> extends MethodHandleProbe<S> {
         super(getterMethod, isStatic, probe, type, sourceMetadata);
     }
 
-    static <S> MethodHandleProbe<S> createProbe(Field field, Probe probe, SourceMetadata sourceMetadata) {
+    static <S> MethodHandleProbe<S> createFieldProbe(Field field, Probe probe, SourceMetadata sourceMetadata) {
         try {
             field.setAccessible(true);
             return createProbe(LOOKUP.unreflectGetter(field), Modifier.isStatic(field.getModifiers()), probe, sourceMetadata);

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodHandleProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodHandleProbe.java
@@ -147,6 +147,7 @@ abstract class MethodHandleProbe<S> implements ProbeFunction {
             }
         }
 
+        @SuppressWarnings({"checkstyle:npathcomplexity"})
         @Override
         public long get(S source) throws Exception {
             switch (type) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodHandleProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodHandleProbe.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import static com.hazelcast.internal.metrics.impl.ProbeType.getType;
+import static java.lang.String.format;
+
+import org.lanternpowered.lmbda.LambdaFactory;
+import org.lanternpowered.lmbda.LambdaType;
+
+import com.hazelcast.internal.metrics.DoubleProbeFunction;
+import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricDescriptor;
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.metrics.ProbeFunction;
+import com.hazelcast.internal.util.counters.Counter;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.WrongMethodTypeException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+import java.util.function.DoubleSupplier;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
+
+abstract class MethodHandleProbe<S> implements ProbeFunction {
+    protected static final Lookup LOOKUP = MethodHandles.lookup();
+
+    protected final boolean isStatic;
+    protected final CachedProbe probe;
+    protected final ProbeType type;
+    protected final SourceMetadata sourceMetadata;
+    protected final String probeName;
+
+    @Nullable
+    protected Function<S, Object> objectGetter;
+    @Nullable
+    protected Supplier<Object> objectStaticGetter;
+
+    protected MethodHandleProbe(MethodHandle getterMethod, boolean isStatic, Probe probe, ProbeType type,
+            SourceMetadata sourceMetadata) {
+        this.probe = new CachedProbe(probe);
+        this.type = type;
+        this.sourceMetadata = sourceMetadata;
+
+        probeName = probe.name();
+        assert probeName != null;
+        assert probeName.length() > 0;
+
+        this.isStatic = isStatic;
+
+        try {
+            if (type.isPrimitive()) {
+                populatePrimitiveGetters(getterMethod);
+            } else {
+                if (isStatic) {
+                    objectStaticGetter = LambdaFactory.create(new LambdaType<Supplier<Object>>() {
+                    }, getterMethod);
+                } else {
+                    objectGetter = LambdaFactory.create(new LambdaType<Function<S, Object>>() {
+                    }, getterMethod);
+                }
+            }
+        } catch (
+
+        IllegalStateException e) {
+            if (e.getCause() instanceof WrongMethodTypeException) {
+                throw new IllegalArgumentException(e.getCause());
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    abstract void populatePrimitiveGetters(MethodHandle getterMethod);
+
+    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
+        MetricDescriptor descriptor = metricsRegistry.newMetricDescriptor().withPrefix(namePrefix).withMetric(getProbeName());
+        metricsRegistry.registerInternal(source, descriptor, probe.level(), this);
+    }
+
+    void register(MetricsRegistryImpl metricsRegistry, MetricDescriptor descriptor, Object source) {
+        metricsRegistry.registerStaticProbe(source, descriptor, getProbeName(), probe.level(), probe.unit(), this);
+    }
+
+    String getProbeName() {
+        return probeName;
+    }
+
+    static <S> MethodHandleProbe<S> createProbe(MethodHandle getterMethod, boolean isStatic, Probe probe,
+            SourceMetadata sourceMetadata) {
+        ProbeType type = getType(getterMethod.type().returnType());
+        if (type == null) {
+            throw new IllegalArgumentException(format("@Probe '%s' is of an unhandled type", getterMethod));
+        }
+
+        if (type.getMapsTo() == double.class) {
+            return new DoubleMethodHandleProbe<>(getterMethod, isStatic, probe, type, sourceMetadata);
+        } else if (type.getMapsTo() == long.class) {
+            return new LongMethodHandleProbe<>(getterMethod, isStatic, probe, type, sourceMetadata);
+        } else {
+            throw new IllegalArgumentException(type.toString());
+        }
+    }
+
+    static class LongMethodHandleProbe<S> extends MethodHandleProbe<S> implements LongProbeFunction<S> {
+        @Nullable
+        private ToLongFunction<S> primitiveGetter;
+        @Nullable
+        private LongSupplier primitiveStaticGetter;
+
+        LongMethodHandleProbe(MethodHandle getterMethod, boolean isStatic, Probe probe, ProbeType type,
+                SourceMetadata sourceMetadata) {
+            super(getterMethod, isStatic, probe, type, sourceMetadata);
+        }
+
+        @Override
+        void populatePrimitiveGetters(MethodHandle getterMethod) {
+            if (isStatic) {
+                primitiveStaticGetter = LambdaFactory.create(new LambdaType<LongSupplier>() {
+                }, getterMethod);
+            } else {
+                primitiveGetter = LambdaFactory.create(new LambdaType<ToLongFunction<S>>() {
+                }, getterMethod);
+            }
+        }
+
+        @Override
+        public long get(S source) throws Exception {
+            switch (type) {
+                case TYPE_LONG_PRIMITIVE:
+                    return isStatic ? primitiveStaticGetter.getAsLong() : primitiveGetter.applyAsLong(source);
+                case TYPE_LONG_NUMBER:
+                    Number longNumber = getObject(source);
+                    return longNumber == null ? 0 : longNumber.longValue();
+                case TYPE_MAP:
+                    Map<?, ?> map = getObject(source);
+                    return map == null ? 0 : map.size();
+                case TYPE_COLLECTION:
+                    Collection<?> collection = getObject(source);
+                    return collection == null ? 0 : collection.size();
+                case TYPE_COUNTER:
+                    Counter counter = getObject(source);
+                    return counter == null ? 0 : counter.get();
+                case TYPE_SEMAPHORE:
+                    Semaphore semaphore = getObject(source);
+                    return semaphore == null ? 0 : semaphore.availablePermits();
+                default:
+                    throw new IllegalStateException("Unrecognized type: " + type);
+            }
+        }
+    }
+
+    static class DoubleMethodHandleProbe<S> extends MethodHandleProbe<S> implements DoubleProbeFunction<S> {
+        @Nullable
+        private ToDoubleFunction<S> primitiveGetter;
+        @Nullable
+        private DoubleSupplier primitiveStaticGetter;
+
+        DoubleMethodHandleProbe(MethodHandle getterMethod, boolean isStatic, Probe probe, ProbeType type,
+                SourceMetadata sourceMetadata) {
+            super(getterMethod, isStatic, probe, type, sourceMetadata);
+        }
+
+        @Override
+        void populatePrimitiveGetters(MethodHandle getterMethod) {
+            if (isStatic) {
+                primitiveStaticGetter = LambdaFactory.create(new LambdaType<DoubleSupplier>() {
+                }, getterMethod);
+            } else {
+                primitiveGetter = LambdaFactory.create(new LambdaType<ToDoubleFunction<S>>() {
+                }, getterMethod);
+            }
+
+        }
+
+        @Override
+        public double get(S source) throws Exception {
+            switch (type) {
+                case TYPE_DOUBLE_PRIMITIVE:
+                    return isStatic ? primitiveStaticGetter.getAsDouble() : primitiveGetter.applyAsDouble(source);
+                case TYPE_DOUBLE_NUMBER:
+                    Number doubleNumber = getObject(source);
+                    return doubleNumber == null ? 0 : doubleNumber.doubleValue();
+                default:
+                    throw new IllegalStateException("Unrecognized type: " + type);
+            }
+        }
+
+    }
+
+    protected <T> T getObject(S source) {
+        return (T) (isStatic ? objectStaticGetter.get() : objectGetter.apply(source));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodHandleProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodHandleProbe.java
@@ -147,7 +147,7 @@ abstract class MethodHandleProbe<S> implements ProbeFunction {
             }
         }
 
-        @SuppressWarnings({"checkstyle:npathcomplexity"})
+        @SuppressWarnings({"checkstyle:cyclomaticcomplexity"})
         @Override
         public long get(S source) throws Exception {
             switch (type) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -16,238 +16,28 @@
 
 package com.hazelcast.internal.metrics.impl;
 
-import static com.hazelcast.internal.metrics.impl.ProbeType.getType;
-import static java.lang.String.format;
-
-import com.hazelcast.internal.metrics.DoubleProbeFunction;
-import com.hazelcast.internal.metrics.LongProbeFunction;
-import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeFunction;
-import com.hazelcast.internal.util.ExceptionUtil;
-import com.hazelcast.internal.util.counters.Counter;
 
-import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodHandles.Lookup;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.Semaphore;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * A {@link MethodProbe} is a {@link ProbeFunction} that invokes a method that is annotated with {@link Probe}.
- * <p>
- * Internally accesses the method using reflection via one of these mechanisms (as a pose to a simple {@link Method#invoke} for
- * <a href="https://github.com/hazelcast/hazelcast/pull/25279">performance reasons</a>):
- * <ul>
- * <li>{@link #methodHandle}
- * <li>{@link #staticAccessor}
- * <li>{@link #nonStaticAccessor}
- * </ul>
  */
-abstract class MethodProbe implements ProbeFunction {
-    private static final Lookup LOOKUP = MethodHandles.lookup();
+abstract class MethodProbe<S> extends MethodHandleProbe<S> {
+    protected MethodProbe(MethodHandle getterMethod, boolean isStatic, Probe probe, ProbeType type,
+            SourceMetadata sourceMetadata) {
+        super(getterMethod, isStatic, probe, type, sourceMetadata);
+    }
 
-    /**
-     * {@link MethodHandle} used to access primitives to avoid boxing, specifically to reduce redundant object creation.
-     * <p>
-     * E.G. for a method that returns {@link long}, when typically invoked via reflection, an {@link Object} would instead be
-     * returned. The {@link long} would be boxed to {@link Long}, and then immediately unboxed again back to a {@link long} for
-     * returning from {@link LongProbeFunction#get(S)}.
-     * <p>
-     * Faster than basic reflection, but slower than a {@link LambdaMetafactory} generated accessor.
-     */
-    final MethodHandle methodHandle;
-
-    /**
-     * A {@link Supplier} used to access static methods returning objects (reference types).
-     * <p>
-     * Generated via a {@link LambdaMetafactory}, bound to a {@link MethodHandle} derived from {@link #methodHandle}.
-     * <p>
-     * Faster than basic reflection and {@link MethodHandle#invokeExact()}, but only applicable for reference types.
-     *
-     * @see <a href= "https://www.optaplanner.org/blog/2018/01/09/JavaReflectionButMuchFaster.html"> Further reading</a>
-     */
-    final Supplier<?> staticAccessor;
-    /**
-     * A {@link Function} used to access instance methods returning objects (reference types)
-     * <p>
-     * {@link Function#apply(T)}'s parameter is the instance to retrieve the value from.
-     *
-     * @see #staticAccessor
-     */
-    final Function<Object, ?> nonStaticAccessor;
-
-    final boolean isMethodStatic;
-    final CachedProbe probe;
-    final ProbeType type;
-    final SourceMetadata sourceMetadata;
-    final String probeName;
-
-    @SuppressWarnings("checkstyle:executablestatementcount")
-    MethodProbe(Method method, Probe probe, ProbeType type, SourceMetadata sourceMetadata) {
+    static <S> MethodHandleProbe<S> createProbe(Method method, Probe probe, SourceMetadata sourceMetadata) {
         try {
             method.setAccessible(true);
-            final MethodHandle unreflected = LOOKUP.unreflect(method);
-
-            isMethodStatic = Modifier.isStatic(method.getModifiers());
-
-            if (type.isPrimitive()) {
-                // Modify return types to support invokeExact
-                MethodType methodType = unreflected.type().changeReturnType(type.getMapsTo());
-
-                if (!isMethodStatic) {
-                    methodType = methodType.changeParameterType(0, Object.class);
-                }
-
-                methodHandle = unreflected.asType(methodType);
-                staticAccessor = null;
-                nonStaticAccessor = null;
-            } else {
-                methodHandle = null;
-
-                final Lookup privateLookup = MethodHandles.privateLookupIn(method.getDeclaringClass(), LOOKUP);
-                final MethodType methodReturnType = MethodType.methodType(method.getReturnType());
-                final MethodHandle implementation;
-                final MethodType dynamicMethodType = unreflected.type();
-
-                if (isMethodStatic) {
-                    implementation = privateLookup.findStatic(method.getDeclaringClass().getClass(), method.getName(),
-                            methodReturnType);
-
-                    staticAccessor = (Supplier<?>) LambdaMetafactory
-                            .metafactory(privateLookup, "get", MethodType.methodType(Supplier.class),
-                                    MethodType.methodType(Object.class, new Class<?>[0]), implementation, dynamicMethodType)
-                            .getTarget().invokeExact();
-                    nonStaticAccessor = null;
-                } else {
-                    implementation = privateLookup.findVirtual(method.getDeclaringClass(), method.getName(), methodReturnType);
-
-                    staticAccessor = null;
-                    nonStaticAccessor = (Function<Object, ?>) LambdaMetafactory
-                            .metafactory(privateLookup, "apply", MethodType.methodType(Function.class),
-                                    MethodType.methodType(Object.class, Object.class), implementation, dynamicMethodType)
-                            .getTarget().invokeExact();
-                }
-            }
-
-            this.probe = new CachedProbe(probe);
-            this.type = type;
-            this.sourceMetadata = sourceMetadata;
-            probeName = probe.name();
-            assert probeName != null;
-            assert probeName.length() > 0;
-        } catch (final Throwable t) {
-            throw new RuntimeException(t);
+            return createProbe(LOOKUP.unreflect(method), Modifier.isStatic(method.getModifiers()), probe, sourceMetadata);
+        } catch (final IllegalAccessException e) {
+            throw new ExceptionInInitializerError(e);
         }
-    }
-
-    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
-        final MetricDescriptor descriptor = metricsRegistry.newMetricDescriptor().withPrefix(namePrefix)
-                .withMetric(getProbeName());
-        metricsRegistry.registerInternal(source, descriptor, probe.level(), this);
-    }
-
-    void register(MetricsRegistryImpl metricsRegistry, MetricDescriptor descriptor, Object source) {
-        metricsRegistry.registerStaticProbe(source, descriptor, getProbeName(), probe.level(), probe.unit(), this);
-    }
-
-    String getProbeName() {
-        return probeName;
-    }
-
-    static <S> MethodProbe createMethodProbe(Method method, Probe probe, SourceMetadata sourceMetadata) {
-        final ProbeType type = getType(method.getReturnType());
-        if (type == null) {
-            throw new IllegalArgumentException(format("@Probe method '%s.%s() has an unsupported return type'",
-                    method.getDeclaringClass().getName(), method.getName()));
-        }
-
-        if (method.getParameterCount() != 0) {
-            throw new IllegalArgumentException(format("@Probe method '%s.%s' can't have arguments",
-                    method.getDeclaringClass().getName(), method.getName()));
-        }
-
-        if (type.getMapsTo() == double.class) {
-            return new DoubleMethodProbe<S>(method, probe, type, sourceMetadata);
-        } else if (type.getMapsTo() == long.class) {
-            return new LongMethodProbe<S>(method, probe, type, sourceMetadata);
-        } else {
-            throw new IllegalArgumentException(type.toString());
-        }
-    }
-
-    static class LongMethodProbe<S> extends MethodProbe implements LongProbeFunction<S> {
-        LongMethodProbe(Method method, Probe probe, ProbeType type, SourceMetadata sourceMetadata) {
-            super(method, probe, type, sourceMetadata);
-        }
-
-        @SuppressWarnings("checkstyle:CyclomaticComplexity")
-        @Override
-        public long get(final S source) throws Exception {
-            try {
-                switch (type) {
-                    case TYPE_LONG_PRIMITIVE:
-                        return isMethodStatic ? (long) methodHandle.invokeExact() : (long) methodHandle.invokeExact(source);
-                    case TYPE_LONG_NUMBER:
-                        final Number longNumber = invoke(source);
-                        return longNumber == null ? 0 : longNumber.longValue();
-                    case TYPE_MAP:
-                        final Map<?, ?> map = invoke(source);
-                        return map == null ? 0 : map.size();
-                    case TYPE_COLLECTION:
-                        final Collection<?> collection = invoke(source);
-                        return collection == null ? 0 : collection.size();
-                    case TYPE_COUNTER:
-                        final Counter counter = invoke(source);
-                        return counter == null ? 0 : counter.get();
-                    case TYPE_SEMAPHORE:
-                        final Semaphore semaphore = invoke(source);
-                        return semaphore == null ? 0 : semaphore.availablePermits();
-                    default:
-                        throw new IllegalStateException("Unrecognized type: " + type);
-                }
-            } catch (final Exception e) {
-                throw e;
-            } catch (final Throwable t) {
-                throw ExceptionUtil.sneakyThrow(t);
-            }
-        }
-    }
-
-    static class DoubleMethodProbe<S> extends MethodProbe implements DoubleProbeFunction<S> {
-        DoubleMethodProbe(Method method, Probe probe, ProbeType type, SourceMetadata sourceMetadata) {
-            super(method, probe, type, sourceMetadata);
-        }
-
-        @Override
-        public double get(final S source) throws Exception {
-            try {
-                switch (type) {
-                    case TYPE_DOUBLE_PRIMITIVE:
-                        return isMethodStatic ? (double) methodHandle.invokeExact() : (double) methodHandle.invokeExact(source);
-                    case TYPE_DOUBLE_NUMBER:
-                        final Number result = invoke(source);
-                        return result == null ? 0 : result.doubleValue();
-                    default:
-                        throw new IllegalStateException("Unrecognized type: " + type);
-                }
-            } catch (final Exception e) {
-                throw e;
-            } catch (final Throwable t) {
-                throw ExceptionUtil.sneakyThrow(t);
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    protected <T> T invoke(final Object source) {
-        return isMethodStatic ? (T) staticAccessor.get() : (T) nonStaticAccessor.apply(source);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -32,7 +32,7 @@ abstract class MethodProbe<S> extends MethodHandleProbe<S> {
         super(getterMethod, isStatic, probe, type, sourceMetadata);
     }
 
-    static <S> MethodHandleProbe<S> createProbe(Method method, Probe probe, SourceMetadata sourceMetadata) {
+    static <S> MethodHandleProbe<S> createMethodProbe(Method method, Probe probe, SourceMetadata sourceMetadata) {
         try {
             method.setAccessible(true);
             return createProbe(LOOKUP.unreflect(method), Modifier.isStatic(method.getModifiers()), probe, sourceMetadata);

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -116,7 +116,7 @@ class MetricsCollectionCycle {
     private void extractAndCollectDynamicMetrics(MetricDescriptor descriptor, Object source) {
         SourceMetadata metadata = lookupMetadataFn.apply(source.getClass());
 
-        for (MethodProbe methodProbe : metadata.methods()) {
+        for (MethodHandleProbe<?> methodProbe : metadata.methods()) {
             if (methodProbe.probe.level().isEnabled(minimumLevel)) {
                 MetricDescriptor descriptorCopy = descriptor
                         .copy()
@@ -129,7 +129,7 @@ class MetricsCollectionCycle {
             }
         }
 
-        for (FieldProbe fieldProbe : metadata.fields()) {
+        for (MethodHandleProbe<?> fieldProbe : metadata.fields()) {
             if (fieldProbe.probe.level().isEnabled(minimumLevel)) {
                 MetricDescriptor descriptorCopy = descriptor
                         .copy()

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -153,11 +153,11 @@ public class MetricsRegistryImpl implements MetricsRegistry {
         checkNotNull(source, "source can't be null");
 
         SourceMetadata metadata = loadSourceMetadata(source.getClass());
-        for (FieldProbe field : metadata.fields()) {
+        for (MethodHandleProbe<?> field : metadata.fields()) {
             field.register(this, descriptor, source);
         }
 
-        for (MethodProbe method : metadata.methods()) {
+        for (MethodHandleProbe<?> method : metadata.methods()) {
             method.register(this, descriptor, source);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsUtil.java
@@ -68,17 +68,12 @@ final class MetricsUtil {
      * @return the excluded targets
      */
     static Collection<MetricTarget> extractExcludedTargets(ProbeFunction function, ProbeLevel minimumLevel) {
-        if (function instanceof FieldProbe) {
-            FieldProbe fieldProbe = (FieldProbe) function;
-            return extractExcludedTargets(fieldProbe.probe, fieldProbe.sourceMetadata, minimumLevel);
+        if (function instanceof MethodHandleProbe) {
+            MethodHandleProbe<?> probe = (MethodHandleProbe<?>) function;
+            return extractExcludedTargets(probe.probe, probe.sourceMetadata, minimumLevel);
+        } else {
+            return emptySet();
         }
-
-        if (function instanceof MethodProbe) {
-            MethodProbe methodProbe = (MethodProbe) function;
-            return extractExcludedTargets(methodProbe.probe, methodProbe.sourceMetadata, minimumLevel);
-        }
-
-        return emptySet();
     }
 
     private static Collection<MetricTarget> extractExcludedTargets(CachedProbe probe, SourceMetadata sourceMetadata,

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
@@ -27,8 +27,6 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 
-import static com.hazelcast.internal.metrics.impl.FieldProbe.createProbe;
-import static com.hazelcast.internal.metrics.impl.MethodProbe.createProbe;
 import static com.hazelcast.internal.metrics.impl.ProbeUtils.flatten;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -86,7 +84,7 @@ final class SourceMetadata {
                 continue;
             }
 
-            MethodHandleProbe<?> fieldProbe = createProbe(field, probe, this);
+            MethodHandleProbe<?> fieldProbe = FieldProbe.createFieldProbe(field, probe, this);
             fields.add(fieldProbe);
         }
     }
@@ -99,7 +97,7 @@ final class SourceMetadata {
                 continue;
             }
 
-            MethodHandleProbe<Object> methodProbe = createProbe(method, probe, this);
+            MethodHandleProbe<Object> methodProbe = MethodProbe.createMethodProbe(method, probe, this);
             methods.add(methodProbe);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
@@ -27,8 +27,8 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 
-import static com.hazelcast.internal.metrics.impl.FieldProbe.createFieldProbe;
-import static com.hazelcast.internal.metrics.impl.MethodProbe.createMethodProbe;
+import static com.hazelcast.internal.metrics.impl.FieldProbe.createProbe;
+import static com.hazelcast.internal.metrics.impl.MethodProbe.createProbe;
 import static com.hazelcast.internal.metrics.impl.ProbeUtils.flatten;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -40,8 +40,8 @@ import static java.util.Collections.unmodifiableList;
  * This object is effectively immutable after construction.
  */
 final class SourceMetadata {
-    private final List<FieldProbe> fields = new ArrayList<>();
-    private final List<MethodProbe> methods = new ArrayList<>();
+    private final List<MethodHandleProbe<?>> fields = new ArrayList<>();
+    private final List<MethodHandleProbe<?>> methods = new ArrayList<>();
     private final Collection<MetricTarget> excludedTargetsClass;
 
     SourceMetadata(Class clazz) {
@@ -58,11 +58,11 @@ final class SourceMetadata {
     }
 
     void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
-        for (FieldProbe field : fields) {
+        for (MethodHandleProbe<?> field : fields) {
             field.register(metricsRegistry, source, namePrefix);
         }
 
-        for (MethodProbe method : methods) {
+        for (MethodHandleProbe<?> method : methods) {
             method.register(metricsRegistry, source, namePrefix);
         }
     }
@@ -86,7 +86,7 @@ final class SourceMetadata {
                 continue;
             }
 
-            FieldProbe fieldProbe = createFieldProbe(field, probe, this);
+            MethodHandleProbe<?> fieldProbe = createProbe(field, probe, this);
             fields.add(fieldProbe);
         }
     }
@@ -99,7 +99,7 @@ final class SourceMetadata {
                 continue;
             }
 
-            MethodProbe methodProbe = createMethodProbe(method, probe, this);
+            MethodHandleProbe<Object> methodProbe = createProbe(method, probe, this);
             methods.add(methodProbe);
         }
     }
@@ -107,14 +107,14 @@ final class SourceMetadata {
     /**
      * Don't modify the returned list!
      */
-    public List<FieldProbe> fields() {
+    public List<MethodHandleProbe<?>> fields() {
         return fields;
     }
 
     /**
      * Don't modify the returned list!
      */
-    public List<MethodProbe> methods() {
+    public List<MethodHandleProbe<?>> methods() {
         return methods;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
@@ -124,7 +124,7 @@ public class FieldProbeTest extends HazelcastTestSupport {
         Probe probe = field.getAnnotation(Probe.class);
 
         MethodHandleProbe<SomeSource> fieldProbe = createFieldProbe(field, probe, new SourceMetadata(SomeSource.class));
-       
+
         DoubleMethodHandleProbe<SomeSource> doubleFieldProbe =  assertInstanceOf(DoubleMethodHandleProbe.class, fieldProbe);
 
         double value = doubleFieldProbe.get(source);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.concurrent.atomic.LongAdder;
 
-import static com.hazelcast.internal.metrics.impl.FieldProbe.createProbe;
+import static com.hazelcast.internal.metrics.impl.FieldProbe.createFieldProbe;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
 
@@ -53,7 +53,7 @@ public class FieldProbeTest extends HazelcastTestSupport {
         Probe probe = field.getAnnotation(Probe.class);
         SourceMetadata ignoredSourceMetadata = new SourceMetadata(Object.class);
 
-        createProbe(field, probe, ignoredSourceMetadata);
+        createFieldProbe(field, probe, ignoredSourceMetadata);
     }
 
     private class UnknownFieldType {
@@ -99,7 +99,7 @@ public class FieldProbeTest extends HazelcastTestSupport {
         SomeSource source = new SomeSource();
         Field field = source.getClass().getDeclaredField(fieldName);
         Probe probe = field.getAnnotation(Probe.class);
-        MethodHandleProbe<SomeSource> fieldProbe = createProbe(field, probe, new SourceMetadata(SomeSource.class));
+        MethodHandleProbe<SomeSource> fieldProbe = createFieldProbe(field, probe, new SourceMetadata(SomeSource.class));
 
         LongMethodHandleProbe<SomeSource> longFieldProbe = assertInstanceOf(LongMethodHandleProbe.class, fieldProbe);
 
@@ -123,7 +123,7 @@ public class FieldProbeTest extends HazelcastTestSupport {
         Field field = source.getClass().getDeclaredField(fieldName);
         Probe probe = field.getAnnotation(Probe.class);
 
-        MethodHandleProbe<SomeSource> fieldProbe = createProbe(field, probe, new SourceMetadata(SomeSource.class));
+        MethodHandleProbe<SomeSource> fieldProbe = createFieldProbe(field, probe, new SourceMetadata(SomeSource.class));
        
         DoubleMethodHandleProbe<SomeSource> doubleFieldProbe =  assertInstanceOf(DoubleMethodHandleProbe.class, fieldProbe);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
@@ -17,8 +17,8 @@
 package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.Probe;
-import com.hazelcast.internal.metrics.impl.FieldProbe.DoubleFieldProbe;
-import com.hazelcast.internal.metrics.impl.FieldProbe.LongFieldProbe;
+import com.hazelcast.internal.metrics.impl.MethodHandleProbe.DoubleMethodHandleProbe;
+import com.hazelcast.internal.metrics.impl.MethodHandleProbe.LongMethodHandleProbe;
 import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.concurrent.atomic.LongAdder;
 
-import static com.hazelcast.internal.metrics.impl.FieldProbe.createFieldProbe;
+import static com.hazelcast.internal.metrics.impl.FieldProbe.createProbe;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
 
@@ -53,7 +53,7 @@ public class FieldProbeTest extends HazelcastTestSupport {
         Probe probe = field.getAnnotation(Probe.class);
         SourceMetadata ignoredSourceMetadata = new SourceMetadata(Object.class);
 
-        createFieldProbe(field, probe, ignoredSourceMetadata);
+        createProbe(field, probe, ignoredSourceMetadata);
     }
 
     private class UnknownFieldType {
@@ -99,9 +99,9 @@ public class FieldProbeTest extends HazelcastTestSupport {
         SomeSource source = new SomeSource();
         Field field = source.getClass().getDeclaredField(fieldName);
         Probe probe = field.getAnnotation(Probe.class);
-        FieldProbe fieldProbe = createFieldProbe(field, probe, new SourceMetadata(SomeSource.class));
+        MethodHandleProbe<SomeSource> fieldProbe = createProbe(field, probe, new SourceMetadata(SomeSource.class));
 
-        LongFieldProbe longFieldProbe = assertInstanceOf(LongFieldProbe.class, fieldProbe);
+        LongMethodHandleProbe<SomeSource> longFieldProbe = assertInstanceOf(LongMethodHandleProbe.class, fieldProbe);
 
         long value = longFieldProbe.get(source);
 
@@ -123,10 +123,9 @@ public class FieldProbeTest extends HazelcastTestSupport {
         Field field = source.getClass().getDeclaredField(fieldName);
         Probe probe = field.getAnnotation(Probe.class);
 
-        FieldProbe fieldProbe = createFieldProbe(field, probe, new SourceMetadata(SomeSource.class));
-        assertInstanceOf(DoubleFieldProbe.class, fieldProbe);
-
-        DoubleFieldProbe doubleFieldProbe = (DoubleFieldProbe) fieldProbe;
+        MethodHandleProbe<SomeSource> fieldProbe = createProbe(field, probe, new SourceMetadata(SomeSource.class));
+       
+        DoubleMethodHandleProbe<SomeSource> doubleFieldProbe =  assertInstanceOf(DoubleMethodHandleProbe.class, fieldProbe);
 
         double value = doubleFieldProbe.get(source);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
@@ -18,7 +18,8 @@ package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeLevel;
-import com.hazelcast.internal.metrics.impl.MethodProbe.LongMethodProbe;
+import com.hazelcast.internal.metrics.impl.MethodHandleProbe.DoubleMethodHandleProbe;
+import com.hazelcast.internal.metrics.impl.MethodHandleProbe.LongMethodHandleProbe;
 import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -38,7 +39,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.hazelcast.internal.metrics.impl.MethodProbe.createMethodProbe;
+import static com.hazelcast.internal.metrics.impl.MethodProbe.createProbe;
 import static com.hazelcast.internal.util.CollectionUtil.getItemAtPositionOrNull;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
@@ -83,7 +84,7 @@ public class MethodProbeTest extends HazelcastTestSupport {
         SomeSource source = new SomeSource();
         Method method = source.getClass().getDeclaredMethod("getSomeIntegerMethod");
         Probe probe = method.getAnnotation(Probe.class);
-        MethodProbe methodProbe = createMethodProbe(method, probe, new SourceMetadata(SomeSource.class));
+        MethodHandleProbe<SomeSource> methodProbe = createProbe(method, probe, new SourceMetadata(SomeSource.class));
 
         MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(mock(ILogger.class), ProbeLevel.DEBUG);
         methodProbe.register(metricsRegistry, source, "prefix");
@@ -98,9 +99,9 @@ public class MethodProbeTest extends HazelcastTestSupport {
         SomeSource source = new SomeSource();
         Method method = source.getClass().getDeclaredMethod(methodName);
         Probe probe = method.getAnnotation(Probe.class);
-        MethodProbe methodProbe = createMethodProbe(method, probe, new SourceMetadata(SomeSource.class));
+        MethodHandleProbe<SomeSource> methodProbe = createProbe(method, probe, new SourceMetadata(SomeSource.class));
 
-        LongMethodProbe<SomeSource> longMethodProbe = assertInstanceOf(LongMethodProbe.class, methodProbe);
+        LongMethodHandleProbe<SomeSource> longMethodProbe = assertInstanceOf(LongMethodHandleProbe.class, methodProbe);
 
         long value = longMethodProbe.get(source);
 
@@ -122,9 +123,9 @@ public class MethodProbeTest extends HazelcastTestSupport {
         SomeSource source = new SomeSource();
         Method method = source.getClass().getDeclaredMethod(fieldName);
         Probe probe = method.getAnnotation(Probe.class);
-        MethodProbe methodProbe = createMethodProbe(method, probe, new SourceMetadata(SomeSource.class));
+        MethodHandleProbe<SomeSource> methodProbe = createProbe(method, probe, new SourceMetadata(SomeSource.class));
 
-        MethodProbe.DoubleMethodProbe<SomeSource> doubleMethodProbe = assertInstanceOf(MethodProbe.DoubleMethodProbe.class, methodProbe);
+        DoubleMethodHandleProbe<SomeSource> doubleMethodProbe = assertInstanceOf(DoubleMethodHandleProbe.class, methodProbe);
         double value = doubleMethodProbe.get(source);
 
         assertEquals(expected, value, 0.1);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
@@ -39,7 +39,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.hazelcast.internal.metrics.impl.MethodProbe.createProbe;
+import static com.hazelcast.internal.metrics.impl.MethodProbe.createMethodProbe;
 import static com.hazelcast.internal.util.CollectionUtil.getItemAtPositionOrNull;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
@@ -84,7 +84,7 @@ public class MethodProbeTest extends HazelcastTestSupport {
         SomeSource source = new SomeSource();
         Method method = source.getClass().getDeclaredMethod("getSomeIntegerMethod");
         Probe probe = method.getAnnotation(Probe.class);
-        MethodHandleProbe<SomeSource> methodProbe = createProbe(method, probe, new SourceMetadata(SomeSource.class));
+        MethodHandleProbe<SomeSource> methodProbe = createMethodProbe(method, probe, new SourceMetadata(SomeSource.class));
 
         MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(mock(ILogger.class), ProbeLevel.DEBUG);
         methodProbe.register(metricsRegistry, source, "prefix");
@@ -99,7 +99,7 @@ public class MethodProbeTest extends HazelcastTestSupport {
         SomeSource source = new SomeSource();
         Method method = source.getClass().getDeclaredMethod(methodName);
         Probe probe = method.getAnnotation(Probe.class);
-        MethodHandleProbe<SomeSource> methodProbe = createProbe(method, probe, new SourceMetadata(SomeSource.class));
+        MethodHandleProbe<SomeSource> methodProbe = createMethodProbe(method, probe, new SourceMetadata(SomeSource.class));
 
         LongMethodHandleProbe<SomeSource> longMethodProbe = assertInstanceOf(LongMethodHandleProbe.class, methodProbe);
 
@@ -123,7 +123,7 @@ public class MethodProbeTest extends HazelcastTestSupport {
         SomeSource source = new SomeSource();
         Method method = source.getClass().getDeclaredMethod(fieldName);
         Probe probe = method.getAnnotation(Probe.class);
-        MethodHandleProbe<SomeSource> methodProbe = createProbe(method, probe, new SourceMetadata(SomeSource.class));
+        MethodHandleProbe<SomeSource> methodProbe = createMethodProbe(method, probe, new SourceMetadata(SomeSource.class));
 
         DoubleMethodHandleProbe<SomeSource> doubleMethodProbe = assertInstanceOf(DoubleMethodHandleProbe.class, methodProbe);
         double value = doubleMethodProbe.get(source);

--- a/pom.xml
+++ b/pom.xml
@@ -1633,6 +1633,10 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencyManagement>


### PR DESCRIPTION
When accessing the data provided by `MethodProbe`s/`FieldProbe`s, reflection is used.

If instead, the [lmbda library](https://github.com/LanternPowered/Lmbda) is used, access performance can be improved by nearly 2x.

In https://github.com/hazelcast/hazelcast/pull/25279 steps were taken to move from core Java reflection to `MethodHandle`s to improve performance, but the dynamic nature of our access means the performance improvements cannot be fully realised.

A similar scenario exists with `FieldProbe`s - [a suggestion was to use `VarHandles` there](https://github.com/hazelcast/hazelcast/issues/25528), but the performance of this was worse.

In both scenarios, ideally the reference should be `static final` to allow compiler folding to occur, but this isn't possible when the `Probe`s are resolved at runtime.

The [lmbda library](https://github.com/LanternPowered/Lmbda) offers increased performance by internally generating a class, **at runtime**, that has a `static final` reference to the `MethodHandle` required, using ASM. And then wraps that in a functional interface to allow easy access.

I've implemented this - for both `MethodProbe`s & `FieldProbes` and [benchmarked it](https://github.com/hazelcast/internal-benchmarks/pull/45) to compare access performance between:
- Current `Probe` implementation
- New `probe-lmbda` implementation
- Direct access (i.e. no reflection) to understand the ceiling / reflective overhead

I've compared this for:
- Primitive & reference types
- Methods & fields

To get an overall picture of the effect of this change:
| Probe Type    	| Access Type    	| Direct field/method invocation ns/op	| `master` ns/op 	| `probe-lmbda` ns/op 	|
|---------------	|---------------------|---------------------	|----------------	|---------------------	|
| `long` | Field  	| 0.5                 	| 2.6            	| 1.3                 	|
| `Long` | Field  	|                     	| 2.6            	| 1.4                 	|
| `long` | Method 	| 0.5                 	| 3.7            	| 1.4                 	|
| `Long` | Method 	|                     	| 1.5            	| 1.4                 	|

It's nearly twice as fast, and there is no change in litter / memory allocation - both were already effectively 0 memory allocation.
However, it's still not as fast as direct access.

Full benchmark results:
- [master-benchmarking.txt](https://github.com/hazelcast/hazelcast/files/12797431/master-benchmarking.txt)
- [probe-lmbda-benchmarking.txt](https://github.com/hazelcast/hazelcast/files/12797432/probe-lmbda-benchmarking.txt)

Of note - [JEP416](https://openjdk.org/jeps/416) (Java 18+) is likely to make the current `FieldProbe` reflection access style slower, whereas the Lmbda implementation is unaffected - [related investigation](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/4648763421/Improving+ReflectiveCompactSerializer+performance#Bonus-Java-18%2B-%2F-JEP416-Benchmarks).

Changes:
- `FieldProbe`s and `MethodProbe`s now extend `MethodHandleProbe`
    - both do minimal work to convert the `Method` or `Field` into a `MethodHandle` which `MethodHandleProbe` use
    - reduced duplicated code
- `Lmbda` dependency added
- `JitPack` repository added to get the latest version of `Lmbda` with a [blocking bug](https://github.com/LanternPowered/Lmbda/issues/6) fixed

Pros:
- Faster
- Probably other places in the system this can be applied

Cons:
- Additional dependency
- Dependency version sourced through JitPack at a specific commit because blocking bug fix is not in a released version

Fixes https://github.com/hazelcast/hazelcast/issues/25528

Breaking changes (list specific methods/types/messages):
* Only `internal` classes