### PR TITLE
Substitute CollectionUtil#addToValueList with Map#computeIfAbsent [HZ-3379]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/CollectionUtil.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
@@ -58,26 +57,6 @@ public final class CollectionUtil {
         return !isEmpty(collection);
     }
 
-    /**
-     * Adds a value to a list of values in the map.
-     * <p>
-     * Creates a new list if no list is found for the key.
-     *
-     * @param map   the given map of lists
-     * @param key   the key of the target list
-     * @param value the value to add to the target list
-     * @return the updated list of values
-     */
-    public static <K, V> List<V> addToValueList(Map<K, List<V>> map, K key, V value) {
-        List<V> valueList = map.get(key);
-        if (valueList == null) {
-            valueList = new ArrayList<V>();
-            map.put(key, valueList);
-        }
-        valueList.add(value);
-
-        return valueList;
-    }
 
     /**
      * Returns the n-th item or {@code null} if collection is smaller.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
@@ -21,9 +21,9 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.internal.util.CollectionUtil;
 import com.hazelcast.internal.util.UnmodifiableIterator;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -91,7 +91,7 @@ public final class MapKeyLoaderUtil {
      */
     static Iterator<Map<Integer, List<Data>>> toBatches(final Iterator<Entry<Integer, Data>> entries,
                                                         final int maxBatch, Semaphore nodeWideLoadedKeyLimiter) {
-        return new UnmodifiableIterator<Map<Integer, List<Data>>>() {
+        return new UnmodifiableIterator<>() {
             @Override
             public boolean hasNext() {
                 return entries.hasNext();
@@ -126,8 +126,8 @@ public final class MapKeyLoaderUtil {
             }
 
             Entry<Integer, Data> e = entries.next();
-            List<Data> partitionKeys = CollectionUtil.addToValueList(batch, e.getKey(), e.getValue());
-
+            List<Data> partitionKeys = batch.computeIfAbsent(e.getKey(), k -> new ArrayList<>());
+            partitionKeys.add(e.getValue());
             if (partitionKeys.size() >= maxBatch) {
                 break;
             }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.internal.util;
 
-import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -29,20 +29,17 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 
-import static com.hazelcast.internal.util.CollectionUtil.addToValueList;
+import static com.hazelcast.internal.util.CollectionUtil.asIntegerList;
 import static com.hazelcast.internal.util.CollectionUtil.getItemAtPositionOrNull;
 import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
 import static com.hazelcast.internal.util.CollectionUtil.isNotEmpty;
 import static com.hazelcast.internal.util.CollectionUtil.nullToEmpty;
 import static com.hazelcast.internal.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.internal.util.CollectionUtil.toIntArray;
-import static com.hazelcast.internal.util.CollectionUtil.asIntegerList;
 import static com.hazelcast.internal.util.CollectionUtil.toLongArray;
 import static java.util.Arrays.asList;
 import static java.util.Collections.EMPTY_LIST;
@@ -80,37 +77,10 @@ public class CollectionUtilTest extends HazelcastTestSupport {
         assertTrue(isNotEmpty(singletonList(23)));
     }
 
-    @Test
-    public void testAddToValueList() {
-        List<Integer> list = new ArrayList<Integer>();
-        list.add(23);
-
-        Map<String, List<Integer>> map = new HashMap<String, List<Integer>>();
-        map.put("existingKey", list);
-
-        addToValueList(map, "existingKey", 42);
-
-        assertEquals(1, map.size());
-        assertEquals(2, list.size());
-        assertContains(list, 42);
-    }
-
-    @Test
-    public void testAddToValueList_whenKeyDoesNotExist_thenNewListIsCreated() {
-        Map<String, List<Integer>> map = new HashMap<String, List<Integer>>();
-
-        addToValueList(map, "nonExistingKey", 42);
-
-        assertEquals(1, map.size());
-
-        List<Integer> list = map.get("nonExistingKey");
-        assertEquals(1, list.size());
-        assertContains(list, 42);
-    }
 
     @Test
     public void testGetItemAtPositionOrNull_whenEmptyArray_thenReturnNull() {
-        Collection<Object> src = new LinkedHashSet<Object>();
+        Collection<Object> src = new LinkedHashSet<>();
         Object result = getItemAtPositionOrNull(src, 0);
 
         assertNull(result);
@@ -119,7 +89,7 @@ public class CollectionUtilTest extends HazelcastTestSupport {
     @Test
     public void testGetItemAtPositionOrNull_whenPositionExist_thenReturnTheItem() {
         Object obj = new Object();
-        Collection<Object> src = new LinkedHashSet<Object>();
+        Collection<Object> src = new LinkedHashSet<>();
         src.add(obj);
 
         Object result = getItemAtPositionOrNull(src, 0);
@@ -130,7 +100,7 @@ public class CollectionUtilTest extends HazelcastTestSupport {
     @Test
     public void testGetItemAtPositionOrNull_whenSmallerArray_thenReturnNull() {
         Object obj = new Object();
-        Collection<Object> src = new LinkedHashSet<Object>();
+        Collection<Object> src = new LinkedHashSet<>();
         src.add(obj);
 
         Object result = getItemAtPositionOrNull(src, 1);
@@ -156,7 +126,7 @@ public class CollectionUtilTest extends HazelcastTestSupport {
     @Test
     public void testObjectToDataCollection_size() {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        Collection<Object> list = new ArrayList<Object>();
+        Collection<Object> list = new ArrayList<>();
         list.add(1);
         list.add("foo");
 
@@ -168,7 +138,7 @@ public class CollectionUtilTest extends HazelcastTestSupport {
     @Test(expected = NullPointerException.class)
     public void testObjectToDataCollection_withNullItem() {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        Collection<Object> list = new ArrayList<Object>();
+        Collection<Object> list = new ArrayList<>();
         list.add(null);
 
         objectToDataCollection(list, serializationService);
@@ -184,14 +154,14 @@ public class CollectionUtilTest extends HazelcastTestSupport {
     @Test
     public void testObjectToDataCollection_deserializeBack() {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        Collection<Object> list = new ArrayList<Object>();
+        Collection<Object> list = new ArrayList<>();
         list.add(1);
         list.add("foo");
 
         Collection<Data> dataCollection = objectToDataCollection(list, serializationService);
 
         Iterator<Data> it1 = dataCollection.iterator();
-        Iterator it2 = list.iterator();
+        Iterator<Object> it2 = list.iterator();
         while (it1.hasNext() && it2.hasNext()) {
             assertEquals(serializationService.toObject(it1.next()), it2.next());
         }
@@ -199,7 +169,7 @@ public class CollectionUtilTest extends HazelcastTestSupport {
 
     @Test
     public void testToIntArray() {
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         list.add(42);
         list.add(23);
         list.add(Integer.MAX_VALUE);
@@ -220,7 +190,7 @@ public class CollectionUtilTest extends HazelcastTestSupport {
 
     @Test
     public void testToLongArray() {
-        List<Long> list = new ArrayList<Long>();
+        List<Long> list = new ArrayList<>();
         list.add(42L);
         list.add(23L);
         list.add(Long.MAX_VALUE);


### PR DESCRIPTION
Java already provides the same functionality. 
The addToValueList  is only used by single method for a HashMap in production code

Jira : https://hazelcast.atlassian.net/browse/HZ-3379

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible