### PR TITLE
Remove dead code CollectionUtil#toLongArray [HZ-3384]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/CollectionUtil.java
@@ -130,22 +130,6 @@ public final class CollectionUtil {
     }
 
     /**
-     * Converts a {@link Collection} of {@link Long} to a primitive {@code long[]} array.
-     *
-     * @param collection the given collection
-     * @return a primitive long[] array
-     * @throws NullPointerException if collection is {@code null}
-     */
-    public static long[] toLongArray(Collection<Long> collection) {
-        long[] collectionArray = new long[collection.size()];
-        int index = 0;
-        for (Long item : collection) {
-            collectionArray[index++] = item;
-        }
-        return collectionArray;
-    }
-
-    /**
      * Adapts an int array to an Integer {@link List}.
      *
      * @param array the array

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
@@ -40,7 +40,6 @@ import static com.hazelcast.internal.util.CollectionUtil.isNotEmpty;
 import static com.hazelcast.internal.util.CollectionUtil.nullToEmpty;
 import static com.hazelcast.internal.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.internal.util.CollectionUtil.toIntArray;
-import static com.hazelcast.internal.util.CollectionUtil.toLongArray;
 import static java.util.Arrays.asList;
 import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.emptyList;
@@ -186,27 +185,6 @@ public class CollectionUtilTest extends HazelcastTestSupport {
     @Test(expected = NullPointerException.class)
     public void testToIntArray_whenNull_thenThrowNPE() {
         toIntArray(null);
-    }
-
-    @Test
-    public void testToLongArray() {
-        List<Long> list = new ArrayList<>();
-        list.add(42L);
-        list.add(23L);
-        list.add(Long.MAX_VALUE);
-
-        long[] longArray = toLongArray(list);
-
-        assertNotNull(longArray);
-        assertEquals(list.size(), longArray.length);
-        assertEquals(list.get(0).longValue(), longArray[0]);
-        assertEquals(list.get(1).longValue(), longArray[1]);
-        assertEquals(list.get(2).longValue(), longArray[2]);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testToLongArray_whenNull_thenThrowNPE() {
-        toLongArray(null);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
Jira : https://hazelcast.atlassian.net/browse/HZ-3384

Method is dead code, not used except tests

If this method is ever needed Java streams provide easier conversion. 
https://stackoverflow.com/questions/31394715/how-to-convert-integer-to-int-array-in-java

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
