### PR TITLE
Bump snappy-java to 1.1.10.5 [5.3.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1836,7 +1836,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.10.1</version>
+                <version>1.1.10.5</version>
             </dependency>
             <dependency>
                 <groupId>com.google.api.grpc</groupId>


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/25607

Bump snappy-java to 1.1.10.5 to mitigate https://nvd.nist.gov/vuln/detail/CVE-2023-43642

Fixes https://github.com/hazelcast/hazelcast/issues/25595

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
