### PR TITLE
Download datagen jar file to test-classes [HZ-3396]

### DIFF
--- a/extensions/kafka-connect/pom.xml
+++ b/extensions/kafka-connect/pom.xml
@@ -74,7 +74,7 @@
                         <configuration>
                             <url>https://repository.hazelcast.com/download/tests/confluentinc-kafka-connect-datagen-0.6.0.zip</url>
                             <unpack>false</unpack>
-                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                            <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
The file was downloaded to classes folder instead of  test-classes

Jira : https://hazelcast.atlassian.net/browse/HZ-3396

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
