### PR TITLE
Best-effort fix for merging metadata over WAN after merge rejection [HZ-3392]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -75,7 +75,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
 import static com.hazelcast.config.NativeMemoryConfig.MemoryAllocatorType.POOLED;


### PR DESCRIPTION
As demonstrated in the reproducer for HZ-3392, it is possible for metadata to be incorrectly applied on WAN targets after the entry has been rejected by the supplied merge policy.

Unfortunately, due to limitations of the existing `SplitBrainMergePolicy`, there is no information passed about whether the `merge()` call modified the outcome or not (whether the incoming entry was rejected, accepted, or altered). This limitation has been documented in HZ-3397 to be addressed in HZ 6.0 as modifications would almost certainly break existing usage (such as custom merge policies).

As a short-term solution that helps improve this scenario (but does not fully resolve it), we can make an "educated guess" about whether the `merge()` call altered the outcome by comparing the returned value against the original value - if they are equal, it's likely the `merge()` did not modify the outcome.

This solution does not cover all scenarios, as it's possible for an operation to modify TTL while setting the same key/value - in this case the expiration would not be merged, resulting in the target expiration metadata always being preferred. Once the merge policy shortfalls have been addressed, this scenario can be resolved.

This commit also adds more TTL-based regression tests, including one for the future scenario outlined in the paragraph above (annotated with `@Ignore` for now and documented in HZ-3397 for removal in the future).

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6609
Fixes https://hazelcast.atlassian.net/browse/HZ-3392