### PR TITLE
Use consistent serialization service for ByKey plans and simplify assertions [HZ-3128]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorSupplier.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.impl.processor.AsyncTransformUsingServiceBatchedP;
+import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.jet.pipeline.ServiceFactories;
 import com.hazelcast.map.IMap;
 import com.hazelcast.nio.ObjectDataInput;
@@ -69,7 +70,13 @@ final class UpdateProcessorSupplier implements ProcessorSupplier, DataSerializab
 
     @Override
     public void init(@Nonnull Context context) {
-        evalContext = ExpressionEvalContext.from(context);
+        evalContext = ExpressionEvalContext.from(context)
+                // IMap updates will be executed in partition thread
+                // and might be executed on local or remote instance.
+                // Remote execution will not be able to use Jet job classloader,
+                // so for consistency also local execution should not use it.
+                .withSerializationService(Util.getSerializationService(context.hazelcastInstance()));
+
     }
 
     @Nonnull

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/SqlServiceImpl.java
@@ -164,14 +164,20 @@ public class SqlServiceImpl implements InternalSqlService {
         return execute(statement, NoOpSqlSecurityContext.INSTANCE);
     }
 
+    @Nonnull
+    @Override
     public SqlResult execute(@Nonnull SqlStatement statement, SqlSecurityContext securityContext) {
         return execute(statement, securityContext, null);
     }
 
+    @Nonnull
+    @Override
     public SqlResult execute(@Nonnull SqlStatement statement, SqlSecurityContext securityContext, QueryId queryId) {
         return execute(statement, securityContext, queryId, false);
     }
 
+    @Nonnull
+    @Override
     public SqlResult execute(
             @Nonnull SqlStatement statement,
             SqlSecurityContext securityContext,

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/ExpressionEvalContext.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/ExpressionEvalContext.java
@@ -25,6 +25,7 @@ import com.hazelcast.jet.impl.execution.init.Contexts;
 import com.hazelcast.jet.impl.execution.init.Contexts.MetaSupplierCtx;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.sql.impl.security.NoOpSqlSecurityContext;
 import com.hazelcast.sql.impl.security.SqlSecurityContext;
 
 import javax.annotation.Nonnull;
@@ -75,7 +76,7 @@ public interface ExpressionEvalContext {
                     arguments,
                     new DefaultSerializationServiceBuilder().build(),
                     Util.getNodeEngine(ctx.hazelcastInstance()),
-                    (SqlSecurityContext) null
+                    NoOpSqlSecurityContext.INSTANCE
             );
         }
     }
@@ -111,6 +112,12 @@ public interface ExpressionEvalContext {
      * @return serialization service
      */
     InternalSerializationService getSerializationService();
+
+    /**
+     * Changes serialization service for this context
+     * @return context with changed serialization service
+     */
+    ExpressionEvalContext withSerializationService(@Nonnull InternalSerializationService newService);
 
     /**
      * @return node engine

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/ExpressionEvalContextImpl.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/ExpressionEvalContextImpl.java
@@ -90,6 +90,18 @@ public class ExpressionEvalContextImpl implements ExpressionEvalContext {
         return serializationService;
     }
 
+    @Override
+    public ExpressionEvalContextImpl withSerializationService(@Nonnull InternalSerializationService newService) {
+        if (serializationService == newService) {
+            return this;
+        }
+        if (contextRef != null) {
+            return new ExpressionEvalContextImpl(arguments, newService, nodeEngine, contextRef);
+        } else {
+            return new ExpressionEvalContextImpl(arguments, newService, nodeEngine, ssc);
+        }
+    }
+
     /**
      * @return node engine
      */

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/MockExpressionEvalContext.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/MockExpressionEvalContext.java
@@ -20,10 +20,12 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.spi.impl.NodeEngine;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.security.auth.Subject;
 import java.security.Permission;
 import java.util.List;
+import java.util.Objects;
 
 public class MockExpressionEvalContext implements ExpressionEvalContext {
     InternalSerializationService ss;
@@ -45,6 +47,13 @@ public class MockExpressionEvalContext implements ExpressionEvalContext {
     @Override
     public InternalSerializationService getSerializationService() {
         return ss;
+    }
+
+    @Override
+    public ExpressionEvalContext withSerializationService(@Nonnull InternalSerializationService newService) {
+        MockExpressionEvalContext newCtx = new MockExpressionEvalContext();
+        newCtx.ss = Objects.requireNonNull(newService);
+        return newCtx;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/serialization/DelegatingSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/serialization/DelegatingSerializationService.java
@@ -44,6 +44,10 @@ import static com.hazelcast.jet.impl.util.ReflectionUtils.newInstance;
 import static java.lang.Thread.currentThread;
 import static java.util.Collections.emptyMap;
 
+/**
+ * Provides per-job serializers and produces user-friendly Jet-specific error message when serializer
+ * is not found.
+ */
 public class DelegatingSerializationService extends AbstractSerializationService {
 
     private final Map<Class<?>, SerializerAdapter> serializersByClass;


### PR DESCRIPTION
Correct implementation of sanity checks discussed in https://github.com/hazelcast/hazelcast/pull/25477#discussion_r1344069542 + fix of uncovered inconsistencies.

Fixes HZ-3128

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
