### PR TITLE
Increase the timeout for assertTrueEventually [HZ-3404] [5.3.z]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/hz3/Hazelcast3StarterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/hz3/Hazelcast3StarterTest.java
@@ -65,14 +65,9 @@ public class Hazelcast3StarterTest {
         HazelcastInstance instance = Hazelcast3Starter.newHazelcastInstance(HZ3_MEMBER_CONFIG);
         ITopic<String> topic = instance.getTopic("my-topic");
         List<String> result = new ArrayList<>();
-        topic.addMessageListener(message -> {
-            result.add(message.getMessageObject());
-        });
+        topic.addMessageListener(message -> result.add(message.getMessageObject()));
         topic.publish("value");
-        assertTrueEventually(
-                () -> assertThat(result).contains("value"),
-                5
-        );
+        assertTrueEventually(() -> assertThat(result).contains("value"));
 
         instance.shutdown();
     }


### PR DESCRIPTION
The test is probably failing because 5 second time out is not enough

Backport of: https://github.com/hazelcast/hazelcast/pull/25642

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible