### PR TITLE
Resolve `javax.transaction.xa` module accessibility

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -632,10 +632,10 @@
             <version>${atomikos.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jta_1.1_spec</artifactId>
+            <groupId>javax.transaction</groupId>
+            <artifactId>javax.transaction-api</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
-            <version>1.1.1</version>
         </dependency>
         <!-- OSGi -->
         <dependency>


### PR DESCRIPTION
Eclipse reports the following error:

> The package javax.transaction.xa is accessible from more than one module: <unnamed>, java.transaction.xa	ReferenceObjects.java

This is because the `javax.transaction.xa.XAException` class is in the JDK AND the `geronimo-jta_1.1_spec` artifact - i.e. a split-package.

The same scenario occurs with `javax.transaction.xa.Xid` - and results in nearly 400 errors in the IDE :(

The typical fix is to remove the problematic dependency if it's redundant, but `geronimo-jta_1.1_spec` _also_ contains a declaration of `javax.transaction.Transaction` which we are using.

Instead, based [on this](https://stackoverflow.com/a/51007675), I've swapped to a newer derivative of the same definition, which includes _only_ the additional types not present in the JDK.


JTA version history is described in the spec Appendix B: https://download.oracle.com/otndocs/jcp/jta-1_3-mrel-spec/