### PR TITLE
Workaround Eclipse erroneous `Cannot infer type arguments for` error

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestOutbox.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestOutbox.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.function.IntFunction;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNegative;
@@ -77,10 +78,10 @@ public final class TestOutbox implements OutboxInternal {
         allOrdinals = IntStream.range(0, edgeCapacities.length).toArray();
 
         OutboundCollector[] outstreams = new OutboundCollector[edgeCapacities.length + (snapshotCapacity > 0 ? 1 : 0)];
-        Arrays.setAll(outstreams, i ->
-                i < edgeCapacities.length
-                    ? e -> addToQueue(buckets[i], edgeCapacities[i], e)
-                    : e -> addToQueue(snapshotQueue, snapshotCapacity, deserializeSnapshotEntry((Entry<Data, Data>) e)));
+        IntFunction<OutboundCollector> generator = i -> i < edgeCapacities.length
+                ? e -> addToQueue(buckets[i], edgeCapacities[i], e)
+                : e -> addToQueue(snapshotQueue, snapshotCapacity, deserializeSnapshotEntry((Entry<Data, Data>) e));
+        Arrays.setAll(outstreams, generator);
 
         serializationService = new DefaultSerializationServiceBuilder().build();
         outbox = new OutboxImpl(outstreams, snapshotCapacity > 0, new ProgressTracker(), serializationService,

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestOutbox.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/test/TestOutbox.java
@@ -78,6 +78,8 @@ public final class TestOutbox implements OutboxInternal {
         allOrdinals = IntStream.range(0, edgeCapacities.length).toArray();
 
         OutboundCollector[] outstreams = new OutboundCollector[edgeCapacities.length + (snapshotCapacity > 0 ? 1 : 0)];
+        // Intermediate variable required to workaround Eclipse bug
+        // https://github.com/hazelcast/hazelcast/pull/25652
         IntFunction<OutboundCollector> generator = i -> i < edgeCapacities.length
                 ? e -> addToQueue(buckets[i], edgeCapacities[i], e)
                 : e -> addToQueue(snapshotQueue, snapshotCapacity, deserializeSnapshotEntry((Entry<Data, Data>) e));


### PR DESCRIPTION
Eclipse (erroneously) reports an error with the `com.hazelcast.jet.core.test.TestOutbox.TestOutbox(int[], int)` constructor:

> Cannot infer type argument(s) for <T> setAll(T[], IntFunction<? extends T>)	TestOutbox.java

This behaviour is subject to an [open Eclipse bug](https://bugs.eclipse.org/bugs/show_bug.cgi?id=566989), but there have been no updates for three years.

A workaround is to explicitly specify the type arguments by creating an intermediate `IntFunction<OutboundCollector>` variable.