### PR TITLE
Replace `Preconditions.checkNotNull` implementation with `Objects.requireNonNull`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/Preconditions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/Preconditions.java
@@ -93,7 +93,7 @@ public final class Preconditions {
     }
 
     /**
-     * Tests if a argument is not null.
+     * Tests if an argument is not null.
      *
      * @param argument the argument tested to see if it is not null.
      * @param argName  the argument name (used in message if an error is thrown).

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/Preconditions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/Preconditions.java
@@ -49,14 +49,8 @@ public final class Preconditions {
         return argument;
     }
 
-    /**
-     * Tests if an argument is not null.
-     *
-     * @param argument     the argument tested to see if it is not null.
-     * @param errorMessage the errorMessage
-     * @return the argument that was tested.
-     * @throws java.lang.NullPointerException if argument is null
-     */
+    /** @deprecated {@link Objects.requireNonNull(T, String) */
+    @Deprecated(since = "5.4")
     public static <T> T checkNotNull(T argument, String errorMessage) {
         return Objects.requireNonNull(argument, errorMessage);
     }
@@ -75,18 +69,13 @@ public final class Preconditions {
             return argument;
         }
         for (T element : argument) {
-            checkNotNull(element, errorMessage);
+            Objects.requireNonNull(element, errorMessage);
         }
         return argument;
     }
 
-    /**
-     * Tests if an argument is not null.
-     *
-     * @param argument the argument tested to see if it is not null.
-     * @return the argument that was tested.
-     * @throws java.lang.NullPointerException if argument is null
-     */
+    /** @deprecated {@link Objects.requireNonNull(T) */
+    @Deprecated(since = "5.4")
     @Nonnull
     public static <T> T checkNotNull(T argument) {
         return Objects.requireNonNull(argument);

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/Preconditions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/Preconditions.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.util;
 import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Properties;
 
 import static com.hazelcast.internal.partition.InternalPartition.MAX_BACKUP_COUNT;
@@ -57,10 +58,7 @@ public final class Preconditions {
      * @throws java.lang.NullPointerException if argument is null
      */
     public static <T> T checkNotNull(T argument, String errorMessage) {
-        if (argument == null) {
-            throw new NullPointerException(errorMessage);
-        }
-        return argument;
+        return Objects.requireNonNull(argument, errorMessage);
     }
 
     /**
@@ -91,17 +89,14 @@ public final class Preconditions {
      */
     @Nonnull
     public static <T> T checkNotNull(T argument) {
-        if (argument == null) {
-            throw new NullPointerException();
-        }
-        return argument;
+        return Objects.requireNonNull(argument);
     }
 
     /**
-     * Tests if a string is not null.
+     * Tests if a argument is not null.
      *
-     * @param argument the string tested to see if it is not null.
-     * @param argName  the string name (used in message if an error is thrown).
+     * @param argument the argument tested to see if it is not null.
+     * @param argName  the argument name (used in message if an error is thrown).
      * @return the string argument that was tested.
      * @throws java.lang.IllegalArgumentException if the string is null.
      */

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/PreconditionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/PreconditionsTest.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -52,18 +53,16 @@ public class PreconditionsTest {
 
     // =====================================================
 
+    @SuppressWarnings("deprecation")
     @Test
     public void checkNotNull_whenNull() {
         String msg = "Can't be null";
 
-        try {
-            Preconditions.checkNotNull(null, msg);
-            fail();
-        } catch (NullPointerException expected) {
-            assertEquals(msg, expected.getMessage());
-        }
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> Preconditions.checkNotNull(null, msg));
+        assertEquals(msg, exception.getMessage());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void checkNotNull_whenNotNull() {
         Object o = "foobar";


### PR DESCRIPTION
`Preconditions.checkNotNull` duplicates [`Objects.requireNonNull`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Objects.html#requireNonNull(T)) - it's implementation should delegate to that instead.