### PR TITLE
Implement 'view-mapping' permission [HZ-3190]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/service/GetDdlFunction.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/service/GetDdlFunction.java
@@ -87,7 +87,7 @@ public class GetDdlFunction extends TriExpression<String> {
             } else if (catalogObject instanceof DataConnectionCatalogEntry) {
                 context.checkPermission(new SqlPermission(catalogObject.name(), ACTION_VIEW_DATACONNECTION));
             }
-            // Note: bpoth view and type can't contain sensitive information -> we don't check them
+            // Note: both view and type can't contain sensitive information -> we don't check them
             ddl = ((SqlCatalogObject) obj).unparse();
         } else {
             throw new AssertionError("Object must not be present in information_schema");

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/service/GetDdlFunction.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/service/GetDdlFunction.java
@@ -32,8 +32,8 @@ import com.hazelcast.sql.impl.schema.dataconnection.DataConnectionCatalogEntry;
 import com.hazelcast.sql.impl.type.QueryDataType;
 
 import static com.hazelcast.jet.impl.JetServiceBackend.SQL_CATALOG_MAP_NAME;
-import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_VIEW_DATACONNECTION;
+import static com.hazelcast.security.permission.ActionConstants.ACTION_VIEW_MAPPING;
 import static com.hazelcast.sql.impl.expression.string.StringFunctionUtils.asVarchar;
 
 public class GetDdlFunction extends TriExpression<String> {
@@ -83,11 +83,11 @@ public class GetDdlFunction extends TriExpression<String> {
         } else if (obj instanceof SqlCatalogObject) {
             SqlCatalogObject catalogObject = (SqlCatalogObject) obj;
             if (catalogObject instanceof Mapping) {
-                context.checkPermission(new SqlPermission(catalogObject.name(), ACTION_READ));
+                context.checkPermission(new SqlPermission(catalogObject.name(), ACTION_VIEW_MAPPING));
             } else if (catalogObject instanceof DataConnectionCatalogEntry) {
                 context.checkPermission(new SqlPermission(catalogObject.name(), ACTION_VIEW_DATACONNECTION));
             }
-            // Note: 'view' view and 'view' type can't contain sensitive information -> we don't check them
+            // Note: bpoth view and type can't contain sensitive information -> we don't check them
             ddl = ((SqlCatalogObject) obj).unparse();
         } else {
             throw new AssertionError("Object must not be present in information_schema");

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
@@ -80,6 +80,7 @@ public final class ActionConstants {
     public static final String LISTENER_MIGRATION = "migration";
 
     // SQL-specific actions
+    public static final String ACTION_VIEW_MAPPING = "view-mapping";
     public static final String ACTION_CREATE_VIEW = "create-view";
     public static final String ACTION_DROP_VIEW = "drop-view";
     public static final String ACTION_CREATE_TYPE = "create-type";

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/SqlPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/SqlPermission.java
@@ -70,7 +70,7 @@ public class SqlPermission extends InstancePermission {
                     mask |= CREATE_DATACONNECTION;
                 } else if (ActionConstants.ACTION_DROP_DATACONNECTION.equals(action)) {
                     mask |= DROP_DATACONNECTION;
-                } else if (ActionConstants.ACTION_READ.equals(action)) {
+                } else if (ActionConstants.ACTION_VIEW_MAPPING.equals(action)) {
                     mask |= VIEW_MAPPING;
                 }
                 // Note: DROP INDEX is not implemented yet, no need to have separate permission.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/SqlPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/SqlPermission.java
@@ -28,8 +28,14 @@ public class SqlPermission extends InstancePermission {
     private static final int VIEW_DATACONNECTION = DROP_TYPE << 1;
     private static final int CREATE_DATACONNECTION = VIEW_DATACONNECTION << 1;
     private static final int DROP_DATACONNECTION = CREATE_DATACONNECTION << 1;
-    private static final int ALL = CREATE_MAPPING | DROP_MAPPING | CREATE_INDEX | CREATE_VIEW | DROP_VIEW
-            | CREATE_TYPE | DROP_TYPE | VIEW_DATACONNECTION | CREATE_DATACONNECTION | DROP_DATACONNECTION;
+    private static final int VIEW_MAPPING = DROP_DATACONNECTION << 1;
+    private static final int ALL = CREATE_MAPPING | DROP_MAPPING
+            | CREATE_INDEX
+            | CREATE_VIEW | DROP_VIEW
+            | CREATE_TYPE | DROP_TYPE
+            | VIEW_DATACONNECTION | CREATE_DATACONNECTION | DROP_DATACONNECTION
+            // Note: added to the tail for backward compatibility
+            | VIEW_MAPPING;
 
     public SqlPermission(String name, String... actions) {
         super(name, actions);
@@ -43,6 +49,7 @@ public class SqlPermission extends InstancePermission {
             if (ActionConstants.ACTION_ALL.equals(action)) {
                 return ALL;
             } else {
+                // Note: mappings permission are mapped to the standard ACTION_* permissions
                 if (ActionConstants.ACTION_CREATE.equals(action)) {
                     mask |= CREATE_MAPPING;
                 } else if (ActionConstants.ACTION_DESTROY.equals(action)) {
@@ -63,6 +70,8 @@ public class SqlPermission extends InstancePermission {
                     mask |= CREATE_DATACONNECTION;
                 } else if (ActionConstants.ACTION_DROP_DATACONNECTION.equals(action)) {
                     mask |= DROP_DATACONNECTION;
+                } else if (ActionConstants.ACTION_READ.equals(action)) {
+                    mask |= VIEW_MAPPING;
                 }
                 // Note: DROP INDEX is not implemented yet, no need to have separate permission.
             }

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/SqlPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/SqlPermission.java
@@ -34,7 +34,7 @@ public class SqlPermission extends InstancePermission {
             | CREATE_VIEW | DROP_VIEW
             | CREATE_TYPE | DROP_TYPE
             | VIEW_DATACONNECTION | CREATE_DATACONNECTION | DROP_DATACONNECTION
-            // Note: added to the tail for backward compatibility
+            // Note: added to the tail for backward compatibility.
             | VIEW_MAPPING;
 
     public SqlPermission(String name, String... actions) {


### PR DESCRIPTION
This patch introduces 'view-mapping'  permission to check user access to mapping during runtime (mainly, GET_DDL)

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/6623