### PR TITLE
Delete ArrayUtils#copyWithoutNulls that is only used in tests [HZ-3419]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ArrayUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ArrayUtils.java
@@ -116,29 +116,6 @@ public final class ArrayUtils {
         return -1;
     }
 
-    /**
-     * Copy src array into destination and skip null values.
-     * Warning: It does not do any validation. It expect the dst[] is
-     * created with right capacity.
-     *
-     * You can calculate required capacity as <code>src.length - getNoOfNullItems(src)</code>
-     *
-     * @param src source array
-     * @param dst destination. It has to have the right capacity
-     * @param <T>
-     */
-    public static <T> void copyWithoutNulls(T[] src, T[] dst) {
-        int skipped = 0;
-        for (int i = 0; i < src.length; i++) {
-            T object = src[i];
-            if (object == null) {
-                skipped++;
-            } else {
-                dst[i - skipped] = object;
-            }
-        }
-    }
-
     public static <T> boolean contains(T[] array, T item) {
         for (T o : array) {
             if (o == null) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/ArrayUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/ArrayUtilsTest.java
@@ -66,29 +66,6 @@ public class ArrayUtilsTest extends HazelcastTestSupport {
         assertThat(result[0]).isSameAs(o);
     }
 
-
-    @Test
-    public void copyWithoutNulls_whenSrcHasNullItem_thenDoNotCopyItIntoTarget() {
-        Object[] src = new Object[1];
-        src[0] = null;
-        Object[] dst = new Object[0];
-
-        ArrayUtils.copyWithoutNulls(src, dst);
-        assertThat(dst).isEmpty();
-    }
-
-    @Test
-    public void copyWithoutNulls_whenSrcHasNonNullItem_thenCopyItIntoTarget() {
-        Object[] src = new Object[1];
-        Object o = new Object();
-        src[0] = o;
-        Object[] dst = new Object[1];
-
-        ArrayUtils.copyWithoutNulls(src, dst);
-        assertThat(dst).hasSize(1);
-        assertThat(dst[0]).isSameAs(o);
-    }
-
     @Test
     public void contains() {
         Object[] array = new Object[1];


### PR DESCRIPTION
Jira : https://hazelcast.atlassian.net/browse/HZ-3419

It is easy to have the same functionality with java streams if necessary
```java
Integer[] targetArray = Arrays.stream(sourceArray)
  .filter(element -> element != null)
  .toArray(Integer[]::new);
```

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
