### PR TITLE
Handle unreliable getDistributedObjects in ObservableImpl#configureCapacity [HZ-3420]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/observer/ObservableImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/observer/ObservableImpl.java
@@ -118,7 +118,7 @@ public class ObservableImpl<T> implements Observable<T> {
                 return this;
             } catch (InvalidConfigurationException e) {
                 logger.warning("Configuration for ringbuffer " + name + " already exists. "
-                        + "Maybe the ringbuffer was missed due to unreliableHazelcastInstance#getDistributedObjects");
+                        + "Maybe the ringbuffer was missed due to unreliable HazelcastInstance#getDistributedObjects");
                 if (i == 2) {
                     throw new RuntimeException("Failed configuring capacity: " + e, e);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/observer/ObservableImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/observer/ObservableImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.observer;
 import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
@@ -105,16 +106,26 @@ public class ObservableImpl<T> implements Observable<T> {
     @Override
     public Observable<T> configureCapacity(int capacity) {
         String ringbufferName = ringbufferName(name);
-        if (ringbufferExists(ringbufferName)) {
-            throw new IllegalStateException("Underlying buffer for observable '" + name + "' is already created.");
+        int i = 0;
+        while (true) {
+            i++;
+            if (ringbufferExists(ringbufferName)) {
+                throw new IllegalStateException("Underlying buffer for observable '" + name + "' is already created.");
+            }
+            Config config = hzInstance.getConfig();
+            try {
+                config.addRingBufferConfig(new RingbufferConfig(ringbufferName).setCapacity(capacity));
+                return this;
+            } catch (InvalidConfigurationException e) {
+                logger.warning("Configuration for ringbuffer " + name + " already exists. "
+                        + "Maybe the ringbuffer was missed due to unreliableHazelcastInstance#getDistributedObjects");
+                if (i == 2) {
+                    throw new RuntimeException("Failed configuring capacity: " + e, e);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Failed configuring capacity: " + e, e);
+            }
         }
-        Config config = hzInstance.getConfig();
-        try {
-            config.addRingBufferConfig(new RingbufferConfig(ringbufferName).setCapacity(capacity));
-        } catch (Exception e) {
-            throw new RuntimeException("Failed configuring capacity: " + e, e);
-        }
-        return this;
     }
 
     @Override


### PR DESCRIPTION
Fixes #24814

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
