### PR TITLE
Bump netty to 4.1.100.Final [HZ-3424] [5.3.3]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <reload4j.version>1.2.24</reload4j.version>
         <log4j2.version>2.20.0</log4j2.version>
         <mysql.connector.version>8.0.30</mysql.connector.version>
-        <netty.version>4.1.96.Final</netty.version>
+        <netty.version>4.1.100.Final</netty.version>
         <objenesis.version>3.3</objenesis.version>
         <osgi.version>4.2.0</osgi.version>
         <parquet.version>1.13.0</parquet.version>


### PR DESCRIPTION
Fixes #25669
Addresses CVE-2023-4586 vulnerability

EE PR https://github.com/hazelcast/hazelcast-enterprise/pull/6628

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
