### PR TITLE
Added check for negative position on `getItemAtPositionOrNull`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/CollectionUtil.java
@@ -67,7 +67,7 @@ public final class CollectionUtil {
      * @throws NullPointerException if collection is {@code null}
      */
     public static <T> T getItemAtPositionOrNull(Collection<T> collection, int position) {
-        if (position >= collection.size()) {
+        if (position >= collection.size() || position < 0) {
             return null;
         }
         if (collection instanceof List) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
@@ -108,6 +108,17 @@ public class CollectionUtilTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testGetItemAtPositionOrNull_whenNegativePosition_thenReturnNull() {
+        Object obj = new Object();
+        Collection<Object> src = new ArrayList<>();
+        src.add(obj);
+
+        Object result = getItemAtPositionOrNull(src, -1);
+
+        assertNull(result);
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void testGetItemAsPositionOrNull_whenInputImplementsList_thenDoNotUserIterator() {
         Object obj = new Object();


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.pinpointhq.com/
-->

For some reason, we are using the `CollectionUtil#getItemAtPositionOrNull` in one of our projects and the `IndexOutOfBoundsException` was thrown coming from this lib. Upon investigation, the problem and fix was fairly simple hence the PR.

No checklist item seems applicable although I am leaving it empty for now. Happy to remove it if needed.

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
- [ ] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
