### PR TITLE
Fix usage of deprecated Junit4 asserts and minor compiler warnings [HZ-3434]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
@@ -219,7 +219,7 @@ public class BasicCacheLiteMemberTest
         @Override
         public void onUpdated(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
+            for (CacheEntryEvent<? extends K, ? extends V> ignored : cacheEntryEvents) {
                 updated.incrementAndGet();
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
@@ -48,10 +48,10 @@ import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -86,14 +86,12 @@ public class BasicCacheLiteMemberTest
     }
 
     @Test
-    public void testCacheCreation()
-            throws InterruptedException {
+    public void testCacheCreation() {
         testCacheCreation(instanceCachingProvider, liteCachingProvider);
     }
 
     @Test
-    public void testCacheCreationFromLiteMember()
-            throws InterruptedException {
+    public void testCacheCreationFromLiteMember() {
         testCacheCreation(liteCachingProvider, instanceCachingProvider);
     }
 
@@ -104,17 +102,13 @@ public class BasicCacheLiteMemberTest
 
         assertNull(cacheManager.getCache(cacheName));
 
-        CacheConfig<Integer, String> config = new CacheConfig<Integer, String>();
+        CacheConfig<Integer, String> config = new CacheConfig<>();
         Cache<Integer, String> cache = cacheManager.createCache(cacheName, config);
         assertNotNull(cache);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                CacheManager cm2 = providerToValidate.getCacheManager();
-                assertNotNull(cm2.getCache(cacheName));
-            }
+        assertTrueEventually(() -> {
+            CacheManager cm2 = providerToValidate.getCacheManager();
+            assertNotNull(cm2.getCache(cacheName));
         });
     }
 
@@ -123,7 +117,7 @@ public class BasicCacheLiteMemberTest
             throws InterruptedException {
         CacheManager cacheManager = liteCachingProvider.getCacheManager();
 
-        CacheConfig<Integer, String> config = new CacheConfig<Integer, String>();
+        CacheConfig<Integer, String> config = new CacheConfig<>();
         Cache<Integer, String> cache = cacheManager.createCache(cacheName, config);
         assertNotNull(cache);
 
@@ -134,15 +128,14 @@ public class BasicCacheLiteMemberTest
     }
 
     @Test
-    public void testCompletion()
-            throws InterruptedException {
+    public void testCompletion() {
 
         CacheManager cacheManager = liteCachingProvider.getCacheManager();
 
-        CacheConfig<Integer, String> config = new CacheConfig<Integer, String>();
-        final SimpleEntryListener<Integer, String> listener = new SimpleEntryListener<Integer, String>();
+        CacheConfig<Integer, String> config = new CacheConfig<>();
+        final SimpleEntryListener<Integer, String> listener = new SimpleEntryListener<>();
         MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration =
-                new MutableCacheEntryListenerConfiguration<Integer, String>(
+                new MutableCacheEntryListenerConfiguration<>(
                         FactoryBuilder.factoryOf(listener), null, true, true);
 
         config.addCacheEntryListenerConfiguration(listenerConfiguration);
@@ -152,33 +145,15 @@ public class BasicCacheLiteMemberTest
         Integer key1 = 1;
         String value1 = "value1";
         instanceCache.put(key1, value1);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(1, listener.created.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(1, listener.created.get()));
         Integer key2 = 2;
         String value2 = "value2";
         instanceCache.put(key2, value2);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(2, listener.created.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(2, listener.created.get()));
 
         instanceCache.remove(key1);
         instanceCache.remove(key2);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(2, listener.removed.get());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(2, listener.removed.get()));
     }
 
     @Test
@@ -190,16 +165,12 @@ public class BasicCacheLiteMemberTest
         final Cache c2 = cacheManager2.getCache("c1");
         c1.put("key", "value");
         cacheManager.destroyCache("c1");
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                try {
-                    c2.get("key");
-                    fail("get should throw IllegalStateException");
-                } catch (IllegalStateException e) {
-                    //ignored as expected
-                }
+        assertTrueEventually(() -> {
+            try {
+                c2.get("key");
+                fail("get should throw IllegalStateException");
+            } catch (IllegalStateException e) {
+                //ignored as expected
             }
         });
     }
@@ -239,7 +210,7 @@ public class BasicCacheLiteMemberTest
         @Override
         public void onCreated(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
+            for (CacheEntryEvent<? extends K, ? extends V> ignored : cacheEntryEvents) {
                 created.incrementAndGet();
             }
         }
@@ -247,7 +218,7 @@ public class BasicCacheLiteMemberTest
         @Override
         public void onExpired(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
+            for (CacheEntryEvent<? extends K, ? extends V> ignored : cacheEntryEvents) {
                 expired.incrementAndGet();
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
@@ -165,14 +165,7 @@ public class BasicCacheLiteMemberTest
         final Cache c2 = cacheManager2.getCache("c1");
         c1.put("key", "value");
         cacheManager.destroyCache("c1");
-        assertTrueEventually(() -> {
-            try {
-                c2.get("key");
-                fail("get should throw IllegalStateException");
-            } catch (IllegalStateException e) {
-                //ignored as expected
-            }
-        });
+        assertTrueEventually(() -> assertThrows(IllegalStateException.class, () -> c2.get("key")));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -51,7 +50,6 @@ import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -178,13 +176,7 @@ public class BasicCacheLiteMemberTest
         c1.put("key", "value");
         c2.put("key", "value");
         cacheManager.close();
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                c2.get("key");
-            }
-        }, 10);
+        assertTrueAllTheTime(() -> c2.get("key"), 10);
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorTest.java
@@ -38,9 +38,9 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 import static com.hazelcast.cache.CacheTestSupport.createServerCachingProvider;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(HazelcastParametrizedRunner.class)
@@ -72,7 +72,7 @@ public class CachePartitionIteratorTest extends HazelcastTestSupport {
     private <K, V> CacheProxy<K, V> getCacheProxy() {
         String cacheName = randomString();
         CacheManager cacheManager = cachingProvider.getCacheManager();
-        CacheConfig<K, V> config = new CacheConfig<K, V>();
+        CacheConfig<K, V> config = new CacheConfig<>();
         config.getEvictionConfig().setMaxSizePolicy(MaxSizePolicy.ENTRY_COUNT).setSize(10000000);
         return (CacheProxy<K, V>) cacheManager.createCache(cacheName, config);
 
@@ -83,14 +83,14 @@ public class CachePartitionIteratorTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_HasNext_Returns_False_On_EmptyPartition() throws Exception {
+    public void test_HasNext_Returns_False_On_EmptyPartition() {
         CacheProxy<Integer, Integer> cache = getCacheProxy();
         Iterator<Cache.Entry<Integer, Integer>> iterator = getIterator(cache);
         assertFalse(iterator.hasNext());
     }
 
     @Test
-    public void test_HasNext_Returns_True_On_NonEmptyPartition() throws Exception {
+    public void test_HasNext_Returns_True_On_NonEmptyPartition() {
         CacheProxy<String, String> cache = getCacheProxy();
 
         String key = generateKeyForPartition(server, 1);
@@ -102,7 +102,7 @@ public class CachePartitionIteratorTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_Next_Returns_Value_On_NonEmptyPartition() throws Exception {
+    public void test_Next_Returns_Value_On_NonEmptyPartition() {
         CacheProxy<String, String> cache = getCacheProxy();
 
         String key = generateKeyForPartition(server, 1);
@@ -110,12 +110,12 @@ public class CachePartitionIteratorTest extends HazelcastTestSupport {
         cache.put(key, value);
 
         Iterator<Cache.Entry<String, String>> iterator = getIterator(cache);
-        Cache.Entry entry = iterator.next();
+        Cache.Entry<String, String> entry = iterator.next();
         assertEquals(value, entry.getValue());
     }
 
     @Test
-    public void test_Next_Returns_Value_On_NonEmptyPartition_and_HasNext_Returns_False_when_Item_Consumed() throws Exception {
+    public void test_Next_Returns_Value_On_NonEmptyPartition_and_HasNext_Returns_False_when_Item_Consumed() {
         CacheProxy<String, String> cache = getCacheProxy();
 
         String key = generateKeyForPartition(server, 1);
@@ -123,14 +123,14 @@ public class CachePartitionIteratorTest extends HazelcastTestSupport {
         cache.put(key, value);
 
         Iterator<Cache.Entry<String, String>> iterator = getIterator(cache);
-        Cache.Entry entry = iterator.next();
+        Cache.Entry<String, String> entry = iterator.next();
         assertEquals(value, entry.getValue());
         boolean hasNext = iterator.hasNext();
         assertFalse(hasNext);
     }
 
     @Test
-    public void test_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() throws Exception {
+    public void test_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() {
         CacheProxy<String, String> cache = getCacheProxy();
         String value = randomString();
         int count = 1000;
@@ -140,7 +140,7 @@ public class CachePartitionIteratorTest extends HazelcastTestSupport {
         }
         Iterator<Cache.Entry<String, String>> iterator = getIterator(cache);
         for (int i = 0; i < count; i++) {
-            Cache.Entry entry = iterator.next();
+            Cache.Entry<String, String> entry = iterator.next();
             assertEquals(value, entry.getValue());
 
         }

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/AbstractCacheEvictionPolicyComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/AbstractCacheEvictionPolicyComparatorTest.java
@@ -34,8 +34,8 @@ import javax.cache.spi.CachingProvider;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/AbstractClientCachePartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/AbstractClientCachePartitionIteratorTest.java
@@ -32,8 +32,8 @@ import javax.cache.spi.CachingProvider;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractClientCachePartitionIteratorTest extends HazelcastTestSupport {
@@ -60,14 +60,14 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
     }
 
     @Test
-    public void test_HasNext_Returns_False_On_EmptyPartition() throws Exception {
+    public void test_HasNext_Returns_False_On_EmptyPartition() {
         ICacheInternal<Integer, Integer> cache = getCacheProxy();
         Iterator<Cache.Entry<Integer, Integer>> iterator = getIterator(cache);
         assertFalse(iterator.hasNext());
     }
 
     @Test
-    public void test_HasNext_Returns_True_On_NonEmptyPartition() throws Exception {
+    public void test_HasNext_Returns_True_On_NonEmptyPartition() {
         ICacheInternal<String, String> cache = getCacheProxy();
 
         String key = generateKeyForPartition(server, 1);
@@ -79,7 +79,7 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
     }
 
     @Test
-    public void test_Next_Returns_Value_On_NonEmptyPartition() throws Exception {
+    public void test_Next_Returns_Value_On_NonEmptyPartition() {
         ICacheInternal<String, String> cache = getCacheProxy();
 
         String key = generateKeyForPartition(server, 1);
@@ -87,12 +87,12 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
         cache.put(key, value);
 
         Iterator<Cache.Entry<String, String>> iterator = getIterator(cache);
-        Cache.Entry entry = iterator.next();
+        Cache.Entry<String, String> entry = iterator.next();
         assertEquals(value, entry.getValue());
     }
 
     @Test
-    public void test_Next_Returns_Value_On_NonEmptyPartition_and_HasNext_Returns_False_when_Item_Consumed() throws Exception {
+    public void test_Next_Returns_Value_On_NonEmptyPartition_and_HasNext_Returns_False_when_Item_Consumed() {
         ICacheInternal<String, String> cache = getCacheProxy();
 
         String key = generateKeyForPartition(server, 1);
@@ -100,14 +100,14 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
         cache.put(key, value);
 
         Iterator<Cache.Entry<String, String>> iterator = getIterator(cache);
-        Cache.Entry entry = iterator.next();
+        Cache.Entry<String, String> entry = iterator.next();
         assertEquals(value, entry.getValue());
         boolean hasNext = iterator.hasNext();
         assertFalse(hasNext);
     }
 
     @Test
-    public void test_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() throws Exception {
+    public void test_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() {
         ICacheInternal<String, String> cache = getCacheProxy();
         String value = randomString();
         int count = 1000;
@@ -117,7 +117,7 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
         }
         Iterator<Cache.Entry<String, String>> iterator = getIterator(cache);
         for (int i = 0; i < count; i++) {
-            Cache.Entry entry = iterator.next();
+            Cache.Entry<String, String> entry = iterator.next();
             assertEquals(value, entry.getValue());
         }
     }
@@ -125,7 +125,7 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
     private <K, V> ICacheInternal<K, V> getCacheProxy() {
         String cacheName = randomString();
         CacheManager cacheManager = cachingProvider.getCacheManager();
-        CacheConfig<K, V> config = new CacheConfig<K, V>();
+        CacheConfig<K, V> config = new CacheConfig<>();
         config.getEvictionConfig().setMaxSizePolicy(MaxSizePolicy.ENTRY_COUNT).setSize(10000000);
         return (ICacheInternal<K, V>) cacheManager.createCache(cacheName, config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterServiceMemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterServiceMemberListTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -40,14 +39,14 @@ import static com.hazelcast.cluster.memberselector.MemberSelectors.LOCAL_MEMBER_
 import static com.hazelcast.cluster.memberselector.MemberSelectors.NON_LOCAL_MEMBER_SELECTOR;
 import static com.hazelcast.test.Accessors.getClusterService;
 import static com.hazelcast.test.Accessors.getNode;
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClusterServiceMemberListTest
         extends HazelcastTestSupport {
 
-    private Config liteConfig = new Config().setLiteMember(true);
+    private final Config liteConfig = new Config().setLiteMember(true);
 
     private TestHazelcastInstanceFactory factory;
 
@@ -72,27 +71,19 @@ public class ClusterServiceMemberListTest
 
     @Test
     public void testGetMembersWithMemberSelector() {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                verifyMembersFromLiteMember(liteInstance);
-                verifyMembersFromDataMember(dataInstance);
-                verifyMembersFromDataMember(dataInstance2);
-            }
+        assertTrueEventually(() -> {
+            verifyMembersFromLiteMember(liteInstance);
+            verifyMembersFromDataMember(dataInstance);
+            verifyMembersFromDataMember(dataInstance2);
         });
     }
 
     @Test
     public void testSizeWithMemberSelector() {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                verifySizeFromLiteMember(liteInstance);
-                verifySizeFromDataMember(dataInstance);
-                verifySizeFromDataMember(dataInstance2);
-            }
+        assertTrueEventually(() -> {
+            verifySizeFromLiteMember(liteInstance);
+            verifySizeFromDataMember(dataInstance);
+            verifySizeFromDataMember(dataInstance2);
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
@@ -16,35 +16,36 @@
 
 package com.hazelcast.internal.partition.impl;
 
-import static com.hazelcast.test.Accessors.getAddress;
-import static com.hazelcast.test.Accessors.getNode;
-import static java.util.Arrays.asList;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
-
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.partition.IPartition;
 import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.partition.NoDataMemberInClusterException;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.Accessors.getAddress;
+import static com.hazelcast.test.Accessors.getNode;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -148,12 +149,9 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         for (HazelcastInstance instance : asList(master, lite)) {
             final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(instance);
 
-            assertTrueEventually(new AssertTask() {
-                @Override
-                public void run() throws Exception {
-                    for (int i = 0; i < partitionService.getPartitionCount(); i++) {
-                        assertEquals(getNode(master).getThisAddress(), partitionService.getPartition(i).getOwnerOrNull());
-                    }
+            assertTrueEventually(() -> {
+                for (int i = 0; i < partitionService.getPartitionCount(); i++) {
+                    assertEquals(getNode(master).getThisAddress(), partitionService.getPartition(i).getOwnerOrNull());
                 }
             });
         }
@@ -169,7 +167,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
 
         final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(instance);
 
-        Set<Integer> partitionIds = Arrays.stream(partitionService.getPartitions()).map(p -> p.getPartitionId()).collect(Collectors.toSet());
+        Set<Integer> partitionIds = Arrays.stream(partitionService.getPartitions()).map(IPartition::getPartitionId).collect(Collectors.toSet());
 
         Set<Object> keys = partitionIds.stream().map(id -> {
             String item;
@@ -241,16 +239,13 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
 
         master.getLifecycleService().terminate();
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                try {
-                    final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(lite);
-                    partitionService.getPartitionOwnerOrWait(0);
-                    fail();
-                } catch (NoDataMemberInClusterException expected) {
-                    ignore(expected);
-                }
+        assertTrueEventually(() -> {
+            try {
+                final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(lite);
+                partitionService.getPartitionOwnerOrWait(0);
+                fail();
+            } catch (NoDataMemberInClusterException expected) {
+                ignore(expected);
             }
         });
     }
@@ -266,16 +261,13 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
 
         master.getLifecycleService().shutdown();
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                try {
-                    final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(lite);
-                    partitionService.getPartitionOwnerOrWait(0);
-                    fail();
-                } catch (NoDataMemberInClusterException expected) {
-                    ignore(expected);
-                }
+        assertTrueEventually(() -> {
+            try {
+                final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(lite);
+                partitionService.getPartitionOwnerOrWait(0);
+                fail();
+            } catch (NoDataMemberInClusterException expected) {
+                ignore(expected);
             }
         });
     }
@@ -484,12 +476,9 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
     }
 
     private void assertMemberGroupsSizeEventually(final HazelcastInstance instance, final int memberGroupSize) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(instance);
-                assertEquals(memberGroupSize, partitionService.getMemberGroupsSize());
-            }
+        assertTrueEventually(() -> {
+            final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(instance);
+            assertEquals(memberGroupSize, partitionService.getMemberGroupsSize());
         });
     }
 
@@ -547,12 +536,9 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
     }
 
     private void assertMaxBackupCountEventually(final HazelcastInstance instance, final int maxBackupCount) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(instance);
-                assertEquals(maxBackupCount, partitionService.getMaxAllowedBackupCount());
-            }
+        assertTrueEventually(() -> {
+            final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(instance);
+            assertEquals(maxBackupCount, partitionService.getMaxAllowedBackupCount());
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ResultSetTest.java
@@ -30,9 +30,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -54,7 +54,7 @@ public class ResultSetTest {
 
     @Test
     public void testSize_whenNotEmpty() {
-        List<Map.Entry> entries = new ArrayList<Map.Entry>();
+        List<Map.Entry> entries = new ArrayList<>();
         entries.add(new MapEntrySimple(null, null));
         ResultSet resultSet = new ResultSet(entries, IterationType.KEY);
         assertEquals(1, resultSet.size());
@@ -77,7 +77,7 @@ public class ResultSetTest {
 
     @Test
     public void testIterator_whenNotEmpty_IterationType_Key() {
-        List<Map.Entry> entries = new ArrayList<Map.Entry>();
+        List<Map.Entry> entries = new ArrayList<>();
         MapEntrySimple entry = new MapEntrySimple("key", "value");
         entries.add(entry);
         ResultSet resultSet = new ResultSet(entries, IterationType.KEY);
@@ -88,7 +88,7 @@ public class ResultSetTest {
 
     @Test
     public void testIterator_whenNotEmpty_IterationType_Value() {
-        List<Map.Entry> entries = new ArrayList<Map.Entry>();
+        List<Map.Entry> entries = new ArrayList<>();
         MapEntrySimple entry = new MapEntrySimple("key", "value");
         entries.add(entry);
         ResultSet resultSet = new ResultSet(entries, IterationType.VALUE);
@@ -99,7 +99,7 @@ public class ResultSetTest {
 
     @Test
     public void testIterator_whenNotEmpty_IterationType_Entry() {
-        List<Map.Entry> entries = new ArrayList<Map.Entry>();
+        List<Map.Entry> entries = new ArrayList<>();
         MapEntrySimple entry = new MapEntrySimple("key", "value");
         entries.add(entry);
         ResultSet resultSet = new ResultSet(entries, IterationType.ENTRY);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionLiteMemberTest.java
@@ -43,7 +43,7 @@ import java.util.function.BiConsumer;
 import static com.hazelcast.internal.partition.InternalPartitionService.SERVICE_NAME;
 import static com.hazelcast.test.Accessors.getOperationService;
 import static java.util.Collections.singletonList;
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -53,7 +53,7 @@ import static org.junit.Assert.fail;
 public class OperationServiceImpl_invokeOnPartitionLiteMemberTest
         extends HazelcastTestSupport {
 
-    private Config liteMemberConfig = new Config().setLiteMember(true);
+    private final Config liteMemberConfig = new Config().setLiteMember(true);
 
     private Operation operation;
 


### PR DESCRIPTION
The deprecated 
`junit.framework.Assert.abc`
imports are changed with

`org.junit..Assert.abc`
imports

Also some minor warnings are fixed

Jira : https://hazelcast.atlassian.net/browse/HZ-3434

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
