### PR TITLE
`wiremock` artifact relocation

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -803,7 +803,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
             <version>${wiremock.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
During a build, the following warning is logged:
```
[WARNING] The artifact com.github.tomakehurst:wiremock-standalone:jar:3.0.1 has been relocated to org.wiremock:wiremock-standalone:jar:3.0.1
```