### PR TITLE
Use `static` `ILogger` declarations if possible

### DIFF
--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisTestHelper.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisTestHelper.java
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 
 class KinesisTestHelper {
-
+    private static final ILogger LOGGER = Logger.getLogger(KinesisIntegrationTest.class);
     static final RetryStrategy RETRY_STRATEGY = RetryStrategies.custom()
             .maxAttempts(30)
             .intervalFunction(IntervalFunction.exponentialBackoffWithCap(250L, 2.0, 2000L))
@@ -64,8 +64,6 @@ class KinesisTestHelper {
 
     private final AmazonKinesisAsync kinesis;
     private final String stream;
-
-    private final ILogger logger = Logger.getLogger(KinesisIntegrationTest.class);
 
     KinesisTestHelper(AmazonKinesisAsync kinesis, String stream) {
         this.kinesis = kinesis;
@@ -189,14 +187,14 @@ class KinesisTestHelper {
             } catch (LimitExceededException lee) {
                 String message = "The requested resource exceeds the maximum number allowed, or the number of " +
                         "concurrent stream requests exceeds the maximum number allowed. Will retry.";
-                logger.warning(message, lee);
+                LOGGER.warning(message, lee);
             } catch (ExpiredNextTokenException ente) {
                 String message = "The pagination token passed to the operation is expired. Will retry.";
-                logger.warning(message, ente);
+                LOGGER.warning(message, ente);
             } catch (ResourceInUseException riue) {
                 String message = "The resource is not available for this operation. For successful operation, the " +
                         "resource must be in the ACTIVE state. Will retry.";
-                logger.warning(message, riue);
+                LOGGER.warning(message, riue);
             } catch (ResourceNotFoundException rnfe) {
                 String message = "The requested resource could not be found. The stream might not be specified correctly.";
                 throw new JetException(message, rnfe);
@@ -205,7 +203,7 @@ class KinesisTestHelper {
                 throw new JetException(message, iae);
             } catch (SdkClientException sce) {
                 String message = "Amazon SDK failure, ignoring and retrying.";
-                logger.warning(message, sce);
+                LOGGER.warning(message, sce);
             } catch (Exception e) {
                 throw rethrow(e);
             }
@@ -219,7 +217,7 @@ class KinesisTestHelper {
             throw new JetException(String.format("Abort waiting for %s, too many attempts", action));
         }
 
-        logger.info(String.format("Waiting for %s ...", action));
+        LOGGER.info(String.format("Waiting for %s ...", action));
         long duration = RETRY_STRATEGY.getIntervalFunction().waitAfterAttempt(attempt);
         try {
             TimeUnit.MILLISECONDS.sleep(duration);

--- a/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisTestHelper.java
+++ b/extensions/kinesis/src/test/java/com/hazelcast/jet/kinesis/KinesisTestHelper.java
@@ -56,11 +56,11 @@ import java.util.stream.Collectors;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 
 class KinesisTestHelper {
-    private static final ILogger LOGGER = Logger.getLogger(KinesisIntegrationTest.class);
     static final RetryStrategy RETRY_STRATEGY = RetryStrategies.custom()
             .maxAttempts(30)
             .intervalFunction(IntervalFunction.exponentialBackoffWithCap(250L, 2.0, 2000L))
             .build();
+    private static final ILogger LOGGER = Logger.getLogger(KinesisIntegrationTest.class);
 
     private final AmazonKinesisAsync kinesis;
     private final String stream;

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoConnection.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/MongoConnection.java
@@ -44,6 +44,7 @@ import static com.hazelcast.jet.retry.IntervalFunction.exponentialBackoffWithCap
  * Manages connection to MongoDB, reconnects if necessary.
  */
 class MongoConnection implements Closeable {
+    private static final ILogger LOGGER = Logger.getLogger(MongoConnection.class);
     @SuppressWarnings("checkstyle:MagicNumber")
     private static final RetryStrategy RETRY_STRATEGY =
             RetryStrategies.custom()
@@ -55,7 +56,6 @@ class MongoConnection implements Closeable {
     private final DataConnectionRef dataConnectionRef;
     private final Consumer<MongoClient> afterConnection;
     private final RetryTracker connectionRetryTracker;
-    private final ILogger logger = Logger.getLogger(MongoConnection.class);
 
     private MongoClient mongoClient;
     private MongoDataConnection dataConnection;
@@ -98,14 +98,14 @@ class MongoConnection implements Closeable {
                     throw new JetException("NonResumableChangeStreamError thrown by Mongo", e);
                 }
                 connectionRetryTracker.attemptFailed();
-                logger.warning("Could not connect to MongoDB." + willRetryMessage(), e);
+                LOGGER.warning("Could not connect to MongoDB." + willRetryMessage(), e);
                 lastException = e;
                 return false;
             } catch (MongoClientException | MongoSocketException e) {
                 lastException = e;
 
                 connectionRetryTracker.attemptFailed();
-                logger.warning("Could not connect to MongoDB due to client/socket error."
+                LOGGER.warning("Could not connect to MongoDB due to client/socket error."
                         + willRetryMessage(), e);
                 return false;
             } catch (Exception e) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/statistics/ClientStatisticsService.java
@@ -59,7 +59,7 @@ public class ClientStatisticsService {
 
     private final MetricsRegistry metricsRegistry;
     private final boolean enabled;
-    private final ILogger logger = Logger.getLogger(this.getClass());
+    private final ILogger logger = Logger.getLogger(getClass());
 
     private final HazelcastClientInstanceImpl client;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/AbstractPbeReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/AbstractPbeReplacer.java
@@ -38,8 +38,6 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
  * {@link #getPassword()} implementation - the password will be used to generate a secret key.
  */
 public abstract class AbstractPbeReplacer implements ConfigReplacer {
-    private static final ILogger LOGGER = Logger.getLogger(AbstractPbeReplacer.class);
-
     /**
      * Replacer property name to configure {@link Cipher} algorithm name.
      */
@@ -74,6 +72,8 @@ public abstract class AbstractPbeReplacer implements ConfigReplacer {
      * Default value for {@value #PROPERTY_SECRET_KEY_FACTORY_ALGORITHM} property.
      */
     public static final String DEFAULT_SECRET_KEY_FACTORY_ALGORITHM = "PBKDF2WithHmacSHA256";
+
+    private static final ILogger LOGGER = Logger.getLogger(AbstractPbeReplacer.class);
 
     private String cipherAlgorithm;
     private String secretKeyFactoryAlgorithm;

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/AbstractPbeReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/AbstractPbeReplacer.java
@@ -38,6 +38,7 @@ import static com.hazelcast.internal.util.Preconditions.checkTrue;
  * {@link #getPassword()} implementation - the password will be used to generate a secret key.
  */
 public abstract class AbstractPbeReplacer implements ConfigReplacer {
+    private static final ILogger LOGGER = Logger.getLogger(AbstractPbeReplacer.class);
 
     /**
      * Replacer property name to configure {@link Cipher} algorithm name.
@@ -74,8 +75,6 @@ public abstract class AbstractPbeReplacer implements ConfigReplacer {
      */
     public static final String DEFAULT_SECRET_KEY_FACTORY_ALGORITHM = "PBKDF2WithHmacSHA256";
 
-    private final ILogger logger = Logger.getLogger(AbstractPbeReplacer.class);
-
     private String cipherAlgorithm;
     private String secretKeyFactoryAlgorithm;
     private String secretKeyAlgorithm;
@@ -108,7 +107,7 @@ public abstract class AbstractPbeReplacer implements ConfigReplacer {
         try {
             return decrypt(variable);
         } catch (Exception e) {
-            logger.warning("Unable to decrypt variable " + variable, e);
+            LOGGER.warning("Unable to decrypt variable " + variable, e);
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractXmlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractXmlConfigRootTagRecognizer.java
@@ -49,9 +49,9 @@ import static java.util.Objects.requireNonNull;
  * configuration and doesn't look further into the provided configuration.
  */
 public class AbstractXmlConfigRootTagRecognizer implements ConfigRecognizer {
+    private static final ILogger LOGGER = Logger.getLogger(AbstractXmlConfigRootTagRecognizer.class);
     private final SAXParser saxParser;
     private final String expectedRootNode;
-    private final ILogger logger = Logger.getLogger(AbstractXmlConfigRootTagRecognizer.class);
 
     public AbstractXmlConfigRootTagRecognizer(String expectedRootNode) throws Exception {
         this.expectedRootNode = expectedRootNode;
@@ -79,14 +79,14 @@ public class AbstractXmlConfigRootTagRecognizer implements ConfigRecognizer {
     }
 
     private void handleParseException(SAXParseException ex) {
-        if (logger.isFineEnabled()) {
-            logger.fine("An exception is encountered while processing the provided XML configuration", ex);
+        if (LOGGER.isFineEnabled()) {
+            LOGGER.fine("An exception is encountered while processing the provided XML configuration", ex);
         }
     }
 
     private void handleUnexpectedException(Exception ex) {
-        if (logger.isFineEnabled()) {
-            logger.fine("An unexpected exception is encountered while processing the provided XML configuration", ex);
+        if (LOGGER.isFineEnabled()) {
+            LOGGER.fine("An unexpected exception is encountered while processing the provided XML configuration", ex);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractYamlConfigRootTagRecognizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractYamlConfigRootTagRecognizer.java
@@ -47,8 +47,8 @@ import java.util.Optional;
  * configuration and doesn't look further into the provided configuration.
  */
 public abstract class AbstractYamlConfigRootTagRecognizer implements ConfigRecognizer {
+    private static final ILogger LOGGER = Logger.getLogger(AbstractYamlConfigRootTagRecognizer.class);
     private final String expectedRootNode;
-    private final ILogger logger = Logger.getLogger(AbstractYamlConfigRootTagRecognizer.class);
 
     public AbstractYamlConfigRootTagRecognizer(String expectedRootNode) {
         this.expectedRootNode = expectedRootNode;
@@ -70,14 +70,14 @@ public abstract class AbstractYamlConfigRootTagRecognizer implements ConfigRecog
     }
 
     private void handleParseException(YamlException ex) {
-        if (logger.isFineEnabled()) {
-            logger.fine("An exception is encountered while processing the provided YAML configuration", ex);
+        if (LOGGER.isFineEnabled()) {
+            LOGGER.fine("An exception is encountered while processing the provided YAML configuration", ex);
         }
     }
 
     private void handleUnexpectedException(Exception ex) {
-        if (logger.isFineEnabled()) {
-            logger.fine("An unexpected exception is encountered while processing the provided YAML configuration", ex);
+        if (LOGGER.isFineEnabled()) {
+            LOGGER.fine("An unexpected exception is encountered while processing the provided YAML configuration", ex);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCollectionCycle.java
@@ -44,6 +44,7 @@ import static com.hazelcast.internal.metrics.impl.MetricsUtil.extractExcludedTar
  * @see MetricsRegistry#collect(MetricsCollector)
  */
 class MetricsCollectionCycle {
+    private static final ILogger LOGGER = Logger.getLogger(MetricsCollectionCycle.class);
     private static final MetricValueCatcher NOOP_CATCHER = new NoOpMetricValueCatcher();
 
     private final PoolingMetricDescriptorSupplier descriptorSupplier;
@@ -53,7 +54,6 @@ class MetricsCollectionCycle {
     private final ProbeLevel minimumLevel;
     private final MetricsContext metricsContext = new MetricsContext();
     private final long collectionId = System.nanoTime();
-    private final ILogger logger = Logger.getLogger(MetricsCollectionCycle.class);
 
     MetricsCollectionCycle(Function<Class, SourceMetadata> lookupMetadataFn,
                            Function<MetricDescriptor, MetricValueCatcher> lookupMetricValueCatcherFn,
@@ -93,7 +93,7 @@ class MetricsCollectionCycle {
             try {
                 metricsSource.provideDynamicMetrics(descriptorSupplier.get(), metricsContext);
             } catch (Throwable t) {
-                logger.warning("Collecting metrics from source " + metricsSource.getClass().getName() + " failed", t);
+                LOGGER.warning("Collecting metrics from source " + metricsSource.getClass().getName() + " failed", t);
                 assert false : "Collecting metrics from source " + metricsSource.getClass().getName() + " failed\n"
                         + ExceptionUtil.toString(t);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/PublisherMetricsCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/PublisherMetricsCollector.java
@@ -28,7 +28,7 @@ import com.hazelcast.logging.Logger;
  * publishers.
  */
 public class PublisherMetricsCollector implements MetricsCollector {
-    private final ILogger logger = Logger.getLogger(PublisherMetricsCollector.class);
+    private static final ILogger LOGGER = Logger.getLogger(PublisherMetricsCollector.class);
 
     private final MetricsPublisher[] publishers;
 
@@ -43,7 +43,7 @@ public class PublisherMetricsCollector implements MetricsCollector {
             } catch (OutOfMemoryError e) {
                 OutOfMemoryErrorDispatcher.onOutOfMemory(e);
             } catch (Throwable throwable) {
-                logger.severe("Error completing publication for publisher "
+                LOGGER.severe("Error completing publication for publisher "
                         + publishers[i].name(), throwable);
             }
         }
@@ -56,7 +56,7 @@ public class PublisherMetricsCollector implements MetricsCollector {
             } catch (OutOfMemoryError e) {
                 OutOfMemoryErrorDispatcher.onOutOfMemory(e);
             } catch (Throwable throwable) {
-                logger.severe("Error shutting down metrics publisher "
+                LOGGER.severe("Error shutting down metrics publisher "
                         + publishers[i].name(), throwable);
             }
         }
@@ -90,7 +90,7 @@ public class PublisherMetricsCollector implements MetricsCollector {
 
     @Override
     public void collectException(MetricDescriptor descriptor, Exception e) {
-        logger.warning("Error when collecting '" + descriptor.toString() + '\'', e);
+        LOGGER.warning("Error when collecting '" + descriptor.toString() + '\'', e);
     }
 
     @Override
@@ -100,7 +100,7 @@ public class PublisherMetricsCollector implements MetricsCollector {
 
     private void logError(MetricDescriptor descriptor, Object value,
                           MetricsPublisher publisher, Throwable throwable) {
-        logger.fine("Error publishing metric to: " + publisher.name() + ", metric=" + descriptor.toString()
+        LOGGER.fine("Error publishing metric to: " + publisher.name() + ", metric=" + descriptor.toString()
                 + ", value=" + value, throwable);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -70,7 +70,7 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static java.nio.ByteOrder.BIG_ENDIAN;
 
 public abstract class AbstractSerializationService implements InternalSerializationService {
-
+    private static final ILogger LOGGER = Logger.getLogger(InternalSerializationService.class);
     protected final ManagedContext managedContext;
     protected final InputOutputFactory inputOutputFactory;
     protected final PartitioningStrategy globalPartitioningStrategy;
@@ -100,7 +100,6 @@ public abstract class AbstractSerializationService implements InternalSerializat
     private final int outputBufferSize;
     private volatile boolean active = true;
     private final byte version;
-    private final ILogger logger = Logger.getLogger(InternalSerializationService.class);
     private boolean isCompatibility;
     private final boolean allowOverrideDefaultSerializers;
 
@@ -673,7 +672,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
     private SerializerAdapter lookupGlobalSerializer(Class type) {
         SerializerAdapter serializer = global.get();
         if (serializer != null) {
-            logger.fine("Registering global serializer for: " + type.getName());
+            LOGGER.fine("Registering global serializer for: " + type.getName());
             safeRegister(type, serializer);
         }
         return serializer;
@@ -682,7 +681,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
     private SerializerAdapter lookupJavaSerializer(Class type) {
         if (Externalizable.class.isAssignableFrom(type)) {
             if (safeRegister(type, javaExternalizableAdapter) && !Throwable.class.isAssignableFrom(type)) {
-                logger.info("Performance Hint: Serialization service will use java.io.Externalizable for: " + type.getName()
+                LOGGER.info("Performance Hint: Serialization service will use java.io.Externalizable for: " + type.getName()
                         + ". Please consider using a faster serialization option such as DataSerializable.");
             }
             return javaExternalizableAdapter;
@@ -690,7 +689,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
 
         if (Serializable.class.isAssignableFrom(type)) {
             if (safeRegister(type, javaSerializerAdapter) && !Throwable.class.isAssignableFrom(type)) {
-                logger.info("Performance Hint: Serialization service will use java.io.Serializable for: " + type.getName()
+                LOGGER.info("Performance Hint: Serialization service will use java.io.Serializable for: " + type.getName()
                         + ". Please consider using a faster serialization option such as DataSerializable.");
             }
             return javaSerializerAdapter;

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AsyncHazelcastWriterP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AsyncHazelcastWriterP.java
@@ -39,8 +39,8 @@ import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.Util.tryIncrement;
 
 public abstract class AsyncHazelcastWriterP implements Processor {
-    private static final ILogger LOGGER = Logger.getLogger(AsyncHazelcastWriterP.class);
     protected static final int MAX_PARALLEL_ASYNC_OPS_DEFAULT = 1000;
+    private static final ILogger LOGGER = Logger.getLogger(AsyncHazelcastWriterP.class);
 
     private final int maxParallelAsyncOps;
     private final AtomicInteger numConcurrentOps = new AtomicInteger();

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AsyncHazelcastWriterP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AsyncHazelcastWriterP.java
@@ -39,17 +39,16 @@ import static com.hazelcast.internal.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.Util.tryIncrement;
 
 public abstract class AsyncHazelcastWriterP implements Processor {
-
+    private static final ILogger LOGGER = Logger.getLogger(AsyncHazelcastWriterP.class);
     protected static final int MAX_PARALLEL_ASYNC_OPS_DEFAULT = 1000;
 
-    private final ILogger logger = Logger.getLogger(AsyncHazelcastWriterP.class);
     private final int maxParallelAsyncOps;
     private final AtomicInteger numConcurrentOps = new AtomicInteger();
     private final AtomicReference<Throwable> firstError = new AtomicReference<>();
     private final HazelcastInstance instance;
     private final boolean isLocal;
 
-    private final BiConsumer callback = withTryCatch(logger, (response, t) -> {
+    private final BiConsumer callback = withTryCatch(LOGGER, (response, t) -> {
         numConcurrentOps.decrementAndGet();
         if (t != null) {
             firstError.compareAndSet(null, t);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsDispatcher.java
@@ -33,8 +33,7 @@ import com.hazelcast.map.impl.event.MapEventData;
  * Dispatches multiMapEvents to appropriate methods of given listener
  */
 class MultiMapEventsDispatcher {
-
-    private final ILogger logger = Logger.getLogger(MultiMapEventsDispatcher.class);
+    private static final ILogger LOGGER = Logger.getLogger(MultiMapEventsDispatcher.class);
 
     private final ClusterService clusterService;
     private final MultiMapService multiMapService;
@@ -86,8 +85,8 @@ class MultiMapEventsDispatcher {
     private Member getMemberOrNull(EventData eventData) {
         Member member = clusterService.getMember(eventData.getCaller());
         if (member == null) {
-            if (logger.isInfoEnabled()) {
-                logger.info("Dropping event " + eventData + " from unknown address:" + eventData.getCaller());
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("Dropping event " + eventData + " from unknown address:" + eventData.getCaller());
             }
         }
         return member;

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/JCacheDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/JCacheDetectorTest.java
@@ -33,8 +33,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class JCacheDetectorTest extends HazelcastTestSupport {
-
-    private final ILogger logger = Logger.getLogger(JCacheDetectorTest.class);
+    private static final ILogger LOGGER = Logger.getLogger(JCacheDetectorTest.class);
 
     @Test
     public void testConstructor() {
@@ -52,7 +51,7 @@ public class JCacheDetectorTest extends HazelcastTestSupport {
     public void testIsJCacheAvailable_withCorrectVersion_withLogger() {
         JCacheDetector.ClassAvailabilityChecker classAvailabilityChecker = (className) -> true;
 
-        assertTrue(isJCacheAvailable(logger, classAvailabilityChecker));
+        assertTrue(isJCacheAvailable(LOGGER, classAvailabilityChecker));
     }
 
     @Test
@@ -66,7 +65,7 @@ public class JCacheDetectorTest extends HazelcastTestSupport {
     public void testIsJCacheAvailable_notFound_withLogger() {
         JCacheDetector.ClassAvailabilityChecker classAvailabilityChecker = (className) -> false;
 
-        assertFalse(isJCacheAvailable(logger, classAvailabilityChecker));
+        assertFalse(isJCacheAvailable(LOGGER, classAvailabilityChecker));
     }
 
     @Test
@@ -80,6 +79,6 @@ public class JCacheDetectorTest extends HazelcastTestSupport {
     public void testIsJCacheAvailable_withWrongJCacheVersion_withLogger() {
         JCacheDetector.ClassAvailabilityChecker classAvailabilityChecker = (className) -> className.equals("javax.cache.Caching");
 
-        assertFalse(isJCacheAvailable(logger, classAvailabilityChecker));
+        assertFalse(isJCacheAvailable(LOGGER, classAvailabilityChecker));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperationTest.java
@@ -48,14 +48,13 @@ import static org.mockito.Mockito.when;
  */
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class OnJoinCacheOperationTest {
-
+    private static final ILogger LOGGER = mock(ILogger.class);
     private static MockedStatic<JCacheDetector> mockedStatic;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
     private final NodeEngine nodeEngine = mock(NodeEngine.class);
-    private final ILogger logger = mock(ILogger.class);
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -70,7 +69,7 @@ public class OnJoinCacheOperationTest {
     @Before
     public void setUp() {
         when(nodeEngine.getConfigClassLoader()).thenReturn(getClass().getClassLoader());
-        when(nodeEngine.getLogger(any(Class.class))).thenReturn(logger);
+        when(nodeEngine.getLogger(any(Class.class))).thenReturn(LOGGER);
     }
 
     @Test
@@ -89,7 +88,7 @@ public class OnJoinCacheOperationTest {
         verify(nodeEngine).getConfigClassLoader();
         verify(nodeEngine).getService(CacheService.SERVICE_NAME);
         // verify logger was not invoked
-        verify(logger, never()).warning(anyString());
+        verify(LOGGER, never()).warning(anyString());
 
     }
 
@@ -104,7 +103,7 @@ public class OnJoinCacheOperationTest {
 
         verify(nodeEngine).getConfigClassLoader();
         // verify a warning was logged
-        verify(logger).warning(anyString());
+        verify(LOGGER).warning(anyString());
         // verify CacheService instance was not requested in OnJoinCacheOperation.run
         verify(nodeEngine, never()).getService(CacheService.SERVICE_NAME);
     }
@@ -126,6 +125,6 @@ public class OnJoinCacheOperationTest {
 
         verify(nodeEngine).getConfigClassLoader();
         verify(nodeEngine).getService(CacheService.SERVICE_NAME);
-        verify(logger, never()).warning(anyString());
+        verify(LOGGER, never()).warning(anyString());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -76,7 +76,6 @@ import javax.cache.processor.EntryProcessorException;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
-import javax.transaction.xa.XAException;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.NotSerializableException;
@@ -226,7 +225,6 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
                 new Object[]{new UTFDataFormatException(randomString())},
                 new Object[]{new UnsupportedOperationException(randomString())},
                 new Object[]{new WrongTargetException(randomString())},
-                new Object[]{new XAException(randomString())},
                 new Object[]{new AccessControlException(randomString())},
                 new Object[]{new LoginException(randomString())},
                 new Object[]{

--- a/hazelcast/src/test/java/com/hazelcast/client/map/MapMemoryUsageStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/MapMemoryUsageStressTest.java
@@ -46,8 +46,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(NightlyTest.class)
 public class MapMemoryUsageStressTest extends HazelcastTestSupport {
-
-    private final ILogger logger = Logger.getLogger(MapMemoryUsageStressTest.class);
+    private static final ILogger LOGGER = Logger.getLogger(MapMemoryUsageStressTest.class);
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
     private HazelcastInstance client;
@@ -112,7 +111,7 @@ public class MapMemoryUsageStressTest extends HazelcastTestSupport {
                     map.destroy();
 
                     if (index % 1000 == 0) {
-                        logger.info("At: " + index);
+                        LOGGER.info("At: " + index);
                     }
                 }
             } catch (Throwable t) {

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerHostnameTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerHostnameTest.java
@@ -52,17 +52,17 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class DefaultAddressPickerHostnameTest {
+    private static final ILogger LOGGER = Logger.getLogger(AddressPicker.class);
 
     @Rule
     public final OverridePropertyRule ruleSysPropPreferIpv4 = set(PREFER_IPV4_STACK, "true");
     @Rule
     public final OverridePropertyRule ruleSysPropHazelcastLocalAddress = clear("hazelcast.local.localAddress");
 
-    private final ILogger logger = Logger.getLogger(AddressPicker.class);
     private final Config config = new Config();
     private final String theHostname = "hazelcast.istanbul";
     private final String theAddress = "10.34.34.0";
-    private final DefaultAddressPicker addressPicker = new DefaultAddressPicker(config, logger);
+    private final DefaultAddressPicker addressPicker = new DefaultAddressPicker(config, LOGGER);
     private final HostnameResolver hostnameResolver = new MockHostnameResolver();
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerInterfacesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerInterfacesTest.java
@@ -54,8 +54,7 @@ import static org.junit.Assert.assertNull;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class DefaultAddressPickerInterfacesTest {
-
-    private final ILogger logger = Logger.getLogger(AddressPicker.class);
+    private static final ILogger LOGGER = Logger.getLogger(AddressPicker.class);
     private final Config config = new Config();
 
     @Rule
@@ -309,7 +308,7 @@ public class DefaultAddressPickerInterfacesTest {
      * or {@code null} if the result was {@code null}.
      */
     private InetAddress getInetAddressFromDefaultAddressPicker() throws Exception {
-        DefaultAddressPicker picker = new DefaultAddressPicker(config, logger);
+        DefaultAddressPicker picker = new DefaultAddressPicker(config, LOGGER);
         picker.setNetworkInterfacesEnumerator(networkInterfacesEnumerator);
         DefaultAddressPicker.AddressDefinition addressDefinition = picker.pickMatchingAddress(null);
         return addressDefinition == null ? null : addressDefinition.inetAddress;

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
@@ -68,7 +68,7 @@ import static org.junit.Assume.assumeNotNull;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class})
 public class DefaultAddressPickerTest {
-
+    private static final ILogger LOGGER = Logger.getLogger(AddressPicker.class);
     private static final String PUBLIC_HOST = "www.hazelcast.org";
     private static final String HAZELCAST_LOCAL_ADDRESS_PROP = "hazelcast.local.localAddress";
 
@@ -84,7 +84,6 @@ public class DefaultAddressPickerTest {
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
-    private final ILogger logger = Logger.getLogger(AddressPicker.class);
     private final Config config = new Config();
     private AddressPicker addressPicker;
     private InetAddress loopback;
@@ -196,7 +195,7 @@ public class DefaultAddressPickerTest {
     }
 
     private void testBindAddress(InetAddress address) throws Exception {
-        addressPicker = new DefaultAddressPicker(config, logger);
+        addressPicker = new DefaultAddressPicker(config, LOGGER);
         addressPicker.pickAddress();
 
         int port = config.getNetworkConfig().getPort();
@@ -209,7 +208,7 @@ public class DefaultAddressPickerTest {
         config.setProperty(HAZELCAST_LOCAL_ADDRESS_PROP, loopback.getHostAddress());
         config.getNetworkConfig().setPort(0);
 
-        addressPicker = new DefaultAddressPicker(config, logger);
+        addressPicker = new DefaultAddressPicker(config, LOGGER);
         addressPicker.pickAddress();
 
         int port = addressPicker.getServerSocketChannel(null).socket().getLocalPort();
@@ -224,11 +223,11 @@ public class DefaultAddressPickerTest {
         config.getNetworkConfig().setPort(port);
         config.getNetworkConfig().setPortAutoIncrement(false);
 
-        addressPicker = new DefaultAddressPicker(config, logger);
+        addressPicker = new DefaultAddressPicker(config, LOGGER);
         addressPicker.pickAddress();
 
         try {
-            new DefaultAddressPicker(config, logger).pickAddress();
+            new DefaultAddressPicker(config, LOGGER).pickAddress();
             fail("Should fail with 'java.net.BindException: Address already in use'");
         } catch (Exception expected) {
             // expected exception
@@ -241,10 +240,10 @@ public class DefaultAddressPickerTest {
         config.getNetworkConfig().setPort(port);
         config.getNetworkConfig().setPortAutoIncrement(true);
 
-        addressPicker = new DefaultAddressPicker(config, logger);
+        addressPicker = new DefaultAddressPicker(config, LOGGER);
         addressPicker.pickAddress();
 
-        new DefaultAddressPicker(config, logger).pickAddress();
+        new DefaultAddressPicker(config, LOGGER).pickAddress();
     }
 
     @Test
@@ -270,7 +269,7 @@ public class DefaultAddressPickerTest {
     private void testPublicAddress(String host, int port) throws Exception {
         NetworkConfig networkConfig = config.getNetworkConfig();
         networkConfig.setPublicAddress(port < 0 ? host : (host + ":" + port));
-        addressPicker = new DefaultAddressPicker(config, logger);
+        addressPicker = new DefaultAddressPicker(config, LOGGER);
         addressPicker.pickAddress();
 
         if (port < 0) {
@@ -289,7 +288,7 @@ public class DefaultAddressPickerTest {
         int port = 6789;
         config.setProperty("hazelcast.local.publicAddress", host + ":" + port);
 
-        addressPicker = new DefaultAddressPicker(config, logger);
+        addressPicker = new DefaultAddressPicker(config, LOGGER);
         addressPicker.pickAddress();
 
         assertEquals(new Address(host, port), addressPicker.getPublicAddress(null));
@@ -300,7 +299,7 @@ public class DefaultAddressPickerTest {
     public void testPublicAddress_whenBlankViaProperty() throws Exception {
         config.setProperty("hazelcast.local.publicAddress", " ");
 
-        addressPicker = new DefaultAddressPicker(config, logger);
+        addressPicker = new DefaultAddressPicker(config, LOGGER);
         assertThrows(IllegalArgumentException.class, () -> addressPicker.pickAddress());
     }
 
@@ -308,7 +307,7 @@ public class DefaultAddressPickerTest {
     public void testPublicAddress_withInvalidAddress() throws Exception {
         config.getNetworkConfig().setPublicAddress("invalid");
 
-        addressPicker = new DefaultAddressPicker(config, logger);
+        addressPicker = new DefaultAddressPicker(config, LOGGER);
         assertThrows(UnknownHostException.class, () -> addressPicker.pickAddress());
     }
 
@@ -316,7 +315,7 @@ public class DefaultAddressPickerTest {
     public void testPublicAddress_withBlankAddress() throws Exception {
         config.getNetworkConfig().setPublicAddress(" ");
 
-        addressPicker = new DefaultAddressPicker(config, logger);
+        addressPicker = new DefaultAddressPicker(config, LOGGER);
         assertThrows(IllegalArgumentException.class, () -> addressPicker.pickAddress());
     }
 
@@ -328,7 +327,7 @@ public class DefaultAddressPickerTest {
         System.setProperty(DefaultAddressPicker.PREFER_IPV6_ADDRESSES, "true");
         config.setProperty(ClusterProperty.PREFER_IPv4_STACK.getName(), "false");
 
-        addressPicker = new DefaultAddressPicker(config, logger);
+        addressPicker = new DefaultAddressPicker(config, LOGGER);
         addressPicker.pickAddress();
 
         Address bindAddress = addressPicker.getBindAddress(null);

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DuplicatedResourcesScannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DuplicatedResourcesScannerTest.java
@@ -49,10 +49,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class DuplicatedResourcesScannerTest {
-
+    private static final ILogger LOGGER = mock(ILogger.class);
     private static final byte[] SOME_CONTENT = "some-content".getBytes(UTF_8);
     private static final String SOME_EXISTING_RESOURCE_FILE = "META-INF/some-resource-file";
-    private final ILogger logger = mock(ILogger.class);
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -69,19 +68,19 @@ public class DuplicatedResourcesScannerTest {
     public void should_NOT_log_warning_when_single_occurrence() throws Exception {
         URLClassLoader classLoader = classLoaderWithJars(dummyJarFile);
 
-        DuplicatedResourcesScanner.checkForDuplicates(classLoader, logger, SOME_EXISTING_RESOURCE_FILE);
+        DuplicatedResourcesScanner.checkForDuplicates(classLoader, LOGGER, SOME_EXISTING_RESOURCE_FILE);
 
-        verifyNoInteractions(logger);
+        verifyNoInteractions(LOGGER);
     }
 
     @Test
     public void should_log_warning_when_duplicate_found() throws Exception {
         URLClassLoader classLoader = classLoaderWithJars(dummyJarFile, duplicateJar(dummyJarFile));
 
-        DuplicatedResourcesScanner.checkForDuplicates(classLoader, logger, SOME_EXISTING_RESOURCE_FILE);
+        DuplicatedResourcesScanner.checkForDuplicates(classLoader, LOGGER, SOME_EXISTING_RESOURCE_FILE);
 
         ArgumentCaptor<String> logCaptor = ArgumentCaptor.forClass(String.class);
-        verify(logger).warning(logCaptor.capture());
+        verify(LOGGER).warning(logCaptor.capture());
         assertThat(logCaptor.getValue()).contains("WARNING: Classpath misconfiguration: found multiple " + SOME_EXISTING_RESOURCE_FILE);
     }
 
@@ -101,9 +100,9 @@ public class DuplicatedResourcesScannerTest {
 
     @Test
     public void should_NOT_log_warning_when_no_occurrence() {
-        DuplicatedResourcesScanner.checkForDuplicates(getClass().getClassLoader(), logger, "META-INF/some-non-existing-file");
+        DuplicatedResourcesScanner.checkForDuplicates(getClass().getClassLoader(), LOGGER, "META-INF/some-non-existing-file");
 
-        verifyNoInteractions(logger);
+        verifyNoInteractions(LOGGER);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTestHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/jmx/JmxPublisherTestHelper.java
@@ -39,12 +39,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class JmxPublisherTestHelper {
+    private static final ILogger LOGGER = Logger.getLogger(JmxPublisherTestHelper.class);
     private static final String MODULE_NAME = "moduleA";
 
     private final MBeanServer platformMBeanServer;
     private final ObjectName objectNameNoModule;
     private final ObjectName objectNameWithModule;
-    private final ILogger logger = Logger.getLogger(JmxPublisherTestHelper.class);
 
     public JmxPublisherTestHelper(String domainPrefix) throws Exception {
         objectNameNoModule = new ObjectName(domainPrefix + ":*");
@@ -70,7 +70,7 @@ public class JmxPublisherTestHelper {
         Set<ObjectInstance> instances = queryOurInstances();
         if (instances.size() > 0) {
             String jvmName = ManagementFactory.getRuntimeMXBean().getName();
-            logger.info("Dangling metrics MBeans created by " + jvmName + ": " + instances);
+            LOGGER.info("Dangling metrics MBeans created by " + jvmName + ": " + instances);
         }
         assertEquals(0, instances.size());
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/LocalAddressRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/LocalAddressRegistryTest.java
@@ -41,13 +41,12 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class LocalAddressRegistryTest extends HazelcastTestSupport {
-
-    private final ILogger logger = Logger.getLogger(LocalAddressRegistry.class);
+    private static final ILogger LOGGER = Logger.getLogger(LocalAddressRegistry.class);
     private LocalAddressRegistry addressRegistry;
 
     @Before
     public void setUp() {
-        addressRegistry = new LocalAddressRegistry(logger);
+        addressRegistry = new LocalAddressRegistry(LOGGER);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddAllReadManyStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddAllReadManyStressTest.java
@@ -52,10 +52,9 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
 public class RingbufferAddAllReadManyStressTest extends HazelcastTestSupport {
-
+    private static final ILogger LOGGER = getLogger(RingbufferAddAllReadManyStressTest.class);
     private static final int MAX_BATCH = 100;
 
-    private final ILogger logger = getLogger(RingbufferAddAllReadManyStressTest.class);
     private final AtomicBoolean stop = new AtomicBoolean();
 
     private Ringbuffer<Long> ringbuffer;
@@ -128,13 +127,13 @@ public class RingbufferAddAllReadManyStressTest extends HazelcastTestSupport {
         producer.start();
 
         sleepAndStop(stop, 60);
-        logger.info("Waiting for completion");
+        LOGGER.info("Waiting for completion");
 
         producer.assertSucceedsEventually();
         consumer1.assertSucceedsEventually();
         consumer2.assertSucceedsEventually();
 
-        logger.info(producer.getName() + " produced:" + producer.produced);
+        LOGGER.info(producer.getName() + " produced:" + producer.produced);
 
         assertEquals(producer.produced, consumer1.seq);
         assertEquals(producer.produced, consumer2.seq);

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerMock.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerMock.java
@@ -25,8 +25,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class ReliableMessageListenerMock implements ReliableMessageListener<String> {
-
-    private final ILogger logger = Logger.getLogger(ReliableMessageListenerMock.class);
+    private static final ILogger LOGGER = Logger.getLogger(ReliableMessageListenerMock.class);
     public final List<String> objects = new CopyOnWriteArrayList<String>();
     public final List<Message<String>> messages = new CopyOnWriteArrayList<Message<String>>();
     public volatile long storedSequence;
@@ -38,7 +37,7 @@ public class ReliableMessageListenerMock implements ReliableMessageListener<Stri
     public void onMessage(Message<String> message) {
         objects.add(message.getMessageObject());
         messages.add(message);
-        logger.info("Received: " + message.getMessageObject());
+        LOGGER.info("Received: " + message.getMessageObject());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicStressTest.java
@@ -43,8 +43,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
 public class ReliableTopicStressTest extends HazelcastTestSupport {
-
-    private final ILogger logger = Logger.getLogger(ReliableTopicStressTest.class);
+    private static final ILogger LOGGER = Logger.getLogger(ReliableTopicStressTest.class);
     private final AtomicBoolean stop = new AtomicBoolean();
     private ITopic<Long> topic;
 
@@ -74,13 +73,13 @@ public class ReliableTopicStressTest extends HazelcastTestSupport {
         final ProduceThread produceThread = new ProduceThread();
         produceThread.start();
 
-        logger.info("Starting test");
+        LOGGER.info("Starting test");
         sleepAndStop(stop, MINUTES.toSeconds(5));
-        logger.info("Waiting for completion");
+        LOGGER.info("Waiting for completion");
 
         produceThread.assertSucceedsEventually();
 
-        logger.info("Number of items produced: " + produceThread.send);
+        LOGGER.info("Number of items produced: " + produceThread.send);
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -127,7 +126,7 @@ public class ReliableTopicStressTest extends HazelcastTestSupport {
             final long receivedMessageId = message.getMessageObject();
             if (receivedMessageId != nextExpectedMessageId) {
                 if (listenerWasSlow) {
-                    logger.info(toString() + " was slow, jumping from " + received + " to " + receivedMessageId);
+                    LOGGER.info(toString() + " was slow, jumping from " + received + " to " + receivedMessageId);
                     lost += receivedMessageId - nextExpectedMessageId;
                     nextExpectedMessageId = receivedMessageId;
                     listenerWasSlow = false;
@@ -137,7 +136,7 @@ public class ReliableTopicStressTest extends HazelcastTestSupport {
             }
 
             if (received % 100000 == 0) {
-                logger.info(toString() + " is at: " + received);
+                LOGGER.info(toString() + " is at: " + received);
             }
 
             received++;


### PR DESCRIPTION
I see three styles of `ILogger` declaration in the codebase:
- `static final ILogger LOGGER = Logger.getLogger(TheClass.class)`
   - 110 instances
   - Most common style I'm used to
- `final ILogger logger = Logger.getLogger(getClass())`
   - 44 instances
   - Alternative style I've seen, can be inherited, avoids hardcoded class references, one instance per class
- final ILogger logger = Logger.getLogger(TheClass.class)
   - 23 instances
   - Appears to have the drawbacks of both declarations - it's non-`static` but without the benefit of being so

I've refactored any:
`final ILogger logger = Logger.getLogger(TheClass.class)`

Declarations to:
`static final ILogger LOGGER = Logger.getLogger(TheClass.class)`