### PR TITLE
Make the `ClientInvocationFutureTest` more insensitive to timeouts [API-2115]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientInvocationFutureTest.java
@@ -42,6 +42,7 @@ import static com.hazelcast.internal.util.RootCauseMatcher.rootCause;
 import static com.hazelcast.spi.impl.InternalCompletableFuture.newCompletedFuture;
 import static com.hazelcast.test.HazelcastTestSupport.ignore;
 import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
+import static com.hazelcast.test.HazelcastTestSupport.ASSERT_TRUE_EVENTUALLY_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -141,7 +142,7 @@ public class ClientInvocationFutureTest {
             thisThread.interrupt();
         });
         t.start();
-        assertThatThrownBy(() -> invocationFuture.get(30, TimeUnit.SECONDS))
+        assertThatThrownBy(() -> invocationFuture.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS))
                 .isInstanceOf(InterruptedException.class);
     }
 
@@ -176,7 +177,7 @@ public class ClientInvocationFutureTest {
         });
         invocationFuture.complete(response);
 
-        assertEquals(response, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(response, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();
     }
@@ -188,7 +189,7 @@ public class ClientInvocationFutureTest {
         });
         invocationFuture.complete(response);
 
-        assertEquals(null, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(null, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();
     }
@@ -198,7 +199,7 @@ public class ClientInvocationFutureTest {
         CompletableFuture nextStage = invocationFuture.thenCompose((v) -> newCompletedFuture(v));
         invocationFuture.complete(response);
 
-        assertEquals(response, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(response, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();
     }
@@ -208,7 +209,7 @@ public class ClientInvocationFutureTest {
         CompletableFuture nextStage = invocationFuture.thenApply((v) -> v);
         invocationFuture.complete(response);
 
-        assertEquals(response, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(response, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();
     }
@@ -218,7 +219,7 @@ public class ClientInvocationFutureTest {
         CompletableFuture nextStage = invocationFuture.thenAccept((v) -> ignore(null));
         invocationFuture.complete(response);
 
-        assertEquals(null, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(null, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();
     }
@@ -229,7 +230,7 @@ public class ClientInvocationFutureTest {
                 (t, u) -> ignore(null));
         invocationFuture.complete(null);
 
-        assertEquals(null, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(null, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();
     }
@@ -240,7 +241,7 @@ public class ClientInvocationFutureTest {
                 (t, u) -> t);
         invocationFuture.complete(response);
 
-        assertEquals(response, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(response, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();
     }
@@ -250,7 +251,7 @@ public class ClientInvocationFutureTest {
         CompletableFuture nextStage = invocationFuture.exceptionally((t) -> response);
         invocationFuture.completeExceptionally(new IllegalStateException());
 
-        assertEquals(response, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(response, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();
     }
@@ -260,7 +261,7 @@ public class ClientInvocationFutureTest {
         CompletableFuture nextStage = invocationFuture.handle((t, u) -> t);
         invocationFuture.complete(response);
 
-        assertEquals(response, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(response, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();
     }
@@ -270,7 +271,7 @@ public class ClientInvocationFutureTest {
         CompletableFuture nextStage = invocationFuture.acceptEither(newCompletedFuture(null),
                 t -> ignore(null));
 
-        assertEquals(null, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(null, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(1)).complete();
     }
@@ -279,7 +280,7 @@ public class ClientInvocationFutureTest {
     public void test_applyEither() throws Exception {
         CompletableFuture nextStage = invocationFuture.applyToEither(newCompletedFuture(null), (t) -> t);
 
-        assertEquals(null, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(null, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(1)).complete();
     }
@@ -289,7 +290,7 @@ public class ClientInvocationFutureTest {
         CompletableFuture<Void> nextStage = invocationFuture.runAfterBoth(newCompletedFuture(null), () -> ignore(null));
         invocationFuture.complete(null);
 
-        assertEquals(null, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(null, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(2)).complete();
     }
@@ -299,7 +300,7 @@ public class ClientInvocationFutureTest {
         CompletableFuture<Void> nextStage = invocationFuture.runAfterEither(newCompletedFuture(null),
                 () -> ignore(null));
 
-        assertEquals(null, nextStage.get(10, TimeUnit.SECONDS));
+        assertEquals(null, nextStage.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
         verify(callIdSequence).forceNext();
         verify(callIdSequence, times(1)).complete();
     }


### PR DESCRIPTION
Make the `ClientInvocationFutureTest` more insensitive to test load and timeouts rather than using a magic 10secs timeout.

fixes #24851

