### PR TITLE
Replace `${log4j2.version}` with `log4j-bom`

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -202,17 +202,14 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-layout-template-json</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
 
         <!-- Prometheus to expose JMX metrics as HTTP endpoint -->

--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -139,7 +139,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -127,7 +127,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -118,7 +118,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/csv/pom.xml
+++ b/extensions/csv/pom.xml
@@ -94,7 +94,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/grpc/pom.xml
+++ b/extensions/grpc/pom.xml
@@ -100,7 +100,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/hadoop/pom.xml
+++ b/extensions/hadoop/pom.xml
@@ -113,7 +113,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/kafka-connect/pom.xml
+++ b/extensions/kafka-connect/pom.xml
@@ -92,13 +92,11 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -101,7 +101,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/kinesis/pom.xml
+++ b/extensions/kinesis/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/python/pom.xml
+++ b/extensions/python/pom.xml
@@ -136,7 +136,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/s3/pom.xml
+++ b/extensions/s3/pom.xml
@@ -102,7 +102,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -728,7 +728,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -606,14 +606,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>${log4j2.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
         <kafka.version>3.4.1</kafka.version>
         <kotlin.version>1.9.10</kotlin.version>
         <reload4j.version>1.2.25</reload4j.version>
-        <log4j2.version>2.20.0</log4j2.version>
         <mssql.version>12.4.1.jre11</mssql.version>
         <mysql.connector.version>8.1.0</mysql.connector.version>
         <netty.version>4.1.99.Final</netty.version>
@@ -1945,8 +1944,10 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>${log4j2.version}</version>
+                <artifactId>log4j-bom</artifactId>
+                <version>2.20.0</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.jline</groupId>
@@ -2161,7 +2162,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast/pull/25680 is failing because an updated dependency uses a different version of `log4j-core` to the one one declared in Hazelcast.

A workaround is to specify the `log4j-core` version in `dependencyManagement` - we are already specifying a version of `log4j-api` here.

Alternatively, we can **replace** the `log4j-api` version specification with `log4j-bom`. This delivers the same result, as it asserts the version of `log4j-core`, `log4j-api` etc.

Currently the version of log4j dependencies used through the project is controlled by `${log4j2.version}`, but using `log4j-bom` removes this - and ensures that the log4j dependencies used are all compatible with each other.

As such I've removed the `${log4j2.version}` variable, and all it's applications from the child poms.
