### PR TITLE
Remove JUnit4 dependency management - inherit from `junit-bom`

### DIFF
--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -47,15 +47,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -152,8 +152,6 @@
         <http.core.version>4.4.16</http.core.version>
         <http.client.version>4.5.14</http.client.version>
         <jsr107.tck.version>1.1.1</jsr107.tck.version>
-        <junit.version>4.13.2</junit.version>
-        <junit-jupiter.version>5.10.0</junit-jupiter.version>
         <mockito.version>5.6.0</mockito.version>
         <reflections.version>0.9.10</reflections.version>
         <testcontainers.version>1.19.1</testcontainers.version>
@@ -2037,7 +2035,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>${junit-jupiter.version}</version>
+                <version>5.10.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Hazelcast uses `junit-bom`.
`junit-bom` specifies a version for `junit-vintage-engine`.
`junit-vintage-engine` specifies a version for `junit` (i.e. JUnit4).

Hazelcast *also* specifies, via the `${junit-jupiter.version}` property, a managed version of `junit`.

It's redundant to specify the version of `junit`, as `junit-bom`effectively specifies the same version - but if it didn't, we'd have compatibility issues, which is the problem `junit-bom` seeks to avoid.

Removed `${junit.version}` property, `junit` managed dependency & `hazelcast-archunit-rules/pom.xml` to ensure that a managed version of `junit` is still available.
