### PR TITLE
Adjust Eclipse code formatter import ordering

### DIFF
--- a/ide-configurations/eclipse/Hazelcast-Eclipse.pref.epf
+++ b/ide-configurations/eclipse/Hazelcast-Eclipse.pref.epf
@@ -1,4 +1,3 @@
-#Mon Aug 14 17:03:05 BST 2023
 \!/=
 /instance/org.eclipse.jdt.core/org.eclipse.jdt.core.codeComplete.argumentPrefixes=
 /instance/org.eclipse.jdt.core/org.eclipse.jdt.core.codeComplete.argumentSuffixes=
@@ -557,7 +556,7 @@
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.formatterprofiles.version=23
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.gettersetter.use.is=true
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.ignorelowercasenames=true
-/instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.importorder=org;com;javax;java;
+/instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.importorder=;javax;java;\#;
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.ondemandthreshold=99
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.overrideannotation=true
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.staticondemandthreshold=99


### PR DESCRIPTION
Adjust Eclipse import ordering to match that of IntelliJ:
<img width="721" alt="image" src="https://github.com/hazelcast/hazelcast/assets/8626721/d7f2070d-d443-4e76-bbd1-01fb6bc4477a">

Eclipse configuration updated to:
<img width="500" alt="image" src="https://github.com/hazelcast/hazelcast/assets/8626721/aae8d326-473c-4dac-beb0-4bdfe3c0fa2c">

Unfortunately doesn't add the blank lines in _quite_ the right place (it will put a line between **every** import group, not just _some_ groups), but an improvement.