### PR TITLE
HZ-3428 Remove Mongo permissions

### DIFF
--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/DbCheckingPMetaSupplier.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/DbCheckingPMetaSupplier.java
@@ -46,7 +46,6 @@ import static com.hazelcast.jet.mongodb.impl.MongoUtilities.checkDatabaseExists;
  */
 public class DbCheckingPMetaSupplier implements ProcessorMetaSupplier {
 
-    private final Permission requiredPermission;
     private final boolean shouldCheckOnEachCall;
     private ProcessorMetaSupplier standardForceOnePMS;
     private final boolean forceTotalParallelismOne;
@@ -60,8 +59,7 @@ public class DbCheckingPMetaSupplier implements ProcessorMetaSupplier {
     /**
      * Creates a new instance of this meta supplier.
      */
-    public DbCheckingPMetaSupplier(@Nullable Permission requiredPermission,
-                                   boolean shouldCheckOnEachCall,
+    public DbCheckingPMetaSupplier(boolean shouldCheckOnEachCall,
                                    boolean forceTotalParallelismOne,
                                    @Nullable String databaseName,
                                    @Nullable String collectionName,
@@ -70,7 +68,6 @@ public class DbCheckingPMetaSupplier implements ProcessorMetaSupplier {
                                    @Nonnull ProcessorSupplier processorSupplier,
                                    int preferredLocalParallelism
     ) {
-        this.requiredPermission = requiredPermission;
         this.shouldCheckOnEachCall = shouldCheckOnEachCall;
         this.forceTotalParallelismOne = forceTotalParallelismOne;
         this.databaseName = databaseName;
@@ -84,12 +81,6 @@ public class DbCheckingPMetaSupplier implements ProcessorMetaSupplier {
     @Override
     public int preferredLocalParallelism() {
         return preferredLocalParallelism;
-    }
-
-    @Nullable
-    @Override
-    public Permission getRequiredPermission() {
-        return requiredPermission;
     }
 
     @Override

--- a/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/DbCheckingPMetaSupplierBuilder.java
+++ b/extensions/mongodb/src/main/java/com/hazelcast/jet/mongodb/impl/DbCheckingPMetaSupplierBuilder.java
@@ -24,7 +24,6 @@ import com.mongodb.client.MongoClient;
 import java.security.Permission;
 
 public class DbCheckingPMetaSupplierBuilder {
-    private Permission requiredPermission;
     private boolean checkResourceExistence;
     private boolean forceTotalParallelismOne;
     private String databaseName;
@@ -33,11 +32,6 @@ public class DbCheckingPMetaSupplierBuilder {
     private DataConnectionRef dataConnectionRef;
     private ProcessorSupplier processorSupplier;
     private int preferredLocalParallelism = Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
-
-    public DbCheckingPMetaSupplierBuilder withRequiredPermission(Permission requiredPermission) {
-        this.requiredPermission = requiredPermission;
-        return this;
-    }
 
     public DbCheckingPMetaSupplierBuilder withCheckResourceExistence(boolean checkResourceExistence) {
         this.checkResourceExistence = checkResourceExistence;
@@ -84,7 +78,7 @@ public class DbCheckingPMetaSupplierBuilder {
     }
 
     public DbCheckingPMetaSupplier build() {
-        return new DbCheckingPMetaSupplier(requiredPermission, checkResourceExistence, forceTotalParallelismOne,
+        return new DbCheckingPMetaSupplier(checkResourceExistence, forceTotalParallelismOne,
                 databaseName, collectionName, clientSupplier, dataConnectionRef, processorSupplier,
                 preferredLocalParallelism);
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/InsertProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/InsertProcessorSupplier.java
@@ -65,13 +65,6 @@ public class InsertProcessorSupplier extends MongoProcessorSupplier implements D
         this.idField = table.primaryKeyExternalName();
     }
 
-    @Nullable
-    @Override
-    public List<Permission> permissions() {
-        String connDetails = connectionString == null ? dataConnectionName : connectionString;
-        return singletonList(ConnectorPermission.mongo(connDetails, databaseName, collectionName, ACTION_WRITE));
-    }
-
     @Override
     public void init(@Nonnull Context context) throws Exception {
         if (connectionString != null) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/SelectProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/SelectProcessorSupplier.java
@@ -104,13 +104,6 @@ public class SelectProcessorSupplier extends MongoProcessorSupplier implements D
         this(table, predicate, projection, null, false, null);
     }
 
-    @Nullable
-    @Override
-    public List<Permission> permissions() {
-        String connDetails = connectionString == null ? dataConnectionName : connectionString;
-        return singletonList(ConnectorPermission.mongo(connDetails, databaseName, collectionName, ACTION_READ));
-    }
-
     @Override
     public void init(@Nonnull Context context) {
         if (connectionString != null) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/UpdateProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/UpdateProcessorSupplier.java
@@ -86,13 +86,6 @@ public class UpdateProcessorSupplier extends MongoProcessorSupplier implements D
         this.afterScan = hasInput;
     }
 
-    @Nullable
-    @Override
-    public List<Permission> permissions() {
-        String connDetails = connectionString == null ? dataConnectionName : connectionString;
-        return singletonList(ConnectorPermission.mongo(connDetails, databaseName, collectionName, ACTION_WRITE));
-    }
-
     @Override
     public void init(@Nonnull Context context) throws Exception {
         if (connectionString != null) {


### PR DESCRIPTION
Instead of half-baked solution, remove this and implement proper checks later.

Breaking changes (list specific methods/types/messages):
* Who used permissions, cannot do it anymore.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
