### PR TITLE
Don't fail proxies creation if any of permissions is missing in CreateProxiesMessageTask [HZ-3464] [5.3.3]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxiesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxiesMessageTask.java
@@ -29,6 +29,7 @@ import com.hazelcast.spi.impl.proxyservice.ProxyService;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyInfo;
 import com.hazelcast.spi.impl.proxyservice.impl.operations.PostJoinProxyOperation;
 
+import java.security.AccessControlException;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,6 +41,8 @@ import java.util.function.Supplier;
 public class CreateProxiesMessageTask extends AbstractMultiTargetMessageTask<List<Map.Entry<String, String>>>
         implements Supplier<Operation> {
 
+    private List<Map.Entry<String, String>> filteredProxies;
+
     public CreateProxiesMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -50,8 +53,8 @@ public class CreateProxiesMessageTask extends AbstractMultiTargetMessageTask<Lis
 
     @Override
     public Operation get() {
-        List<ProxyInfo> proxyInfos = new ArrayList<ProxyInfo>(parameters.size());
-        for (Map.Entry<String, String> proxy : parameters) {
+        List<ProxyInfo> proxyInfos = new ArrayList<ProxyInfo>(filteredProxies.size());
+        for (Map.Entry<String, String> proxy : filteredProxies) {
             proxyInfos.add(new ProxyInfo(proxy.getValue(), proxy.getKey(), endpoint.getUuid()));
         }
         return new PostJoinProxyOperation(proxyInfos);
@@ -95,6 +98,7 @@ public class CreateProxiesMessageTask extends AbstractMultiTargetMessageTask<Lis
         // replacement for getRequiredPermission-based checks, we have to check multiple permission
         SecurityContext securityContext = clientEngine.getSecurityContext();
         if (securityContext != null) {
+            filteredProxies = new ArrayList<>(parameters.size());
             ProxyService proxyService = clientEngine.getProxyService();
             for (Map.Entry<String, String> proxy : parameters) {
                 String objectName = proxy.getKey();
@@ -102,9 +106,24 @@ public class CreateProxiesMessageTask extends AbstractMultiTargetMessageTask<Lis
                 if (proxyService.existsDistributedObject(serviceName, objectName)) {
                     continue;
                 }
-                Permission permission = ActionConstants.getPermission(objectName, serviceName, ActionConstants.ACTION_CREATE);
-                securityContext.checkPermission(endpoint.getSubject(), permission);
+                try {
+                    Permission permission = ActionConstants.getPermission(objectName, serviceName,
+                            ActionConstants.ACTION_CREATE);
+                    securityContext.checkPermission(endpoint.getSubject(), permission);
+                    filteredProxies.add(proxy);
+                } catch (AccessControlException ace) {
+                    logger.info("Insufficient client permissions. Proxy won't be created for type '" + serviceName + "': "
+                            + objectName);
+                    if (logger.isFineEnabled()) {
+                        logger.fine("Skipping proxy creation due to AccessControlException", ace);
+                    }
+                } catch (Exception e) {
+                    // unknown serviceName or another unexpected issue
+                    logger.warning("Proxy won't be created for type '" + serviceName + "': " + objectName, e);
+                }
             }
+        } else {
+            filteredProxies = parameters;
         }
         super.beforeProcess();
     }


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/25703

Fixes https://hazelcast.atlassian.net/browse/HZ-3464

Follow-up to #25509

This PR aligns check permission behavior in the message task with the message description in the [protocol definition](https://github.com/hazelcast/hazelcast-client-protocol/blob/master/protocol-definitions/Client.yaml#L721):

```
Any proxy creation failure is logged on the server side.
Exceptions related to a proxy creation failure is not send to the client.
A proxy creation failure does not cancel this operation, all proxies will be attempted to be created.
```
