### PR TITLE
Add changes for data migration phone home [HZ-3127]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHome.java
@@ -153,6 +153,22 @@ public class PhoneHome {
         return parameterCreator.getParameters();
     }
 
+    /**
+     * Performs a phone request for {@code node} and returns the generated request
+     * parameters. If {@code pretend} is {@code true}, only returns the parameters
+     * without actually performing the request.
+     *
+     * @param pretend if {@code true}, do not perform the request
+     * @param parameterCreator the parameter creator to use
+     * @return the generated request parameters
+     */
+    public Map<String, String> phoneHome(boolean pretend, PhoneHomeParameterCreator parameterCreator) {
+        if (!pretend) {
+            postPhoneHomeData(parameterCreator.build());
+        }
+        return parameterCreator.getParameters();
+    }
+
     public PhoneHomeParameterCreator createParameters() {
         PhoneHomeParameterCreator parameterCreator = new PhoneHomeParameterCreator();
         for (MetricsCollector metricsCollector : metricsCollectorList) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -206,15 +206,15 @@ public enum PhoneHomeMetrics {
     REST_UNIQUE_REQUEST_COUNT("restuniqrequestct"),
 
     // DMT metrics
-    DMT_ENABLED("dmte"),
-    DMT_TIMESTAMP("t"),
-    DMT_NUMBER_OF_DS_TO_MIGRATE("dscnt"),
-    DMT_NUMBER_OF_DS_MIGRATED("dsmigcnt"),
-    DMT_MIGRATION_COMPLETED("cmp"),
-    DMT_SOURCE_VERSION("sv"),
-    DMT_TARGET_VERSION("tv"),
-    DMT_TARGET_VIRIDIAN("tvrd"),
-    DMT_DS_INFO("dsdata");
+    DMT_ENABLED("dmtenabled"),
+    DMT_TIMESTAMP("dmttimestamp"),
+    DMT_NUMBER_OF_DS_TO_MIGRATE("dmtdscount"),
+    DMT_NUMBER_OF_DS_MIGRATED("dmtmigratedcount"),
+    DMT_MIGRATION_COMPLETED("dmtmigrationcompleted"),
+    DMT_SOURCE_VERSION("dmtsourceversion"),
+    DMT_TARGET_VERSION("dmttargetversion"),
+    DMT_TARGET_VIRIDIAN("dmttargetviridian"),
+    DMT_DS_INFO("dsdsinfo");
 
     private final String query;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -206,15 +206,15 @@ public enum PhoneHomeMetrics {
     REST_UNIQUE_REQUEST_COUNT("restuniqrequestct"),
 
     // DMT metrics
-    DMT_ENABLED("dmtenabled"),
-    DMT_TIMESTAMP("dmttimestamp"),
-    DMT_NUMBER_OF_DS_TO_MIGRATE("dmtdscount"),
-    DMT_NUMBER_OF_DS_MIGRATED("dmtmigratedcount"),
-    DMT_MIGRATION_COMPLETED("dmtmigrationcompleted"),
-    DMT_SOURCE_VERSION("dmtsourceversion"),
-    DMT_TARGET_VERSION("dmttargetversion"),
-    DMT_TARGET_VIRIDIAN("dmttargetviridian"),
-    DMT_DS_INFO("dsdsinfo");
+    DMT_ENABLED("dmtEnabled"),
+    DMT_TIMESTAMP("dmtTimestamp"),
+    DMT_NUMBER_OF_DS_TO_MIGRATE("dmtDsCount"),
+    DMT_NUMBER_OF_DS_MIGRATED("dmtMigratedCount"),
+    DMT_MIGRATION_COMPLETED("dmtMigrationCompleted"),
+    DMT_SOURCE_VERSION("dmtSourceVersion"),
+    DMT_TARGET_VERSION("dmtTargetVersion"),
+    DMT_TARGET_VIRIDIAN("dmtTargetViridian"),
+    DMT_DS_INFO("dmtDsInfo");
 
     private final String query;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -203,7 +203,20 @@ public enum PhoneHomeMetrics {
     REST_CONFIG_RELOAD_FAILURE("restconfigreloadfail"),
 
     REST_REQUEST_COUNT("restrequestct"),
-    REST_UNIQUE_REQUEST_COUNT("restuniqrequestct");
+    REST_UNIQUE_REQUEST_COUNT("restuniqrequestct"),
+
+    // DMT metrics
+    DMT_ENABLED("dmte"),
+    DMT_TIMESTAMP("t"),
+    DMT_NUMBER_OF_DS_TO_MIGRATE("dscnt"),
+    DMT_NUMBER_OF_DS_MIGRATED("dsmigcnt"),
+    DMT_MIGRATION_COMPLETED("cmp"),
+    DMT_SOURCE_VERSION("sv"),
+    DMT_TARGET_VERSION("tv"),
+    DMT_TARGET_VIRIDIAN("tvrd");
+
+
+
     private final String query;
 
     PhoneHomeMetrics(String query) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/phonehome/PhoneHomeMetrics.java
@@ -213,9 +213,8 @@ public enum PhoneHomeMetrics {
     DMT_MIGRATION_COMPLETED("cmp"),
     DMT_SOURCE_VERSION("sv"),
     DMT_TARGET_VERSION("tv"),
-    DMT_TARGET_VIRIDIAN("tvrd");
-
-
+    DMT_TARGET_VIRIDIAN("tvrd"),
+    DMT_DS_INFO("dsdata");
 
     private final String query;
 


### PR DESCRIPTION
Adds required changes to be able to manually trigger a phone home with custom parameters & adds DMT related phone home parameters. 

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6649