### PR TITLE
Fix ServiceAccount for K8s test suite

### DIFF
--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -93,6 +93,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Add env vars
+        run: |
+          echo "GCLOUD_SA=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")" >> "$GITHUB_ENV"
+          echo "GCLOUD_ID_TOKEN=$(gcloud auth print-identity-token)" >> "$GITHUB_ENV"
+
       - name: Run Tests
         working-directory: auto-discovery-suite/terraform/test
         run: |


### PR DESCRIPTION
Fix GCP ServiceAccount for K8s test suites

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
