### PR TITLE
Formally define `SlowTest` / `QuickTest`

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/SqlIndexTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/SqlIndexTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.jet.sql.impl.connector.map.index;
 import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -28,7 +28,7 @@ import java.util.Collection;
 
 @RunWith(HazelcastParametrizedRunner.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category({SlowTest.class, ParallelJVMTest.class})
+@Category({QuickTest.class, ParallelJVMTest.class})
 public class SqlIndexTest extends SqlIndexAbstractTest {
     @Parameterized.Parameters(name = "indexType:{0}, composite:{1}, field1:{2}, field2:{3}")
     public static Collection<Object[]> parameters() {

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/SqlIndexTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/SqlIndexTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.jet.sql.impl.connector.map.index;
 import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -28,7 +28,7 @@ import java.util.Collection;
 
 @RunWith(HazelcastParametrizedRunner.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class SqlIndexTest extends SqlIndexAbstractTest {
     @Parameterized.Parameters(name = "indexType:{0}, composite:{1}, field1:{2}, field2:{3}")
     public static Collection<Object[]> parameters() {

--- a/hazelcast/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
@@ -26,9 +26,11 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
@@ -38,8 +40,8 @@ import java.util.concurrent.CountDownLatch;
 import static com.hazelcast.cache.CacheTestSupport.createClientCachingProvider;
 import static org.junit.Assert.assertEquals;
 
+@Category(SlowTest.class)
 public class CacheClientListenerTest extends CacheListenerTest {
-
     @Before
     @After
     public void cleanup() {
@@ -109,8 +111,7 @@ public class CacheClientListenerTest extends CacheListenerTest {
 
         assertTrueAllTheTime(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 assertEquals("Expired event is received more than once", 1, expiredLatch.getCount());
             }
         }, 3);

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionlessSemaphoreClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionlessSemaphoreClientBasicTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -32,7 +33,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class SessionlessSemaphoreClientBasicTest extends SessionlessSemaphoreBasicTest {
 
     private HazelcastInstance client;

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionlessSemaphoreClientBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/datastructures/semaphore/SessionlessSemaphoreClientBasicTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.cp.internal.datastructures.semaphore.SessionlessSemaphoreBa
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_BlockingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_BlockingTest.java
@@ -34,6 +34,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -63,7 +64,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelJVMTest.class})
+@Category({SlowTest.class, ParallelJVMTest.class})
 public class Invocation_BlockingTest extends HazelcastTestSupport {
 
     // ============================ heartbeat timeout =============================================================================

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_BlockingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_BlockingTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
-import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -17,9 +17,9 @@
 package com.hazelcast.test;
 
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
+import com.hazelcast.internal.util.collection.ArrayUtils;
 import com.hazelcast.test.annotation.ConfigureParallelRunnerWith;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.FrameworkMethod;

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -18,6 +18,9 @@ package com.hazelcast.test;
 
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.test.annotation.ConfigureParallelRunnerWith;
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
@@ -161,8 +164,14 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
                 System.out.println("Started Running Test: " + testName);
                 HazelcastParallelClassRunner.super.runChild(method, notifier);
                 numThreads.decrementAndGet();
-                float took = (float) (System.currentTimeMillis() - start) / 1000;
-                System.out.println(format("Finished Running Test: %s in %.3f seconds.", testName, took));
+                float tookSeconds = (float) (System.currentTimeMillis() - start) / 1000;
+                System.out.println(format("Finished Running Test: %s in %.3f seconds.", testName, tookSeconds));
+
+                Category classAnnotations = method.getDeclaringClass().getAnnotation(Category.class);
+
+                if (classAnnotations != null && ArrayUtils.contains(classAnnotations.value(), QuickTest.class)) {
+                    QuickTest.logMessageIfTestOverran(method, tookSeconds);
+                }
             } finally {
                 removeThreadLocalTestMethodName();
             }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialClassRunner.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.test;
 
+import com.hazelcast.internal.util.collection.ArrayUtils;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.FrameworkMethod;

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialClassRunner.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.test;
 
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
@@ -48,8 +51,14 @@ public class HazelcastSerialClassRunner extends AbstractHazelcastClassRunner {
             long start = System.currentTimeMillis();
             System.out.println("Started Running Test: " + testName);
             super.runChild(method, notifier);
-            float took = (float) (System.currentTimeMillis() - start) / 1000;
-            System.out.println(String.format("Finished Running Test: %s in %.3f seconds.", testName, took));
+            float tookSeconds = (float) (System.currentTimeMillis() - start) / 1000;
+            System.out.println(String.format("Finished Running Test: %s in %.3f seconds.", testName, tookSeconds));
+
+            Category classAnnotations = method.getDeclaringClass().getAnnotation(Category.class);
+
+            if (classAnnotations != null && ArrayUtils.contains(classAnnotations.value(), QuickTest.class)) {
+                QuickTest.logMessageIfTestOverran(method, tookSeconds);
+            }
         } finally {
             removeThreadLocalTestMethodName();
             // restore the system properties

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/QuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/QuickTest.java
@@ -16,10 +16,31 @@
 
 package com.hazelcast.test.annotation;
 
+import org.junit.runners.model.FrameworkMethod;
+
+import java.text.MessageFormat;
+import java.time.Duration;
+
 /**
- * Annotates quick tests which are fast enough for the PR builder.
+ * Annotates quick tests which are fast enough (i.e. execution sub-{@link #EXPECTED_RUNTIME_THRESHOLD} per test) for the PR builder.
  * <p>
  * Will be executed in the PR builder and for code coverage measurements.
+ * <p>
+ * The opposite of a {@link SlowTest}
  */
 public final class QuickTest {
+    public static final Duration EXPECTED_RUNTIME_THRESHOLD = Duration.ofMinutes(1);
+
+    /**
+     * TODO Remove and add to PR
+     * Prints output like "testMigrationStats_whenMigrationProcessCompletes is annotated as a QuickTest, expected to complete
+     * within 60 seconds - but took 120 seconds"
+     */
+    public static void logMessageIfTestOverran(FrameworkMethod method, float tookSeconds) {
+        if (tookSeconds > QuickTest.EXPECTED_RUNTIME_THRESHOLD.getSeconds()) {
+            System.err.println(MessageFormat.format(
+                    "{0} is annotated as a {1}, expected to complete within {2} seconds - but took {3} seconds",
+                    method.getName(), QuickTest.class.getSimpleName(), EXPECTED_RUNTIME_THRESHOLD.getSeconds(), tookSeconds));
+        }
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/QuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/QuickTest.java
@@ -26,7 +26,7 @@ import java.time.Duration;
  * <p>
  * Will be executed in the PR builder and for code coverage measurements.
  * <p>
- * The opposite of a {@link SlowTest}
+ * @see {@link SlowTest}
  */
 public final class QuickTest {
     public static final Duration EXPECTED_RUNTIME_THRESHOLD = Duration.ofMinutes(1);

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/QuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/QuickTest.java
@@ -31,11 +31,6 @@ import java.time.Duration;
 public final class QuickTest {
     public static final Duration EXPECTED_RUNTIME_THRESHOLD = Duration.ofMinutes(1);
 
-    /**
-     * TODO Remove and add to PR
-     * Prints output like "testMigrationStats_whenMigrationProcessCompletes is annotated as a QuickTest, expected to complete
-     * within 60 seconds - but took 120 seconds"
-     */
     public static void logMessageIfTestOverran(FrameworkMethod method, float tookSeconds) {
         if (tookSeconds > QuickTest.EXPECTED_RUNTIME_THRESHOLD.getSeconds()) {
             System.err.println(MessageFormat.format(

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/QuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/QuickTest.java
@@ -25,7 +25,7 @@ import java.time.Duration;
  * Annotates quick tests which are fast enough (i.e. execution sub-{@link #EXPECTED_RUNTIME_THRESHOLD} per test) for the PR builder.
  * <p>
  * Will be executed in the PR builder and for code coverage measurements.
- * <p>
+ *
  * @see {@link SlowTest}
  */
 public final class QuickTest {

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/SlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/SlowTest.java
@@ -20,6 +20,8 @@ package com.hazelcast.test.annotation;
  * Annotates tests which are too slow for the PR builder.
  * <p>
  * Will be executed in nightly builds and for code coverage measurements.
+ * <p>
+ * The opposite of a {@link QuickTest}
  */
 public final class SlowTest {
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/SlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/SlowTest.java
@@ -21,7 +21,7 @@ package com.hazelcast.test.annotation;
  * <p>
  * Will be executed in nightly builds and for code coverage measurements.
  * <p>
- * The opposite of a {@link QuickTest}
+ * @see {@link QuickTest}
  */
 public final class SlowTest {
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/SlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/SlowTest.java
@@ -20,7 +20,7 @@ package com.hazelcast.test.annotation;
  * Annotates tests which are too slow for the PR builder.
  * <p>
  * Will be executed in nightly builds and for code coverage measurements.
- * <p>
+ *
  * @see {@link QuickTest}
  */
 public final class SlowTest {


### PR DESCRIPTION
PR-builder time is growing, and the `SlowTest` / `QuickTest` annotations are meant to address that - but without a clear definition of the distinction between the two, many tests are probably in the wrong place.

Following a [Slack discussion](https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1697440607109029), we've tentatively agreed 60 seconds is the threshold.

From this, I've written a simple application to scrape Jenkins to gather metrics on the average test time taken in the PR builder per test, over the last N builds:
```
import com.fasterxml.jackson.core.JsonParseException;
import com.fasterxml.jackson.databind.*;
import com.google.common.collect.*;
import com.hazelcast.test.annotation.*;

import java.net.URI;
import java.net.http.*;
import java.net.http.HttpResponse.BodyHandlers;
import java.text.NumberFormat;
import java.util.*;
import java.util.Map.Entry;
import java.util.regex.*;
import java.util.stream.*;

/**
 * Looks at the Jenkins job history for {@code job}, averages the time taken per test, printing any that took longer than
 * {@link QuickTest#EXPECTED_RUNTIME_THRESHOLD} - these are expected to be {@link SlowTest}s
 */
public class TestSlowTests {
    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
    private static final Pattern TEST_PATTERN = Pattern
            .compile("\\[INFO\\]\\sTests\\srun:.+elapsed:\\s*(?<time>[\\d\\.]+).*in\\s+(?<test>.+)");

    private static String job = "Hazelcast-EE-pr-builder";
    private static String instance = "https://jenkins.hazelcast.com";
    private static String jenkinsCookie;

    public static void main(String[] args) throws Exception {
        if (args.length != 1) {
            throw new IllegalArgumentException("Requires Jenkins cookie as argument! Take the cookie from the browser...");
        } else {
            jenkinsCookie = args[0];

            Multimap<String, Double> testToTimes = getJobIDs().parallel().flatMap(id -> {
                try (Stream<String> stream = HTTP_CLIENT.send(getRequest(id + "/consoleText"), BodyHandlers.ofLines()).body()) {
                    return stream.collect(Collectors.toList()).stream();
                } catch (Exception e) {
                    throw new RuntimeException(e);
                }
            }).map(TEST_PATTERN::matcher).filter(Matcher::matches).sequential()
                    .collect(ImmutableListMultimap.toImmutableListMultimap(matcher -> matcher.group("test"),
                            matcher -> Double.parseDouble(matcher.group("time"))));

            Map<String, Double> testToAverageTime = testToTimes.asMap().entrySet().stream().collect(Collectors
                    .toMap(Entry::getKey, entry -> entry.getValue().stream().mapToDouble(x -> x).average().orElseThrow()));

            String FORMAT = "|%-100s|%20s|%n";
            System.out.format(FORMAT, "Test Class", "Runtime (Seconds)");
            System.out.format(FORMAT, "-", "-");

            testToAverageTime.entrySet().stream()
                    .filter(entry -> entry.getValue() > QuickTest.EXPECTED_RUNTIME_THRESHOLD.getSeconds())
                    .sorted(Comparator.<Entry<String, Double>, Double> comparing(Entry::getValue).reversed()
                            .thenComparing(Entry::getKey))
                    .forEach(entry -> System.out.format(FORMAT, entry.getKey(),
                            NumberFormat.getInstance().format(entry.getValue())));
        }
    }

    private static Stream<String> getJobIDs() throws Exception {
        String response = HTTP_CLIENT.send(getRequest("api/json?tree=allBuilds[id]"), BodyHandlers.ofString()).body();

        try {
            return new ObjectMapper().readTree(response).get("allBuilds").findValues("id").stream().map(JsonNode::asText);
        } catch (JsonParseException e) {
            throw new RuntimeException(response, e);
        }
    }

    private static HttpRequest getRequest(String query) {
        return HttpRequest.newBuilder().header("Cookie", jenkinsCookie).uri(URI.create(instance + "/job/" + job + "/" + query))
                .build();
    }
}
```

Which lists the following tests run in `Hazelcast-pr-builder` above this threshold:
|Test Class                                                                                          |   Runtime (Seconds)|
|-                                                                                                   |                   -|
|com.hazelcast.sql.index.SqlIndexTest                                                                |             281.631|
|com.hazelcast.jet.kafka.impl.StreamKafkaPTest                                                       |             122.889|
|com.hazelcast.client.ClientRegressionWithRealNetworkTest                                            |             117.338|
|com.hazelcast.multimap.MultiMapSplitBrainTest                                                       |             111.444|
|com.hazelcast.jet.kafka.connect.KafkaConnectIntegrationTest                                         |             108.639|
|com.hazelcast.cardinality.CardinalityEstimatorSplitBrainTest                                        |             102.922|
|com.hazelcast.spi.impl.operationservice.impl.Invocation_TimeoutTest                                 |              97.868|
|com.hazelcast.internal.partition.GracefulShutdownTest                                               |              97.244|
|com.hazelcast.jet.mongodb.MongoSourceTest                                                           |              91.743|
|com.hazelcast.jet.kafka.impl.WriteKafkaPTest                                                        |              90.807|
|com.hazelcast.jet.kafka.impl.KafkaDataConnectionStressTest                                          |              85.778|
|com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest                                        |              84.219|
|com.hazelcast.cp.internal.raft.impl.LocalRaftTest                                                   |                79.9|
|com.hazelcast.jet.sql.impl.connector.map.index.JetSqlIndexTest                                      |              79.825|
|com.hazelcast.spi.impl.operationservice.impl.RaftInvocationFailureTest                              |              75.094|
|com.hazelcast.cp.internal.CPGroupRebalanceTest                                                      |              74.869|
|com.hazelcast.client.cp.internal.datastructures.lock.FencedLockClientBasicTest                      |              74.032|
|com.hazelcast.internal.cluster.impl.MembershipFailureTest                                           |               71.04|
|com.hazelcast.client.cp.internal.datastructures.semaphore.SessionAwareSemaphoreClientBasicTest      |              70.959|
|com.hazelcast.cluster.LiteMemberJoinTest                                                            |              69.345|
|com.hazelcast.sql.SqlOrderByTest                                                                    |              68.977|
|com.hazelcast.cp.internal.datastructures.lock.FencedLockBasicTest                                   |              68.025|
|com.hazelcast.cp.internal.datastructures.semaphore.SessionAwareSemaphoreBasicTest                   |              67.459|
|classloading.ThreadLeakClientTest                                                                   |              67.387|
|com.hazelcast.client.cache.CacheClientListenerTest                                                  |              66.495|
|com.hazelcast.connector.Hz3SourcesTest                                                              |              63.871|
|com.hazelcast.client.cp.internal.datastructures.semaphore.SessionlessSemaphoreClientBasicTest       |               63.26|
|com.hazelcast.client.topic.ClientReliableTopicBlockTest                                             |              61.535|
|com.hazelcast.client.io.AdvancedNetworkClientIntegrationTest                                        |              60.435|
|com.hazelcast.spi.impl.operationservice.impl.Invocation_BlockingTest                                |               60.16|

**Changes:**
- Add Javadoc definition to `QuickTest`
- Made `HazelcastSerialClassRunner`/`HazelcastParallelClassRunner` log a warning to `System.err` if `QuickTest` goes above the threshold
   - `testMigrationStats_whenMigrationProcessCompletes is annotated as a QuickTest, expected to complete within 60 seconds - but took 120 seconds`
   - This isn't super obvious outside of Jenkins, and won't go onto the PR etc, but will flag when run locally at least
- Updated the `QuickTest`s to be `SlowTest`s.
   - Some already were, but the `pr-builder` happened to be building a backport to `4.1` when I collected this dataset

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6654
