### PR TITLE
Remove duplicated map serialization code

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/ReplicationOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.cardinality.impl.operations;
 import com.hazelcast.cardinality.impl.CardinalityEstimatorContainer;
 import com.hazelcast.cardinality.impl.CardinalityEstimatorDataSerializerHook;
 import com.hazelcast.cardinality.impl.CardinalityEstimatorService;
+import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -26,8 +27,6 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.io.IOException;
 import java.util.Map;
-
-import static com.hazelcast.internal.util.MapUtil.createHashMap;
 
 public class ReplicationOperation
         extends Operation
@@ -68,21 +67,11 @@ public class ReplicationOperation
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeInt(migrationData.size());
-        for (Map.Entry<String, CardinalityEstimatorContainer> entry : migrationData.entrySet()) {
-            out.writeString(entry.getKey());
-            out.writeObject(entry.getValue());
-        }
+        SerializationUtil.writeMapStringKey(migrationData, out);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        int mapSize = in.readInt();
-        migrationData = createHashMap(mapSize);
-        for (int i = 0; i < mapSize; i++) {
-            String name = in.readString();
-            CardinalityEstimatorContainer newCont = in.readObject();
-            migrationData.put(name, newCont);
-        }
+        migrationData = SerializationUtil.readMapStringKey(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractWanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractWanPublisherConfig.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -125,12 +126,7 @@ public abstract class AbstractWanPublisherConfig implements IdentifiedDataSerial
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        int size = properties.size();
-        out.writeInt(size);
-        for (Map.Entry<String, Comparable> entry : properties.entrySet()) {
-            out.writeString(entry.getKey());
-            out.writeObject(entry.getValue());
-        }
+        SerializationUtil.writeMapStringKey(properties, out);
         out.writeString(className);
         out.writeObject(implementation);
         out.writeString(publisherId);

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
+import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -145,12 +146,7 @@ public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeString(className);
-
-        out.writeInt(properties.size());
-        for (Map.Entry<String, Comparable> entry : properties.entrySet()) {
-            out.writeString(entry.getKey());
-            out.writeObject(entry.getValue());
-        }
+        SerializationUtil.writeMapStringKey(properties, out);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.config.ConfigDataSerializerHook;
+import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -170,12 +171,7 @@ public class WanConsumerConfig implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        int size = properties.size();
-        out.writeInt(size);
-        for (Map.Entry<String, Comparable> entry : properties.entrySet()) {
-            out.writeString(entry.getKey());
-            out.writeObject(entry.getValue());
-        }
+        SerializationUtil.writeMapStringKey(properties, out);
         out.writeString(className);
         out.writeObject(implementation);
         out.writeBoolean(persistWanReplicatedData);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.PartitionGroupConfig;
+import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -28,7 +29,6 @@ import java.util.Map;
 
 import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_COUNT;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
-import static com.hazelcast.internal.util.MapUtil.createHashMap;
 
 /**
  * Contains enough information about Hazelcast Config to do a validation check so that clusters with different configurations
@@ -170,17 +170,8 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
             out.writeString(entry.getValue());
         }
 
-        out.writeInt(maps.size());
-        for (Map.Entry<String, Object> entry : maps.entrySet()) {
-            out.writeString(entry.getKey());
-            out.writeObject(entry.getValue());
-        }
-
-        out.writeInt(queues.size());
-        for (Map.Entry<String, Object> entry : queues.entrySet()) {
-            out.writeString(entry.getKey());
-            out.writeObject(entry.getValue());
-        }
+        SerializationUtil.writeMapStringKey(maps, out);
+        SerializationUtil.writeMapStringKey(queues, out);
     }
 
     @Override
@@ -196,13 +187,8 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
                 ignore(ignored);
             }
         }
-        int propSize = in.readInt();
-        properties = createHashMap(propSize);
-        for (int k = 0; k < propSize; k++) {
-            String key = in.readString();
-            String value = in.readString();
-            properties.put(key, value);
-        }
+
+        properties = SerializationUtil.readMap(in);
 
         int mapSize = in.readInt();
         for (int k = 0; k < mapSize; k++) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static com.hazelcast.spi.properties.ClusterProperty.PARTITION_COUNT;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
+import static com.hazelcast.internal.util.MapUtil.createHashMap;
 
 /**
  * Contains enough information about Hazelcast Config to do a validation check so that clusters with different configurations
@@ -187,8 +188,13 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
                 ignore(ignored);
             }
         }
-
-        properties = SerializationUtil.readMap(in);
+        int propSize = in.readInt();
+        properties = createHashMap(propSize);
+        for (int k = 0; k < propSize; k++) {
+            String key = in.readString();
+            String value = in.readString();
+            properties.put(key, value);
+        }
 
         int mapSize = in.readInt();
         for (int k = 0; k < mapSize; k++) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/crdt/AbstractCRDTReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/crdt/AbstractCRDTReplicationOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.crdt;
 
 import com.hazelcast.internal.partition.MigrationCycleOperation;
+import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -24,9 +25,6 @@ import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Map.Entry;
-
-import static com.hazelcast.internal.util.MapUtil.createHashMap;
 
 /**
  * Base class for CRDT replication operations. It supports replicating a
@@ -78,21 +76,11 @@ public abstract class AbstractCRDTReplicationOperation<T extends IdentifiedDataS
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeInt(replicationData.size());
-        for (Entry<String, T> entry : replicationData.entrySet()) {
-            out.writeString(entry.getKey());
-            out.writeObject(entry.getValue());
-        }
+        SerializationUtil.writeMapStringKey(replicationData, out);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        final int mapSize = in.readInt();
-        replicationData = createHashMap(mapSize);
-        for (int i = 0; i < mapSize; i++) {
-            final String name = in.readString();
-            final T crdt = in.readObject();
-            replicationData.put(name, crdt);
-        }
+        replicationData = SerializationUtil.readMap(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/crdt/AbstractCRDTReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/crdt/AbstractCRDTReplicationOperation.java
@@ -81,6 +81,6 @@ public abstract class AbstractCRDTReplicationOperation<T extends IdentifiedDataS
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        replicationData = SerializationUtil.readMap(in);
+        replicationData = SerializationUtil.readMapStringKey(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -220,6 +220,19 @@ public final class SerializationUtil {
         assert size == k : "Map has been updated during serialization! Initial size: " + size + ", written size: " + k;
     }
 
+    public static <V> void writeMapStringKey(@Nonnull Map<String, V> map, ObjectDataOutput out) throws IOException {
+        int size = map.size();
+        out.writeInt(size);
+
+        int k = 0;
+        for (Map.Entry<String, V> entry : map.entrySet()) {
+            out.writeString(entry.getKey());
+            out.writeObject(entry.getValue());
+            k++;
+        }
+        assert size == k : "Map has been updated during serialization! Initial size: " + size + ", written size: " + k;
+    }
+
     /**
      * Reads a map written by {@link #writeNullableMap(Map, ObjectDataOutput)}. The map itself
      * may be {@code null}. No guarantee is provided about the type of Map returned or its suitability
@@ -246,6 +259,18 @@ public final class SerializationUtil {
         Map<K, V> map = createHashMap(size);
         for (int i = 0; i < size; i++) {
             K key = in.readObject();
+            V value = in.readObject();
+            map.put(key, value);
+        }
+        return map;
+    }
+
+    @Nonnull
+    public static <V> Map<String, V> readMapStringKey(ObjectDataInput in) throws IOException {
+        int size = in.readInt();
+        Map<String, V> map = createHashMap(size);
+        for (int i = 0; i < size; i++) {
+            String key = in.readString();
             V value = in.readObject();
             map.put(key, value);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/AbstractMapStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/defaultserializers/AbstractMapStreamSerializer.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization.impl.defaultserializers;
 
+import com.hazelcast.internal.serialization.impl.SerializationUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.StreamSerializer;
@@ -30,15 +31,7 @@ abstract class AbstractMapStreamSerializer<MapType extends Map> implements Strea
 
     @Override
     public void write(ObjectDataOutput out, MapType map) throws IOException {
-        int size = map.size();
-        out.writeInt(size);
-        if (size > 0) {
-            for (Object entryObject : map.entrySet()) {
-                Map.Entry entry = (Map.Entry) entryObject;
-                out.writeObject(entry.getKey());
-                out.writeObject(entry.getValue());
-            }
-        }
+        SerializationUtil.writeMap(map, out);
     }
 
     MapType deserializeEntries(ObjectDataInput in, int size, MapType result) throws IOException {


### PR DESCRIPTION
`SerializationUtil` contains a utility method to deser a map with `Object` keys, by deser it's size and then entry contents.

An identical scenario occurs for maps with `String` keys, but this implementation is duplicated across the system - I've changed this so it's centralised also.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6658