### PR TITLE
Increase k8s test suite timeout

### DIFF
--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -101,4 +101,5 @@ jobs:
       - name: Run Tests
         working-directory: auto-discovery-suite/terraform/test
         run: |
-          go test -v -timeout 20m -run TestSuite -suite ${{ matrix.suite }} -member-image ${{ needs.build.outputs.HZ_IMG }} -client-image ${{ needs.build.outputs.CL_IMG }}
+          go test -v -timeout 60m -run TestSuite -suite ${{ matrix.suite }} -member-image ${{ needs.build.outputs.HZ_IMG }} 
+          -client-image ${{ needs.build.outputs.CL_IMG }}


### PR DESCRIPTION
Increase k8s test suite timeout

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
