### PR TITLE
Bump elasticsearch version to 7.17.13 [5.1.z]

### DIFF
--- a/extensions/elasticsearch/elasticsearch-7/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-7/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>7.16.3</version>
+            <version>7.17.13</version>
         </dependency>
 
         <!-- TEST -->


### PR DESCRIPTION
Backport of: #25660

Fixes #25596 in `5.1.z` branch.

<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.pinpointhq.com/
-->




