### PR TITLE
Fix global index destruction [HZ-3218] 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -58,7 +58,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -311,29 +310,6 @@ public class MapContainer {
     // Only used for testing
     public ConcurrentMap<Integer, IndexRegistry> getPartitionedIndexRegistry() {
         return partitionedIndexRegistry;
-    }
-
-    @SuppressWarnings("squid:S1751")
-    public void consumeIndexConfigs(Consumer<IndexConfig> consumer) {
-        // 1. Add from global-indexes
-        if (globalIndexRegistry != null) {
-            add(consumer, globalIndexRegistry);
-            return;
-        }
-
-        // 2. Add from partitioned-indexes
-        for (IndexRegistry entry : partitionedIndexRegistry.values()) {
-            add(consumer, entry);
-            break;
-        }
-    }
-
-    private void add(Consumer<IndexConfig> consumer, IndexRegistry indexRegistry) {
-        InternalIndex[] indexes = indexRegistry.getIndexes();
-        for (int i = 0; i < indexes.length; i++) {
-            IndexConfig config = indexes[i].getConfig();
-            consumer.accept(config);
-        }
     }
 
     // Only used for testing

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -74,6 +74,7 @@ import com.hazelcast.partition.PartitioningStrategy;
 import com.hazelcast.query.impl.DefaultIndexProvider;
 import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.IndexProvider;
+import com.hazelcast.query.impl.IndexRegistry;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
 import com.hazelcast.spi.impl.NodeEngine;
@@ -462,10 +463,15 @@ class MapServiceContextImpl implements MapServiceContext {
         // Statistics are destroyed after container to prevent their leak.
         destroyPartitionsAndMapContainer(mapContainer);
         if (mapContainer.isGlobalIndexEnabled()) {
-            mapContainer.getGlobalIndexRegistry().destroyIndexes();
+            destroyGlobalIndexes(mapContainer);
         }
 
         localMapStatsProvider.destroyLocalMapStatsImpl(mapContainer.getName());
+    }
+
+    protected void destroyGlobalIndexes(MapContainer mapContainer) {
+        IndexRegistry indexRegistry = mapContainer.getGlobalIndexRegistry();
+        indexRegistry.destroyIndexes();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -461,6 +461,10 @@ class MapServiceContextImpl implements MapServiceContext {
 
         // Statistics are destroyed after container to prevent their leak.
         destroyPartitionsAndMapContainer(mapContainer);
+        if (mapContainer.isGlobalIndexEnabled()) {
+            mapContainer.getGlobalIndexRegistry().destroyIndexes();
+        }
+
         localMapStatsProvider.destroyLocalMapStatsImpl(mapContainer.getName());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
@@ -72,7 +72,7 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
 
     private static final int BOOK_COUNT = 1000;
 
-    private String mapName = randomMapName();
+    private final String mapName = randomMapName();
 
     @Override
     protected Config getConfig() {


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/6507

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/6684

Destruction of global indexes must be done one time and at the end of the destroy flow. Currently it is destroyed inside partitions and if a later partition wants to clear data from global index it couldn't find it alive(since it has been disposed early)