### PR TITLE
Use new maven coordinates for wiremock-standalone

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -801,7 +801,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
             <version>${wiremock.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
The maven artifact has new maven coordinates.

This PR uses new coordinates, and removes the following warning from logs:

```
[WARNING] The artifact com.github.tomakehurst:wiremock-standalone:jar:3.0.1 has been relocated to org.wiremock:wiremock-standalone:jar:3.0.1
```

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
