### PR TITLE
Check unsupported config when ts is enabled [HZ-3503]

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlOrderByTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/SqlOrderByTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.sql.SqlRowMetadata;
 import com.hazelcast.test.HazelcastParametrizedRunner;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -136,7 +137,11 @@ public class SqlOrderByTest extends HazelcastTestSupport {
 
     @Before
     public void before() {
-        members = createHazelcastInstances(memberConfig(), membersCount);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        members = new HazelcastInstance[membersCount];
+        for (int i = 0; i < membersCount; i++) {
+            members[i] = factory.newHazelcastInstance(memberConfig());
+        }
 
         if (isPortable()) {
             createMapping(members[0], mapName(), PORTABLE_FACTORY_ID, PORTABLE_KEY_CLASS_ID, 0, PORTABLE_FACTORY_ID, PORTABLE_VALUE_CLASS_ID, 0);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/SqlIndexAbstractTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/index/SqlIndexAbstractTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.sql.impl.connector.map.index;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
+import com.hazelcast.config.Config;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
 import com.hazelcast.config.MapConfig;
@@ -115,7 +116,15 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
 
     @BeforeClass
     public static void beforeClass() {
-        initialize(DEFAULT_MEMBERS_COUNT, null);
+        Config config = smallInstanceConfig();
+
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setName("map*")
+                .setBackupCount(0);
+
+        config.addMapConfig(mapConfig);
+
+        initialize(DEFAULT_MEMBERS_COUNT, config);
     }
 
     @Before
@@ -124,9 +133,9 @@ public abstract class SqlIndexAbstractTest extends SqlIndexTestSupport {
         valueClass = ExpressionBiValue.createBiClass(f1, f2);
 
         createMapping(mapName, int.class, valueClass);
-        MapConfig mapConfig = getMapConfig();
-        instance().getConfig().addMapConfig(mapConfig);
         map = instance().getMap(mapName);
+        map.addIndex(getIndexConfig());
+
         fill();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -65,6 +65,7 @@ import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.InstanceTrackingConfig;
 import com.hazelcast.config.IntegrityCheckerConfig;
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.ManagementCenterConfig;
@@ -134,6 +135,11 @@ public class ClientDynamicClusterConfig extends Config {
 
     @Override
     public Config addMapConfig(MapConfig mapConfig) {
+        if (mapConfig.getTieredStoreConfig().isEnabled()) {
+            throw new InvalidConfigurationException("Tiered store enabled map config"
+                    + " cannot be added dynamically [" + mapConfig + "]");
+        }
+
         List<ListenerConfigHolder> listenerConfigs = adaptListenerConfigs(mapConfig.getEntryListenerConfigs());
         List<ListenerConfigHolder> partitionLostListenerConfigs =
                 adaptListenerConfigs(mapConfig.getPartitionLostListenerConfigs());

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -267,6 +267,10 @@ public class DynamicConfigurationAwareConfig extends Config {
         boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getMapConfigs(),
                 mapConfig.getName(), mapConfig);
         if (staticConfigDoesNotExist) {
+            if (mapConfig.getTieredStoreConfig().isEnabled()) {
+                throw new InvalidConfigurationException("Tiered store enabled map config"
+                        + " cannot be added dynamically [" + mapConfig + "]");
+            }
             configurationService.broadcastConfig(mapConfig);
         }
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -51,7 +51,7 @@ class MapRemoteService implements RemoteService {
         MapConfig mapConfig = config.findMapConfig(name);
         SplitBrainMergePolicyProvider mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
 
-        checkMapConfig(mapConfig, config.getNativeMemoryConfig(), mergePolicyProvider
+        checkMapConfig(config, mapConfig, mergePolicyProvider
         );
 
         if (mapConfig.isNearCacheEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -51,8 +51,8 @@ class MapRemoteService implements RemoteService {
         MapConfig mapConfig = config.findMapConfig(name);
         SplitBrainMergePolicyProvider mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
 
-        checkMapConfig(mapConfig, config.getNativeMemoryConfig(), mergePolicyProvider,
-                mapServiceContext.getNodeEngine().getProperties(), nodeEngine.getLogger(MapConfig.class));
+        checkMapConfig(mapConfig, config.getNativeMemoryConfig(), mergePolicyProvider
+        );
 
         if (mapConfig.isNearCacheEnabled()) {
             checkNearCacheConfig(name, mapConfig.getNearCacheConfig(), config.getNativeMemoryConfig(), false);

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -79,18 +79,18 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
 
     @Test
     public void checkMapConfig_BINARY() {
-        checkMapConfig(getMapConfig(BINARY), nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
+        checkMapConfig(getMapConfig(BINARY), nativeMemoryConfig, splitBrainMergePolicyProvider);
     }
 
     @Test(expected = InvalidConfigurationException.class)
     public void checkMapConfig_fails_with_merge_policy_which_requires_per_entry_stats_enabled() {
         checkMapConfig(getMapConfig(BINARY).setPerEntryStatsEnabled(false),
-                nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
+                nativeMemoryConfig, splitBrainMergePolicyProvider);
     }
 
     @Test
     public void checkMapConfig_OBJECT() {
-        checkMapConfig(getMapConfig(OBJECT), nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
+        checkMapConfig(getMapConfig(OBJECT), nativeMemoryConfig, splitBrainMergePolicyProvider);
     }
 
     /**
@@ -98,7 +98,7 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
      */
     @Test(expected = InvalidConfigurationException.class)
     public void checkMapConfig_NATIVE() {
-        checkMapConfig(getMapConfig(NATIVE), nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
+        checkMapConfig(getMapConfig(NATIVE), nativeMemoryConfig, splitBrainMergePolicyProvider);
     }
 
     /**
@@ -106,7 +106,7 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
      */
     @Test(expected = InvalidConfigurationException.class)
     public void checkMapConfig_TieredStore() {
-        checkMapConfig(getMapConfig(true), nativeMemoryConfig, splitBrainMergePolicyProvider, properties, logger);
+        checkMapConfig(getMapConfig(true), nativeMemoryConfig, splitBrainMergePolicyProvider);
     }
 
     private MapConfig getMapConfig(InMemoryFormat inMemoryFormat) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -25,11 +25,9 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.merge.HigherHitsMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
-import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -53,23 +51,16 @@ import static org.mockito.Mockito.when;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ConfigValidatorTest extends HazelcastTestSupport {
 
-    private HazelcastProperties properties;
-    private NativeMemoryConfig nativeMemoryConfig;
     private SplitBrainMergePolicyProvider splitBrainMergePolicyProvider;
-    private ILogger logger;
 
     @Before
     public void setUp() {
         Config config = new Config();
-        nativeMemoryConfig = config.getNativeMemoryConfig();
         NodeEngine nodeEngine = Mockito.mock(NodeEngine.class);
         when(nodeEngine.getConfigClassLoader()).thenReturn(config.getClassLoader());
 
         splitBrainMergePolicyProvider = new SplitBrainMergePolicyProvider(config.getClassLoader());
         when(nodeEngine.getSplitBrainMergePolicyProvider()).thenReturn(splitBrainMergePolicyProvider);
-
-        properties = nodeEngine.getProperties();
-        logger = nodeEngine.getLogger(MapConfig.class);
     }
 
     @Test
@@ -79,18 +70,18 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
 
     @Test
     public void checkMapConfig_BINARY() {
-        checkMapConfig(getMapConfig(BINARY), nativeMemoryConfig, splitBrainMergePolicyProvider);
+        checkMapConfig(new Config(), getMapConfig(BINARY), splitBrainMergePolicyProvider);
     }
 
     @Test(expected = InvalidConfigurationException.class)
     public void checkMapConfig_fails_with_merge_policy_which_requires_per_entry_stats_enabled() {
-        checkMapConfig(getMapConfig(BINARY).setPerEntryStatsEnabled(false),
-                nativeMemoryConfig, splitBrainMergePolicyProvider);
+        checkMapConfig(new Config(), getMapConfig(BINARY).setPerEntryStatsEnabled(false),
+                splitBrainMergePolicyProvider);
     }
 
     @Test
     public void checkMapConfig_OBJECT() {
-        checkMapConfig(getMapConfig(OBJECT), nativeMemoryConfig, splitBrainMergePolicyProvider);
+        checkMapConfig(new Config(), getMapConfig(OBJECT), splitBrainMergePolicyProvider);
     }
 
     /**
@@ -98,7 +89,7 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
      */
     @Test(expected = InvalidConfigurationException.class)
     public void checkMapConfig_NATIVE() {
-        checkMapConfig(getMapConfig(NATIVE), nativeMemoryConfig, splitBrainMergePolicyProvider);
+        checkMapConfig(new Config(), getMapConfig(NATIVE), splitBrainMergePolicyProvider);
     }
 
     /**
@@ -106,7 +97,7 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
      */
     @Test(expected = InvalidConfigurationException.class)
     public void checkMapConfig_TieredStore() {
-        checkMapConfig(getMapConfig(true), nativeMemoryConfig, splitBrainMergePolicyProvider);
+        checkMapConfig(new Config(), getMapConfig(true), splitBrainMergePolicyProvider);
     }
 
     private MapConfig getMapConfig(InMemoryFormat inMemoryFormat) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -41,6 +41,7 @@ import com.hazelcast.config.HotRestartConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
@@ -104,6 +105,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -478,6 +480,19 @@ public class DynamicConfigTest extends HazelcastTestSupport {
 
         assertConfigurationsEqualOnAllMembers(config);
         assertConfigurationsEqualOnAllMembers(reordered);
+    }
+
+    @Test
+    public void testMapConfig_throws_InvalidConfigurationException_when_tiered_store_enabled() {
+        MapConfig config = getMapConfig();
+
+        config.getTieredStoreConfig().setEnabled(true);
+
+        InvalidConfigurationException exception = assertThrows(InvalidConfigurationException.class,
+                () -> driver.getConfig().addMapConfig(config));
+
+        assertTrue(exception.getMessage().contains("Tiered store enabled map config cannot be added dynamically"));
+
     }
 
     @Test


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/6674

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/6685

**Modifications:**
- Add fail-fast behavior for unsupported configs when tstore is configured for IMap.These unsupported configs are eviction, expiry and in-memory-format configs