### PR TITLE
Revert MongoDB Driver version, due to a bug with field nullability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <spring.version>4.3.0.RELEASE</spring.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <snakeyaml.engine.version>2.7</snakeyaml.engine.version>
-        <mongodb.version>4.11.0</mongodb.version>
+        <mongodb.version>4.10.2</mongodb.version>
 
         <!-- test dependencies -->
         <activemq-artemis.version>2.31.0</activemq-artemis.version>


### PR DESCRIPTION
Fixes [hazelcast-enterprise#6646](https://github.com/hazelcast/hazelcast-enterprise/issues/6646)

Reverts https://github.com/hazelcast/hazelcast/pull/25684

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
