### PR TITLE
Mongo operationType NPE prevention

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/SelectProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/mongodb/SelectProcessorSupplier.java
@@ -182,7 +182,7 @@ public class SelectProcessorSupplier extends MongoProcessorSupplier implements D
                 row[index] = fromDoc;
             }
         }
-        addIfInProjection(changeStreamDocument.getOperationType().getValue(), "operationType", row);
+        addIfInProjection(changeStreamDocument.getOperationTypeString(), "operationType", row);
         addIfInProjection(changeStreamDocument.getResumeToken().toString(), "resumeToken", row);
         addIfInProjection(LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), systemDefault()), "ts", row);
         addIfInProjection(bsonDateTimeToLocalDateTime(changeStreamDocument.getWallTime()), "wallTime", row);


### PR DESCRIPTION
This field should never be null for us, but as practice shows, bugs happens ;) This improves NPE-resistance. 

Related to https://github.com/hazelcast/hazelcast-enterprise/issues/6646

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Label `Add to Release Notes` or `Not Release Notes content` set
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases