### PR TITLE
Refactor `ClusterWideConfigurationService` to reduce duplication of configuration declarations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -139,11 +139,14 @@ public class ClusterWideConfigurationService implements
         CONFIG_TO_VERSION = Collections.unmodifiableMap(configToVersion);
     }
 
-    public ClusterWideConfigurationService(NodeEngine nodeEngine, DynamicConfigListener dynamicConfigListener) {
+    public ClusterWideConfigurationService(
+            NodeEngine nodeEngine,
+            DynamicConfigListener dynamicConfigListener
+    ) {
         this.nodeEngine = nodeEngine;
-        listener = dynamicConfigListener;
-        configPatternMatcher = nodeEngine.getConfig().getConfigPatternMatcher();
-        logger = nodeEngine.getLogger(getClass());
+        this.listener = dynamicConfigListener;
+        this.configPatternMatcher = nodeEngine.getConfig().getConfigPatternMatcher();
+        this.logger = nodeEngine.getLogger(getClass());
     }
 
     @Override


### PR DESCRIPTION
While trying to add a new configuration element to `ClusterWideConfigurationService`, I realised that the new element must be declared in multiple places:

1. `Map`s of `name` -> instances (e.g. `mapConfigs`)
2. `allConfigurations` - an array of every instance of (1)
3. `CONFIG_TO_VERSION` - a `Map` of handles configs and their introduction versions
4. `registerConfigLocally` - a method that, if applicable, adds the instance to (1)
5. The getters for (1) (e.g. `getMapConfigs()`)

I refactored the code to remove the need to update (1) & (2) and simplify (4).

Specifically:
- `allConfigurations` is now a `Map` of `Class` to (1), lazily created as required
- `registerConfigLocally` has had all of the common operations (if it's an `XConfig`, `putIfAbsent` to the `XConfig` `Map)  combined for all types
- The getters now query the map for the specified config class, rather than accessing the field directly
- Refactored `DynamicConfigVersionTest` to be a parameterized JUnit5 test

Pros:
- 15% less LOC
- need to update half as many places when adding new config types
- less repeated code = less chance of duplications getting out of sync

Cons:
- cognitive complexity increase
- the getters accessing via a `Map` will be slower than pure field access, but I hope we don't hit the dynamic config enough for that to be of any significance