### PR TITLE
Clone PN operation on retry

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/crdt/pncounter/PNCounterProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/crdt/pncounter/PNCounterProxy.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static com.hazelcast.internal.crdt.pncounter.PNCounterService.SERVICE_NAME;
+import static com.hazelcast.spi.impl.operationservice.OperationAccessor.cloneAndReset;
 
 /**
  * Member proxy implementation for a {@link PNCounter}.
@@ -199,9 +200,10 @@ public class PNCounterProxy extends AbstractDistributedObject<PNCounterService> 
         } catch (HazelcastException e) {
             logger.fine("Exception occurred while invoking operation on target " + target + ", choosing different target", e);
             if (excludedAddresses == EMPTY_ADDRESS_LIST) {
-                excludedAddresses = new ArrayList<Address>();
+                excludedAddresses = new ArrayList<>();
             }
             excludedAddresses.add(target);
+            operation = cloneAndReset(operation, getNodeEngine().getSerializationService());
             return invokeInternal(operation, excludedAddresses, e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/Operation.java
@@ -385,6 +385,11 @@ public abstract class Operation implements DataSerializable, Tenantable {
         onSetCallId(newId);
     }
 
+    // Accessed using OperationAccessor
+    final void resetCallId() {
+        CALL_ID.set(this, 0);
+    }
+
     /**
      * Called every time a new <code>callId</code> is set on the operation. A new
      * <code>callId</code> is set before initial invocation and before every

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/OperationAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/OperationAccessor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.operationservice;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.server.ServerConnection;
 import com.hazelcast.spi.annotation.PrivateApi;
 
@@ -77,6 +78,21 @@ public final class OperationAccessor {
      */
     public static void setCallTimeout(Operation op, long callTimeout) {
         op.setCallTimeout(callTimeout);
+    }
+
+    /**
+     * Clone and reset the supplied operation.
+     *
+     * @param op the operation to clone and reset.
+     * @param serializationService the serialization service to use for cloning.
+     * @return a clone of the supplied operation, with its invocation time reset
+     * to -1 and its call ID reset to 0.
+     */
+    public static Operation cloneAndReset(Operation op, SerializationService serializationService) {
+        Operation clone = serializationService.toObject(serializationService.toData(op));
+        clone.setInvocationTime(-1);
+        clone.resetCallId();
+        return clone;
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/OperationAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/OperationAccessorTest.java
@@ -34,7 +34,9 @@ import static com.hazelcast.spi.impl.operationservice.OperationAccessor.setCallI
 import static com.hazelcast.spi.impl.operationservice.OperationAccessor.setCallTimeout;
 import static com.hazelcast.spi.impl.operationservice.OperationAccessor.setCallerAddress;
 import static com.hazelcast.spi.impl.operationservice.OperationAccessor.setInvocationTime;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/OperationAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/OperationAccessorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice;
+
+import com.hazelcast.cluster.Address;
+
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.server.ServerConnection;
+import com.hazelcast.spi.impl.operationservice.impl.DummyOperation;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.hazelcast.spi.impl.operationservice.OperationAccessor.deactivate;
+import static com.hazelcast.spi.impl.operationservice.OperationAccessor.setCallId;
+import static com.hazelcast.spi.impl.operationservice.OperationAccessor.setCallTimeout;
+import static com.hazelcast.spi.impl.operationservice.OperationAccessor.setCallerAddress;
+import static com.hazelcast.spi.impl.operationservice.OperationAccessor.setInvocationTime;
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(MockitoJUnitRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class OperationAccessorTest {
+
+    @Mock
+    private ServerConnection serverConnection;
+    @Mock
+    private Address address;
+
+    @Test
+    public void testCloneAndResetOperation() {
+        Operation operation = new DummyOperation();
+
+        setCallId(operation, 1);
+        setInvocationTime(operation, 1000);
+        Operation clone = OperationAccessor.cloneAndReset(operation, new DefaultSerializationServiceBuilder().build());
+        assertEquals(0, clone.getCallId());
+        assertEquals(-1, clone.getInvocationTime());
+    }
+
+    @Test
+    public void testSetCallId() {
+        Operation operation = new DummyOperation();
+        setCallId(operation, 10);
+        assertEquals(10, operation.getCallId());
+    }
+
+    @Test
+    public void testSetInvocationTime() {
+        Operation operation = new DummyOperation();
+        setInvocationTime(operation, 10);
+        assertEquals(10, operation.getInvocationTime());
+    }
+
+    @Test
+    public void testSetCallerAddress() {
+        Operation operation = new DummyOperation();
+        setCallerAddress(operation, address);
+        assertEquals(address, operation.getCallerAddress());
+    }
+
+    @Test
+    public void testDeactivate() {
+        Operation operation = new DummyOperation();
+        setCallId(operation, 10);
+        assertTrue(deactivate(operation));
+        assertFalse(operation.isActive());
+    }
+
+    @Test
+    public void testSetCallTimeout() {
+        Operation operation = new DummyOperation();
+        setCallTimeout(operation, 10);
+        assertEquals(10, operation.getCallTimeout());
+    }
+
+    @Test
+    public void testSetConnection() {
+        Operation operation = new DummyOperation();
+        OperationAccessor.setConnection(operation, serverConnection);
+        assertEquals(serverConnection, operation.getConnection());
+    }
+}


### PR DESCRIPTION
This change ensures that PNCounter operations that are retried due to any operation are cloned and reset with a fresh callId and invocation time. 

The original test issues related to an unidentified and highly subtle race condition. It was agreed that it would not be worth allocating further time to tracking down the root cause of the race condition, given it has not been possible to reproduce and sufficient investigation time has already been spent - this fix fully prevents the error from occurring. 

Change also adds some missing test coverage for the class `OperationAccessor`

Fixes #23203 #25106 

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Label `Add to Release Notes` or `Not Release Notes content` set
- [X] Request reviewers if possible