### PR TITLE
Update pull request template format

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,8 +20,8 @@ Breaking changes (list specific methods/types/messages):
 
 Checklist:
 - [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
-- [ ] Label `Add to Release Notes` or `Not Release Notes content` set
+- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
 - [ ] Request reviewers if possible
-- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
 - [ ] New public APIs have `@Nonnull/@Nullable` annotations
 - [ ] New public APIs have `@since` tags in Javadoc
+- [ ] Send backports/forwardports if fix needs to be applied to past/future releases


### PR DESCRIPTION
Minor updates to the PR templates to unify the format between OS & EE (for all us OCD lovers out there). I preferred the format of OS, so most of the changes are for the EE template. Only formatting changes, no content affecting changes.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6688