### PR TITLE
Bump everit-json-schema to mitigate CVE-2023-5072 [HZ-3518] [5.3.3]

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -513,7 +513,7 @@
         <dependency>
             <groupId>com.github.erosb</groupId>
             <artifactId>everit-json-schema</artifactId>
-            <version>1.14.2</version>
+            <version>1.14.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.re2j</groupId>


### PR DESCRIPTION
so it depends on an `org.json:json` version that is not vulnerable to https://github.com/advisories/GHSA-rm7j-f5g5-27vv

Fixes #25768 in 5.3.3 branch.

 - [x] Backport to 5.3.z, 5.2.z & 5.1.z 