### PR TITLE
Bump everit-json-schema to mitigate CVE-2023-5072 [HZ-3518] [5.1.z]

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -489,7 +489,7 @@
         <dependency>
             <groupId>com.github.erosb</groupId>
             <artifactId>everit-json-schema</artifactId>
-            <version>1.14.2</version>
+            <version>1.14.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.re2j</groupId>


### PR DESCRIPTION
(cherry picked from commit f172031d59b1b9ead31b1e3c371f9f7650c18572)

Fixes https://github.com/hazelcast/hazelcast/issues/25768

Forward port of https://github.com/hazelcast/hazelcast/pull/25739