### PR TITLE
Introduce ImmutableLazyEntry [HZ-2703]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalFunctions.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalFunctions.java
@@ -18,8 +18,8 @@ package com.hazelcast.cache.impl.journal;
 
 import com.hazelcast.cache.CacheEventType;
 import com.hazelcast.cache.EventJournalCacheEvent;
-import com.hazelcast.internal.journal.DeserializingEntry;
 import com.hazelcast.internal.serialization.SerializableByConvention;
+import com.hazelcast.internal.util.collection.ImmutableLazyEntry;
 
 import java.io.Serializable;
 import java.util.Map.Entry;
@@ -65,7 +65,11 @@ public final class CacheEventJournalFunctions {
         @Override
         public Entry<K, V> apply(EventJournalCacheEvent<K, V> e) {
             DeserializingEventJournalCacheEvent<K, V> casted = (DeserializingEventJournalCacheEvent<K, V>) e;
-            return new DeserializingEntry<K, V>(casted.getDataKey(), casted.getDataNewValue());
+            return new ImmutableLazyEntry<>(
+                    casted.getDataKey(),
+                    casted.getDataNewValue(),
+                    casted.getSerializationService()
+            );
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserializingEventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserializingEventJournalCacheEvent.java
@@ -99,4 +99,8 @@ public class DeserializingEventJournalCacheEvent<K, V>
     public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
         serializationService = ((SerializationServiceSupport) hazelcastInstance).getSerializationService();
     }
+
+    public SerializationService getSerializationService() {
+        return serializationService;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ImmutableLazyEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ImmutableLazyEntry.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
+
+import java.io.IOException;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+/**
+ * Implementation of {@link Entry} which lazily deserializes keyData and valueData on access.
+ * This class is not thread-safe.
+ * <p>
+ * @param <K> key
+ * @param <V> value
+ */
+public final class ImmutableLazyEntry<K, V> implements Entry<K, V>, HazelcastInstanceAware, IdentifiedDataSerializable {
+
+    private Data keyData;
+    private Data valueData;
+
+    private transient K key;
+    private transient V value;
+    private transient SerializationService serializationService;
+
+    ImmutableLazyEntry() {
+    }
+
+    public ImmutableLazyEntry(Data keyData, Data valueData, SerializationService serializationService) {
+        this.keyData = keyData;
+        this.valueData = valueData;
+        this.serializationService = serializationService;
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        serializationService = ((SerializationServiceSupport) hazelcastInstance).getSerializationService();
+    }
+
+    @Override
+    public K getKey() {
+        if (key == null && keyData != null) {
+            key = serializationService.toObject(keyData);
+        }
+        return key;
+    }
+
+    public Data getKeyData() {
+        return keyData;
+    }
+
+    @Override
+    public V getValue() {
+        if (value == null && valueData != null) {
+            value = serializationService.toObject(valueData);
+        }
+        return value;
+    }
+
+    @Override
+    public V setValue(V value) {
+        throw new UnsupportedOperationException(
+                "ImmutableLazyEntry does not support setValue, create a new Map.Entry instead."
+        );
+    }
+
+    public Data getValueData() {
+        return valueData;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return UtilCollectionSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return UtilCollectionSerializerHook.IMMUTABLE_LAZY_ENTRY;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        IOUtil.writeData(out, keyData);
+        IOUtil.writeData(out, valueData);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        keyData = IOUtil.readData(in);
+        valueData = IOUtil.readData(in);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof ImmutableLazyEntry) {
+            ImmutableLazyEntry<?, ?> that = (ImmutableLazyEntry<?, ?>) o;
+            return Objects.equals(keyData, that.keyData) && Objects.equals(valueData, that.valueData);
+        } else if (o instanceof Entry) {
+            Entry<?, ?> that = (Entry<?, ?>) o;
+            return Objects.equals(getKey(), that.getKey()) && Objects.equals(getValue(), that.getValue());
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keyData, valueData);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/UtilCollectionSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/UtilCollectionSerializerHook.java
@@ -29,6 +29,7 @@ public class UtilCollectionSerializerHook implements DataSerializerHook {
 
     public static final int PARTITION_ID_SET = 1;
     public static final int IMMUTABLE_PARTITION_ID_SET = 2;
+    public static final int IMMUTABLE_LAZY_ENTRY = 3;
 
     @Override
     public int getFactoryId() {
@@ -42,6 +43,8 @@ public class UtilCollectionSerializerHook implements DataSerializerHook {
                     return new PartitionIdSet();
                 case IMMUTABLE_PARTITION_ID_SET:
                     return new ImmutablePartitionIdSet();
+                case IMMUTABLE_LAZY_ENTRY:
+                    return new ImmutableLazyEntry<>();
                 default:
                     throw new IllegalArgumentException("Undefined type: " + typeId);
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/DeserializingEventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/DeserializingEventJournalMapEvent.java
@@ -98,4 +98,8 @@ public class DeserializingEventJournalMapEvent<K, V>
     public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
         serializationService = ((SerializationServiceSupport) hazelcastInstance).getSerializationService();
     }
+
+    public SerializationService getSerializationService() {
+        return serializationService;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalFunctions.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalFunctions.java
@@ -17,8 +17,8 @@
 package com.hazelcast.map.impl.journal;
 
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.internal.journal.DeserializingEntry;
 import com.hazelcast.internal.serialization.SerializableByConvention;
+import com.hazelcast.internal.util.collection.ImmutableLazyEntry;
 import com.hazelcast.map.EventJournalMapEvent;
 
 import java.io.Serializable;
@@ -65,7 +65,11 @@ public final class MapEventJournalFunctions {
         @Override
         public Entry<K, V> apply(EventJournalMapEvent<K, V> e) {
             DeserializingEventJournalMapEvent<K, V> casted = (DeserializingEventJournalMapEvent<K, V>) e;
-            return new DeserializingEntry<>(casted.getDataKey(), casted.getDataNewValue());
+            return new ImmutableLazyEntry<>(
+                    casted.getDataKey(),
+                    casted.getDataNewValue(),
+                    casted.getSerializationService()
+            );
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/ImmutableLazyEntryEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/ImmutableLazyEntryEqualsTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class ImmutableLazyEntryEqualsTest {
+
+    @Test
+    public void equals() {
+        EqualsVerifier.simple()
+                      .forClass(ImmutableLazyEntry.class)
+                      .verify();
+
+    }
+}


### PR DESCRIPTION
Add ImmutableLazyEntry which considers its keys and values immutable and avoids deserialization when the key or value is not accessed. When serializing it re-uses already serialized Data.

It is important that the key and value are immutable - any modifications of the value will not be reflected in the serialized version.

The class is similar to
`com.hazelcast.internal.journal.DeserializingEntry` and `com.hazelcast.map.impl.LazyMapEntry`, but provides a smaller set of interfaces, and the behaviour for ser/de is different.

Breaking changes (list specific methods/types/messages):
* Entry returned from some APIs does not support some operations - `Entry#setValue` is not supported
* Modifications to the entry key/value are not reflected in the serialized form

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
