### PR TITLE
Ensure `Config.loadFromFile(Properties)` closes stream

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -402,19 +402,23 @@ public class Config {
         checkTrue(properties != null, "properties can't be null");
 
         String path = configFile.getPath();
-        InputStream stream = new FileInputStream(configFile);
-        if (path.endsWith(".xml")) {
-            return applyEnvAndSystemVariableOverrides(
-                    new XmlConfigBuilder(stream).setProperties(properties).build().setConfigurationFile(configFile)
-            );
-        }
-        if (path.endsWith(".yaml") || path.endsWith(".yml")) {
-            return applyEnvAndSystemVariableOverrides(
-                    new YamlConfigBuilder(stream).setProperties(properties).build().setConfigurationFile(configFile)
-            );
-        }
+        try (InputStream stream = new FileInputStream(configFile)) {
+            final Config config;
 
-        throw new IllegalArgumentException("Unknown configuration file extension");
+            if (path.endsWith(".xml")) {
+                config = new XmlConfigBuilder(stream).setProperties(properties).build();
+            } else if (path.endsWith(".yaml") || path.endsWith(".yml")) {
+                config = new YamlConfigBuilder(stream).setProperties(properties).build();
+            } else {
+                throw new IllegalArgumentException("Unknown configuration file extension");
+            }
+
+            return applyEnvAndSystemVariableOverrides(config.setConfigurationFile(configFile));
+        } catch (FileNotFoundException e) {
+            throw e;
+        } catch (IOException e) {
+            throw ExceptionUtil.sneakyThrow(e);
+        }
     }
 
     /**


### PR DESCRIPTION
The `FileInputStream` in this method is never closed.

I think the impact of this is low - I was **unable** to reproduce file handles being left open with the following:
```
Config.loadFromFile(Paths.get(getClass().getClassLoader().getResource("test-hazelcast.xml").toURI()).toFile());    
System.out.println(new Scanner(Runtime.getRuntime().exec("lsof").getInputStream()).useDelimiter("\\A").next());
```