### PR TITLE
Kubernetes Plugin throws NullPointerException when LoadBalancer address is empty [CN-1040]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -521,15 +521,19 @@ class KubernetesClient {
     }
 
     private static String extractLoadBalancerAddress(JsonObject serviceResponse) {
-        JsonObject ingress = serviceResponse
-                .get("status").asObject()
-                .get("loadBalancer").asObject()
-                .get("ingress").asArray().get(0).asObject();
-        JsonValue address = ingress.get("ip");
-        if (address == null) {
-            address = ingress.get("hostname");
+        try {
+            JsonObject ingress = serviceResponse
+                    .get("status").asObject()
+                    .get("loadBalancer").asObject()
+                    .get("ingress").asArray().get(0).asObject();
+            JsonValue address = ingress.get("ip");
+            if (address == null) {
+                address = ingress.get("hostname");
+            }
+            return address.asString();
+        } catch (Exception e) {
+            throw new KubernetesClientException("Unable to extract the public address from the LoadBalancer service", e);
         }
-        return address.asString();
     }
 
     private static Integer extractServicePort(JsonObject serviceJson) {


### PR DESCRIPTION
Kubernetes Discovery Plugin throws NullPointerException in case the Load Balancer ingress address is empty. It is better to throw `KubernetesClientException` with descriptive message when the ingress has no entry.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
