### PR TITLE
Update Eclipse wildcard import threshold

### DIFF
--- a/ide-configurations/eclipse/Hazelcast-Eclipse.pref.epf
+++ b/ide-configurations/eclipse/Hazelcast-Eclipse.pref.epf
@@ -557,9 +557,9 @@
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.gettersetter.use.is=true
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.ignorelowercasenames=true
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.importorder=;javax;java;\#;
-/instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.ondemandthreshold=99
+/instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.ondemandthreshold=2147483647
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.overrideannotation=true
-/instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.staticondemandthreshold=99
+/instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.staticondemandthreshold=2147483647
 /instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UTF-8" standalone\="no"?><templates><template autoinsert\="false" context\="filecomment_context" deleted\="false" description\="Comment for created Java files" enabled\="true" id\="org.eclipse.jdt.ui.text.codetemplates.filecomment" name\="filecomment">/*\n * Copyright (c) 2008-${year}, Hazelcast, Inc. All Rights Reserved.\n *\n * Licensed under the Apache License, Version 2.0 (the "License");\n * you may not use this file except in compliance with the License.\n * You may obtain a copy of the License at\n *\n * http\://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an "AS IS" BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n */\n</template><template autoinsert\="false" context\="typecomment_context" deleted\="false" description\="Comment for created types" enabled\="true" id\="org.eclipse.jdt.ui.text.codetemplates.typecomment" name\="typecomment">/**\n *\n * ${tags}\n */</template></templates>
 /instance/org.eclipse.jdt.ui/sp_cleanup.remove_trailing_whitespaces=true
 @org.eclipse.jdt.core=3.34.0.v20230512-1803


### PR DESCRIPTION
There was a scenario where we had more than 99 imports from a single package, increasing the threshold prevents wildcard imports in this scenario which was causing checkstyle issues.