### PR TITLE
Fix flaky test failure in PartitionMigrationListenerTest [HZ-3556]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/partitionservice/ClientMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/partitionservice/ClientMigrationListenerTest.java
@@ -219,7 +219,7 @@ public class ClientMigrationListenerTest {
     }
 
     private PartitionMigrationListenerTest.EventCollectingMigrationListener eventCollectingMigrationListener() {
-        return new PartitionMigrationListenerTest.EventCollectingMigrationListener();
+        return new PartitionMigrationListenerTest.EventCollectingMigrationListener(false);
     }
 
     private void assertRegistrationsSizeEventually(HazelcastInstance instance, int size) {

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationComputeIntensiveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationComputeIntensiveTest.java
@@ -57,7 +57,7 @@ public class PartitionMigrationComputeIntensiveTest extends HazelcastTestSupport
         warmUpPartitions(instances);
 
         LOGGER.info("Adding migration listener");
-        EventCollectingMigrationListener listener = new EventCollectingMigrationListener();
+        EventCollectingMigrationListener listener = new EventCollectingMigrationListener(false);
         instances[0].getPartitionService().addMigrationListener(listener);
 
         LOGGER.info("Changing cluster state to PASSIVE");


### PR DESCRIPTION
Refer to added code comment for reasoning - also includes additional logging in case further investigation is needed in the future.

Fixes https://hazelcast.atlassian.net/browse/HZ-3556
Closes https://github.com/hazelcast/hazelcast/issues/24708
