### PR TITLE
Rework snapshotting tests to test that snapshotting happened [HZ-3560]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/AbstractAtomicRegisterSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/AbstractAtomicRegisterSnapshotTest.java
@@ -21,10 +21,13 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.CPSubsystem;
 import com.hazelcast.cp.exception.CPSubsystemException;
+import com.hazelcast.cp.internal.DummyOp;
 import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
 import com.hazelcast.cp.internal.RaftInvocationManager;
 import com.hazelcast.cp.internal.RaftOp;
 import com.hazelcast.cp.internal.raft.QueryPolicy;
+import com.hazelcast.cp.internal.raft.impl.RaftNodeImpl;
+import com.hazelcast.cp.internal.raft.impl.log.SnapshotEntry;
 import com.hazelcast.spi.impl.InternalCompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,8 +53,6 @@ public abstract class AbstractAtomicRegisterSnapshotTest<T> extends HazelcastRaf
 
     protected abstract T setAndGetInitialValue();
 
-    protected abstract T readValue();
-
     protected abstract RaftOp getQueryRaftOp();
 
     @Override
@@ -65,11 +66,14 @@ public abstract class AbstractAtomicRegisterSnapshotTest<T> extends HazelcastRaf
     public void test_snapshot() throws Exception {
         T initialValue = setAndGetInitialValue();
 
-        // force snapshot
+        RaftNodeImpl leaderNode = getLeaderNode(instances, getGroupId());
+        // force snapshot by adding dummy entries to the RaftLog
         for (int i = 0; i < SNAPSHOT_THRESHOLD; i++) {
-            T v = readValue();
-            assertEquals(initialValue, v);
+            leaderNode.replicate(new DummyOp()).joinInternal();
         }
+
+        SnapshotEntry snapshotEntry = leaderNode.state().log().snapshot();
+        assertEquals(SNAPSHOT_THRESHOLD, snapshotEntry.index());
 
         // shutdown the last instance
         instances[instances.length - 1].shutdown();
@@ -78,7 +82,7 @@ public abstract class AbstractAtomicRegisterSnapshotTest<T> extends HazelcastRaf
         instance.getCPSubsystem().getCPSubsystemManagementService().promoteToCPMember()
                 .toCompletableFuture().get();
 
-        // Read from local CP member, which should install snapshot after promotion.
+        // Read from local CP member, which should install snapshot after promotion, that should contain the initial value
         assertTrueEventually(() -> {
             InternalCompletableFuture<Object> future = queryLocally(instance);
             try {
@@ -95,6 +99,10 @@ public abstract class AbstractAtomicRegisterSnapshotTest<T> extends HazelcastRaf
             T value = getValue(future);
             assertEquals(initialValue, value);
         }, 5);
+
+        RaftNodeImpl raftNode = getRaftNode(instance, getGroupId());
+        SnapshotEntry newNodeSnapshotEntry = raftNode.state().log().snapshot();
+        assertEquals(SNAPSHOT_THRESHOLD, newNodeSnapshotEntry.index());
     }
 
     protected T getValue(InternalCompletableFuture<Object> future) {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/atomiclong/AtomicLongSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/atomiclong/AtomicLongSnapshotTest.java
@@ -54,11 +54,6 @@ public class AtomicLongSnapshotTest extends AbstractAtomicRegisterSnapshotTest<L
     }
 
     @Override
-    protected Long readValue() {
-        return atomicLong.get();
-    }
-
-    @Override
     protected RaftOp getQueryRaftOp() {
         return new LocalGetOp(name);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/atomicref/AtomicRefSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/atomicref/AtomicRefSnapshotTest.java
@@ -54,11 +54,6 @@ public class AtomicRefSnapshotTest extends AbstractAtomicRegisterSnapshotTest<St
     }
 
     @Override
-    protected String readValue() {
-        return atomicRef.get();
-    }
-
-    @Override
     protected RaftOp getQueryRaftOp() {
         return new GetOp(name);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/CountDownLatchSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/CountDownLatchSnapshotTest.java
@@ -56,11 +56,6 @@ public class CountDownLatchSnapshotTest extends AbstractAtomicRegisterSnapshotTe
     }
 
     @Override
-    protected Integer readValue() {
-        return latch.getCount();
-    }
-
-    @Override
     protected RaftOp getQueryRaftOp() {
         return new GetCountOp(name);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockSnapshotTest.java
@@ -52,11 +52,6 @@ public class FencedLockSnapshotTest extends AbstractAtomicRegisterSnapshotTest<L
     }
 
     @Override
-    protected Long readValue() {
-        return lock.getFence();
-    }
-
-    @Override
     protected RaftOp getQueryRaftOp() {
         return new GetLockOwnershipStateOp(name);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/SemaphoreSnapshotTest.java
@@ -57,11 +57,6 @@ public class SemaphoreSnapshotTest extends AbstractAtomicRegisterSnapshotTest<In
     }
 
     @Override
-    protected Integer readValue() {
-        return semaphore.availablePermits();
-    }
-
-    @Override
     protected RaftOp getQueryRaftOp() {
         return new AvailablePermitsOp(name);
     }


### PR DESCRIPTION
Replaced read/get operations that are not added to the `RaftLog` with those that are added.

Introduced the check that snapshotting actually happened.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
