### PR TITLE
Move parameterized logging from `LoggingUtil` to `ILogger`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/LoggingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/LoggingUtil.java
@@ -19,58 +19,44 @@ package com.hazelcast.jet.impl.util;
 import com.hazelcast.logging.ILogger;
 
 /**
- * Utility methods to suppress building of messages for a disabled logging
- * level.
+ * Utility methods to suppress building of messages for a disabled logging level.
+ * 
+ * @deprecated just access the methods directly on the {@link ILogger}
  */
+@Deprecated
 public final class LoggingUtil {
     private LoggingUtil() {
     }
 
     public static void logFine(ILogger logger, String template, Object arg1) {
-        if (logger.isFineEnabled()) {
-            logger.fine(String.format(template, arg1));
-        }
+        logger.logFine(template, arg1);
     }
 
     public static void logFine(ILogger logger, String template, Object arg1, Object arg2) {
-        if (logger.isFineEnabled()) {
-            logger.fine(String.format(template, arg1, arg2));
-        }
+        logger.logFine(template, arg1, arg2);
     }
 
     public static void logFine(ILogger logger, String template, Object arg1, Object arg2, Object arg3) {
-        if (logger.isFineEnabled()) {
-            logger.fine(String.format(template, arg1, arg2, arg3));
-        }
+        logger.logFine(template, arg1, arg2, arg3);
     }
 
     public static void logFine(ILogger logger, String template, Object arg1, Object arg2, Object arg3, Object arg4) {
-        if (logger.isFineEnabled()) {
-            logger.fine(String.format(template, arg1, arg2, arg3, arg4));
-        }
+        logger.logFine(template, arg1, arg2, arg3, arg4);
     }
 
     public static void logFinest(ILogger logger, String template, Object arg1) {
-        if (logger.isFinestEnabled()) {
-            logger.finest(String.format(template, arg1));
-        }
+        logger.logFinest(template, arg1);
     }
 
     public static void logFinest(ILogger logger, String template, Object arg1, Object arg2) {
-        if (logger.isFinestEnabled()) {
-            logger.finest(String.format(template, arg1, arg2));
-        }
+        logger.logFinest(template, arg1, arg2);
     }
 
     public static void logFinest(ILogger logger, String template, Object arg1, Object arg2, Object arg3) {
-        if (logger.isFinestEnabled()) {
-            logger.finest(String.format(template, arg1, arg2, arg3));
-        }
+        logger.logFinest(template, arg1, arg2, arg3);
     }
 
     public static void logFinest(ILogger logger, String template, Object arg1, Object arg2, Object arg3, Object arg4) {
-        if (logger.isFinestEnabled()) {
-            logger.finest(String.format(template, arg1, arg2, arg3, arg4));
-        }
+        logger.logFinest(template, arg1, arg2, arg3, arg4);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/LoggingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/LoggingUtil.java
@@ -28,34 +28,42 @@ public final class LoggingUtil {
     private LoggingUtil() {
     }
 
+    /** @see ILogger#logFine(String, Object) */
     public static void logFine(ILogger logger, String template, Object arg1) {
         logger.logFine(template, arg1);
     }
 
+    /** @see ILogger#logFine(String, Object, Object) */
     public static void logFine(ILogger logger, String template, Object arg1, Object arg2) {
         logger.logFine(template, arg1, arg2);
     }
 
+    /** @see ILogger#logFine(String, Object, Object, Object) */
     public static void logFine(ILogger logger, String template, Object arg1, Object arg2, Object arg3) {
         logger.logFine(template, arg1, arg2, arg3);
     }
 
+    /** @see ILogger#logFine(String, Object, Object, Object, Object) */
     public static void logFine(ILogger logger, String template, Object arg1, Object arg2, Object arg3, Object arg4) {
         logger.logFine(template, arg1, arg2, arg3, arg4);
     }
 
+    /** @see ILogger#logFinest(String, Object) */
     public static void logFinest(ILogger logger, String template, Object arg1) {
         logger.logFinest(template, arg1);
     }
 
+    /** @see ILogger#logFinest(String, Object, Object) */
     public static void logFinest(ILogger logger, String template, Object arg1, Object arg2) {
         logger.logFinest(template, arg1, arg2);
     }
 
+    /** @see ILogger#logFinest(String, Object, Object, Object) */
     public static void logFinest(ILogger logger, String template, Object arg1, Object arg2, Object arg3) {
         logger.logFinest(template, arg1, arg2, arg3);
     }
 
+    /** @see ILogger#logFinest(String, Object, Object, Object, Object) */
     public static void logFinest(ILogger logger, String template, Object arg1, Object arg2, Object arg3, Object arg4) {
         logger.logFinest(template, arg1, arg2, arg3, arg4);
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/LoggingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/LoggingUtil.java
@@ -20,7 +20,7 @@ import com.hazelcast.logging.ILogger;
 
 /**
  * Utility methods to suppress building of messages for a disabled logging level.
- * 
+ *
  * @deprecated just access the methods directly on the {@link ILogger}
  */
 @Deprecated

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/LoggingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/LoggingUtil.java
@@ -28,43 +28,43 @@ public final class LoggingUtil {
     private LoggingUtil() {
     }
 
-    /** @see ILogger#logFine(String, Object) */
+    /** @see ILogger#fine(String, Object) */
     public static void logFine(ILogger logger, String template, Object arg1) {
-        logger.logFine(template, arg1);
+        logger.fine(template, arg1);
     }
 
-    /** @see ILogger#logFine(String, Object, Object) */
+    /** @see ILogger#fine(String, Object, Object) */
     public static void logFine(ILogger logger, String template, Object arg1, Object arg2) {
-        logger.logFine(template, arg1, arg2);
+        logger.fine(template, arg1, arg2);
     }
 
-    /** @see ILogger#logFine(String, Object, Object, Object) */
+    /** @see ILogger#fine(String, Object, Object, Object) */
     public static void logFine(ILogger logger, String template, Object arg1, Object arg2, Object arg3) {
-        logger.logFine(template, arg1, arg2, arg3);
+        logger.fine(template, arg1, arg2, arg3);
     }
 
-    /** @see ILogger#logFine(String, Object, Object, Object, Object) */
+    /** @see ILogger#fine(String, Object, Object, Object, Object) */
     public static void logFine(ILogger logger, String template, Object arg1, Object arg2, Object arg3, Object arg4) {
-        logger.logFine(template, arg1, arg2, arg3, arg4);
+        logger.fine(template, arg1, arg2, arg3, arg4);
     }
 
-    /** @see ILogger#logFinest(String, Object) */
+    /** @see ILogger#finest(String, Object) */
     public static void logFinest(ILogger logger, String template, Object arg1) {
-        logger.logFinest(template, arg1);
+        logger.finest(template, arg1);
     }
 
-    /** @see ILogger#logFinest(String, Object, Object) */
+    /** @see ILogger#finest(String, Object, Object) */
     public static void logFinest(ILogger logger, String template, Object arg1, Object arg2) {
-        logger.logFinest(template, arg1, arg2);
+        logger.finest(template, arg1, arg2);
     }
 
-    /** @see ILogger#logFinest(String, Object, Object, Object) */
+    /** @see ILogger#finest(String, Object, Object, Object) */
     public static void logFinest(ILogger logger, String template, Object arg1, Object arg2, Object arg3) {
-        logger.logFinest(template, arg1, arg2, arg3);
+        logger.finest(template, arg1, arg2, arg3);
     }
 
-    /** @see ILogger#logFinest(String, Object, Object, Object, Object) */
+    /** @see ILogger#finest(String, Object, Object, Object, Object) */
     public static void logFinest(ILogger logger, String template, Object arg1, Object arg2, Object arg3, Object arg4) {
-        logger.logFinest(template, arg1, arg2, arg3, arg4);
+        logger.finest(template, arg1, arg2, arg3, arg4);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
@@ -37,7 +37,7 @@ public interface ILogger extends TpcLogger {
     /**
      * Logs to {@link #fine(String)} using a lazily evaluated {@code template} {@link String} with arguments, formatted using
      * {@link String#format(String, Object...)}
-     * 
+     *
      * @since 5.4
      */
     default void logFine(String template, Object arg1) {
@@ -70,7 +70,7 @@ public interface ILogger extends TpcLogger {
     /**
      * Logs to {@link #finest(String)} using a lazily evaluated {@code template} {@link String} with arguments, formatted using
      * {@link String#format(String, Object...)}
-     * 
+     *
      * @since 5.4
      */
     default void logFinest(String template, Object arg1) {

--- a/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
@@ -34,48 +34,66 @@ public interface ILogger extends TpcLogger {
     @Deprecated
     void log(LogEvent logEvent);
 
+    /**
+     * Logs to {@link #fine(String)} using a lazily evaluated {@code template} {@link String} with arguments, formatted using
+     * {@link String#format(String, Object...)}
+     * 
+     * @since 5.4
+     */
     default void logFine(String template, Object arg1) {
         if (isFineEnabled()) {
             fine(String.format(template, arg1));
         }
     }
 
+    /** @see #logFine(String, Object) */
     default void logFine(String template, Object arg1, Object arg2) {
         if (isFineEnabled()) {
             fine(String.format(template, arg1, arg2));
         }
     }
 
+    /** @see #logFine(String, Object) */
     default void logFine(String template, Object arg1, Object arg2, Object arg3) {
         if (isFineEnabled()) {
             fine(String.format(template, arg1, arg2, arg3));
         }
     }
 
+    /** @see #logFine(String, Object) */
     default void logFine(String template, Object arg1, Object arg2, Object arg3, Object arg4) {
         if (isFineEnabled()) {
             fine(String.format(template, arg1, arg2, arg3, arg4));
         }
     }
 
+    /**
+     * Logs to {@link #finest(String)} using a lazily evaluated {@code template} {@link String} with arguments, formatted using
+     * {@link String#format(String, Object...)}
+     * 
+     * @since 5.4
+     */
     default void logFinest(String template, Object arg1) {
         if (isFinestEnabled()) {
             finest(String.format(template, arg1));
         }
     }
 
+    /** @see #logFinest(String, Object) */
     default void logFinest(String template, Object arg1, Object arg2) {
         if (isFinestEnabled()) {
             finest(String.format(template, arg1, arg2));
         }
     }
 
+    /** @see #logFinest(String, Object) */
     default void logFinest(String template, Object arg1, Object arg2, Object arg3) {
         if (isFinestEnabled()) {
             finest(String.format(template, arg1, arg2, arg3));
         }
     }
 
+    /** @see #logFinest(String, Object) */
     default void logFinest(String template, Object arg1, Object arg2, Object arg3, Object arg4) {
         if (isFinestEnabled()) {
             finest(String.format(template, arg1, arg2, arg3, arg4));

--- a/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
@@ -40,28 +40,28 @@ public interface ILogger extends TpcLogger {
      *
      * @since 5.4
      */
-    default void logFine(String template, Object arg1) {
+    default void fine(String template, Object arg1) {
         if (isFineEnabled()) {
             fine(String.format(template, arg1));
         }
     }
 
-    /** @see #logFine(String, Object) */
-    default void logFine(String template, Object arg1, Object arg2) {
+    /** @see #fine(String, Object) */
+    default void fine(String template, Object arg1, Object arg2) {
         if (isFineEnabled()) {
             fine(String.format(template, arg1, arg2));
         }
     }
 
-    /** @see #logFine(String, Object) */
-    default void logFine(String template, Object arg1, Object arg2, Object arg3) {
+    /** @see #fine(String, Object) */
+    default void fine(String template, Object arg1, Object arg2, Object arg3) {
         if (isFineEnabled()) {
             fine(String.format(template, arg1, arg2, arg3));
         }
     }
 
-    /** @see #logFine(String, Object) */
-    default void logFine(String template, Object arg1, Object arg2, Object arg3, Object arg4) {
+    /** @see #fine(String, Object) */
+    default void fine(String template, Object arg1, Object arg2, Object arg3, Object arg4) {
         if (isFineEnabled()) {
             fine(String.format(template, arg1, arg2, arg3, arg4));
         }
@@ -73,28 +73,28 @@ public interface ILogger extends TpcLogger {
      *
      * @since 5.4
      */
-    default void logFinest(String template, Object arg1) {
+    default void finest(String template, Object arg1) {
         if (isFinestEnabled()) {
             finest(String.format(template, arg1));
         }
     }
 
-    /** @see #logFinest(String, Object) */
-    default void logFinest(String template, Object arg1, Object arg2) {
+    /** @see #finest(String, Object) */
+    default void finest(String template, Object arg1, Object arg2) {
         if (isFinestEnabled()) {
             finest(String.format(template, arg1, arg2));
         }
     }
 
-    /** @see #logFinest(String, Object) */
-    default void logFinest(String template, Object arg1, Object arg2, Object arg3) {
+    /** @see #finest(String, Object) */
+    default void finest(String template, Object arg1, Object arg2, Object arg3) {
         if (isFinestEnabled()) {
             finest(String.format(template, arg1, arg2, arg3));
         }
     }
 
-    /** @see #logFinest(String, Object) */
-    default void logFinest(String template, Object arg1, Object arg2, Object arg3, Object arg4) {
+    /** @see #finest(String, Object) */
+    default void finest(String template, Object arg1, Object arg2, Object arg3, Object arg4) {
         if (isFinestEnabled()) {
             finest(String.format(template, arg1, arg2, arg3, arg4));
         }

--- a/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
@@ -18,183 +18,13 @@ package com.hazelcast.logging;
 
 import com.hazelcast.internal.tpcengine.logging.TpcLogger;
 
-import java.util.logging.Level;
-
 /**
- * The Hazelcast logging interface. It exists because Hazelcast doesn't want any dependencies
- * on concrete logging frameworks, so it creates its own meta logging framework behind which
- * existing frameworks can be placed.
+ * The Hazelcast logging interface. It exists because Hazelcast doesn't want any dependencies on concrete logging frameworks, so
+ * it creates its own meta logging framework behind which existing frameworks can be placed.
  *
  * @see AbstractLogger
  */
 public interface ILogger extends TpcLogger {
-
-    /**
-     * Logs a message at the {@link Level#FINEST} level.
-     *
-     * @param message the message to log
-     */
-    void finest(String message);
-
-    /**
-     * Logs a throwable at the {@link Level#FINEST} level. The message of the
-     * Throwable will be the logged message.
-     *
-     * @param thrown the Throwable to log
-     */
-    void finest(Throwable thrown);
-
-    /**
-     * Logs a message with an associated throwable at the {@link Level#FINEST} level.
-     *
-     * @param message the message to log
-     * @param thrown  the Throwable associated to the message
-     */
-    void finest(String message, Throwable thrown);
-
-    /**
-     * Checks if the {@link Level#FINEST} level is enabled.
-     *
-     * @return true if enabled, false otherwise
-     */
-    boolean isFinestEnabled();
-
-    /**
-     * Logs a message at the {@link Level#FINE} level.
-     *
-     * @param message the message to log
-     */
-    void fine(String message);
-
-    /**
-     * Logs a throwable at the {@link Level#FINE} level. The message of the
-     * Throwable will be the logged message.
-     *
-     * @param thrown the Throwable to log
-     */
-    void fine(Throwable thrown);
-
-    /**
-     * Logs a message with an associated throwable at the {@link Level#FINE} level.
-     *
-     * @param message the message to log
-     * @param thrown  the Throwable associated to the message
-     */
-    void fine(String message, Throwable thrown);
-
-    /**
-     * Checks if the {@link Level#FINE} level is enabled.
-     *
-     * @return true if enabled, false otherwise
-     */
-    boolean isFineEnabled();
-
-    /**
-     * Logs a message at the {@link Level#INFO} level.
-     *
-     * @param message the message to log
-     */
-    void info(String message);
-
-    /**
-     * Logs a throwable at the {@link Level#INFO} level. The message of the
-     * Throwable will be the logged message.
-     *
-     * @param thrown the Throwable to log
-     */
-    void info(Throwable thrown);
-
-    /**
-     * Logs a message with an associated throwable at the {@link Level#INFO} level.
-     *
-     * @param message the message to log
-     * @param thrown  the Throwable associated to the message
-     */
-    void info(String message, Throwable thrown);
-
-    /**
-     * Checks if the {@link Level#INFO} level is enabled.
-     *
-     * @return true if enabled, false otherwise
-     */
-    boolean isInfoEnabled();
-
-    /**
-     * Logs a message at the {@link Level#WARNING} level.
-     *
-     * @param message the message to log
-     */
-    void warning(String message);
-
-    /**
-     * Logs a throwable at the {@link Level#WARNING} level. The message of the
-     * Throwable will be the logged message.
-     *
-     * @param thrown the Throwable to log
-     */
-    void warning(Throwable thrown);
-
-    /**
-     * Logs a message with an associated throwable at the {@link Level#WARNING} level.
-     *
-     * @param message the message to log
-     * @param thrown  the Throwable associated to the message
-     */
-    void warning(String message, Throwable thrown);
-
-    /**
-     * Checks if the {@link Level#WARNING} is enabled.
-     *
-     * @return true if enabled, false otherwise
-     */
-    boolean isWarningEnabled();
-
-    /**
-     * Logs a message at {@link Level#SEVERE}.
-     *
-     * @param message the message to log.
-     */
-    void severe(String message);
-
-    /**
-     * Logs a throwable at the {@link Level#SEVERE} level. The message of the
-     * Throwable will be the logged message.
-     *
-     * @param thrown the Throwable to log
-     */
-    void severe(Throwable thrown);
-
-    /**
-     * Logs a message with an associated throwable at the {@link Level#SEVERE} level.
-     *
-     * @param message the message to log
-     * @param thrown  the Throwable associated to the message
-     */
-    void severe(String message, Throwable thrown);
-
-    /**
-     * Checks if the {@link Level#SEVERE} is enabled.
-     *
-     * @return true if enabled, false otherwise
-     */
-    boolean isSevereEnabled();
-
-    /**
-     * Logs a message at the given level.
-     *
-     * @param level   the log level
-     * @param message the message to log
-     */
-    void log(Level level, String message);
-
-    /**
-     * Logs a message with an associated throwable at the given level.
-     *
-     * @param message the message to log
-     * @param thrown  the Throwable associated to the message
-     */
-    void log(Level level, String message, Throwable thrown);
-
     /**
      * Logs a LogEvent.
      *
@@ -204,18 +34,51 @@ public interface ILogger extends TpcLogger {
     @Deprecated
     void log(LogEvent logEvent);
 
-    /**
-     * Gets the logging level.
-     *
-     * @return the logging level
-     */
-    Level getLevel();
+    default void logFine(String template, Object arg1) {
+        if (isFineEnabled()) {
+            fine(String.format(template, arg1));
+        }
+    }
 
-    /**
-     * Checks if a message at the given level is going to be logged by this logger.
-     *
-     * @param level the log level
-     * @return true if this logger will log messages for the given level, false otherwise
-     */
-    boolean isLoggable(Level level);
+    default void logFine(String template, Object arg1, Object arg2) {
+        if (isFineEnabled()) {
+            fine(String.format(template, arg1, arg2));
+        }
+    }
+
+    default void logFine(String template, Object arg1, Object arg2, Object arg3) {
+        if (isFineEnabled()) {
+            fine(String.format(template, arg1, arg2, arg3));
+        }
+    }
+
+    default void logFine(String template, Object arg1, Object arg2, Object arg3, Object arg4) {
+        if (isFineEnabled()) {
+            fine(String.format(template, arg1, arg2, arg3, arg4));
+        }
+    }
+
+    default void logFinest(String template, Object arg1) {
+        if (isFinestEnabled()) {
+            finest(String.format(template, arg1));
+        }
+    }
+
+    default void logFinest(String template, Object arg1, Object arg2) {
+        if (isFinestEnabled()) {
+            finest(String.format(template, arg1, arg2));
+        }
+    }
+
+    default void logFinest(String template, Object arg1, Object arg2, Object arg3) {
+        if (isFinestEnabled()) {
+            finest(String.format(template, arg1, arg2, arg3));
+        }
+    }
+
+    default void logFinest(String template, Object arg1, Object arg2, Object arg3, Object arg4) {
+        if (isFinestEnabled()) {
+            finest(String.format(template, arg1, arg2, arg3, arg4));
+        }
+    }
 }


### PR DESCRIPTION
When I first started working with the codebase, I wondered if the `ILogger` supported parameterized logging (based on previous log4j experience) - but the interface offered nothing, so I didn't think it did. 

Later I found that this is possible, but with the `LoggingUtil` utility class.

Changes:
- Migrated `LoggingUtil` methods into `ILogger` so that they are more discoverable
- Delegated `LoggingUtil` functionality to directly call `ILogger` implementations
- Deprecated `LoggingUtil`
- Added Javadoc
- Remove duplication of methods defined in `ILogger` interface already declared in `TpcLogger` parent

This is a step towards addressing https://github.com/hazelcast/hazelcast/issues/25836