### PR TITLE
Fix setExpiryPolicy for ICache 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -959,7 +959,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         expiryPolicy = getExpiryPolicy(record, expiryPolicy);
         long expiryTime = TIME_NOT_AVAILABLE;
         try {
-            Duration expiryDuration = expiryPolicy.getExpiryForUpdate();
+            Duration expiryDuration = expiryPolicy.getExpiryForCreation();
             if (expiryDuration != null) {
                 expiryTime = getAdjustedExpireTime(expiryDuration, now);
             }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -974,7 +974,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         expiryPolicy = getExpiryPolicy(record, expiryPolicy);
         long expiryTime = TIME_NOT_AVAILABLE;
         try {
-            Duration expiryDuration = expiryPolicy.getExpiryForUpdate();
+            Duration expiryDuration = expiryPolicy.getExpiryForCreation();
             if (expiryDuration != null) {
                 expiryTime = getAdjustedExpireTime(expiryDuration, now);
             }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.cache;
 
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.iteration.IterationPointer;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;


### PR DESCRIPTION
Issue #25547 found that it is possible to update the expiry policy for a ICache entry and it would never get removed in-line with the provided policy. The issue appears to be that the update to the records policy accessed the expiry-for-update time (which is null) rather than creation time, which meant the record is updated with the value `-1` for expiry time. 

Added unit tests to cover the reported failure case. 

Fixes #25547 

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [X] Request reviewers if possible

