### PR TITLE
Add missing custom-lib directory [5.3.z]

### DIFF
--- a/distribution/src/assembly/assembly-descriptor.xml
+++ b/distribution/src/assembly/assembly-descriptor.xml
@@ -179,9 +179,11 @@
             <filtered>true</filtered>
         </fileSet>
 
-        <fileSet>
-            <directory>${project.build.directory}/custom-lib</directory>
+        <fileSet> <!-- Create empty directory -->
             <outputDirectory>custom-lib</outputDirectory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
         </fileSet>
         <fileSet> <!-- Create empty directory -->
             <outputDirectory>bin/user-lib</outputDirectory>


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/25848

After removal of the hazelcast 3 connector it turned out that `custom-lib` directory is missing in the distribution archives

Fixes https://hazelcast.atlassian.net/browse/HZ-3591