### PR TITLE
Remove redundant JRE8 test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIT.java
@@ -16,13 +16,12 @@
 
 package com.hazelcast.osgi;
 
-import com.hazelcast.instance.BuildInfoProvider;
-import com.hazelcast.test.annotation.QuickTest;
+import static org.ops4j.pax.exam.CoreOptions.bundle;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
 import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
@@ -36,12 +35,10 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
-import javax.inject.Inject;
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.test.annotation.QuickTest;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.ops4j.pax.exam.CoreOptions.bundle;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.options;
+import javax.inject.Inject;
 
 
 @Category(QuickTest.class)
@@ -83,20 +80,6 @@ class HazelcastOSGiIT {
         } else {
             System.setProperty(MAVEN_REPOSITORIES_PROP, oldMavenRepoProperty);
         }
-    }
-
-    /**
-     * Is this test failing in your IDE?
-     * Some versions of Intellij IDEA use a wrong working directory in multi-module Maven projects.
-     * See this for a fix: https://youtrack.jetbrains.com/issue/IDEA-60965
-     * <p>
-     * An outdated PaxRunner used by the OSGi test prevents executing on Java 9+.
-     */
-    @EnabledOnJre({JRE.JAVA_8})
-    @Test
-    void serviceRetrievedSuccessfully() {
-        HazelcastOSGiService service = getService();
-        assertNotNull(service);
     }
 
     private HazelcastOSGiService getService() {

--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIT.java
@@ -16,10 +16,8 @@
 
 package com.hazelcast.osgi;
 
-import static org.ops4j.pax.exam.CoreOptions.bundle;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.AfterEach;
 import org.ops4j.pax.exam.Option;
@@ -35,11 +33,11 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
-import com.hazelcast.instance.BuildInfoProvider;
-import com.hazelcast.test.annotation.QuickTest;
-
 import javax.inject.Inject;
 
+import static org.ops4j.pax.exam.CoreOptions.bundle;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.options;
 
 @Category(QuickTest.class)
 @ExamReactorStrategy(AllConfinedStagedReactorFactory.class)


### PR DESCRIPTION
`com.hazelcast.osgi.HazelcastOSGiIT.serviceRetrievedSuccessfully()` is configured to run *only* on JRE8... but as the project is Java 11, this test can never run.