### PR TITLE
Migrate Java 8 dependencies to Java 11

### DIFF
--- a/hazelcast-it/distribution-it/pom.xml
+++ b/hazelcast-it/distribution-it/pom.xml
@@ -65,7 +65,6 @@
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <version>${hsqldb.version}</version>
-            <classifier>jdk8</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -476,10 +476,6 @@
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-stdlib</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-jdk8</artifactId>
-                </exclusion>
                 <!-- Unused geospatial libraries (only jts-core is required) -->
                 <exclusion>
                     <groupId>org.locationtech.jts.io</groupId>

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -476,6 +476,10 @@
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-stdlib</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib-jdk8</artifactId>
+                </exclusion>
                 <!-- Unused geospatial libraries (only jts-core is required) -->
                 <exclusion>
                     <groupId>org.locationtech.jts.io</groupId>


### PR DESCRIPTION
Some of the dependencies are using Java-8 specific dependency versions - now Hazelcast is on Java 11, this is no longer required and the vanilla versions can be used.