### PR TITLE
De-duplicate `.class` file utilities

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientUserCodeDeploymentService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/ClientUserCodeDeploymentService.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.config.ClientUserCodeDeploymentConfig;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientDeployClassesCodec;
+import com.hazelcast.jet.impl.util.ReflectionUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -66,7 +67,7 @@ public class ClientUserCodeDeploymentService {
 
     private void loadClasses() throws ClassNotFoundException {
         for (String className : clientUserCodeDeploymentConfig.getClassNames()) {
-            String resource = className.replace('.', '/').concat(".class");
+            String resource = ReflectionUtils.toClassResourceId(className);
             try (InputStream is = configClassLoader.getResourceAsStream(resource)) {
                 if (is == null) {
                     throw new ClassNotFoundException(resource);

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProvider.java
@@ -17,10 +17,10 @@
 package com.hazelcast.internal.usercodedeployment.impl;
 
 import com.hazelcast.config.UserCodeDeploymentConfig;
+import com.hazelcast.jet.impl.util.ReflectionUtils;
 import com.hazelcast.logging.ILogger;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
@@ -150,14 +150,11 @@ public final class ClassDataProvider {
     }
 
     private byte[] loadBytecodeFromParent(String className) {
-        String resource = className.replace('.', '/').concat(".class");
-        try (InputStream is = parent.getResourceAsStream(resource)) {
-            if (is != null) {
-                return is.readAllBytes();
-            }
+        try {
+            return ReflectionUtils.getClassContent(className, parent);
         } catch (IOException e) {
             logger.severe(e);
+            return null;
         }
-        return null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ReflectionUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ReflectionUtils.java
@@ -24,6 +24,9 @@ import io.github.classgraph.ScanResult;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -269,6 +272,21 @@ public final class ReflectionUtils {
 
     public static String toClassResourceId(String name) {
         return toPath(name) + ".class";
+    }
+
+    public static String toClassResourceId(Class<?> clazz) {
+        return toClassResourceId(clazz.getName());
+    }
+
+    @Nullable
+    public static byte[] getClassContent(String name, ClassLoader classLoader) throws IOException {
+        try (InputStream is = classLoader.getResourceAsStream(toClassResourceId(name))) {
+            if (is == null) {
+                return null;
+            } else {
+                return is.readAllBytes();
+            }
+        }
     }
 
     public static Object getFieldValue(String fieldName, Object obj) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ServiceLoaderTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.util;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.portable.PortableHook;
+import com.hazelcast.jet.impl.util.ReflectionUtils;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.Serializer;
@@ -658,15 +659,11 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         }
 
         private byte[] loadBytecodeFromParent(String className) {
-            String resource = className.replace('.', '/').concat(".class");
-            try (InputStream is = parent.getResourceAsStream(resource)) {
-                if (is != null) {
-                    return is.readAllBytes();
-                }
+            try {
+                return ReflectionUtils.getClassContent(className, parent);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            return null;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/config/ResourceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/config/ResourceConfigTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.config;
 
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.impl.util.ReflectionUtils;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -67,7 +68,7 @@ public class ResourceConfigTest extends JetTestSupport {
 
         // Then
         ResourceConfig resourceConfig = getFirstResourceConfig();
-        assertEquals(toId(this.getClass()), resourceConfig.getId());
+        assertEquals(ReflectionUtils.toClassResourceId(this.getClass()), resourceConfig.getId());
         assertEquals(ResourceType.CLASS, resourceConfig.getResourceType());
     }
 
@@ -81,7 +82,7 @@ public class ResourceConfigTest extends JetTestSupport {
         assertTrue(resourceConfigs
                 .stream()
                 .anyMatch(resourceConfig ->
-                        resourceConfig.getId().equals(toId(this.getClass())) &&
+                        resourceConfig.getId().equals(ReflectionUtils.toClassResourceId(this.getClass())) &&
                                 resourceConfig.getResourceType().equals(ResourceType.CLASS)
                 ));
         assertTrue(resourceConfigs
@@ -1090,9 +1091,5 @@ public class ResourceConfigTest extends JetTestSupport {
         File dirFile = new File(baseDir, path);
         assertTrue("Failed to create directory " + dirFile, dirFile.mkdirs());
         return dirFile;
-    }
-
-    private static String toId(Class<?> clazz) {
-        return clazz.getName().replace('.', '/') + ".class";
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ProcessorClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ProcessorClassLoaderTest.java
@@ -25,10 +25,14 @@ import com.hazelcast.jet.JetService;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.impl.util.LoggingUtil;
+import com.hazelcast.jet.impl.util.ReflectionUtils;
 import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.JarUtil;
@@ -50,14 +54,15 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Lists.newArrayList;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ProcessorClassLoaderTest extends JetTestSupport {
-
+    private static final ILogger LOGGER = Logger.getLogger(ProcessorClassLoaderTest.class);
     private static final String SOURCE_NAME = "test-source";
 
     private HazelcastInstance member;
@@ -72,16 +77,16 @@ public class ProcessorClassLoaderTest extends JetTestSupport {
         jarFile = File.createTempFile("source_", ".jar");
         JarUtil.createJarFile(
                 "target/test-classes/",
-                newArrayList(
-                        classToPath(TestProcessor.ResourceReader.class),
-                        classToPath(TestProcessor.TestProcessorMetaSupplier.class),
-                        classToPath(TestProcessor.TestProcessorSupplier.class),
-                        classToPath(TestProcessor.class),
-                        classToPath(SourceWithClassLoader.class)
-                ),
+                Stream.of(
+                        TestProcessor.ResourceReader.class,
+                        TestProcessor.TestProcessorMetaSupplier.class,
+                        TestProcessor.TestProcessorSupplier.class,
+                        TestProcessor.class,
+                        SourceWithClassLoader.class
+                ).map(ReflectionUtils::toClassResourceId).collect(Collectors.toList()),
                 jarFile.getAbsolutePath()
         );
-        System.out.println(jarFile);
+        LoggingUtil.logFinest(LOGGER, "%s", jarFile);
 
         resourcesJarFile = File.createTempFile("resources_", ".jar");
         JarUtil.createResourcesJarFile(resourcesJarFile);
@@ -89,10 +94,6 @@ public class ProcessorClassLoaderTest extends JetTestSupport {
         // Setup the path for custom lib directory, this is by default set to `custom-lib` directory in hazelcast
         // distribution zip
         System.setProperty(ClusterProperty.PROCESSOR_CUSTOM_LIB_DIR.getName(), System.getProperty("java.io.tmpdir"));
-    }
-
-    private static String classToPath(Class<?> clazz) {
-        return clazz.getName().replace(".", "/") + ".class";
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ReflectionUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ReflectionUtilsTest.java
@@ -201,7 +201,7 @@ public class ReflectionUtilsTest {
     }
 
     private static ClassResource classResource(Class<?> clazz) {
-        URL url = clazz.getClassLoader().getResource(clazz.getName().replace('.', '/') + ".class");
+        URL url = clazz.getClassLoader().getResource(ReflectionUtils.toClassResourceId(clazz));
         return new ClassResource(clazz.getName(), url);
     }
 


### PR DESCRIPTION
Conversion between a class' name, resource identifier and binary content is replicated in several parts of the codebase.

Centralised (into `com.hazelcast.jet.impl.util.ReflectionUtils`) and updated references.