### PR TITLE
Remove unused activemq.version property from the root POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,6 @@
 
         <!-- test dependencies -->
         <activemq-artemis.version>2.31.2</activemq-artemis.version>
-        <activemq.version>5.15.11</activemq.version>
         <assertj.version>3.24.2</assertj.version>
         <atomikos.version>3.9.3</atomikos.version>
         <bytebuddy.version>1.14.9</bytebuddy.version>


### PR DESCRIPTION
It seems the property is a leftover. We only use the `activemq-artemis.version` property.
