### PR TITLE
Bump avro from 1.11.1 to 1.11.3 [HZ-3416] [5.2.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <!-- Third-party dependencies (sorted alphabetically) -->
         <!--<affinity.version>3.2.3</affinity.version>-->
         <antlr4.version>4.9.3</antlr4.version>
-        <avro.version>1.11.1</avro.version>
+        <avro.version>1.11.3</avro.version>
         <aws.sdk.version>1.12.276</aws.sdk.version>
         <classgraph.version>4.8.149</classgraph.version>
         <debezium.version>1.9.5.Final</debezium.version>


### PR DESCRIPTION
Increment avro version due to https://github.com/hazelcast/hazelcast/issues/25625

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
