### PR TITLE
Compare raw values when merging expiration in WAN [HZ-3661] [5.3.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1124,7 +1124,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                 //  changed data and use that. Since this only matters for WAN-received merge events, we can avoid
                 //  additional overhead by checking provenance. Fixes HZ-3392, Backlog for merge changes: HZ-3397
                 boolean shouldMergeExpiration = provenance != CallerProvenance.WAN
-                        || valueComparator.isEqual(oldValue, mergingEntry.getValue(), serializationService);
+                        || valueComparator.isEqual(existingEntry.getRawValue(), mergingEntry.getRawValue(), serializationService);
                 if (shouldMergeExpiration) {
                     mergeRecordExpiration(key, record, mergingEntry, now);
                 }


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/25899

Comparing non-raw values invokes deserialization on the target member, which should not occur, and a raw value comparison is sufficient for our checks here. I've run QE's WAN ITs locally, including newly added TTL tests for the original issue, to verify functionality is not affected.

Related to https://github.com/hazelcast/hazelcast/pull/25627
Fixes https://hazelcast.atlassian.net/browse/HZ-3661