### PR TITLE
Fix typos in `protocol-definition` docs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryAddListenerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ContinuousQueryAddListenerCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Adds a listener to be notified for the events fired on the underlying map on all nodes.
  */
 @SuppressWarnings("unused")
-@Generated("24f64ec29a9d966130bae01448c901c2")
+@Generated("d32d3b41e378dcaeff0093898024fcd3")
 public final class ContinuousQueryAddListenerCodec {
     //hex: 0x160400
     public static final int REQUEST_MESSAGE_TYPE = 1442816;
@@ -171,7 +171,7 @@ public final class ContinuousQueryAddListenerCodec {
         /**
          * @param events List of events in the form of data that holds the details of the event such as key, value, old value,
          *               new value and creation time.
-         * @param source Source that dispathces this batch event.
+         * @param source Source that dispatches this batch event.
          * @param partitionId Id of the partition that holds the keys of the batch event.
          */
         public abstract void handleQueryCacheBatchEvent(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FencedLockGetLockOwnershipCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/FencedLockGetLockOwnershipCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Returns current lock ownership status of the given FencedLock instance.
  */
 @SuppressWarnings("unused")
-@Generated("777b6472096f1a1660ff92ebf5d1a8ec")
+@Generated("64e748beca2c26b10195b5751d7916d8")
 public final class FencedLockGetLockOwnershipCodec {
     //hex: 0x070400
     public static final int REQUEST_MESSAGE_TYPE = 459776;
@@ -99,7 +99,7 @@ public final class FencedLockGetLockOwnershipCodec {
         public long fence;
 
         /**
-         * Reenterant lock count
+         * Reentrant lock count
          */
         public int lockCount;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetMapConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MCGetMapConfigCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Gets the config of a map on the member it's called on.
  */
 @SuppressWarnings("unused")
-@Generated("d2dcbc253244ff224513869a94e5df06")
+@Generated("96721e5ff2d1454ce78a32a423967728")
 public final class MCGetMapConfigCodec {
     //hex: 0x200300
     public static final int REQUEST_MESSAGE_TYPE = 2097920;
@@ -151,7 +151,7 @@ public final class MCGetMapConfigCodec {
         public java.lang.String mergePolicy;
 
         /**
-         * Global indexs of the map.
+         * Global indexes of the map.
          */
         public java.util.List<com.hazelcast.config.IndexConfig> globalIndexes;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalReadCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapEventJournalReadCodec.java
@@ -35,7 +35,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 
 /**
  * Reads from the map event journal in batches. You may specify the start sequence,
- * the minumum required number of items in the response, the maximum number of items
+ * the minimum required number of items in the response, the maximum number of items
  * in the response, a predicate that the events should pass and a projection to
  * apply to the events in the journal.
  * If the event journal currently contains less events than {@code minSize}, the
@@ -44,7 +44,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * and no projection is applied.
  */
 @SuppressWarnings("unused")
-@Generated("a699315c1120fb4a95a7398e0c88b4b0")
+@Generated("672b19f4a7355a280fc06b317804ee81")
 public final class MapEventJournalReadCodec {
     //hex: 0x014200
     public static final int REQUEST_MESSAGE_TYPE = 82432;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchNearCacheInvalidationMetadataCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MapFetchNearCacheInvalidationMetadataCodec.java
@@ -37,7 +37,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * Fetches invalidation metadata from partitions of map.
  */
 @SuppressWarnings("unused")
-@Generated("e74ddacc6b0be6f9dac783588c8d38bc")
+@Generated("49e183fb5e5fb7b40dba113e481716e0")
 public final class MapFetchNearCacheInvalidationMetadataCodec {
     //hex: 0x013D00
     public static final int REQUEST_MESSAGE_TYPE = 81152;
@@ -59,7 +59,7 @@ public final class MapFetchNearCacheInvalidationMetadataCodec {
         public java.util.List<java.lang.String> names;
 
         /**
-         * The uuid of the member to fetch the near cahce invalidation meta data
+         * The uuid of the member to fetch the near cache invalidation meta data
          */
         public java.util.UUID uuid;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadManyCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/RingbufferReadManyCodec.java
@@ -43,7 +43,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * This reduces the amount of IO and the number of operations being executed, and can result in a significant performance improvement.
  */
 @SuppressWarnings("unused")
-@Generated("620471b173e3f78fb4808ed805e335f6")
+@Generated("a0b986d3ce1651ebb6661c307871ca0f")
 public final class RingbufferReadManyCodec {
     //hex: 0x170900
     public static final int REQUEST_MESSAGE_TYPE = 1509632;
@@ -127,7 +127,7 @@ public final class RingbufferReadManyCodec {
         public int readCount;
 
         /**
-         * List of items that have beee read.
+         * List of items that have been read.
          */
         public java.util.List<com.hazelcast.internal.serialization.Data> items;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueOfferCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/TransactionalQueueOfferCodec.java
@@ -38,7 +38,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * become available.
  */
 @SuppressWarnings("unused")
-@Generated("0fd30eeb8d74c3a09c33655fbdb8e73f")
+@Generated("1139c7af89463bfed2f2eedabf8d858b")
 public final class TransactionalQueueOfferCodec {
     //hex: 0x120100
     public static final int REQUEST_MESSAGE_TYPE = 1179904;
@@ -58,7 +58,7 @@ public final class TransactionalQueueOfferCodec {
     public static class RequestParameters {
 
         /**
-         * Name of the Transcational Queue
+         * Name of the Transactional Queue
          */
         public java.lang.String name;
 


### PR DESCRIPTION
Regenerated based off https://github.com/hazelcast/hazelcast-client-protocol/pull/485