### PR TITLE
Batch partition replica updates [HZ-3652]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/DefaultPartitionReplicaInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/DefaultPartitionReplicaInterceptor.java
@@ -18,10 +18,11 @@ package com.hazelcast.internal.partition.impl;
 
 import com.hazelcast.internal.partition.PartitionReplica;
 import com.hazelcast.internal.partition.PartitionReplicaInterceptor;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 
 /**
  * PartitionReplicaInterceptor used to intercept partition changes internally.
- * Most significant responsibility of this interceptor is to increment the partition-state version on each change
+ * Most significant responsibility of this interceptor is to update the partition-state stamp on each change
  * and cancel any ongoing replica synchronization on the changed partition.
  */
 final class DefaultPartitionReplicaInterceptor implements PartitionReplicaInterceptor {
@@ -31,6 +32,12 @@ final class DefaultPartitionReplicaInterceptor implements PartitionReplicaInterc
         this.partitionService = partitionService;
     }
 
+    /**
+     * If this logic changes, consider also changing the implementation of
+     * {@link PartitionStateManager#partitionOwnersChanged(PartitionIdSet)}, which should apply
+     * the same logic per partition batch.
+     * </b></p>.
+     */
     @Override
     public void replicaChanged(int partitionId, int replicaIndex, PartitionReplica oldReplica, PartitionReplica newReplica) {
         if (replicaIndex == 0) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
@@ -104,9 +104,17 @@ public class InternalPartitionImpl extends AbstractInternalPartition implements 
         onReplicaChange(index2, a2, a1);
     }
 
-    void setReplicasAndVersion(InternalPartition partition) {
-        setReplicas(partition.getReplicasCopy());
+    /**
+     * This method is always called from batch partition update situations, so it does
+     * not invoke interceptors individually per partition.
+     * (apply partition assignments from master while joining, apply partition table recovered
+     * from hot restart)
+     * @return {@code true} if partition owner was changed, otherwise {@code false}.
+     */
+    boolean setReplicasAndVersion(InternalPartition partition) {
+        boolean ownerChanged = setReplicas(partition.getReplicasCopy(), false);
         version = partition.version();
+        return ownerChanged;
     }
 
     void setVersion(int version) {
@@ -122,6 +130,17 @@ public class InternalPartitionImpl extends AbstractInternalPartition implements 
         onReplicasChange(newReplicas, oldReplicas);
     }
 
+    /**
+     * Variant of {@link #setReplicas(PartitionReplica[])} that's suitable for batch partition replica updates.
+     *
+     * @return {@code true} if partition owner was changed, otherwise {@code false}.
+     */
+    boolean setReplicas(PartitionReplica[] newReplicas, boolean invokeInterceptor) {
+        PartitionReplica[] oldReplicas = replicas;
+        replicas = newReplicas;
+        return onReplicasChange(newReplicas, oldReplicas, invokeInterceptor);
+    }
+
     void setReplica(int replicaIndex, PartitionReplica newReplica) {
         PartitionReplica[] newReplicas = copyOf(replicas, MAX_REPLICA_COUNT);
         PartitionReplica oldReplica = newReplicas[replicaIndex];
@@ -130,19 +149,46 @@ public class InternalPartitionImpl extends AbstractInternalPartition implements 
         onReplicaChange(replicaIndex, oldReplica, newReplica);
     }
 
-    /** Calls the partition replica change interceptor for all changed replicas. */
-    private void onReplicasChange(PartitionReplica[] newReplicas, PartitionReplica[] oldReplicas) {
-        for (int replicaIndex = 0; replicaIndex < MAX_REPLICA_COUNT; replicaIndex++) {
-            PartitionReplica oldReplicasId = oldReplicas[replicaIndex];
-            PartitionReplica newReplicasId = newReplicas[replicaIndex];
-            onReplicaChange(replicaIndex, oldReplicasId, newReplicasId);
-        }
+    /**
+     * Calls the partition replica change interceptor for all changed replicas.
+     * @return {@code true} if partition owner change was detected, otherwise {@code false}.
+     */
+    private boolean onReplicasChange(PartitionReplica[] newReplicas, PartitionReplica[] oldReplicas) {
+        return onReplicasChange(newReplicas, oldReplicas, true);
     }
 
-    /** Calls the partition replica change interceptor for the changed replica. */
+    private boolean onReplicasChange(PartitionReplica[] newReplicas, PartitionReplica[] oldReplicas, boolean invokeInterceptor) {
+        PartitionReplica oldReplicasOwner = oldReplicas[0];
+        PartitionReplica newReplicasOwner = newReplicas[0];
+        boolean partitionOwnerChanged = onReplicaChange(0, oldReplicasOwner, newReplicasOwner, invokeInterceptor);
+
+        for (int replicaIndex = 1; replicaIndex < MAX_REPLICA_COUNT; replicaIndex++) {
+            PartitionReplica oldReplicasId = oldReplicas[replicaIndex];
+            PartitionReplica newReplicasId = newReplicas[replicaIndex];
+            onReplicaChange(replicaIndex, oldReplicasId, newReplicasId, invokeInterceptor);
+        }
+        return partitionOwnerChanged;
+    }
+
+    /**
+     * If a replica change is detected, then increments partition version and calls the partition replica change interceptor
+     * for the changed replica.
+     * @return {@code true} if a replica change was detected, otherwise {@code false}.
+     */
     @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
             justification = "This method is called under InternalPartitionServiceImpl.lock")
-    private void onReplicaChange(int replicaIndex, PartitionReplica oldReplica, PartitionReplica newReplica) {
+    private boolean onReplicaChange(int replicaIndex, PartitionReplica oldReplica, PartitionReplica newReplica) {
+        return onReplicaChange(replicaIndex, oldReplica, newReplica, true);
+    }
+
+    /**
+     * Calls the partition replica change interceptor for the changed replica.
+     * @return {@code true} if a replica change was detected, otherwise {@code false}.
+     */
+    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
+            justification = "This method is called under InternalPartitionServiceImpl.lock")
+    private boolean onReplicaChange(int replicaIndex, PartitionReplica oldReplica, PartitionReplica newReplica,
+                                 boolean invokeInterceptor) {
         boolean changed;
         if (oldReplica == null) {
             changed = newReplica != null;
@@ -150,12 +196,13 @@ public class InternalPartitionImpl extends AbstractInternalPartition implements 
             changed = !oldReplica.equals(newReplica);
         }
         if (!changed) {
-            return;
+            return false;
         }
         version++;
-        if (interceptor != null) {
+        if (interceptor != null && invokeInterceptor) {
             interceptor.replicaChanged(partitionId, replicaIndex, oldReplica, newReplica);
         }
+        return true;
     }
 
     InternalPartitionImpl copy(PartitionReplicaInterceptor interceptor) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -800,9 +800,10 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
             }
         }
 
-        // Manually trigger partition stamp calculation.
         // Because partition versions are explicitly set to master's versions
-        // while applying the partition table updates.
+        // while applying the partition table updates, we need to
+        // (1) cancel any ongoing replica syncs (for partitions whose owners changed) and
+        // (2) update the partition state stamp.
         partitionStateManager.partitionOwnersChanged(changedOwnerPartitions);
 
         if (logger.isFineEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -295,8 +295,8 @@ public class PartitionStateManager {
                 }
             }
         }
-        partitionOwnersChanged(changedOwnerPartitions);
         if (foundReplica) {
+            partitionOwnersChanged(changedOwnerPartitions);
             setInitialized();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -238,7 +238,7 @@ public class PartitionStateManager {
     void partitionOwnersChanged(PartitionIdSet partitionIdSet) {
         partitionIdSet.intIterator().forEachRemaining(
                 (IntConsumer) partitionId -> partitionService.getReplicaManager().cancelReplicaSync(partitionId));
-        partitionService.getPartitionStateManager().updateStamp();
+        updateStamp();
         replicaUpdateInterceptor.onPartitionOwnersChanged();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -35,6 +35,7 @@ import com.hazelcast.internal.partition.PartitionTableView;
 import com.hazelcast.internal.partition.ReadonlyInternalPartition;
 import com.hazelcast.internal.partition.membergroup.MemberGroupFactory;
 import com.hazelcast.internal.partition.membergroup.MemberGroupFactoryFactory;
+import com.hazelcast.internal.util.collection.PartitionIdSet;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.partitiongroup.MemberGroup;
 
@@ -44,6 +45,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.IntConsumer;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.PARTITIONS_METRIC_PARTITION_REPLICA_STATE_MANAGER_ACTIVE_PARTITION_COUNT;
@@ -98,6 +100,9 @@ public class PartitionStateManager {
     // can be read and written concurrently...
     private volatile int memberGroupsSize;
 
+    /** For test usage only */
+    private ReplicaUpdateInterceptor replicaUpdateInterceptor;
+
     public PartitionStateManager(Node node, InternalPartitionServiceImpl partitionService) {
         this.node = node;
         this.logger = node.getLogger(getClass());
@@ -117,6 +122,7 @@ public class PartitionStateManager {
                 node.getDiscoveryService());
         partitionStateGenerator = new PartitionStateGeneratorImpl();
         snapshotOnRemove = new ConcurrentHashMap<>();
+        this.replicaUpdateInterceptor = NoOpBatchReplicatUpdateInterceptor.INSTANCE;
     }
 
     /**
@@ -192,11 +198,7 @@ public class PartitionStateManager {
                     + "Expected: " + partitionCount + ", Actual: " + newState.length);
         }
 
-        for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
-            InternalPartitionImpl partition = partitions[partitionId];
-            PartitionReplica[] replicas = newState[partitionId];
-            partition.setReplicas(replicas);
-        }
+        batchUpdateReplicas(newState);
 
         ClusterState clusterState = node.getClusterService().getClusterState();
         if (!clusterState.isMigrationAllowed()) {
@@ -208,6 +210,36 @@ public class PartitionStateManager {
 
         setInitialized();
         return true;
+    }
+
+    void batchUpdateReplicas(PartitionReplica[][] newState) {
+        PartitionIdSet changedOwnersSet = new PartitionIdSet(partitionCount);
+        for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+            InternalPartitionImpl partition = partitions[partitionId];
+            PartitionReplica[] replicas = newState[partitionId];
+            if (partition.setReplicas(replicas, false)) {
+                changedOwnersSet.add(partitionId);
+            }
+        }
+        partitionOwnersChanged(changedOwnersSet);
+    }
+
+    /**
+     * Called after a batch of partition replica assignments have been applied. This is an optimization for batch
+     * changes, to avoid repeatedly performing costly computations (like updating partition assignments stamp).
+     * <p><b>
+     * If this logic changes, consider also changing the implementation of
+     * {@link PartitionReplicaInterceptor#replicaChanged(int, int, PartitionReplica, PartitionReplica)}, which should apply
+     * the same logic per partition.
+     * </b></p>
+     *
+     * @param partitionIdSet
+     */
+    void partitionOwnersChanged(PartitionIdSet partitionIdSet) {
+        partitionIdSet.intIterator().forEachRemaining(
+                (IntConsumer) partitionId -> partitionService.getReplicaManager().cancelReplicaSync(partitionId));
+        partitionService.getPartitionStateManager().updateStamp();
+        replicaUpdateInterceptor.onPartitionOwnersChanged();
     }
 
     /**
@@ -247,6 +279,7 @@ public class PartitionStateManager {
         logger.info("Setting cluster partition table...");
         boolean foundReplica = false;
         PartitionReplica localReplica = PartitionReplica.from(node.getLocalMember());
+        PartitionIdSet changedOwnerPartitions = new PartitionIdSet(partitionCount);
         for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
             InternalPartitionImpl partition = partitions[partitionId];
             InternalPartition newPartition = partitionTable.getPartition(partitionId);
@@ -257,9 +290,12 @@ public class PartitionStateManager {
             }
             partition.reset(localReplica);
             if (newPartition != null) {
-                partition.setReplicasAndVersion(newPartition);
+                if (partition.setReplicasAndVersion(newPartition)) {
+                    changedOwnerPartitions.add(partitionId);
+                }
             }
         }
+        partitionOwnersChanged(changedOwnerPartitions);
         if (foundReplica) {
             setInitialized();
         }
@@ -388,6 +424,7 @@ public class PartitionStateManager {
         if (logger.isFinestEnabled()) {
             logger.finest("New calculated partition state stamp is: " + stateStamp);
         }
+        replicaUpdateInterceptor.onPartitionStampUpdate();
     }
 
     public long getStamp() {
@@ -409,7 +446,8 @@ public class PartitionStateManager {
 
     boolean setInitialized() {
         if (!initialized) {
-            updateStamp();
+            // partition state stamp is already calculated
+            assert stateStamp != 0 : "Partition state stamp should already have been calculated";
             initialized = true;
             node.getNodeExtension().onPartitionStateChange();
             return true;
@@ -471,5 +509,27 @@ public class PartitionStateManager {
 
     void removeSnapshot(UUID memberUuid) {
         snapshotOnRemove.remove(memberUuid);
+    }
+
+    /** For test usage only */
+    void setReplicaUpdateInterceptor(ReplicaUpdateInterceptor interceptor) {
+        this.replicaUpdateInterceptor = interceptor;
+    }
+
+    interface ReplicaUpdateInterceptor {
+        void onPartitionOwnersChanged();
+        void onPartitionStampUpdate();
+    }
+
+    static final class NoOpBatchReplicatUpdateInterceptor implements ReplicaUpdateInterceptor {
+        static final NoOpBatchReplicatUpdateInterceptor INSTANCE = new NoOpBatchReplicatUpdateInterceptor();
+
+        @Override
+        public void onPartitionOwnersChanged() {
+        }
+
+        @Override
+        public void onPartitionStampUpdate() {
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/BatchReplicaUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/BatchReplicaUpdateTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.impl;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigAccessor;
+import com.hazelcast.config.ServiceConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.services.CoreService;
+import com.hazelcast.internal.services.PreJoinAwareService;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.test.Accessors;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.internal.partition.impl.BatchReplicaUpdateTest.InjectInterceptorOp.REPLICA_UPDATE_COUNTER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BatchReplicaUpdateTest {
+
+    TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory();
+
+    @AfterEach
+    void tearDown() {
+        factory.terminateAll();
+        REPLICA_UPDATE_COUNTER.reset();
+    }
+
+    @Test
+    void testFirstArrangement() {
+        // configure member with high partition count
+        Config config = HazelcastTestSupport.smallInstanceConfigWithoutJetAndMetrics();
+        config.setProperty(ClusterProperty.PARTITION_COUNT.getName(), "" + 20000);
+        HazelcastInstance member = factory.newHazelcastInstance(config);
+        // setup interceptor
+        InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) Accessors.getPartitionService(member);
+        PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
+        ReplicaUpdateCounter counter = new ReplicaUpdateCounter();
+        partitionStateManager.setReplicaUpdateInterceptor(counter);
+        // trigger first arrangement of partitions
+        partitionStateManager.initializePartitionAssignments(Collections.emptySet());
+        assertEquals(1, counter.batchReplicaCounter.get());
+        assertEquals(1, counter.updateStampCounter.get());
+    }
+
+    @Test
+    void testOneMemberJoinsCluster() {
+        // configure member with high partition count
+        Config config = HazelcastTestSupport.smallInstanceConfigWithoutJetAndMetrics();
+        config.setProperty(ClusterProperty.PARTITION_COUNT.getName(), "" + 20000);
+        // setup interceptor service that will track partition state stamp updates on joining member
+        ConfigAccessor.getServicesConfig(config)
+                .addServiceConfig(
+                        new ServiceConfig()
+                                .setName("InjectInterceptorService")
+                                .setEnabled(true)
+                                .setClassName(InjectInterceptorService.class.getName())
+                );
+        HazelcastInstance[] members = factory.newInstances(config, 2);
+        Accessors.getPartitionService(members[0]).firstArrangement();
+        HazelcastTestSupport.waitClusterForSafeState(members[0]);
+
+        // do not allow migrations to be triggered as soon as member joins - we only want to measure the
+        // effect of applying the initial partition state, as provided from master to joining member
+        members[0].getCluster().changeClusterState(ClusterState.NO_MIGRATION);
+        HazelcastTestSupport.assertClusterStateEventually(ClusterState.NO_MIGRATION, members);
+        // start a new member
+        HazelcastInstance joiningMember = factory.newHazelcastInstance(config);
+        HazelcastTestSupport.assertClusterSizeEventually(3, joiningMember);
+        InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) Accessors.getPartitionService(joiningMember);
+        PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
+        HazelcastTestSupport.assertTrueEventually(() -> assertTrue(partitionStateManager.isInitialized()));
+
+        assertEquals(1, REPLICA_UPDATE_COUNTER.batchReplicaCounter.get());
+        assertEquals(1, REPLICA_UPDATE_COUNTER.updateStampCounter.get());
+    }
+
+    static final class ReplicaUpdateCounter implements PartitionStateManager.ReplicaUpdateInterceptor {
+        final AtomicInteger batchReplicaCounter = new AtomicInteger();
+        final AtomicInteger updateStampCounter = new AtomicInteger();
+        @Override
+        public void onPartitionOwnersChanged() {
+            batchReplicaCounter.incrementAndGet();
+        }
+
+        @Override
+        public void onPartitionStampUpdate() {
+            updateStampCounter.incrementAndGet();
+        }
+
+        void reset() {
+            batchReplicaCounter.set(0);
+            updateStampCounter.set(0);
+        }
+    }
+
+    public static class InjectInterceptorService implements CoreService, PreJoinAwareService<InjectInterceptorOp> {
+        @Override
+        public InjectInterceptorOp getPreJoinOperation() {
+            return new InjectInterceptorOp();
+        }
+    }
+
+    public static class InjectInterceptorOp extends Operation implements AllowedDuringPassiveState {
+        // replica update counter is only used in a single test, so even though static it doesn't matter that we don't reset it
+        static final ReplicaUpdateCounter REPLICA_UPDATE_COUNTER = new ReplicaUpdateCounter();
+
+        @Override
+        public void run() {
+            // only act on the joining member
+            if (getNodeEngine().getThisAddress().getPort() == 5703) {
+                InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) getNodeEngine().getPartitionService();
+                PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
+                // replace the default no-op implementation with the counter implementation
+                partitionStateManager.setReplicaUpdateInterceptor(REPLICA_UPDATE_COUNTER);
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionImplTest.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.internal.partition.impl;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.partition.PartitionReplica;
 import com.hazelcast.internal.partition.PartitionReplicaInterceptor;
-import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.internal.util.UuidUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;


### PR DESCRIPTION
Since Hazelcast IMDG 4.1 with the introduction of parallel migrations, the "partition assignments version", a monotonically increasing version number for the whole partition replica assignments data structure, was replaced with a "partition state stamp" - a hash calculated over individual partitions' version. On each partition replica assignment update, the partition state stamp needs to be recalculated.

In certain cases, it is expected that all partition replica assignments will be updated:
- during initial partitions assignment ("first arrangement")
- when a member that joins the cluster applies the partition replica assignments, as received from master member
- when a member recovers partition replica assignments from persistence

In such cases, updating the partition state stamp on each partition replica update is inefficient. Instead, the partition state stamp can be updated just once, after the whole batch of partition replica assignments has been applied.

Measured the following timings:
- Initial partitions assignment on a single member with 20K partitions
  - current `master` branch: 3870 millis (20001 partition stamp updates)
  - with this PR: 28 millis (1 partition stamp update)
-  Apply initial partition state on the 3rd member joining a cluster with 2 members
   - current `master` branch: 3260 (40002 partition stamp updates)
   - with this PR: 4 millis (1 partition stamp update)