### PR TITLE
Add typecheck to ServerConnectionManager package filtering

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/PacketFiltersUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/PacketFiltersUtil.java
@@ -46,8 +46,7 @@ public final class PacketFiltersUtil {
 
     public static ServerConnectionManager getConnectionManager(HazelcastInstance instance) {
         Node node = getNode(instance);
-        ServerConnectionManager connectionManager = node.getServer().getConnectionManager(EndpointQualifier.MEMBER);
-        return connectionManager;
+        return node.getServer().getConnectionManager(EndpointQualifier.MEMBER);
     }
 
     public static void resetPacketFiltersFrom(HazelcastInstance instance) {

--- a/hazelcast/src/test/java/com/hazelcast/test/PacketFiltersUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/PacketFiltersUtil.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.server.FirewallingServer.FirewallingServerConnectionManager;
 import com.hazelcast.internal.server.OperationPacketFilter;
 import com.hazelcast.internal.server.PacketFilter;
+import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.internal.util.collection.IntHashSet;
 
@@ -43,14 +44,17 @@ public final class PacketFiltersUtil {
     private PacketFiltersUtil() {
     }
 
-    public static FirewallingServerConnectionManager getConnectionManager(HazelcastInstance instance) {
+    public static ServerConnectionManager getConnectionManager(HazelcastInstance instance) {
         Node node = getNode(instance);
-        return (FirewallingServerConnectionManager) node.getServer().getConnectionManager(EndpointQualifier.MEMBER);
+        ServerConnectionManager connectionManager = node.getServer().getConnectionManager(EndpointQualifier.MEMBER);
+        return connectionManager;
     }
 
     public static void resetPacketFiltersFrom(HazelcastInstance instance) {
-        FirewallingServerConnectionManager cm = getConnectionManager(instance);
-        cm.removePacketFilter();
+        ServerConnectionManager cm = getConnectionManager(instance);
+        if (cm instanceof FirewallingServerConnectionManager) {
+            ((FirewallingServerConnectionManager) cm).removePacketFilter();
+        }
     }
 
     public static void delayOperationsFrom(HazelcastInstance instance, int factory, List<Integer> opTypes) {

--- a/hazelcast/src/test/java/com/hazelcast/test/PacketFiltersUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/PacketFiltersUtil.java
@@ -27,6 +27,7 @@ import com.hazelcast.internal.server.PacketFilter;
 import com.hazelcast.internal.server.ServerConnectionManager;
 import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.internal.util.collection.IntHashSet;
+import com.hazelcast.logging.ILogger;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -53,6 +54,9 @@ public final class PacketFiltersUtil {
         ServerConnectionManager cm = getConnectionManager(instance);
         if (cm instanceof FirewallingServerConnectionManager) {
             ((FirewallingServerConnectionManager) cm).removePacketFilter();
+        } else {
+            ILogger logger = instance.getLoggingService().getLogger(PacketFiltersUtil.class);
+            logger.warning("Trying to reset packet filters when using real network");
         }
     }
 


### PR DESCRIPTION
SimpleTestInCluster#supportAfter won't fail now if it's launched with real network.

Related to #25880

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
