### PR TITLE
Fix members list persistence race [HZ-2894]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -920,7 +920,7 @@ public final class IOUtil {
             }
             return;
         }
-        try (final FileChannel file = open(dir, READ)) {
+        try (FileChannel file = open(dir, READ)) {
             try {
                 file.force(true);
             } catch (final IOException e) {

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -46,7 +46,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.management.OperatingSystemMXBean;
 import java.net.ServerSocket;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
@@ -96,7 +95,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -800,48 +798,52 @@ public class IOUtilTest extends HazelcastTestSupport {
 
     @Test
     public void testFsyncDirNotForcedOnWindows() throws IOException {
-        MockedStatic<OS> os = mockStatic(OS.class);
-        MockedStatic<FileChannel> fc = mockStatic(FileChannel.class);
-        os.when(OS::isWindows).thenReturn(true);
+        try (MockedStatic<OS> os = mockStatic(OS.class);
+        MockedStatic<FileChannel> fc = mockStatic(FileChannel.class)) {
+            os.when(OS::isWindows).thenReturn(true);
 
-        IOUtil.fsyncDir(tempFolder.getRoot().toPath());
-        fc.verifyNoInteractions();
+            IOUtil.fsyncDir(tempFolder.getRoot().toPath());
+            fc.verifyNoInteractions();
+        }
     }
 
     @Test(expected = NoSuchFileException.class)
     public void testFsyncDirThrowsNoSuchFileExceptionWindows() throws IOException {
-        MockedStatic<OS> os = mockStatic(OS.class);
-        MockedStatic<Files> files = mockStatic(Files.class);
-        os.when(OS::isWindows).thenReturn(true);
-        files.when(() -> Files.exists(any(), any())).thenReturn(false);
+        try (MockedStatic<OS> os = mockStatic(OS.class);
+             MockedStatic<Files> files = mockStatic(Files.class)) {
+            os.when(OS::isWindows).thenReturn(true);
+            files.when(() -> Files.exists(any(), any())).thenReturn(false);
 
-        IOUtil.fsyncDir(tempFolder.getRoot().toPath());
+            IOUtil.fsyncDir(tempFolder.getRoot().toPath());
+        }
     }
 
     @Test
     public void testFsyncDirWhenOSLinux() throws IOException {
-        MockedStatic<OS> os = mockStatic(OS.class);
-        MockedStatic<FileChannel> fc = mockStatic(FileChannel.class);
-        FileChannel mockFileChannel = mock(FileChannel.class);
+        try (MockedStatic<OS> os = mockStatic(OS.class);
+             MockedStatic<FileChannel> fc = mockStatic(FileChannel.class)) {
+            FileChannel mockFileChannel = mock(FileChannel.class);
 
-        os.when(OS::isLinux).thenReturn(true);
-        fc.when(() -> FileChannel.open(tempFolder.getRoot().toPath(), READ)).thenReturn(mockFileChannel);
+            os.when(OS::isLinux).thenReturn(true);
+            fc.when(() -> FileChannel.open(tempFolder.getRoot().toPath(), READ)).thenReturn(mockFileChannel);
 
-        IOUtil.fsyncDir(tempFolder.getRoot().toPath());
-        verify(mockFileChannel).force(true);
+            IOUtil.fsyncDir(tempFolder.getRoot().toPath());
+            verify(mockFileChannel).force(true);
+        }
     }
 
     @Test
     public void testFsyncDirWhenOSIsMac() throws IOException {
-        MockedStatic<OS> os = mockStatic(OS.class);
-        MockedStatic<FileChannel> fc = mockStatic(FileChannel.class);
-        FileChannel mockFileChannel = mock(FileChannel.class);
+        try (MockedStatic<OS> os = mockStatic(OS.class);
+             MockedStatic<FileChannel> fc = mockStatic(FileChannel.class)) {
+            FileChannel mockFileChannel = mock(FileChannel.class);
 
-        os.when(OS::isMac).thenReturn(true);
-        fc.when(() -> FileChannel.open(tempFolder.getRoot().toPath(), READ)).thenReturn(mockFileChannel);
+            os.when(OS::isMac).thenReturn(true);
+            fc.when(() -> FileChannel.open(tempFolder.getRoot().toPath(), READ)).thenReturn(mockFileChannel);
 
-        IOUtil.fsyncDir(tempFolder.getRoot().toPath());
-        verify(mockFileChannel).force(true);
+            IOUtil.fsyncDir(tempFolder.getRoot().toPath());
+            verify(mockFileChannel).force(true);
+        }
     }
 
     private File newFile(String filename) {


### PR DESCRIPTION
Adds utility function to fsync on a directory. 

Directory fsync is not supported for the [Windows OS ](https://mail.openjdk.org/pipermail/nio-dev/2013-February/002124.html) therefore the force is skipped. 

See [Lucene's directory fsync method](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/util/IOUtils.java#L408-L444) for more information. 

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6767

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [X] Request reviewers if possible