### PR TITLE
Eclipse Formatter - Don't add space after generic type

### DIFF
--- a/ide-configurations/eclipse/Hazelcast-Eclipse.pref.epf
+++ b/ide-configurations/eclipse/Hazelcast-Eclipse.pref.epf
@@ -160,7 +160,7 @@
 /instance/org.eclipse.jdt.core/org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation=do not insert
 /instance/org.eclipse.jdt.core/org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration=do not insert
 /instance/org.eclipse.jdt.core/org.eclipse.jdt.core.formatter.insert_space_after_bitwise_operator=insert
-/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments=insert
+/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments=do not insert
 /instance/org.eclipse.jdt.core/org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters=insert
 /instance/org.eclipse.jdt.core/org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block=insert
 /instance/org.eclipse.jdt.core/org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast=insert


### PR DESCRIPTION
With the following input:
`.<Banana> map(fruit -> peel(fruit))`

Checkstyle complains:
`'>' is followed by whitespace. [GenericWhitespace]`

Adjust formatter to follow convention.