### PR TITLE
Refactor `InstancePermission.actions` String manipulation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
@@ -17,6 +17,7 @@
 package com.hazelcast.security.permission;
 
 import com.hazelcast.config.matcher.WildcardConfigPatternMatcher;
+import com.hazelcast.internal.util.StringUtil;
 
 import java.security.Permission;
 
@@ -34,22 +35,14 @@ public abstract class InstancePermission extends ClusterPermission {
     protected final int mask;
     protected final String actions;
 
-    public InstancePermission(String name, String... actions) {
+    protected InstancePermission(String name, String... actions) {
         super(name);
-        if (name == null || "".equals(name)) {
+        if (StringUtil.isNullOrEmpty(name)) {
             throw new IllegalArgumentException("Permission name is mandatory!");
         }
         mask = initMask(actions);
 
-        final StringBuilder s = new StringBuilder();
-        for (String action : actions) {
-            s.append(action).append(" ");
-        }
-        // trim the trailing space
-        if (s.length() > 0) {
-            s.setLength(s.length() - 1);
-        }
-        this.actions = s.toString();
+        this.actions = String.join(" ", actions);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
@@ -17,7 +17,7 @@
 package com.hazelcast.security.permission;
 
 import com.hazelcast.config.matcher.WildcardConfigPatternMatcher;
-import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.internal.util.Preconditions;
 
 import java.security.Permission;
 
@@ -37,9 +37,7 @@ public abstract class InstancePermission extends ClusterPermission {
 
     protected InstancePermission(String name, String... actions) {
         super(name);
-        if (StringUtil.isNullOrEmpty(name)) {
-            throw new IllegalArgumentException("Permission name is mandatory!");
-        }
+        Preconditions.checkHasText(name, "Permission name is mandatory!");
         mask = initMask(actions);
 
         this.actions = String.join(" ", actions);

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/InstancePermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/InstancePermissionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.security.permission;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class InstancePermissionTest {
+    @Test
+    void testActions() {
+        assertEquals("A B C", new InstancePermission(getClass().getSimpleName(), "A", "B", "C") {
+            @Override
+            protected int initMask(String[] actions) {
+                return 0;
+            }
+        }.getActions());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/InstancePermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/InstancePermissionTest.java
@@ -33,7 +33,7 @@ class InstancePermissionTest {
     @NullSource
     @EmptySource
     @ParameterizedTest
-    void testThrows(String name) {
+    void testInvalidNameThrows(String name) {
         assertThrows(IllegalArgumentException.class, () -> new InstantiatableInstancePermission(name));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/InstancePermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/InstancePermissionTest.java
@@ -16,18 +16,36 @@
 
 package com.hazelcast.security.permission;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class InstancePermissionTest {
     @Test
     void testActions() {
-        assertEquals("A B C", new InstancePermission(getClass().getSimpleName(), "A", "B", "C") {
-            @Override
-            protected int initMask(String[] actions) {
-                return 0;
-            }
-        }.getActions());
+        assertEquals("A B C", new InstantiatableInstancePermission(getClass().getSimpleName(), "A", "B", "C").getActions());
+    }
+
+    @NullSource
+    @EmptySource
+    @ParameterizedTest
+    void testThrows(String name) {
+        assertThrows(IllegalArgumentException.class, () -> new InstantiatableInstancePermission(name));
+    }
+
+    @SuppressWarnings("serial")
+    private static class InstantiatableInstancePermission extends InstancePermission {
+        protected InstantiatableInstancePermission(String name, String... actions) {
+            super(name, actions);
+        }
+
+        @Override
+        protected int initMask(String[] actions) {
+            return Integer.MIN_VALUE;
+        }
     }
 }


### PR DESCRIPTION
`com.hazelcast.security.permission.InstancePermission.actions` is generated by concatenating the supplied `actions` together with a space delimiter - the code to do this can be simplified to avoid having to add and subsequently remove an extra trailing space.

Refactored this and tidied up the code a little.

Added a test case to cover this behaviour.