### PR TITLE
Introduce MergingValue#getDeserializedValue [HZ-3701]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractCollectionMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractCollectionMergingValueImpl.java
@@ -56,7 +56,7 @@ public abstract class AbstractCollectionMergingValueImpl<V, T extends AbstractCo
     }
 
     @Override
-    public Collection<V> getValue() {
+    public Collection<V> getDeserializedValue() {
         Collection<Object> deserializedValues = new ArrayList<>(value.size());
         for (Object aValue : value) {
             deserializedValues.add(serializationService.toObject(aValue));

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingEntryImpl.java
@@ -71,7 +71,7 @@ public abstract class AbstractMergingEntryImpl<K, V, T extends AbstractMergingEn
     }
 
     @Override
-    public V getValue() {
+    public V getDeserializedValue() {
         return serializationService.toObject(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergingValueImpl.java
@@ -53,7 +53,7 @@ public abstract class AbstractMergingValueImpl<V, T extends AbstractMergingValue
     }
 
     @Override
-    public V getValue() {
+    public V getDeserializedValue() {
         return serializationService.toObject(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CacheMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CacheMergingEntryImpl.java
@@ -59,7 +59,7 @@ public class CacheMergingEntryImpl<K, V>
     }
 
     @Override
-    public V getValue() {
+    public V getDeserializedValue() {
         return serializationService.toObject(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
@@ -67,7 +67,7 @@ public class MapMergingEntryImpl<K, V>
     }
 
     @Override
-    public V getValue() {
+    public V getDeserializedValue() {
         return serializationService.toObject(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MultiMapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MultiMapMergingEntryImpl.java
@@ -77,7 +77,7 @@ public class MultiMapMergingEntryImpl<K, V> implements MultiMapMergeTypes<K, V>,
     }
 
     @Override
-    public Collection<V> getValue() {
+    public Collection<V> getDeserializedValue() {
         Collection<Object> deserializedValues = new ArrayList<>(value.size());
         for (Object aValue : value) {
             deserializedValues.add(serializationService.toObject(aValue));

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/ReplicatedMapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/ReplicatedMapMergingEntryImpl.java
@@ -59,7 +59,7 @@ public class ReplicatedMapMergingEntryImpl<K, V>
     }
 
     @Override
-    public V getValue() {
+    public V getDeserializedValue() {
         return serializationService.toObject(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/RingbufferMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/RingbufferMergingValueImpl.java
@@ -56,7 +56,7 @@ public class RingbufferMergingValueImpl
     }
 
     @Override
-    public RingbufferMergeData getValue() {
+    public RingbufferMergeData getDeserializedValue() {
         final RingbufferMergeData deserializedValues = new RingbufferMergeData(value.getItems().length);
         deserializedValues.setHeadSequence(value.getHeadSequence());
         deserializedValues.setTailSequence(value.getTailSequence());

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
@@ -40,7 +40,7 @@ public interface MergingValue<V> extends MergingView {
      */
     @Deprecated
     default V getValue() {
-        return getValue();
+        return getDeserializedValue();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
@@ -25,11 +25,37 @@ package com.hazelcast.spi.merge;
 public interface MergingValue<V> extends MergingView {
 
     /**
-     * Returns the deserialized merging value.
+     * Returns the merging value in deserialized form.
+     *
+     * @implNote This method invokes deserialization of the value
+     * when called - <b>be careful not to use it internally</b>
+     * within a cluster as the member may not have information
+     * available to deserialize correctly, resulting in an
+     * {@code Exception} being raised.
      *
      * @return the deserialized merging value
+     * @deprecated since 5.4 - this method name is too ambiguous and does
+     * not convey its functionality well (it deserializes the value) - so
+     * it is being replaced by {@link #getDeserializedValue()}.
      */
-    V getValue();
+    @Deprecated
+    default V getValue() {
+        return getValue();
+    }
+
+    /**
+     * Returns the merging value in deserialized form.
+     *
+     * @implNote This method invokes deserialization of the value
+     * when called - <b>be careful not to use it internally</b>
+     * within a cluster as the member may not have information
+     * available to deserialize correctly, resulting in an
+     * {@code Exception} being raised.
+     *
+     * @return the deserialized merging value
+     * @since 5.4
+     */
+    V getDeserializedValue();
 
     /**
      * Returns the merging value in the in-memory format of the backing data structure.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicy.java
@@ -44,7 +44,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
  * could throw a {@link java.lang.ClassNotFoundException}.</li>
  * </ul>
  * If you need the deserialized data you can call
- * {@link MergingValue#getValue()}
+ * {@link MergingValue#getDeserializedValue()}
  * or {@link MergingEntry#getKey()},
  * which will deserialize the data lazily.
  * <p>


### PR DESCRIPTION
During the RCA for an issue related to data being deserialized by mistake during WAN replication, it was agreed that the MergingValue class's `getValue` method is misleading in that it deserializes the value, whereas most `getValue` methods in the codebase return the in-memory value without deserializing it.

To decrease the likelihood of deserialization being invoked when it shouldn't be, this commit deprecates `MergingValue#getValue` and introduces `MergingValue#getDeserializedValue` to replace it. This commit also improves javadocs for further clarity to developers.

Fixes https://hazelcast.atlassian.net/browse/HZ-3701

Breaking changes (list specific methods/types/messages):
* API: `MergingValue` interface within SPI package now requires the `getDeserializedValue` method to be defined within implementations, replacing the `getValue` definition.
