### PR TITLE
Remove references to `JSON License`

### DIFF
--- a/hazelcast-build-utils/src/main/resources/hazelcast-thirdparty-template.ftl
+++ b/hazelcast-build-utils/src/main/resources/hazelcast-thirdparty-template.ftl
@@ -1560,33 +1560,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----
 
-The JSON License
-Copyright (c) 2002 JSON.org
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files
-(the "Software"), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of the Software,
-and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-The Software shall be used for Good, not Evil.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
-AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
-OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-IN THE SOFTWARE.
-
------
-
                   GNU LIBRARY GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 

--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,6 @@
                                 <includedLicense>Eclipse Distribution License - v 1.0</includedLicense>
                                 <includedLicense>EPL-1.0</includedLicense>
                                 <includedLicense>EPL-2.0</includedLicense>
-                                <includedLicense>JSON</includedLicense>
                                 <includedLicense>Public Domain</includedLicense>
                             </includedLicenses>
                             <licenseMerges>
@@ -646,10 +645,6 @@
                                     EPL 2.0 |
                                     Eclipse Public License - Version 2.0 |
                                     Eclipse Public License, Version 2.0
-                                </licenseMerge>
-                                <licenseMerge>
-                                    JSON |
-                                    The JSON License
                                 </licenseMerge>
                             </licenseMerges>
                         </configuration>


### PR DESCRIPTION
The JSON license was included for the `org.json` transitive dependency, but that [no longer uses this
license](https://github.com/stleary/JSON-java/pull/688).

Changes:
- Removed support for this license (so that the build will fail if re-introduced)
- Removed license text from `thirdparty-template`

Fixes https://github.com/hazelcast/hazelcast/issues/25343