### PR TITLE
Add derivative of `ArrayUtils.concat` that doesn't require explicit destination

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ArrayUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ArrayUtils.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.util.collection;
 
+import javax.annotation.Nonnull;
+
 import java.lang.reflect.Array;
 import java.util.Arrays;
 
@@ -146,10 +148,26 @@ public final class ArrayUtils {
      * @param sourceSecond
      * @param dest
      * @param <T>
+     * @return the concatenated array ({@code dest})
      */
-    public static <T> void concat(T[] sourceFirst, T[] sourceSecond, T[] dest) {
+    public static <T> T[] concat(@Nonnull T[] sourceFirst, @Nonnull T[] sourceSecond, @Nonnull T[] dest) {
         System.arraycopy(sourceFirst, 0, dest, 0, sourceFirst.length);
         System.arraycopy(sourceSecond, 0, dest, sourceFirst.length, sourceSecond.length);
+
+        return dest;
+    }
+
+    /**
+     * Copies in order {@code sourceFirst} and {@code sourceSecond} into a new array.
+     *
+     * @param sourceFirst
+     * @param sourceSecond
+     * @param <T>
+     * @return the concatenated array
+     */
+    public static <T> T[] concat(@Nonnull T[] first, @Nonnull T... second) {
+        return concat(first, second,
+                (T[]) Array.newInstance(first.getClass().getComponentType(), first.length + second.length));
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/SqlPredicate.java
@@ -339,8 +339,7 @@ public class SqlPredicate
             Predicate[] left = getSubPredicatesIfClass(predicateLeft, klass);
             Predicate[] right = getSubPredicatesIfClass(predicateRight, klass);
 
-            predicates = new Predicate[left.length + right.length];
-            ArrayUtils.concat(left, right, predicates);
+            predicates = ArrayUtils.concat(left, right);
         } else {
             predicates = new Predicate[]{predicateLeft, predicateRight};
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/ArrayUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/ArrayUtilsTest.java
@@ -186,8 +186,7 @@ public class ArrayUtilsTest extends HazelcastTestSupport {
     public void concat() {
         Integer[] first = new Integer[]{1, 2, 3};
         Integer[] second = new Integer[]{4};
-        Integer[] concatenated = new Integer[4];
-        ArrayUtils.concat(first, second, concatenated);
+        Integer[] concatenated = ArrayUtils.concat(first, second);
         assertEquals(4, concatenated.length);
         assertEquals(Integer.valueOf(1), concatenated[0]);
         assertEquals(Integer.valueOf(2), concatenated[1]);
@@ -199,8 +198,7 @@ public class ArrayUtilsTest extends HazelcastTestSupport {
     public void concat_whenFirstNull() {
         Integer[] first = null;
         Integer[] second = new Integer[]{4};
-        Integer[] concatenated = new Integer[4];
-        ArrayUtils.concat(first, second, concatenated);
+        ArrayUtils.concat(first, second);
         fail();
     }
 
@@ -208,8 +206,7 @@ public class ArrayUtilsTest extends HazelcastTestSupport {
     public void concat_whenSecondNull() {
         Integer[] first = new Integer[]{1, 2, 3};
         Integer[] second = null;
-        Integer[] concatenated = new Integer[4];
-        ArrayUtils.concat(first, second, concatenated);
+        ArrayUtils.concat(first, second);
         fail();
     }
 


### PR DESCRIPTION
`ArrayUtils.concat` requires a destination array as a parameter of the required size. To avoid callers calculating this, added a derivative that creates a new array internally and returns that.

This allows a simpler invocation where you simply want to combine two arrays.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6814