### PR TITLE
Make kafka connector scale

### DIFF
--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/JetSourceOffsetStorageReader.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/JetSourceOffsetStorageReader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.connect.impl;
+
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * OffsetStorageReader provides access to the offset storage used by sources.
+ */
+class JetSourceOffsetStorageReader implements OffsetStorageReader {
+
+    private final State state;
+
+    JetSourceOffsetStorageReader(State state) {
+        this.state = state;
+    }
+
+    @Override
+    public <V> Map<String, Object> offset(Map<String, V> partition) {
+        return offsets(Collections.singletonList(partition)).get(partition);
+    }
+
+    @Override
+    public <V> Map<Map<String, V>, Map<String, Object>> offsets(Collection<Map<String, V>> partitions) {
+        Map<Map<String, V>, Map<String, Object>> map = new HashMap<>();
+        for (Map<String, V> partition : partitions) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> offset = (Map<String, Object>) state.getOffset(partition);
+            map.put(partition, offset);
+        }
+        return map;
+    }
+}

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/JetSourceTaskContext.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/JetSourceTaskContext.java
@@ -16,34 +16,32 @@
 
 package com.hazelcast.jet.kafka.connect.impl;
 
+import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
-class SourceOffsetStorageReader implements OffsetStorageReader {
-
+/**
+ * SourceTaskContext is provided to SourceTasks to allow them to interact with the underlying
+ * runtime.
+ */
+class JetSourceTaskContext implements SourceTaskContext {
+    private final Map<String, String> taskConfig;
     private final State state;
 
-    SourceOffsetStorageReader(State state) {
+    JetSourceTaskContext(Map<String, String> taskConfig,
+                         State state) {
+        this.taskConfig = taskConfig;
         this.state = state;
     }
 
     @Override
-    public <V> Map<String, Object> offset(Map<String, V> partition) {
-        return offsets(Collections.singletonList(partition)).get(partition);
+    public Map<String, String> configs() {
+        return taskConfig;
     }
 
     @Override
-    public <V> Map<Map<String, V>, Map<String, Object>> offsets(Collection<Map<String, V>> partitions) {
-        Map<Map<String, V>, Map<String, Object>> map = new HashMap<>();
-        for (Map<String, V> partition : partitions) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> offset = (Map<String, Object>) state.getOffset(partition);
-            map.put(partition, offset);
-        }
-        return map;
+    public OffsetStorageReader offsetStorageReader() {
+        return new JetSourceOffsetStorageReader(state);
     }
 }

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
@@ -139,7 +139,7 @@ public class ReadKafkaConnectP<T> extends AbstractProcessor implements DynamicMe
         long start = Timer.nanos();
         List<SourceRecord> sourceRecords = sourceConnectorWrapper.poll();
 
-        getLogger().info("polled record size " + counter.addAndGet(sourceRecords.size()));
+        getLogger().info("Total polled record size " + counter.addAndGet(sourceRecords.size()));
 
         long durationInNanos = Timer.nanosElapsed(start);
         localKafkaConnectStats.addSourceRecordPollDuration(Duration.ofNanos(durationInNanos));
@@ -171,7 +171,7 @@ public class ReadKafkaConnectP<T> extends AbstractProcessor implements DynamicMe
         }
         snapshotInProgress = true;
         if (snapshotTraverser == null) {
-            snapshotTraverser = Traversers.singleton(entry(snapshotKey(), sourceConnectorWrapper.getSnapshotCopy()))
+            snapshotTraverser = Traversers.singleton(entry(snapshotKey(), sourceConnectorWrapper.copyState()))
                     .onFirstNull(() -> {
                         snapshotTraverser = null;
                         getLogger().finest("Finished saving snapshot");
@@ -190,7 +190,7 @@ public class ReadKafkaConnectP<T> extends AbstractProcessor implements DynamicMe
 
         boolean forThisProcessor = snapshotKey().equals(key);
         if (forThisProcessor) {
-            sourceConnectorWrapper.restoreSnapshot((State) value);
+            sourceConnectorWrapper.restoreState((State) value);
         }
     }
 

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectP.java
@@ -100,7 +100,6 @@ public class ReadKafkaConnectP<T> extends AbstractProcessor implements DynamicMe
 
         if (sourceConnectorWrapper == null) {
             sourceConnectorWrapper = new SourceConnectorWrapper(propertiesFromUser);
-            sourceConnectorWrapper.setLocalProcessorIndex(localProcessorIndex);
         }
         sourceConnectorWrapper.setLogger(getLogger());
         sourceConnectorWrapper.setProcessorOrder(processorOrder);
@@ -164,7 +163,7 @@ public class ReadKafkaConnectP<T> extends AbstractProcessor implements DynamicMe
 
     @Override
     public boolean saveToSnapshot() {
-        getLogger().info("saveToSnapshot  for globalProcessorIndex=" + globalProcessorIndex +
+        getLogger().info("saveToSnapshot for globalProcessorIndex=" + globalProcessorIndex +
                          " localProcessorIndex= " + localProcessorIndex);
 
         if (!snapshotsEnabled) {

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/State.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/State.java
@@ -19,11 +19,15 @@ package com.hazelcast.jet.kafka.connect.impl;
 import org.apache.kafka.connect.source.SourceRecord;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-class State implements Serializable {
+public class State implements Serializable {
+
+    private List<Map<String, String>> taskConfigs;
 
     /**
      * Key represents the partition which the record originated from. Value
@@ -43,6 +47,18 @@ class State implements Serializable {
      */
     State(Map<Map<String, ?>, Map<String, ?>> partitionsToOffset) {
         this.partitionsToOffset = new ConcurrentHashMap<>(partitionsToOffset);
+    }
+
+    public void setTaskConfigs(List<Map<String, String>> taskConfigs) {
+        this.taskConfigs = taskConfigs;
+    }
+
+    public Map<String, String> getTaskConfig(int globalProcessorIndex) {
+        if (globalProcessorIndex < taskConfigs.size()) {
+            return taskConfigs.get(globalProcessorIndex);
+        } else {
+            return Collections.emptyMap();
+        }
     }
 
     void commitRecord(SourceRecord rec) {
@@ -67,18 +83,20 @@ class State implements Serializable {
         }
 
         State state = (State) o;
-        return partitionsToOffset.equals(state.partitionsToOffset);
+        return Objects.equals(taskConfigs, state.taskConfigs) &&
+               Objects.equals(partitionsToOffset, state.partitionsToOffset);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(partitionsToOffset);
+        return Objects.hash(taskConfigs, partitionsToOffset);
     }
 
     @Override
     public String toString() {
         return "State{" +
-                "partitionsToOffset=" + partitionsToOffset +
-                '}';
+               "taskConfigs=" + taskConfigs +
+               ", partitionsToOffset=" + partitionsToOffset +
+               '}';
     }
 }

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/TaskRunner.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/TaskRunner.java
@@ -20,8 +20,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
-import org.apache.kafka.connect.source.SourceTaskContext;
-import org.apache.kafka.connect.storage.OffsetStorageReader;
 
 import java.util.Collections;
 import java.util.List;
@@ -143,27 +141,6 @@ public class TaskRunner {
         }
     }
 
-    private static final class JetSourceTaskContext implements SourceTaskContext {
-        private final Map<String, String> taskConfig;
-        private final State state;
-
-        private JetSourceTaskContext(Map<String, String> taskConfig,
-                                     State state) {
-            this.taskConfig = taskConfig;
-            this.state = state;
-        }
-
-        @Override
-        public Map<String, String> configs() {
-            return taskConfig;
-        }
-
-        @Override
-        public OffsetStorageReader offsetStorageReader() {
-            return new SourceOffsetStorageReader(state);
-        }
-    }
-
     public void commitRecord(SourceRecord rec) {
         state.commitRecord(rec);
         try {
@@ -193,12 +170,13 @@ public class TaskRunner {
     @Override
     public String toString() {
         return "TaskRunner{" +
-                "name='" + name + '\'' +
-                '}';
+               "name='" + name + '\'' +
+               '}';
     }
 
     @FunctionalInterface
     interface SourceTaskFactory {
         SourceTask create();
     }
+
 }

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/TaskRunner.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/TaskRunner.java
@@ -153,13 +153,13 @@ public class TaskRunner {
         }
     }
 
-    public State getSnapshotCopy() {
+    public State copyState() {
         State snapshot = new State();
         snapshot.load(state);
         return snapshot;
     }
 
-    public void restoreSnapshot(State state) {
+    public void restoreState(State state) {
         this.state.load(state);
     }
 

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/topic/LateJoiningListener.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/topic/LateJoiningListener.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.connect.impl.topic;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.topic.MessageListener;
+import com.hazelcast.topic.impl.reliable.ReliableMessageListenerAdapter;
+
+/**
+ * This listener will get the last published topic if it joins late.
+ */
+class LateJoiningListener<E> extends ReliableMessageListenerAdapter<E> {
+    private final HazelcastInstance hazelcastInstance;
+    private final String topicName;
+
+    LateJoiningListener(HazelcastInstance hazelcastInstance, String topicName, MessageListener<E> messageListener) {
+        super(messageListener);
+        this.hazelcastInstance = hazelcastInstance;
+        this.topicName = topicName;
+    }
+
+    @Override
+    public long retrieveInitialSequence() {
+        Ringbuffer<Object> ringbuffer = hazelcastInstance.getRingbuffer(RingbufferService.TOPIC_RB_PREFIX + topicName);
+        // if tailSequence is -1 get next message
+        // if tailSequence is different from -1 get the oldest message
+        return ringbuffer.tailSequence();
+    }
+}

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/topic/TaskConfigPublisher.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/topic/TaskConfigPublisher.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.connect.impl.topic;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.ReliableMessageListener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class TaskConfigPublisher {
+    private ITopic<TaskConfigTopic> reliableTopic;
+
+    private List<UUID> listeners = new ArrayList<>();
+
+    public void createTopic(HazelcastInstance hazelcastInstance, long executionId) {
+        Config config = hazelcastInstance.getConfig();
+
+        String topicName = String.valueOf(executionId);
+        /*RingbufferConfig ringbufferConfig = config.getRingbufferConfig(topicName);
+        ringbufferConfig.setCapacity(1);
+        */
+        reliableTopic = hazelcastInstance.getReliableTopic(topicName);
+    }
+
+    public void addListener(ReliableMessageListener<TaskConfigTopic> reliableMessageListener) {
+        UUID uuid = reliableTopic.addMessageListener(reliableMessageListener);
+        listeners.add(uuid);
+    }
+
+    public void publish(TaskConfigTopic taskConfigTopic) {
+        reliableTopic.publish(taskConfigTopic);
+    }
+
+    public void destroyTopic() {
+        reliableTopic.destroy();
+    }
+
+    public void removeListeners() {
+        for (UUID listener : listeners) {
+            reliableTopic.removeMessageListener(listener);
+        }
+    }
+}

--- a/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/topic/TaskConfigTopic.java
+++ b/extensions/kafka-connect/src/main/java/com/hazelcast/jet/kafka/connect/impl/topic/TaskConfigTopic.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.kafka.connect.impl.topic;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+public class TaskConfigTopic implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private int id;
+
+    private List<Map<String, String>> taskConfigs;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public List<Map<String, String>> getTaskConfigs() {
+        return taskConfigs;
+    }
+
+    public void setTaskConfigs(List<Map<String, String>> taskConfigs) {
+        this.taskConfigs = taskConfigs;
+    }
+}

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectIntegrationTest.java
@@ -291,7 +291,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
                             Map<String, List<Order>> ordersByTaskId = groupByTaskId(list);
                             LOGGER.info("ordersByTaskId = " + countOrdersByTaskId(ordersByTaskId));
                             assertThat(ordersByTaskId).allSatisfy((taskId, records) ->
-                                    assertThat(records.size()).isGreaterThan(ITEM_COUNT)
+                                    assertThat(records).hasSizeGreaterThan(ITEM_COUNT)
                             );
                         }));
 
@@ -361,6 +361,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         randomProperties.setProperty("name", "datagen-connector");
         randomProperties.setProperty("connector.class", "io.confluent.kafka.connect.datagen.DatagenConnector");
         randomProperties.setProperty("max.interval", "1");
+        randomProperties.setProperty("tasks.max", "3");
         randomProperties.setProperty("kafka.topic", "not-used");
         randomProperties.setProperty("quickstart", "orders");
 
@@ -422,6 +423,7 @@ public class KafkaConnectIntegrationTest extends JetTestSupport {
         ClassLoader classLoader = getClass().getClassLoader();
         final String CONNECTOR_FILE_PATH = "confluentinc-kafka-connect-datagen-0.6.0.zip";
         URL resource = classLoader.getResource(CONNECTOR_FILE_PATH);
+        assert resource != null;
         assertThat(new File(resource.toURI())).exists();
         return resource;
     }

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectJdbcIntegrationTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectJdbcIntegrationTest.java
@@ -73,6 +73,7 @@ public class KafkaConnectJdbcIntegrationTest extends JetTestSupport {
     public static final String PASSWORD = "mysql";
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConnectJdbcIntegrationTest.class);
 
+    @SuppressWarnings("resource")
     private static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.33")
             .withUsername(USERNAME).withPassword(PASSWORD)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER).withPrefix("Docker"));
@@ -199,12 +200,12 @@ public class KafkaConnectJdbcIntegrationTest extends JetTestSupport {
         randomProperties.setProperty("connection.user", USERNAME);
         randomProperties.setProperty("connection.password", PASSWORD);
         randomProperties.setProperty("incrementing.column.name", "id");
-        randomProperties.setProperty("table.whitelist", "parallel_items_1,parallel_items_2");
+        randomProperties.setProperty("table.whitelist", "newmember_parallel_items_1,newmember_parallel_items_2");
         randomProperties.setProperty("table.poll.interval.ms", "5000");
         randomProperties.setProperty("batch.max.rows", "1");
 
-        createTableAndFill(connectionUrl, "parallel_items_1");
-        createTableAndFill(connectionUrl, "parallel_items_2");
+        createTableAndFill(connectionUrl, "newmember_parallel_items_1");
+        createTableAndFill(connectionUrl, "newmember_parallel_items_2");
 
 
         Pipeline pipeline = Pipeline.create();
@@ -218,7 +219,7 @@ public class KafkaConnectJdbcIntegrationTest extends JetTestSupport {
                         list -> assertEquals(2 * ITEM_COUNT, list.size())));
 
         JobConfig jobConfig = new JobConfig();
-        jobConfig.setProcessingGuarantee(ProcessingGuarantee.AT_LEAST_ONCE);
+        jobConfig.setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE);
         jobConfig.addJarsInZip(new URL(CONNECTOR_URL));
 
         Config config = smallInstanceConfig();

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectSourcesTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/KafkaConnectSourcesTest.java
@@ -43,6 +43,7 @@ public class KafkaConnectSourcesTest {
                 .hasMessage("Property 'name' is required");
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void should_fail_when_no_projectionFn() {
         Properties properties = new Properties();
@@ -51,18 +52,6 @@ public class KafkaConnectSourcesTest {
         assertThatThrownBy(() -> connect(properties, null))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("projectionFn is required");
-    }
-
-
-    @Test
-    public void should_fail_when_tasks_max_property_set() {
-        Properties properties = new Properties();
-        properties.setProperty("name", "some-name");
-        properties.setProperty("connector.class", "some-name");
-        properties.setProperty("tasks.max", "1");
-        assertThatThrownBy(() -> connect(properties, SourceRecordUtil::convertToString))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Property 'tasks.max' not allowed. Use setLocalParallelism(1) in the pipeline instead");
     }
 
     @Test

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/ConnectorWrapperTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/ConnectorWrapperTest.java
@@ -48,6 +48,7 @@ public class ConnectorWrapperTest {
     @Test
     public void should_create_task_runners() {
         ConnectorWrapper connectorWrapper = new ConnectorWrapper(minimalProperties());
+        connectorWrapper.setMasterProcessor(true);
 
         TaskRunner taskRunner1 = connectorWrapper.createTaskRunner();
         assertThat(taskRunner1.getName()).isEqualTo("some-name-task-0");
@@ -56,7 +57,8 @@ public class ConnectorWrapperTest {
         expectedTaskProperties.put("name", "some-name");
         expectedTaskProperties.put("connector.class", DummySourceConnector.class.getName());
         expectedTaskProperties.put("task.id", "0");
-        assertThat(lastTaskInstance().getProperties()).containsAllEntriesOf(expectedTaskProperties);
+        DummySourceConnector.DummyTask dummyTask = lastTaskInstance();
+        assertThat(dummyTask.getProperties()).containsAllEntriesOf(expectedTaskProperties);
 
         TaskRunner taskRunner2 = connectorWrapper.createTaskRunner();
         taskRunner2.poll();

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/JetSourceOffsetStorageReaderTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/JetSourceOffsetStorageReaderTest.java
@@ -31,12 +31,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class SourceOffsetStorageReaderTest {
+public class JetSourceOffsetStorageReaderTest {
     @Test
     public void should_return_null_offset_for_non_existing_partition() {
         Map<String, String> partition = mapOf("part1", "something");
         State state = new State();
-        SourceOffsetStorageReader sut = new SourceOffsetStorageReader(state);
+        JetSourceOffsetStorageReader sut = new JetSourceOffsetStorageReader(state);
         Map<String, Object> offset = sut.offset(partition);
         assertThat(offset).isNull();
     }
@@ -46,7 +46,7 @@ public class SourceOffsetStorageReaderTest {
         Map<String, String> partition = mapOf("part1", "something");
         Map<Map<String, ?>, Map<String, ?>> partitionToOffset = mapOf(partition, mapOf("part1", 123));
         State state = new State(partitionToOffset);
-        SourceOffsetStorageReader sut = new SourceOffsetStorageReader(state);
+        JetSourceOffsetStorageReader sut = new JetSourceOffsetStorageReader(state);
         Map<String, Object> offset = sut.offset(partition);
         assertThat(offset).isEqualTo(mapOf("part1", 123));
     }

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectPTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/ReadKafkaConnectPTest.java
@@ -62,9 +62,9 @@ public class ReadKafkaConnectPTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        ConnectorWrapper connectorWrapper = new ConnectorWrapper(minimalProperties());
+        SourceConnectorWrapper sourceConnectorWrapper = new TestSourceConnectorWrapper(minimalProperties());
         readKafkaConnectP = new ReadKafkaConnectP<>(noEventTime(), rec -> (Integer) rec.value());
-        readKafkaConnectP.setConnectorWrapper(connectorWrapper);
+        readKafkaConnectP.setSourceConnectorWrapper(sourceConnectorWrapper);
         outbox = new TestOutbox(new int[]{10}, 10);
         context = new TestProcessorContext();
         hazelcastInstance = createHazelcastInstance(smallInstanceConfig());
@@ -73,7 +73,6 @@ public class ReadKafkaConnectPTest extends HazelcastTestSupport {
 
     @Test
     public void should_run_task() throws Exception {
-
         readKafkaConnectP.init(outbox, context);
         boolean complete = readKafkaConnectP.complete();
 
@@ -83,7 +82,7 @@ public class ReadKafkaConnectPTest extends HazelcastTestSupport {
 
     @Test
     public void should_filter_items() throws Exception {
-        ConnectorWrapper connectorWrapper = new ConnectorWrapper(minimalProperties());
+        SourceConnectorWrapper sourceConnectorWrapper = new TestSourceConnectorWrapper(minimalProperties());
         readKafkaConnectP = new ReadKafkaConnectP<>(noEventTime(), rec -> {
             Integer value = (Integer) rec.value();
             if (value % 2 == 0) {
@@ -92,7 +91,7 @@ public class ReadKafkaConnectPTest extends HazelcastTestSupport {
                 return value;
             }
         });
-        readKafkaConnectP.setConnectorWrapper(connectorWrapper);
+        readKafkaConnectP.setSourceConnectorWrapper(sourceConnectorWrapper);
 
         readKafkaConnectP.init(outbox, context);
         boolean complete = readKafkaConnectP.complete();
@@ -103,19 +102,19 @@ public class ReadKafkaConnectPTest extends HazelcastTestSupport {
 
     @Test
     public void should_require_eventTimePolicy() {
-        ConnectorWrapper connectorWrapper = new ConnectorWrapper(minimalProperties());
+        SourceConnectorWrapper sourceConnectorWrapper = new SourceConnectorWrapper(minimalProperties());
         assertThatThrownBy(() -> new ReadKafkaConnectP<>(null,
                 rec -> (Integer) rec.value())
-                .setConnectorWrapper(connectorWrapper))
+                .setSourceConnectorWrapper(sourceConnectorWrapper))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("eventTimePolicy is required");
     }
 
     @Test
     public void should_require_projectionFn() {
-        ConnectorWrapper connectorWrapper = new ConnectorWrapper(minimalProperties());
+        SourceConnectorWrapper sourceConnectorWrapper = new SourceConnectorWrapper(minimalProperties());
         assertThatThrownBy(() -> new ReadKafkaConnectP<>(noEventTime(), null)
-                .setConnectorWrapper(connectorWrapper))
+                .setSourceConnectorWrapper(sourceConnectorWrapper))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("projectionFn is required");
     }

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/SourceConnectorWrapperTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/SourceConnectorWrapperTest.java
@@ -36,10 +36,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class ConnectorWrapperTest {
+public class SourceConnectorWrapperTest {
     @Test
     public void should_create_and_start_source_with_minimal_properties() {
-        new ConnectorWrapper(minimalProperties());
+        new SourceConnectorWrapper(minimalProperties());
 
         assertThat(sourceConnectorInstance().isInitialized()).isTrue();
         assertThat(sourceConnectorInstance().isStarted()).isTrue();
@@ -47,10 +47,9 @@ public class ConnectorWrapperTest {
 
     @Test
     public void should_create_task_runners() {
-        ConnectorWrapper connectorWrapper = new ConnectorWrapper(minimalProperties());
-        connectorWrapper.setMasterProcessor(true);
+        SourceConnectorWrapper sourceConnectorWrapper = new TestSourceConnectorWrapper(minimalProperties());
 
-        TaskRunner taskRunner1 = connectorWrapper.createTaskRunner();
+        TaskRunner taskRunner1 = sourceConnectorWrapper.createTaskRunner();
         assertThat(taskRunner1.getName()).isEqualTo("some-name-task-0");
         taskRunner1.poll();
         Map<String, String> expectedTaskProperties = new HashMap<>();
@@ -59,22 +58,13 @@ public class ConnectorWrapperTest {
         expectedTaskProperties.put("task.id", "0");
         DummySourceConnector.DummyTask dummyTask = lastTaskInstance();
         assertThat(dummyTask.getProperties()).containsAllEntriesOf(expectedTaskProperties);
-
-        TaskRunner taskRunner2 = connectorWrapper.createTaskRunner();
-        taskRunner2.poll();
-        assertThat(taskRunner2.getName()).isEqualTo("some-name-task-1");
-        expectedTaskProperties = new HashMap<>();
-        expectedTaskProperties.put("name", "some-name");
-        expectedTaskProperties.put("connector.class", DummySourceConnector.class.getName());
-        expectedTaskProperties.put("task.id", "1");
-        assertThat(lastTaskInstance().getProperties()).containsAllEntriesOf(expectedTaskProperties);
     }
 
     @Test
     public void should_reconfigure_task_runners() {
-        ConnectorWrapper connectorWrapper = new ConnectorWrapper(minimalProperties());
+        SourceConnectorWrapper sourceConnectorWrapper = new TestSourceConnectorWrapper(minimalProperties());
 
-        TaskRunner taskRunner1 = connectorWrapper.createTaskRunner();
+        TaskRunner taskRunner1 = sourceConnectorWrapper.createTaskRunner();
         assertThat(taskRunner1.getName()).isEqualTo("some-name-task-0");
         taskRunner1.poll();
         Map<String, String> expectedTaskProperties = new HashMap<>();
@@ -108,7 +98,7 @@ public class ConnectorWrapperTest {
         Properties properties = new Properties();
         properties.setProperty("name", "some-name");
         properties.setProperty("connector.class", "com.example.non.existing.Connector");
-        assertThatThrownBy(() -> new ConnectorWrapper(properties))
+        assertThatThrownBy(() -> new SourceConnectorWrapper(properties))
                 .isInstanceOf(HazelcastException.class)
                 .hasMessage("Connector class 'com.example.non.existing.Connector' not found. " +
                         "Did you add the connector jar to the job?");
@@ -118,10 +108,10 @@ public class ConnectorWrapperTest {
     public void should_cleanup_on_destroy() {
         Properties properties = minimalProperties();
         properties.setProperty(ITEMS_SIZE, String.valueOf(3));
-        ConnectorWrapper connectorWrapper = new ConnectorWrapper(properties);
+        SourceConnectorWrapper sourceConnectorWrapper = new SourceConnectorWrapper(properties);
         assertThat(sourceConnectorInstance().isStarted()).isTrue();
 
-        connectorWrapper.stop();
+        sourceConnectorWrapper.stop();
 
         assertThat(sourceConnectorInstance().isStarted()).isFalse();
     }

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/TaskRunnerTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/TaskRunnerTest.java
@@ -128,7 +128,7 @@ public class TaskRunnerTest {
         for (SourceRecord sourceRecord : taskRunner.poll()) {
             taskRunner.commitRecord(sourceRecord);
         }
-        State snapshot = taskRunner.createSnapshot();
+        State snapshot = taskRunner.getSnapshotCopy();
 
         Map<Map<String, ?>, Map<String, ?>> partitionsToOffset = new HashMap<>();
         SourceRecord lastRecord = dummyRecord(2);
@@ -138,7 +138,7 @@ public class TaskRunnerTest {
 
     @Test
     public void should_restore_snapshot() {
-        State initialSnapshot = taskRunner.createSnapshot();
+        State initialSnapshot = taskRunner.getSnapshotCopy();
         assertThat(initialSnapshot).isEqualTo(new State(new HashMap<>()));
 
         Map<Map<String, ?>, Map<String, ?>> partitionsToOffset = new HashMap<>();
@@ -148,7 +148,7 @@ public class TaskRunnerTest {
 
         taskRunner.restoreSnapshot(stateToRestore);
 
-        State snapshot = taskRunner.createSnapshot();
+        State snapshot = taskRunner.getSnapshotCopy();
         assertThat(snapshot).isEqualTo(new State(partitionsToOffset));
     }
 

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/TaskRunnerTest.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/TaskRunnerTest.java
@@ -128,7 +128,7 @@ public class TaskRunnerTest {
         for (SourceRecord sourceRecord : taskRunner.poll()) {
             taskRunner.commitRecord(sourceRecord);
         }
-        State snapshot = taskRunner.getSnapshotCopy();
+        State snapshot = taskRunner.copyState();
 
         Map<Map<String, ?>, Map<String, ?>> partitionsToOffset = new HashMap<>();
         SourceRecord lastRecord = dummyRecord(2);
@@ -138,7 +138,7 @@ public class TaskRunnerTest {
 
     @Test
     public void should_restore_snapshot() {
-        State initialSnapshot = taskRunner.getSnapshotCopy();
+        State initialSnapshot = taskRunner.copyState();
         assertThat(initialSnapshot).isEqualTo(new State(new HashMap<>()));
 
         Map<Map<String, ?>, Map<String, ?>> partitionsToOffset = new HashMap<>();
@@ -146,9 +146,9 @@ public class TaskRunnerTest {
         partitionsToOffset.put(sourceRecord.sourcePartition(), sourceRecord.sourceOffset());
         State stateToRestore = new State(partitionsToOffset);
 
-        taskRunner.restoreSnapshot(stateToRestore);
+        taskRunner.restoreState(stateToRestore);
 
-        State snapshot = taskRunner.getSnapshotCopy();
+        State snapshot = taskRunner.copyState();
         assertThat(snapshot).isEqualTo(new State(partitionsToOffset));
     }
 

--- a/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/TestSourceConnectorWrapper.java
+++ b/extensions/kafka-connect/src/test/java/com/hazelcast/jet/kafka/connect/impl/TestSourceConnectorWrapper.java
@@ -14,22 +14,21 @@
  * limitations under the License.
  */
 
-package com.hazelcast.jet.kafka.connect.impl.topic;
+package com.hazelcast.jet.kafka.connect.impl;
 
-import java.io.Serializable;
-import java.util.List;
-import java.util.Map;
+import com.hazelcast.jet.kafka.connect.impl.topic.TaskConfigTopic;
 
-public class TaskConfigTopic implements Serializable {
-    private static final long serialVersionUID = 1L;
+import java.util.Properties;
 
-    private List<Map<String, String>> taskConfigs;
-
-    public List<Map<String, String>> getTaskConfigs() {
-        return taskConfigs;
+// Test ConnectorWrapper that passes topic directly to taskrunners
+public class TestSourceConnectorWrapper extends SourceConnectorWrapper {
+    public TestSourceConnectorWrapper(Properties propertiesFromUser) {
+        super(propertiesFromUser);
+        setMasterProcessor(true);
     }
 
-    public void setTaskConfigs(List<Map<String, String>> taskConfigs) {
-        this.taskConfigs = taskConfigs;
+    @Override
+    protected void publishTopic(TaskConfigTopic taskConfigTopic) {
+        processMessage(taskConfigTopic);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/JetDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/JetDataSerializerHook.java
@@ -63,6 +63,7 @@ public final class JetDataSerializerHook implements DataSerializerHook {
     public static final int EXPECT_NOTHING_PROCESSOR_SUPPLIER = 19;
     public static final int SPECIFIC_MEMBER_PROCESSOR_META_SUPPLIER = 20;
     public static final int RANDOM_MEMBER_PROCESSOR_META_SUPPLIER = 21;
+    public static final int TASK_MAX_PROCESSOR_META_SUPPLIER = 22;
 
     /**
      * Factory ID
@@ -127,6 +128,8 @@ public final class JetDataSerializerHook implements DataSerializerHook {
                     return new ProcessorMetaSupplier.SpecificMemberPms();
                 case RANDOM_MEMBER_PROCESSOR_META_SUPPLIER:
                     return new ProcessorMetaSupplier.RandomMemberPms();
+                case TASK_MAX_PROCESSOR_META_SUPPLIER:
+                    return new TaskMaxProcessorMetaSupplier();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/ProcessorSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/ProcessorSupplier.java
@@ -66,6 +66,10 @@ public interface ProcessorSupplier extends Serializable, SecuredFunction {
     @Nonnull
     Collection<? extends Processor> get(int count);
 
+    default boolean checkLocalParallelism() {
+        return true;
+    }
+
     /**
      * Returns {@code true} if the {@link #close(Throwable)} method of this
      * instance is cooperative. If it's not, the call to the {@code close()}

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/TaskMaxProcessorMetaSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/TaskMaxProcessorMetaSupplier.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+public class TaskMaxProcessorMetaSupplier implements ProcessorMetaSupplier, IdentifiedDataSerializable {
+    private int tasksMax;
+    private ProcessorSupplier supplier;
+    private boolean partitionedAddresses;
+    private final List<Address> memberAddressList = new ArrayList<>();
+    private final List<Integer> memberLocalParallelismList = new ArrayList<>();
+    private int processorOrder;
+
+    public void setTasksMax(int tasksMax) {
+        this.tasksMax = tasksMax;
+    }
+
+    public void setSupplier(ProcessorSupplier supplier) {
+        this.supplier = supplier;
+    }
+
+    private int getAndIncrementProcessorOrder() {
+        return processorOrder++;
+    }
+
+    @Nonnull
+    @Override
+    public Function<? super Address, ? extends ProcessorSupplier> get(@Nonnull List<Address> addresses) {
+        if (!partitionedAddresses) {
+            partitionedAddresses = true;
+            partitionTasks(addresses);
+        }
+        return memberAddress -> {
+            int indexOf = memberAddressList.indexOf(memberAddress);
+            if (indexOf != -1) {
+                memberAddressList.remove(indexOf);
+                Integer localParallelismForMember = memberLocalParallelismList.remove(indexOf);
+                return new TaskMaxProcessorSupplier(localParallelismForMember, supplier, getAndIncrementProcessorOrder());
+            } else {
+                return new ExpectNothingProcessorSupplier();
+            }
+        };
+    }
+
+    private void partitionTasks(List<Address> addresses) {
+        int localParallelism = calculateAverageLocalParallelism(addresses);
+        List<Address> shuffledAddresses = new ArrayList<>(addresses);
+        Collections.shuffle(shuffledAddresses);
+
+        int taskCounter = 0;
+
+        while (taskCounter < tasksMax) {
+            if (shuffledAddresses.size() == 1) {
+                memberAddressList.add(shuffledAddresses.remove(0));
+                memberLocalParallelismList.add(tasksMax - taskCounter);
+                break;
+            } else {
+                memberAddressList.add(shuffledAddresses.remove(0));
+                memberLocalParallelismList.add(localParallelism);
+                taskCounter += localParallelism;
+            }
+        }
+    }
+
+    private int calculateAverageLocalParallelism(List<Address> addresses) {
+        int averageLocalParallelism = tasksMax / addresses.size();
+        if (averageLocalParallelism == 0) {
+            averageLocalParallelism = 1;
+        }
+        return averageLocalParallelism;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(tasksMax);
+        out.writeObject(supplier);
+        out.writeInt(processorOrder);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        tasksMax = in.readInt();
+        supplier = in.readObject();
+        processorOrder = in.readInt();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return JetDataSerializerHook.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return JetDataSerializerHook.TASK_MAX_PROCESSOR_META_SUPPLIER;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/TaskMaxProcessorSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/TaskMaxProcessorSupplier.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.Permission;
+import java.util.Collection;
+import java.util.List;
+
+public class TaskMaxProcessorSupplier implements ProcessorSupplier {
+    private final int localParallelismForMember;
+    private final ProcessorSupplier supplier;
+
+    private final int processorOrder;
+
+    public TaskMaxProcessorSupplier(int localParallelismForMember, ProcessorSupplier supplier, int processorOrder) {
+        this.localParallelismForMember = localParallelismForMember;
+        this.supplier = supplier;
+        this.processorOrder = processorOrder;
+    }
+
+    @Override
+    public void init(@Nonnull Context context) throws Exception {
+        supplier.init(context);
+    }
+
+    @Override
+    public boolean initIsCooperative() {
+        return supplier.initIsCooperative();
+    }
+
+    @Override
+    public boolean closeIsCooperative() {
+        return supplier.closeIsCooperative();
+    }
+
+    @Override
+    public void close(@Nullable Throwable error) throws Exception {
+        supplier.close(error);
+    }
+
+    @Nullable
+    @Override
+    public List<Permission> permissions() {
+        return supplier.permissions();
+    }
+
+    @Override
+    public boolean checkLocalParallelism() {
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    public Collection<? extends Processor> get(int ignored) {
+        Collection<? extends Processor> processors = supplier.get(localParallelismForMember);
+        for (Processor processor : processors) {
+            setProcessorOrderByReflection(processor);
+        }
+        return processors;
+    }
+
+    private void setProcessorOrderByReflection(Processor processor) {
+        try {
+            Method setter = processor.getClass().getDeclaredMethod("setProcessorOrder", int.class);
+            setter.setAccessible(true);
+            setter.invoke(processor, processorOrder);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ignore) {
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/TaskMaxProcessorSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/TaskMaxProcessorSupplier.java
@@ -28,7 +28,7 @@ public class TaskMaxProcessorSupplier implements ProcessorSupplier {
     private final int localParallelismForMember;
     private final ProcessorSupplier supplier;
 
-    private final int processorOrder;
+    private int processorOrder;
 
     public TaskMaxProcessorSupplier(int localParallelismForMember, ProcessorSupplier supplier, int processorOrder) {
         this.localParallelismForMember = localParallelismForMember;
@@ -77,11 +77,12 @@ public class TaskMaxProcessorSupplier implements ProcessorSupplier {
         return processors;
     }
 
+    @SuppressWarnings({"java:S108", "java:S3011"})
     private void setProcessorOrderByReflection(Processor processor) {
         try {
             Method setter = processor.getClass().getDeclaredMethod("setProcessorOrder", int.class);
             setter.setAccessible(true);
-            setter.invoke(processor, processorOrder);
+            setter.invoke(processor, processorOrder++);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ignore) {
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -504,10 +504,13 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
     }
 
     private static Collection<? extends Processor> createProcessors(VertexDef vertexDef, int parallelism) {
-        final Collection<? extends Processor> processors = vertexDef.processorSupplier().get(parallelism);
-        if (processors.size() != parallelism) {
-            throw new JetException("ProcessorSupplier failed to return the requested number of processors." +
-                    " Requested: " + parallelism + ", returned: " + processors.size());
+        ProcessorSupplier processorSupplier = vertexDef.processorSupplier();
+        final Collection<? extends Processor> processors = processorSupplier.get(parallelism);
+        if (processorSupplier.checkLocalParallelism()) {
+            if (processors.size() != parallelism) {
+                throw new JetException("ProcessorSupplier failed to return the requested number of processors." +
+                                       " Requested: " + parallelism + ", returned: " + processors.size());
+            }
         }
         return processors;
     }


### PR DESCRIPTION
Distribute the Jet processors to cluster members via a new ProcessorMetaSupplier. This supplier tries to partition evenly.

The processor owns a SourceConnectorWrapper.  The SourceConnectorWrapper wraps a Kafka Connector and a TaskRunner

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
