### PR TITLE
Slightly expand LocalMapStatsProviderTest coverage [HZ-2072]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
@@ -91,19 +91,23 @@ public class LocalMapStatsProviderTest extends HazelcastTestSupport {
         IMap<Object, Object> map1 = hzLite.getMap(MAP_NAME);
         map1.put("myKey", "myValue");
 
-        // Collect metrics from the Lite member
-        MetricsRegistry metricsRegistry = getNode(hzLite).getNodeEngine().getMetricsRegistry();
-        MapPutCountMetricsCollector metricsCollector = new MapPutCountMetricsCollector();
-        metricsRegistry.collect(metricsCollector);
-
         // Confirm 1 putCount metric was collected for the Lite member
-        assertEquals(1, metricsCollector.totalCollected.get());
+        assertMapPutCountMetric(hzLite, 1);
+        // Confirm no putCount metric was collected for the full member
+        assertMapPutCountMetric(hzFull, 0);
 
         // Destroy the map and ensure metrics are cleaned up
         map1.destroy();
         MapService mapService = getNode(hzLite).getNodeEngine().getService(MapService.SERVICE_NAME);
         LocalMapStatsProvider statsProvider = mapService.getMapServiceContext().getLocalMapStatsProvider();
         assertFalse(statsProvider.hasLocalMapStatsImpl(MAP_NAME));
+    }
+
+    private void assertMapPutCountMetric(HazelcastInstance instance, int expected) {
+        MetricsRegistry metricsRegistry = getNode(instance).getNodeEngine().getMetricsRegistry();
+        MapPutCountMetricsCollector metricsCollector = new MapPutCountMetricsCollector();
+        metricsRegistry.collect(metricsCollector);
+        assertEquals(expected, metricsCollector.totalCollected.get());
     }
 
     private Config createMetricsBasedConfig() {


### PR DESCRIPTION
Adds extra validation that there was no metric recorded on the full member (only executor submits metrics).

During discussion on https://hazelcast.atlassian.net/browse/HZ-2072 I realised that this unit test could be slightly improved to also validate that the executing member does not record metrics (as expected, even prior to the original fix).