### PR TITLE
Improve FunctionEx security [HZ-3454]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/function/BiFunctionEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/BiFunctionEx.java
@@ -22,8 +22,6 @@ import com.hazelcast.security.impl.function.SecuredFunction;
 import java.io.Serializable;
 import java.util.function.BiFunction;
 
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
-
 /**
  * {@code Serializable} variant of {@link BiFunction
  * java.util.function.BiFunction} which declares checked exception.
@@ -60,7 +58,6 @@ public interface BiFunctionEx<T, U, R> extends BiFunction<T, U, R>, Serializable
      *           composed function
      */
     default <V> BiFunctionEx<T, U, V> andThen(FunctionEx<? super R, ? extends V> after) {
-        checkNotNull(after, "after");
-        return (t, u) -> after.apply(apply(t, u));
+        return new FunctionsImpl.ComposedBiFunctionEx<>(this, after);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/function/ConsumerEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/ConsumerEx.java
@@ -56,10 +56,7 @@ public interface ConsumerEx<T> extends Consumer<T>, Serializable, SecuredFunctio
      */
     default ConsumerEx<T> andThen(ConsumerEx<? super T> after) {
         checkNotNull(after, "after");
-        return t -> {
-            accept(t);
-            after.accept(t);
-        };
+        return new FunctionsImpl.ComposedConsumerEx<>(this, after);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/function/FunctionEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/FunctionEx.java
@@ -23,8 +23,6 @@ import com.hazelcast.security.impl.function.SecuredFunction;
 import java.io.Serializable;
 import java.util.function.Function;
 
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
-
 /**
  * {@code Serializable} variant of {@link Function java.util.function.Function}
  * which declares checked exception.
@@ -69,8 +67,7 @@ public interface FunctionEx<T, R> extends Function<T, R>, Serializable, SecuredF
      *           composed function
      */
     default <V> FunctionEx<V, R> compose(FunctionEx<? super V, ? extends T> before) {
-        checkNotNull(before, "before");
-        return v -> apply(before.apply(v));
+        return new FunctionsImpl.ComposedFunctionEx<>(before, this);
     }
 
     /**
@@ -80,7 +77,6 @@ public interface FunctionEx<T, R> extends Function<T, R>, Serializable, SecuredF
      *           composed function
      */
     default <V> FunctionEx<T, V> andThen(FunctionEx<? super R, ? extends V> after) {
-        checkNotNull(after, "after");
-        return t -> after.apply(apply(t));
+        return new FunctionsImpl.ComposedFunctionEx<>(this, after);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/function/FunctionsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/FunctionsImpl.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.function;
+
+import com.hazelcast.security.impl.function.SecuredFunction;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+
+class FunctionsImpl {
+    static class ComposedSecuredFunction<F extends SecuredFunction, G extends SecuredFunction> implements SecuredFunction {
+        protected final F before;
+        protected final G after;
+
+        ComposedSecuredFunction(F before, G after) {
+            checkNotNull(before, "before");
+            checkNotNull(after, "after");
+            this.before = before;
+            this.after = after;
+        }
+
+        @Nullable
+        @Override
+        public List<Permission> permissions() {
+            List<Permission> beforeP = before.permissions();
+            List<Permission> afterP = after.permissions();
+            return sumPermissions(afterP, beforeP);
+        }
+    }
+
+    static class ComposedFunctionEx<V, T, R>
+            extends ComposedSecuredFunction<FunctionEx<? super V, ? extends T>, FunctionEx<? super T, ? extends R>>
+            implements FunctionEx<V, R> {
+
+        public ComposedFunctionEx(@Nonnull FunctionEx<? super V, ? extends T> before,
+                                  @Nonnull FunctionEx<? super T, ? extends R> after) {
+            super(before, after);
+        }
+
+        @Override
+        public R applyEx(V v) throws Exception {
+            return after.applyEx(before.applyEx(v));
+        }
+    }
+
+    static class ComposedBiFunctionEx<U, V, T, R>
+            extends ComposedSecuredFunction<BiFunctionEx<? super U, ? super V, ? extends T>, FunctionEx<? super T, ? extends R>>
+            implements BiFunctionEx<U, V, R> {
+
+        public ComposedBiFunctionEx(@Nonnull BiFunctionEx<? super U, ? super V, ? extends T> before,
+                                  @Nonnull FunctionEx<? super T, ? extends R> after) {
+            super(before, after);
+        }
+
+        @Override
+        public R applyEx(U t, V u) throws Exception {
+            return after.applyEx(before.applyEx(t, u));
+        }
+    }
+
+    static class ComposedConsumerEx<T>
+            extends ComposedSecuredFunction<ConsumerEx<? super T>, ConsumerEx<? super T>>
+            implements ConsumerEx<T> {
+
+        public ComposedConsumerEx(@Nonnull ConsumerEx<? super T> before,
+                                    @Nonnull ConsumerEx<? super T> after) {
+            super(before, after);
+        }
+
+        @Override
+        public void acceptEx(T t) throws Exception {
+            before.acceptEx(t);
+            after.acceptEx(t);
+        }
+    }
+
+    static class ComposedSupplierEx<T, R>
+            extends ComposedSecuredFunction<SupplierEx<? extends T>, FunctionEx<? super T, ? extends R>>
+            implements SupplierEx<R> {
+
+        ComposedSupplierEx(SupplierEx<? extends T> wrapped, FunctionEx<? super T, ? extends R> wrapperSupplier) {
+            super(wrapped, wrapperSupplier);
+        }
+
+        @Override
+        public R getEx() throws Exception {
+            return after.applyEx(before.getEx());
+        }
+    }
+
+    private static List<Permission> sumPermissions(@Nullable List<Permission> afterP, @Nullable List<Permission> beforeP) {
+        if (isEmpty(afterP)) {
+            return beforeP;
+        } else if (isEmpty(beforeP)) {
+            return afterP;
+        } else {
+            List<Permission> permissions = new ArrayList<>(afterP.size() + beforeP.size());
+            permissions.addAll(beforeP);
+            permissions.addAll(afterP);
+            return permissions;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/function/FunctionsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/FunctionsImpl.java
@@ -20,23 +20,22 @@ import com.hazelcast.security.impl.function.SecuredFunction;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.Serializable;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static com.hazelcast.internal.util.CollectionUtil.isEmpty;
-import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 class FunctionsImpl {
-    static class ComposedSecuredFunction<F extends SecuredFunction, G extends SecuredFunction> implements SecuredFunction {
+    static class ComposedSecuredFunction<F extends SecuredFunction, G extends SecuredFunction> implements SecuredFunction, Serializable {
         protected final F before;
         protected final G after;
 
         ComposedSecuredFunction(F before, G after) {
-            checkNotNull(before, "before");
-            checkNotNull(after, "after");
-            this.before = before;
-            this.after = after;
+            this.before = Objects.requireNonNull(before, "before");
+            this.after = Objects.requireNonNull(after, "after");
         }
 
         @Nullable

--- a/hazelcast/src/main/java/com/hazelcast/function/SupplierEx.java
+++ b/hazelcast/src/main/java/com/hazelcast/function/SupplierEx.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.util.ExceptionUtil;
 import com.hazelcast.security.impl.function.SecuredFunction;
 
 import java.io.Serializable;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -46,5 +47,15 @@ public interface SupplierEx<T> extends Supplier<T>, Serializable, SecuredFunctio
         } catch (Exception e) {
             throw ExceptionUtil.sneakyThrow(e);
         }
+    }
+
+    /**
+     * {@code Serializable} analogue of {@link Function#andThen(Function)
+     * java.util.function.Function#andThen(Function)}.
+     * @param <V> the type of output of the {@code after} function, and of the
+     *           composed function
+     */
+    default <V> SupplierEx<V> andThen(FunctionEx<? super T, ? extends V> after) {
+        return new FunctionsImpl.ComposedSupplierEx(this, after);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/core/processor/DiagnosticProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/processor/DiagnosticProcessors.java
@@ -183,7 +183,8 @@ public final class DiagnosticProcessors {
             @Nonnull PredicateEx<T> shouldLogFn,
             @Nonnull SupplierEx<Processor> wrapped
     ) {
-        return () -> new PeekWrappedP<>(wrapped.get(), toStringFn, shouldLogFn, true, false, false);
+        return  wrapped.andThen(p ->
+                new PeekWrappedP<>(p, toStringFn, shouldLogFn, true, false, false));
     }
 
     /**
@@ -301,7 +302,8 @@ public final class DiagnosticProcessors {
             @Nonnull FunctionEx<? super T, ? extends CharSequence> toStringFn,
             @Nonnull PredicateEx<? super T> shouldLogFn,
             @Nonnull SupplierEx<Processor> wrapped) {
-        return () -> new PeekWrappedP<>(wrapped.get(), toStringFn, shouldLogFn, false, true, false);
+        return wrapped.andThen(p ->
+                new PeekWrappedP<>(p, toStringFn, shouldLogFn, false, true, false));
     }
 
     /**
@@ -402,7 +404,8 @@ public final class DiagnosticProcessors {
             @Nonnull FunctionEx<? super Entry<K, V>, ? extends CharSequence> toStringFn,
             @Nonnull PredicateEx<? super Entry<K, V>> shouldLogFn,
             @Nonnull SupplierEx<Processor> wrapped) {
-        return () -> new PeekWrappedP<>(wrapped.get(), toStringFn, shouldLogFn, false, false, true);
+        return wrapped.andThen(p ->
+                new PeekWrappedP<>(p, toStringFn, shouldLogFn, false, false, true));
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ImdgUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ImdgUtil.java
@@ -43,6 +43,7 @@ import javax.security.auth.Subject;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -263,6 +264,15 @@ public final class ImdgUtil {
         @Override
         public R applyEx(T t) {
             return wrapped.apply(t);
+        }
+
+        @Nullable
+        @Override
+        public List<Permission> permissions() {
+            if (wrapped instanceof FunctionEx) {
+                return ((FunctionEx<T, R>) wrapped).permissions();
+            }
+            return null;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -88,13 +88,13 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeMapP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readMapP;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
-import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static java.lang.Math.abs;
 import static java.lang.String.format;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
@@ -812,7 +812,12 @@ public final class Util {
         public static final Identity INSTANCE = new Identity<>();
 
         @Override
-        public T applyEx(T t) throws Exception {
+        public T apply(T t) {
+            return t;
+        }
+
+        @Override
+        public T applyEx(T t) {
             return t;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunction.java
@@ -34,10 +34,13 @@ public interface SecuredFunction {
 
     /**
      * @return the list of permissions required to run this function
+     *
+     * @implNote If used, permissions should be hardcoded based on function arguments/context.
+     * It is not secure to keep {@code List<Permission>} in the function itself because
+     * it could be tampered with if the function is serialized and passed from untrusted caller.
      */
     @Nullable
     default List<Permission> permissions() {
         return null;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/function/FunctionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/function/FunctionsTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.function;
 
+import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -24,12 +25,18 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nullable;
+import java.security.Permission;
+import java.util.List;
+
 import static com.hazelcast.function.Functions.entryKey;
 import static com.hazelcast.function.Functions.entryValue;
 import static com.hazelcast.function.Functions.wholeItem;
 import static com.hazelcast.function.PredicateEx.alwaysFalse;
 import static com.hazelcast.function.PredicateEx.alwaysTrue;
 import static com.hazelcast.query.impl.predicates.PredicateTestUtils.entry;
+import static com.hazelcast.security.permission.ActionConstants.ACTION_CREATE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
@@ -72,5 +79,218 @@ public class FunctionsTest extends HazelcastTestSupport {
     public void when_noopConsumer() {
         // assert it's non-null and doesn't fail
         ConsumerEx.noop().accept(1);
+    }
+
+
+    //region FunctionEx permission
+    @Test
+    public void when_composeUnsecuredFunctionExWithUnsecured_then_noPermissions() {
+        assertThat(FunctionEx.identity().compose(FunctionEx.identity()).permissions()).isNullOrEmpty();
+        assertThat(FunctionEx.identity().andThen(FunctionEx.identity()).permissions()).isNullOrEmpty();
+    }
+
+    @Test
+    public void when_composeFunctionExWithUnsecured_then_propagatePermissions() {
+        var permission = new MapPermission("somemap", ACTION_CREATE);
+        var fun = new SecurableFunction(permission);
+        assertThat(fun.compose(FunctionEx.identity()).permissions()).containsExactly(permission);
+        assertThat(fun.andThen(FunctionEx.identity()).permissions()).containsExactly(permission);
+        assertThat(FunctionEx.identity().compose(fun).permissions()).containsExactly(permission);
+        assertThat(FunctionEx.identity().andThen(fun).permissions()).containsExactly(permission);
+    }
+
+    @Test
+    public void when_composeFunctionExWithSecured_then_propagatePermissions() {
+        var permission = new MapPermission("somemap", ACTION_CREATE);
+        var permission2 = new MapPermission("someothermap", ACTION_CREATE);
+        var fun = new SecurableFunction(permission);
+        var fun2 = new SecurableFunction(permission2);
+        assertThat(fun.compose(fun2).permissions()).containsExactlyInAnyOrder(permission, permission2);
+        assertThat(fun.andThen(fun2).permissions()).containsExactly(permission, permission2);
+    }
+    //endregion
+
+    //region BiFunctionEx permissions
+    @Test
+    public void when_composeUnsecuredBiFunctionExWithUnsecured_then_noPermissions() {
+        BiFunctionEx<Object, Object, Object> fun = (a, b) -> null;
+        assertThat(fun.andThen(FunctionEx.identity()).permissions()).isNullOrEmpty();
+    }
+
+    @Test
+    public void when_composeBiFunctionExWithUnsecured_then_propagatePermissions() {
+        var permission = new MapPermission("somemap", ACTION_CREATE);
+        var fun = new SecurableBiFunction(permission);
+        assertThat(fun.andThen(FunctionEx.identity()).permissions()).containsExactly(permission);
+    }
+
+    @Test
+    public void when_composeBiFunctionExWithSecured_then_propagatePermissions() {
+        var permission = new MapPermission("somemap", ACTION_CREATE);
+        var permission2 = new MapPermission("someothermap", ACTION_CREATE);
+        var fun = new SecurableBiFunction(permission);
+        var fun2 = new SecurableFunction(permission2);
+        assertThat(fun.andThen(fun2).permissions()).containsExactly(permission, permission2);
+    }
+
+    @Test
+    public void when_composeUnsecuredBiFunctionExWithSecured_then_propagatePermissions() {
+        BiFunctionEx<Object, Object, Object> fun = (a, b) -> null;
+        var permission = new MapPermission("somemap", ACTION_CREATE);
+        var fun2 = new SecurableFunction(permission);
+        assertThat(fun.andThen(fun2).permissions()).containsExactly(permission);
+    }
+    //endregion
+
+    //region ConsumerEx permissions
+    @Test
+    public void when_composeUnsecuredConsumerExWithUnsecured_then_noPermissions() {
+        assertThat(ConsumerEx.noop().andThen(ConsumerEx.noop()).permissions()).isNullOrEmpty();
+    }
+
+    @Test
+    public void when_composeConsumerExWithUnsecured_then_propagatePermissions() {
+        var permission = new MapPermission("somemap", ACTION_CREATE);
+        var fun = new SecurableConsumer(permission);
+        assertThat(fun.andThen(ConsumerEx.noop()).permissions()).containsExactly(permission);
+        assertThat(ConsumerEx.noop().andThen(fun).permissions()).containsExactly(permission);
+    }
+
+    @Test
+    public void when_composeConsumerExWithSecured_then_propagatePermissions() {
+        var permission = new MapPermission("somemap", ACTION_CREATE);
+        var permission2 = new MapPermission("someothermap", ACTION_CREATE);
+        var fun = new SecurableConsumer(permission);
+        var fun2 = new SecurableConsumer(permission2);
+        assertThat(fun.andThen(fun2).permissions()).containsExactly(permission, permission2);
+    }
+    //endregion
+
+    //region SupplierEx permissions
+    @Test
+    public void when_composeUnsecuredSupplierExWithUnsecured_then_noPermissions() {
+        SupplierEx<String> fun = () -> "aaa";
+        assertThat(fun.andThen(FunctionEx.identity()).permissions()).isNullOrEmpty();
+    }
+
+    @Test
+    public void when_composeSupplierExWithUnsecured_then_propagatePermissions() {
+        var permission = new MapPermission("somemap", ACTION_CREATE);
+        var fun = new SecurableSupplier(permission);
+        assertThat(fun.andThen(FunctionEx.identity()).permissions()).containsExactly(permission);
+    }
+
+    @Test
+    public void when_composeUnsecuredSupplierExWithSecured_then_noPermissions() {
+        SupplierEx<String> fun = () -> "aaa";
+        var permission2 = new MapPermission("someothermap", ACTION_CREATE);
+        var fun2 = new SecurableFunction(permission2);
+        assertThat(fun.andThen(fun2).permissions()).containsExactly(permission2);
+    }
+
+    @Test
+    public void when_composeSupplierExWithSecured_then_propagatePermissions() {
+        var permission = new MapPermission("somemap", ACTION_CREATE);
+        var permission2 = new MapPermission("someothermap", ACTION_CREATE);
+        var fun = new SecurableSupplier(permission);
+        var fun2 = new SecurableFunction(permission2);
+        assertThat(fun.andThen(fun2).permissions()).containsExactly(permission, permission2);
+    }
+    //endregion
+
+    static class SecurableFunction implements FunctionEx<Object, Object> {
+
+        private List<Permission> permissions;
+
+        public SecurableFunction(List<Permission> permissions) {
+            this.permissions = permissions;
+        }
+
+        public SecurableFunction(Permission permission) {
+            this(List.of(permission));
+        }
+
+        @Override
+        public Object applyEx(Object t) throws Exception {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public List<Permission> permissions() {
+            return permissions;
+        }
+    }
+
+    static class SecurableBiFunction implements BiFunctionEx<Object, Object, Object> {
+
+        private List<Permission> permissions;
+
+        public SecurableBiFunction(List<Permission> permissions) {
+            this.permissions = permissions;
+        }
+
+        public SecurableBiFunction(Permission permission) {
+            this(List.of(permission));
+        }
+
+        @Override
+        public Object applyEx(Object o, Object o2) throws Exception {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public List<Permission> permissions() {
+            return permissions;
+        }
+    }
+
+    static class SecurableConsumer implements ConsumerEx<Object> {
+
+        private List<Permission> permissions;
+
+        public SecurableConsumer(List<Permission> permissions) {
+            this.permissions = permissions;
+        }
+
+        public SecurableConsumer(Permission permission) {
+            this(List.of(permission));
+        }
+
+        @Override
+        public void acceptEx(Object o) throws Exception {
+        }
+
+        @Nullable
+        @Override
+        public List<Permission> permissions() {
+            return permissions;
+        }
+    }
+
+    static class SecurableSupplier implements SupplierEx<Object> {
+
+        private List<Permission> permissions;
+
+        public SecurableSupplier(List<Permission> permissions) {
+            this.permissions = permissions;
+        }
+
+        public SecurableSupplier(Permission permission) {
+            this(List.of(permission));
+        }
+
+        @Override
+        public Object getEx() throws Exception {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public List<Permission> permissions() {
+            return permissions;
+        }
+
     }
 }


### PR DESCRIPTION
INSERT_PR_DESCRIPTION_HERE

Fixes HZ-3454

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6841

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
