### PR TITLE
`ReplicatedMap.addEntryListener` checks wrong permissions [5.1.z]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/AbstractReplicatedMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/AbstractReplicatedMapAddEntryListenerMessageTask.java
@@ -33,7 +33,7 @@ import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedEntryEventFilter;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedQueryEventFilter;
 import com.hazelcast.security.permission.ActionConstants;
-import com.hazelcast.security.permission.MapPermission;
+import com.hazelcast.security.permission.ReplicatedMapPermission;
 
 import java.security.Permission;
 import java.util.UUID;
@@ -76,7 +76,7 @@ public abstract class AbstractReplicatedMapAddEntryListenerMessageTask<Parameter
 
     @Override
     public Permission getRequiredPermission() {
-        return new MapPermission(getDistributedObjectName(), ActionConstants.ACTION_LISTEN);
+        return new ReplicatedMapPermission(getDistributedObjectName(), ActionConstants.ACTION_LISTEN);
     }
 
     public abstract Predicate getPredicate();


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/25965

`ReplicatedMap.addEntryListener` is checking `MapPermission`, not `ReplicatedMapPermission`.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6847

Fixes: https://hazelcast.atlassian.net/browse/HZ-3731