### PR TITLE
Jet Jdbc source/sink should run against all supported databases [HZ-2422]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/DatabaseProviderTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/DatabaseProviderTestSupport.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector;
+
+import com.hazelcast.jet.SimpleTestInClusterSupport;
+import com.hazelcast.test.jdbc.TestDatabaseProvider;
+
+import javax.sql.CommonDataSource;
+
+public abstract class DatabaseProviderTestSupport extends SimpleTestInClusterSupport {
+
+    private static TestDatabaseProvider databaseProvider;
+
+    public static TestDatabaseProvider getDatabaseProvider() {
+        return databaseProvider;
+    }
+
+    public static void setDatabaseProvider(TestDatabaseProvider dbProvider) {
+        databaseProvider = dbProvider;
+        databaseProvider.createDatabase("test");
+    }
+
+    protected static String getJdbcUrl() {
+        return databaseProvider.getJdbcUrl();
+    }
+
+    protected static String getUsername() {
+        return databaseProvider.user();
+    }
+
+    protected static String getPassword() {
+        return databaseProvider.password();
+    }
+
+    protected static String getDatabaseName() {
+        return databaseProvider.getDatabaseName();
+    }
+
+    protected static CommonDataSource createDataSource(boolean xa) {
+        return databaseProvider.createDataSource(xa);
+    }
+
+    public static void shutdownDatabaseProvider() {
+        if (databaseProvider != null) {
+            databaseProvider.shutdown();
+            databaseProvider = null;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPTest.java
@@ -54,8 +54,6 @@ public class ReadJdbcPTest extends DatabaseProviderTestSupport {
     private static final int ITEM_COUNT = 100;
     private static final String JDBC_DATA_CONNECTION = "jdbc-data-connection";
     private static final String DUMMY_DATA_CONNECTION = "dummy-data-connection";
-
-//    private static String dbConnectionUrl;
     private static List<Entry<Integer, String>> tableContents;
 
     public static void initialize(TestDatabaseProvider provider) throws SQLException {
@@ -78,7 +76,6 @@ public class ReadJdbcPTest extends DatabaseProviderTestSupport {
         }
         tableContents = IntStream.range(0, ITEM_COUNT).mapToObj(i -> entry(i, "name-" + i)).collect(toList());
     }
-
 
     @BeforeClass
     public static void beforeClass() throws SQLException {
@@ -171,5 +168,4 @@ public class ReadJdbcPTest extends DatabaseProviderTestSupport {
 
         instance().getJet().newJob(p).join();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/ReadJdbcPTest.java
@@ -18,11 +18,12 @@ package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.dataconnection.impl.JdbcDataConnection;
-import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.jdbc.H2DatabaseProvider;
+import com.hazelcast.test.jdbc.TestDatabaseProvider;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,35 +38,37 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.stream.IntStream;
 
-import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.dataconnection.impl.DataConnectionTestUtil.configureDummyDataConnection;
 import static com.hazelcast.dataconnection.impl.DataConnectionTestUtil.configureJdbcDataConnection;
+import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.pipeline.DataConnectionRef.dataConnectionRef;
 import static com.hazelcast.jet.pipeline.test.AssertionSinks.assertAnyOrder;
 import static com.hazelcast.jet.pipeline.test.AssertionSinks.assertOrdered;
+import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class ReadJdbcPTest extends SimpleTestInClusterSupport {
+public class ReadJdbcPTest extends DatabaseProviderTestSupport {
 
     private static final int ITEM_COUNT = 100;
     private static final String JDBC_DATA_CONNECTION = "jdbc-data-connection";
     private static final String DUMMY_DATA_CONNECTION = "dummy-data-connection";
 
-    private static String dbConnectionUrl;
+//    private static String dbConnectionUrl;
     private static List<Entry<Integer, String>> tableContents;
 
-    @BeforeClass
-    public static void setupClass() throws SQLException {
-        dbConnectionUrl = "jdbc:h2:mem:" + ReadJdbcPTest.class.getSimpleName() + ";DB_CLOSE_DELAY=-1";
+    public static void initialize(TestDatabaseProvider provider) throws SQLException {
+        assumeDockerEnabled();
+        setDatabaseProvider(provider);
 
         Config config = smallInstanceConfig();
-        configureJdbcDataConnection(JDBC_DATA_CONNECTION, dbConnectionUrl, config);
+        configureJdbcDataConnection(JDBC_DATA_CONNECTION, getJdbcUrl(), getUsername(), getPassword(), config);
         configureDummyDataConnection(DUMMY_DATA_CONNECTION, config);
         initialize(2, config);
+
         // create and fill a table
-        try (Connection conn = DriverManager.getConnection(dbConnectionUrl);
+        try (Connection conn = DriverManager.getConnection(getJdbcUrl());
              Statement stmt = conn.createStatement()
         ) {
             stmt.execute("CREATE TABLE items(id INT PRIMARY KEY, name VARCHAR(10))");
@@ -76,20 +79,24 @@ public class ReadJdbcPTest extends SimpleTestInClusterSupport {
         tableContents = IntStream.range(0, ITEM_COUNT).mapToObj(i -> entry(i, "name-" + i)).collect(toList());
     }
 
+
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        initialize(new H2DatabaseProvider());
+    }
+
     @AfterClass
     public static void afterClass() throws SQLException {
-        try (Connection conn = DriverManager.getConnection(dbConnectionUrl)) {
-            conn.createStatement().execute("shutdown");
-        }
+        shutdownDatabaseProvider();
     }
 
     @Test
     public void test_whenPartitionedQuery() {
         Pipeline p = Pipeline.create();
         p.readFrom(Sources.jdbc(
-                () -> DriverManager.getConnection(dbConnectionUrl),
+                () -> DriverManager.getConnection(getJdbcUrl()),
                 (con, parallelism, index) -> {
-                    PreparedStatement statement = con.prepareStatement("select * from items where mod(id,?)=?");
+                    PreparedStatement statement = con.prepareStatement("select * from items where (id % ?)=?");
                     statement.setInt(1, parallelism);
                     statement.setInt(2, index);
                     return statement.executeQuery();
@@ -106,7 +113,7 @@ public class ReadJdbcPTest extends SimpleTestInClusterSupport {
         p.readFrom(Sources.jdbc(
                         dataConnectionRef(JDBC_DATA_CONNECTION),
                         (con, parallelism, index) -> {
-                            PreparedStatement statement = con.prepareStatement("select * from items where mod(id,?)=?");
+                            PreparedStatement statement = con.prepareStatement("select * from items where (id % ?) = ?");
                             statement.setInt(1, parallelism);
                             statement.setInt(2, index);
                             return statement.executeQuery();
@@ -124,7 +131,7 @@ public class ReadJdbcPTest extends SimpleTestInClusterSupport {
         p.readFrom(Sources.jdbc(
                         dataConnectionRef("non-existing-data-connection"),
                         (con, parallelism, index) -> {
-                            PreparedStatement statement = con.prepareStatement("select * from items where mod(id,?)=?");
+                            PreparedStatement statement = con.prepareStatement("select * from items where (id % ?)=?");
                             statement.setInt(1, parallelism);
                             statement.setInt(2, index);
                             return statement.executeQuery();
@@ -158,7 +165,7 @@ public class ReadJdbcPTest extends SimpleTestInClusterSupport {
     @Test
     public void test_whenTotalParallelismOne() {
         Pipeline p = Pipeline.create();
-        p.readFrom(Sources.jdbc(dbConnectionUrl, "select * from items",
+        p.readFrom(Sources.jdbc(getJdbcUrl(), "select * from items",
                 resultSet -> entry(resultSet.getInt(1), resultSet.getString(2))))
          .writeTo(assertOrdered(tableContents));
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -28,11 +28,13 @@ import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.jdbc.H2DatabaseProvider;
 import com.hazelcast.test.jdbc.MSSQLDatabaseProvider;
 import com.hazelcast.test.jdbc.TestDatabaseProvider;
 import com.zaxxer.hikari.HikariDataSource;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -66,7 +68,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @Category({QuickTest.class, ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
-public abstract class WriteJdbcPTest extends DatabaseProviderTestSupport {
+public class WriteJdbcPTest extends DatabaseProviderTestSupport {
     private static final String JDBC_DATA_CONNECTION = "jdbc-data-connection";
     private static final String DUMMY_DATA_CONNECTION = "dummy-data-connection";
     private static final int PERSON_COUNT = 10;
@@ -81,6 +83,11 @@ public abstract class WriteJdbcPTest extends DatabaseProviderTestSupport {
         configureJdbcDataConnection(JDBC_DATA_CONNECTION, getJdbcUrl(), getUsername(), getPassword(), config);
         configureDummyDataConnection(DUMMY_DATA_CONNECTION, config);
         initialize(2, config);
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        initialize(new H2DatabaseProvider());
     }
 
     @AfterClass
@@ -329,15 +336,17 @@ public abstract class WriteJdbcPTest extends DatabaseProviderTestSupport {
 
     @Test
     public void test_transactional_withRestarts_graceful_exOnce() throws Exception {
-        assumeTestDatabaseProviderIsNotInstanceOf(getDatabaseProvider(), MSSQLDatabaseProvider.class,
-                "XA transactions are not available for MSSQLServerContainer");
+        assumeTestDatabaseProviderIsNotInstanceOf(getDatabaseProvider(),
+                "XA transactions are not available for MSSQLServerContainer",
+                MSSQLDatabaseProvider.class, H2DatabaseProvider.class);
         test_transactional_withRestarts(true, true);
     }
 
     @Test
     public void test_transactional_withRestarts_forceful_exOnce() throws Exception {
-        assumeTestDatabaseProviderIsNotInstanceOf(getDatabaseProvider(), MSSQLDatabaseProvider.class,
-                "XA transactions are not available for MSSQLServerContainer");
+        assumeTestDatabaseProviderIsNotInstanceOf(getDatabaseProvider(),
+                "XA transactions are not available for MSSQLServerContainer",
+                MSSQLDatabaseProvider.class, H2DatabaseProvider.class);
         test_transactional_withRestarts(false, true);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.Config;
 import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.Job;
-import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
@@ -29,24 +28,18 @@ import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.jdbc.MSSQLDatabaseProvider;
+import com.hazelcast.test.jdbc.TestDatabaseProvider;
 import com.zaxxer.hikari.HikariDataSource;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.postgresql.ds.PGSimpleDataSource;
-import org.postgresql.ds.common.BaseDataSource;
-import org.postgresql.xa.PGXADataSource;
-import org.testcontainers.containers.PostgreSQLContainer;
 
-import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
 import java.sql.Statement;
@@ -63,6 +56,7 @@ import static com.hazelcast.dataconnection.impl.DataConnectionTestUtil.configure
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.pipeline.DataConnectionRef.dataConnectionRef;
 import static com.hazelcast.test.DockerTestUtil.assumeDockerEnabled;
+import static com.hazelcast.test.DockerTestUtil.assumeTestDatabaseProviderIsNotInstanceOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -72,37 +66,26 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @Category({QuickTest.class, ParallelJVMTest.class, IgnoreInJenkinsOnWindows.class})
-public class WriteJdbcPTest extends SimpleTestInClusterSupport {
-
+public abstract class WriteJdbcPTest extends DatabaseProviderTestSupport {
     private static final String JDBC_DATA_CONNECTION = "jdbc-data-connection";
     private static final String DUMMY_DATA_CONNECTION = "dummy-data-connection";
-
-    @SuppressWarnings({"rawtypes", "resource"})
-    public static PostgreSQLContainer container = new PostgreSQLContainer<>("postgres:12.1")
-            .withCommand("postgres -c max_prepared_transactions=10 -c max_connections=500");
-
     private static final int PERSON_COUNT = 10;
-
     private static final AtomicInteger TABLE_COUNTER = new AtomicInteger();
-
     private String tableName;
 
-    @BeforeClass
-    public static void setupClass() {
+    public static void initialize(TestDatabaseProvider provider) {
         assumeDockerEnabled();
-        container.start();
+        setDatabaseProvider(provider);
 
         Config config = smallInstanceConfig();
-        configureJdbcDataConnection(JDBC_DATA_CONNECTION, container.getJdbcUrl(), container.getUsername(), container.getPassword(), config);
+        configureJdbcDataConnection(JDBC_DATA_CONNECTION, getJdbcUrl(), getUsername(), getPassword(), config);
         configureDummyDataConnection(DUMMY_DATA_CONNECTION, config);
         initialize(2, config);
     }
 
     @AfterClass
-    public static void afterAll() {
-        if (container != null) {
-            container.stop();
-        }
+    public static void afterClass() {
+        shutdownDatabaseProvider();
     }
 
     @Before
@@ -113,42 +96,11 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
         executeSql("CREATE TABLE " + tableName + "(id int, name varchar(255))");
     }
 
-    @After
-    public void tearDown() throws Exception {
-        listRemainingConnections();
-    }
+
 
     private static void executeSql(String sql) throws SQLException {
         try (Connection connection = ((DataSource) createDataSource(false)).getConnection()) {
             connection.createStatement().execute(sql);
-        }
-    }
-    private void listRemainingConnections() throws SQLException {
-        try (
-                Connection connection = ((DataSource) createDataSource(false)).getConnection();
-                ResultSet resultSet = connection.createStatement().executeQuery(
-                        "SELECT * FROM pg_stat_activity WHERE datname = current_database() and pid <> pg_backend_pid()")
-        ) {
-            ResultSetMetaData metaData = resultSet.getMetaData();
-            List<String> rows = new ArrayList<>();
-            StringBuilder row = new StringBuilder();
-            for (int i = 1; i <= metaData.getColumnCount(); i++) {
-                row.append(metaData.getColumnName(i)).append("\t|");
-            }
-            rows.add(row.toString());
-
-            while (resultSet.next()) {
-                row = new StringBuilder();
-                for (int i = 1; i <= metaData.getColumnCount(); i++) {
-                    row.append(resultSet.getObject(i)).append("\t|\t");
-                }
-                rows.add(row.toString());
-
-            }
-
-            if (!rows.isEmpty()) {
-                logger.warning("Remaining connections: \n" + String.join("\n", rows));
-            }
         }
     }
 
@@ -194,9 +146,9 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
         hikariDataSourceList.add(hikariDataSource);
         assertThat(hikariDataSource).isInstanceOf(AutoCloseable.class);
 
-        hikariDataSource.setJdbcUrl(container.getJdbcUrl());
-        hikariDataSource.setUsername(container.getUsername());
-        hikariDataSource.setPassword(container.getPassword());
+        hikariDataSource.setJdbcUrl(getJdbcUrl());
+        hikariDataSource.setUsername(getUsername());
+        hikariDataSource.setPassword(getPassword());
         return hikariDataSource;
     }
 
@@ -377,11 +329,15 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
 
     @Test
     public void test_transactional_withRestarts_graceful_exOnce() throws Exception {
+        assumeTestDatabaseProviderIsNotInstanceOf(getDatabaseProvider(), MSSQLDatabaseProvider.class,
+                "XA transactions are not available for MSSQLServerContainer");
         test_transactional_withRestarts(true, true);
     }
 
     @Test
     public void test_transactional_withRestarts_forceful_exOnce() throws Exception {
+        assumeTestDatabaseProviderIsNotInstanceOf(getDatabaseProvider(), MSSQLDatabaseProvider.class,
+                "XA transactions are not available for MSSQLServerContainer");
         test_transactional_withRestarts(false, true);
     }
 
@@ -431,16 +387,6 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
             }
             return resultSet.getInt(1);
         }
-    }
-
-    private static CommonDataSource createDataSource(boolean xa) {
-        BaseDataSource dataSource = xa ? new PGXADataSource() : new PGSimpleDataSource();
-        dataSource.setUrl(container.getJdbcUrl());
-        dataSource.setUser(container.getUsername());
-        dataSource.setPassword(container.getPassword());
-        dataSource.setDatabaseName(container.getDatabaseName());
-
-        return dataSource;
     }
 
     private static SupplierEx<DataSource> failTwiceDataSourceSupplier() {

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -337,7 +337,7 @@ public class WriteJdbcPTest extends DatabaseProviderTestSupport {
     @Test
     public void test_transactional_withRestarts_graceful_exOnce() throws Exception {
         assumeTestDatabaseProviderIsNotInstanceOf(getDatabaseProvider(),
-                "XA transactions are not available for MSSQLServerContainer",
+                "XA transactions are not available for DatabaseProvider",
                 MSSQLDatabaseProvider.class, H2DatabaseProvider.class);
         test_transactional_withRestarts(true, true);
     }
@@ -345,8 +345,8 @@ public class WriteJdbcPTest extends DatabaseProviderTestSupport {
     @Test
     public void test_transactional_withRestarts_forceful_exOnce() throws Exception {
         assumeTestDatabaseProviderIsNotInstanceOf(getDatabaseProvider(),
-                "XA transactions are not available for MSSQLServerContainer",
-                MSSQLDatabaseProvider.class, H2DatabaseProvider.class);
+                "XA transactions are not available for DatabaseProvider",
+                MSSQLDatabaseProvider.class);
         test_transactional_withRestarts(false, true);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -346,7 +346,7 @@ public class WriteJdbcPTest extends DatabaseProviderTestSupport {
     public void test_transactional_withRestarts_forceful_exOnce() throws Exception {
         assumeTestDatabaseProviderIsNotInstanceOf(getDatabaseProvider(),
                 "XA transactions are not available for DatabaseProvider",
-                MSSQLDatabaseProvider.class);
+                MSSQLDatabaseProvider.class, H2DatabaseProvider.class);
         test_transactional_withRestarts(false, true);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/mssql/MSSQLReadJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/mssql/MSSQLReadJdbcPTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector.mssql;
+
+import com.hazelcast.jet.impl.connector.ReadJdbcPTest;
+import com.hazelcast.test.jdbc.MSSQLDatabaseProvider;
+import org.junit.BeforeClass;
+
+import java.sql.SQLException;
+
+public class MSSQLReadJdbcPTest extends ReadJdbcPTest {
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        initialize(new MSSQLDatabaseProvider());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/mssql/MSSQLWriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/mssql/MSSQLWriteJdbcPTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector.mssql;
+
+import com.hazelcast.jet.impl.connector.WriteJdbcPTest;
+import com.hazelcast.test.jdbc.MSSQLDatabaseProvider;
+import org.junit.BeforeClass;
+
+public class MSSQLWriteJdbcPTest extends WriteJdbcPTest {
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(new MSSQLDatabaseProvider());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/mysql/MySQLReadJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/mysql/MySQLReadJdbcPTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector.mysql;
+
+import com.hazelcast.jet.impl.connector.ReadJdbcPTest;
+import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
+import org.junit.BeforeClass;
+
+import java.sql.SQLException;
+
+public class MySQLReadJdbcPTest extends ReadJdbcPTest {
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        initialize(new MySQLDatabaseProvider());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/mysql/MySQLWriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/mysql/MySQLWriteJdbcPTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector.mysql;
+
+import com.hazelcast.jet.impl.connector.WriteJdbcPTest;
+import com.hazelcast.test.jdbc.MySQLDatabaseProvider;
+import org.junit.BeforeClass;
+
+public class MySQLWriteJdbcPTest extends WriteJdbcPTest {
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(new MySQLDatabaseProvider());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/postgres/PostgresReadJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/postgres/PostgresReadJdbcPTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector.postgres;
+
+import com.hazelcast.jet.impl.connector.ReadJdbcPTest;
+import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
+import org.junit.BeforeClass;
+
+import java.sql.SQLException;
+
+public class PostgresReadJdbcPTest extends ReadJdbcPTest {
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        initialize(new PostgresDatabaseProvider());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/postgres/PostgresWriteJdbcPTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/connector/postgres/PostgresWriteJdbcPTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector.postgres;
+
+import com.hazelcast.jet.impl.connector.WriteJdbcPTest;
+import com.hazelcast.test.jdbc.PostgresDatabaseProvider;
+import org.junit.After;
+import org.junit.BeforeClass;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PostgresWriteJdbcPTest extends WriteJdbcPTest {
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(new PostgresDatabaseProvider()
+                .withCommand("postgres -c max_prepared_transactions=10 -c max_connections=500"));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        listRemainingConnections();
+    }
+
+    private void listRemainingConnections() throws SQLException {
+        try (
+                Connection connection = ((DataSource) createDataSource(false)).getConnection();
+                ResultSet resultSet = connection.createStatement().executeQuery(
+                        "SELECT * FROM pg_stat_activity WHERE datname = current_database() and pid <> pg_backend_pid()")
+        ) {
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            List<String> rows = new ArrayList<>();
+            StringBuilder row = new StringBuilder();
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                row.append(metaData.getColumnName(i)).append("\t|");
+            }
+            rows.add(row.toString());
+
+            while (resultSet.next()) {
+                row = new StringBuilder();
+                for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                    row.append(resultSet.getObject(i)).append("\t|\t");
+                }
+                rows.add(row.toString());
+
+            }
+
+            if (!rows.isEmpty()) {
+                logger.warning("Remaining connections: \n" + String.join("\n", rows));
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
@@ -42,9 +42,10 @@ public class DockerTestUtil {
         }
     }
 
-    public static void assumeTestDatabaseProviderIsNotInstanceOf(TestDatabaseProvider provider, Class<?> clazz,
-                                                                 String message) {
+    public static void assumeTestDatabaseProviderIsNotInstanceOf(TestDatabaseProvider provider,
+                                                                 String message,
+                                                                 Class<?>... clazz) {
         assumeThat(provider).describedAs(message)
-                .isNotInstanceOf(clazz);
+                .isNotInstanceOfAny(clazz);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DockerTestUtil.java
@@ -41,4 +41,10 @@ public class DockerTestUtil {
                     );
         }
     }
+
+    public static void assumeTestDatabaseProviderIsNotInstanceOf(TestDatabaseProvider provider, Class<?> clazz,
+                                                                 String message) {
+        assumeThat(provider).describedAs(message)
+                .isNotInstanceOf(clazz);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.test.jdbc;
 
+import org.h2.jdbcx.JdbcDataSource;
+
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -24,13 +27,36 @@ public class H2DatabaseProvider implements TestDatabaseProvider {
 
     private static final int LOGIN_TIMEOUT = 60;
 
+    private String dbName;
     private String jdbcUrl;
 
     @Override
     public String createDatabase(String dbName) {
+        this.dbName = dbName;
         jdbcUrl = "jdbc:h2:mem:" + dbName + ";DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1";
         waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
+    }
+
+    @Override
+    public DataSource createDataSource(boolean xa) {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setUrl(getJdbcUrl());
+        dataSource.setUser(user());
+        dataSource.setPassword(password());
+
+        return dataSource;
+
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return jdbcUrl;
+    }
+
+    @Override
+    public String getDatabaseName() {
+        return dbName;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/H2DatabaseProvider.java
@@ -50,6 +50,16 @@ public class H2DatabaseProvider implements TestDatabaseProvider {
     }
 
     @Override
+    public String user() {
+        return "";
+    }
+
+    @Override
+    public String password() {
+        return "";
+    }
+
+    @Override
     public String getJdbcUrl() {
         return jdbcUrl;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/MariaDBDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/MariaDBDatabaseProvider.java
@@ -28,16 +28,37 @@ public class MariaDBDatabaseProvider implements TestDatabaseProvider {
 
     @Override
     public String createDatabase(String dbName) {
+        //noinspection resource
         container = new MariaDBContainer<>("mariadb:" + TEST_MARIADB_VERSION)
                 .withDatabaseName(dbName)
-                .withUsername("user")
-                .withUrlParam("user", "user")
-                .withUrlParam("password", "test");
+                .withUsername(user())
+                .withUrlParam("user", user())
+                .withUrlParam("password", password());
 
         container.start();
         String jdbcUrl = container.getJdbcUrl();
         waitForDb(jdbcUrl, LOGIN_TIMEOUT);
         return jdbcUrl;
+    }
+
+    @Override
+    public String user() {
+        return "user";
+    }
+
+    @Override
+    public String password() {
+        return "test";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return container.getJdbcUrl();
+    }
+
+    @Override
+    public String getDatabaseName() {
+        return container.getDatabaseName();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/jdbc/TestDatabaseProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jdbc/TestDatabaseProvider.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.test.jdbc;
 
+import javax.sql.CommonDataSource;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -30,6 +31,10 @@ import static java.util.stream.Collectors.joining;
  * For sample use see JdbcSqlTestSupport.
  */
 public interface TestDatabaseProvider {
+
+    default CommonDataSource createDataSource(boolean xa) {
+        throw new RuntimeException("Not supported");
+    }
 
     /**
      * Creates database with given name and returns jdbc url that can
@@ -58,6 +63,11 @@ public interface TestDatabaseProvider {
         throw new RuntimeException("Not supported");
     }
 
+    String getJdbcUrl();
+
+
+    String getDatabaseName();
+
     /**
      * Waits for a connection to the database.
      * @param jdbcUrl JDBC url returned by {@link #createDatabase(String)}.
@@ -84,9 +94,10 @@ public interface TestDatabaseProvider {
         return Arrays.stream(parts)
                      .map(part -> '\"' + part.replaceAll("\"", "\"\"") + '\"')
                      .collect(joining("."));
-    };
+    }
 
     default String createSchemaQuery(String schemaName) {
         return "CREATE SCHEMA IF NOT EXISTS " + schemaName;
     }
+
 }


### PR DESCRIPTION
Jira : https://hazelcast.atlassian.net/browse/HZ-2422

A new DatabaseProviderTestSupport class has been introduced. The WriteJdbcPTest class has been modified to be abstract and accept a TestDatabaseProvider instance as a parameter. To accommodate test cases, some methods have been added to the TestDatabaseProvider interface.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
