### PR TITLE
Upgrade `hazelcast-hibernate5` version

### DIFF
--- a/hazelcast-spring-tests/pom.xml
+++ b/hazelcast-spring-tests/pom.xml
@@ -33,8 +33,7 @@
         <!-- needed for CheckStyle -->
         <main.basedir>${project.parent.basedir}</main.basedir>
 
-        <maven-artifact.version>3.9.5</maven-artifact.version>
-        <hazelcast-hibernate5.version>2.0.0</hazelcast-hibernate5.version>
+        <hazelcast-hibernate5.version>2.2.1</hazelcast-hibernate5.version>
     </properties>
 
     <dependencies>
@@ -97,7 +96,6 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>${maven-artifact.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -35,9 +35,7 @@
 
         <org.springframework.version>5.3.30</org.springframework.version>
         <javax.annotation.version>1.3.2</javax.annotation.version>
-        <maven-artifact.version>3.9.5</maven-artifact.version>
         <hazelcast.latest.version>4.0</hazelcast.latest.version>
-        <hazelcast-hibernate5.version>2.0.0</hazelcast-hibernate5.version>
     </properties>
 
     <build>
@@ -162,7 +160,6 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>${maven-artifact.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2097,6 +2097,11 @@
                 <artifactId>j2objc-annotations</artifactId>
                 <version>2.8</version>
             </dependency>
+	        <dependency>
+	            <groupId>org.apache.maven</groupId>
+	            <artifactId>maven-artifact</artifactId>
+	            <version>3.9.5</version>
+	        </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
- `hazelcast-spring-tests` uses `hazelcast-hibernate5` v2.0.0 which is over 3 years old, upgraded to latest (v2.2.1) version
- `hazelcast-spring` replicates this configuration, but does not actually use the dependency - as such, removed
- removed replication of `maven-artifact` between `hazelcast-spring` & `hazelcast-spring-tests` via `dependencyManagement`