### PR TITLE
Resolve `java.xml` module accessibility in `hazelcast-spring-tests`

### DIFF
--- a/hazelcast-spring-tests/pom.xml
+++ b/hazelcast-spring-tests/pom.xml
@@ -93,6 +93,13 @@
             <artifactId>hibernate-core</artifactId>
             <version>5.0.9.Final</version>
             <scope>test</scope>
+            <exclusions>
+            	<!-- Required for Hibernate <5.3.7 -->
+                <exclusion>
+                    <artifactId>xml-apis</artifactId>
+                    <groupId>xml-apis</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Eclipse reports the following error:

> The package org.w3c.dom is accessible from more than one module:
&lt;unnamed&gt;, java.xml	MyServiceConfigParser.java

This is because the `org.w3c.dom.Element` class is in the JDK AND the `xml-apis` artifact (a transitive dependency of Hibernate v5) - i.e. a split-package.

Later version of Hibernate (>5.3.6) do not include this transitive dependency.