### PR TITLE
Show stack trace of exception when member starts from hz command [HZ-2066]

### DIFF
--- a/distribution/src/main/java/com/hazelcast/commandline/ExceptionHandler.java
+++ b/distribution/src/main/java/com/hazelcast/commandline/ExceptionHandler.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.commandline;
 
-import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.internal.util.ExceptionUtil;
 import picocli.CommandLine;
 
 import java.io.PrintWriter;
@@ -24,18 +24,18 @@ import java.io.PrintWriter;
 /**
  * Exception handler for processing the tool & Hazelcast related errors
  */
-class ExceptionHandler
-        implements CommandLine.IExecutionExceptionHandler {
+class ExceptionHandler implements CommandLine.IExecutionExceptionHandler {
     @Override
-    public int handleExecutionException(Exception ex, CommandLine commandLine, CommandLine.ParseResult parseResult) {
-        PrintWriter err = commandLine.getErr();
+    public int handleExecutionException(Exception exception, CommandLine commandLine, CommandLine.ParseResult parseResult) {
+        PrintWriter errorWriter = commandLine.getErr();
         CommandLine.Help.ColorScheme colorScheme = commandLine.getColorScheme();
-        if (!StringUtil.isNullOrEmpty(ex.getMessage())) {
-            err.println(colorScheme.errorText(ex.getMessage()));
-        } else {
-            ex.printStackTrace(err);
-        }
-        commandLine.usage(err, colorScheme);
+
+        // Print exception
+        String stackTrace = ExceptionUtil.toString(exception);
+        errorWriter.println(colorScheme.errorText(stackTrace));
+
+        // Print usage
+        commandLine.usage(errorWriter, colorScheme);
         return 0;
     }
 }

--- a/distribution/src/main/java/com/hazelcast/commandline/HazelcastServerCommandLine.java
+++ b/distribution/src/main/java/com/hazelcast/commandline/HazelcastServerCommandLine.java
@@ -69,7 +69,7 @@ public class HazelcastServerCommandLine {
         }
     }
 
-    private static PrintWriter createPrintWriter(PrintStream printStream) {
+    static PrintWriter createPrintWriter(PrintStream printStream) {
         return new PrintWriter(new OutputStreamWriter(printStream, StandardCharsets.UTF_8));
     }
 

--- a/distribution/src/test/java/com/hazelcast/commandline/ExceptionHandlerTest.java
+++ b/distribution/src/test/java/com/hazelcast/commandline/ExceptionHandlerTest.java
@@ -16,54 +16,51 @@
 
 package com.hazelcast.commandline;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import picocli.CommandLine;
 
 import java.io.PrintWriter;
 
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ExceptionHandlerTest {
+@ExtendWith(MockitoExtension.class)
+class ExceptionHandlerTest {
 
+    @Mock
     private Exception exception;
+
+    @Mock
     private CommandLine commandLine;
+
+    @Mock
     private CommandLine.ParseResult parseResult;
-    private PrintWriter err;
+
+    @Mock
+    private PrintWriter errorWriter;
+
+    @Mock
     private CommandLine.Help.ColorScheme colorScheme;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        exception = mock(Exception.class);
-        commandLine = mock(CommandLine.class);
-        parseResult = mock(CommandLine.ParseResult.class);
-        err = mock(PrintWriter.class);
-        colorScheme = mock(CommandLine.Help.ColorScheme.class);
-        when(commandLine.getErr()).thenReturn(err);
+        when(commandLine.getErr()).thenReturn(errorWriter);
         when(commandLine.getColorScheme()).thenReturn(colorScheme);
     }
 
-    @Test
-    public void test_handleExecutionException() {
-        // given
-        doReturn("some message").when(exception).getMessage();
-        // when
-        new ExceptionHandler().handleExecutionException(exception, commandLine, parseResult);
-        // then
-        verify(err, times(1)).println(colorScheme.errorText(exception.getMessage()));
-        verify(commandLine, times(1)).usage(err, colorScheme);
-    }
 
     @Test
-    public void test_handleExecutionException_withoutExceptionMessage() {
+    void test_handleExecutionException_withoutExceptionMessage() {
         // when
         new ExceptionHandler().handleExecutionException(exception, commandLine, parseResult);
         // then
-        verify(exception, times(1)).printStackTrace(err);
-        verify(commandLine, times(1)).usage(err, colorScheme);
+        verify(exception, times(1)).printStackTrace(any(PrintWriter.class));
+        verify(commandLine, times(1)).usage(errorWriter, colorScheme);
     }
 }

--- a/distribution/src/test/java/com/hazelcast/commandline/HazelcastServerCommandLineTest.java
+++ b/distribution/src/test/java/com/hazelcast/commandline/HazelcastServerCommandLineTest.java
@@ -103,8 +103,8 @@ class HazelcastServerCommandLineTest {
 
             String string = outputStreamCaptor.toString(StandardCharsets.UTF_8);
             assertThat(string)
-                    .contains("org.apache.logging.log4j.core.config.ConfigurationException: " +
-                              "No type attribute provided for Layout on Appender STDOUT");
+                    .contains("org.apache.logging.log4j.core.config.ConfigurationException: "
+                              + "No type attribute provided for Layout on Appender STDOUT");
         } finally {
             System.setOut(standardErr);
         }

--- a/distribution/src/test/resources/faulty-log.properties
+++ b/distribution/src/test/resources/faulty-log.properties
@@ -1,0 +1,10 @@
+# The root logger with appender name 
+rootLogger = DEBUG, STDOUT
+
+# Assign STDOUT a valid appender & define its layout  
+appender.console.name = STDOUT
+appender.console.type = Console
+
+# PatternLayout is commented out to create Log4J2 exception
+#appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - orcun %m%n

--- a/distribution/src/test/resources/faulty-log.properties
+++ b/distribution/src/test/resources/faulty-log.properties
@@ -7,4 +7,4 @@ appender.console.type = Console
 
 # PatternLayout is commented out to create Log4J2 exception
 #appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - orcun %m%n
+appender.console.layout.pattern = %d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n

--- a/distribution/src/test/resources/faulty-log.properties
+++ b/distribution/src/test/resources/faulty-log.properties
@@ -1,7 +1,7 @@
-# The root logger with appender name 
+# The root logger with appender name
 rootLogger = DEBUG, STDOUT
 
-# Assign STDOUT a valid appender & define its layout  
+# Assign STDOUT a valid appender & define its layout
 appender.console.name = STDOUT
 appender.console.type = Console
 


### PR DESCRIPTION
Jira : https://hazelcast.atlassian.net/browse/HZ-2066

- In ExceptionHandler print the stack trace of the exception. Change tests in ExceptionHandlerTest
- Add new test to HazelcastServerCommandLineTest verify that Log4J2 exception is shown 

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
