### PR TITLE
Add serial version field to Jet anonymous classes [HZ-3846]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
@@ -333,6 +333,8 @@ public interface ProcessorMetaSupplier extends Serializable {
     ) {
         Vertex.checkLocalParallelism(preferredLocalParallelism);
         return new ProcessorMetaSupplier() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public int preferredLocalParallelism() {
                 return preferredLocalParallelism;
@@ -481,6 +483,8 @@ public interface ProcessorMetaSupplier extends Serializable {
             @Nonnull ProcessorSupplier supplier, @Nonnull String partitionKey, @Nullable Permission permission
     ) {
         return new ProcessorMetaSupplier() {
+            private static final long serialVersionUID = 1L;
+
             private transient Address ownerAddress;
 
             @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AbstractHazelcastConnectorSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AbstractHazelcastConnectorSupplier.java
@@ -50,6 +50,7 @@ public abstract class AbstractHazelcastConnectorSupplier implements ProcessorSup
             @Nonnull FunctionEx<HazelcastInstance, Processor> procFn
     ) {
         return new AbstractHazelcastConnectorSupplier(clientXml) {
+            private static final long serialVersionUID = 1L;
 
             @Override
             public void init(@Nonnull Context context) {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/HazelcastReaders.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/HazelcastReaders.java
@@ -76,6 +76,8 @@ public final class HazelcastReaders {
                 InternalCompletableFuture<CacheEntriesWithCursor>, CacheEntriesWithCursor, Entry<Data, Data>>(
                 new LocalCacheReaderFunction(cacheName)
         ) {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Permission getRequiredPermission() {
                 return new CachePermission(cacheName, ACTION_CREATE, ACTION_READ);
@@ -174,6 +176,8 @@ public final class HazelcastReaders {
     @Nonnull
     public static ProcessorMetaSupplier readLocalMapSupplier(@Nonnull String mapName) {
         return new LocalProcessorMetaSupplier<>(new LocalMapReaderFunction(mapName)) {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Permission getRequiredPermission() {
                 return new MapPermission(mapName, ACTION_CREATE, ACTION_READ);
@@ -232,6 +236,8 @@ public final class HazelcastReaders {
         return new LocalProcessorMetaSupplier<InternalCompletableFuture<ResultSegment>, ResultSegment, QueryResultRow>(
                 new LocalMapQueryReaderFunction<>(mapName, predicate, projection)
         ) {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Permission getRequiredPermission() {
                 return new MapPermission(mapName, ACTION_CREATE, ACTION_READ);

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
@@ -176,6 +176,8 @@ public final class HazelcastWriters {
     @SuppressWarnings("AnonInnerLength")
     public static ProcessorMetaSupplier writeObservableSupplier(@Nonnull String name) {
         return new ProcessorMetaSupplier() {
+            private static final long serialVersionUID = 1L;
+
             @Nonnull
             @Override
             public Map<String, String> getTags() {

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
@@ -148,6 +148,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
 
         return ProcessorMetaSupplier.preferLocalParallelismOne(
                 new ProcessorSupplier() {
+                    private static final long serialVersionUID = 1L;
 
                     private transient JdbcDataConnection dataConnection;
 
@@ -180,6 +181,7 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
             FunctionEx<? super ResultSet, ? extends T> mapOutputFn
     ) {
         return new ProcessorSupplier() {
+            private static final long serialVersionUID = 1L;
 
             private transient Context context;
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteJdbcP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteJdbcP.java
@@ -131,6 +131,8 @@ public final class WriteJdbcP<T> extends XaSinkProcessorBase {
         // #connectAndPrepareStatement() instance method.
         return ProcessorMetaSupplier.preferLocalParallelismOne(
                 new ProcessorSupplier() {
+                    private static final long serialVersionUID = 1L;
+
                     private transient CommonDataSource dataSource;
 
                     @Override

--- a/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunctions.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunctions.java
@@ -74,6 +74,8 @@ public final class SecuredFunctions {
 
     public static <K, V> FunctionEx<? super Context, IMap<K, V>> iMapFn(String name) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public IMap<K, V> applyEx(Context context) {
                 return context.hazelcastInstance().getMap(name);
@@ -90,6 +92,8 @@ public final class SecuredFunctions {
     public static <K, V> FunctionEx<HazelcastInstance, EventJournalReader<EventJournalMapEvent<K, V>>>
     mapEventJournalReaderFn(String name) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public EventJournalReader<EventJournalMapEvent<K, V>> applyEx(HazelcastInstance instance) {
                 return (EventJournalReader<EventJournalMapEvent<K, V>>) instance.getMap(name);
@@ -106,6 +110,8 @@ public final class SecuredFunctions {
     public static <K, V> FunctionEx<HazelcastInstance, EventJournalReader<EventJournalCacheEvent<K, V>>>
     cacheEventJournalReaderFn(String name) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public EventJournalReader<EventJournalCacheEvent<K, V>> applyEx(HazelcastInstance instance) {
                 return (EventJournalReader<EventJournalCacheEvent<K, V>>) instance.getCacheManager().getCache(name);
@@ -120,6 +126,8 @@ public final class SecuredFunctions {
 
     public static <K, V> FunctionEx<? super Context, ReplicatedMap<K, V>> replicatedMapFn(String name) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public ReplicatedMap<K, V> applyEx(Context context) {
                 return context.hazelcastInstance().getReplicatedMap(name);
@@ -134,6 +142,8 @@ public final class SecuredFunctions {
 
     public static SupplierEx<Processor> readListProcessorFn(String name, String clientXml) {
         return new SupplierEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Processor getEx() {
                 return new ReadIListP(name, clientXml);
@@ -148,6 +158,8 @@ public final class SecuredFunctions {
 
     public static <E> FunctionEx<Processor.Context, ITopic<E>> reliableTopicFn(String name) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public ITopic<E> applyEx(Processor.Context context) {
                 return context.hazelcastInstance().getReliableTopic(name);
@@ -164,6 +176,8 @@ public final class SecuredFunctions {
             FunctionEx<? super Processor.Context, ? extends S> createContextFn
     ) {
         return new BiFunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public S applyEx(Processor.Context context, Void o) throws Exception {
                 return createContextFn.applyEx(context);
@@ -178,6 +192,8 @@ public final class SecuredFunctions {
 
     public static SupplierEx<Processor> streamSocketProcessorFn(String host, int port, String charset) {
         return new SupplierEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Processor getEx() {
                 return new StreamSocketP(host, port, Charset.forName(charset));
@@ -196,6 +212,8 @@ public final class SecuredFunctions {
             BiFunctionEx<? super String, ? super String, ? extends T> mapOutputFn
     ) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Stream<T> applyEx(Path path) throws Exception {
                 String fileName = path.getFileName().toString();
@@ -218,6 +236,8 @@ public final class SecuredFunctions {
             FunctionEx<? super Path, ? extends Stream<T>> readFileFn) {
 
         return new SupplierEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Processor getEx() {
                 return new ReadFilesP<>(directory, glob, sharedFileSystem, ignoreFileNotFound, readFileFn);
@@ -235,6 +255,8 @@ public final class SecuredFunctions {
             Class<T> type
     ) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Stream<T> applyEx(Path path) throws Exception {
                 return JsonUtil.beanSequenceFrom(path, type);
@@ -251,6 +273,8 @@ public final class SecuredFunctions {
             String directory
     ) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Stream<Map<String, Object>> applyEx(Path path) throws Exception {
                 return JsonUtil.mapSequenceFrom(path);
@@ -271,6 +295,8 @@ public final class SecuredFunctions {
             BiFunctionEx<? super String, ? super String, ?> mapOutputFn
     ) {
         return new SupplierEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Processor getEx() {
                 return new StreamFilesP<>(watchedDirectory, Charset.forName(charset), glob,
@@ -290,6 +316,8 @@ public final class SecuredFunctions {
             String host, int port, String charsetName
     ) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public BufferedWriter applyEx(Processor.Context context) throws Exception {
                 return new BufferedWriter(new OutputStreamWriter(new Socket(host, port).getOutputStream(), charsetName));
@@ -312,6 +340,8 @@ public final class SecuredFunctions {
             LongSupplier clock
     ) {
         return new SupplierEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Processor getEx() {
                 return new WriteFileP<>(directoryName, toStringFn, charset, datePattern, maxFileSize, exactlyOnce, clock);
@@ -331,6 +361,7 @@ public final class SecuredFunctions {
             BiFunctionEx<? super V, ? super T, ? extends V> updateFn
     ) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
 
             @Override
             public Processor applyEx(HazelcastInstance instance) {
@@ -352,6 +383,8 @@ public final class SecuredFunctions {
             FunctionEx<? super T, ? extends EntryProcessor<K, V, R>> toEntryProcessorFn
     ) {
         return new FunctionEx<>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Processor applyEx(HazelcastInstance instance) {
                 return new UpdateMapWithEntryProcessorP<>(instance, maxParallelAsyncOps, name,


### PR DESCRIPTION
The anonymous classes cause this exception . See [Message from Eugene Abramchuk in #postgres-kafka-viridian](https://hazelcast.slack.com/archives/C05B24JMCFN/p1699530083353509) 
```java
com.hazelcast.jet.JetException: java.io.InvalidClassException: com.hazelcast.security.impl.function.SecuredFunctions$14; local class incompatible: stream classdesc serialVersionUID = 5725081252102953031, local class serialVersionUID = -7003202013508328512
```
Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
