### PR TITLE
Adds Missing CPMap Config Tests [HZ-3848]

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.config;
 import com.google.common.collect.ImmutableSet;
 import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
 import com.hazelcast.config.PermissionConfig.PermissionType;
+import com.hazelcast.config.cp.CPMapConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
@@ -3934,6 +3935,16 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "      <lock-acquire-limit>2</lock-acquire-limit>\n"
                 + "    </fenced-lock>\n"
                 + "  </locks>\n"
+                + "  <maps>\n"
+                + "    <map>\n"
+                + "      <name>map1</name>\n"
+                + "      <max-size-mb>1</max-size-mb>\n"
+                + "    </map>\n"
+                + "    <map>\n"
+                + "      <name>map2</name>\n"
+                + "      <max-size-mb>2</max-size-mb>\n"
+                + "    </map>\n"
+                + "  </maps>\n"
                 + "</cp-subsystem>"
                 + HAZELCAST_END_TAG;
         Config config = new InMemoryXmlConfig(xml);
@@ -3970,6 +3981,14 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertNotNull(lockConfig2);
         assertEquals(1, lockConfig1.getLockAcquireLimit());
         assertEquals(2, lockConfig2.getLockAcquireLimit());
+        CPMapConfig mapConfig1 = cpSubsystemConfig.findCPMapConfig("map1");
+        CPMapConfig mapConfig2 = cpSubsystemConfig.findCPMapConfig("map2");
+        assertNotNull(mapConfig1);
+        assertNotNull(mapConfig2);
+        assertEquals("map1", mapConfig1.getName());
+        assertEquals(1, mapConfig1.getMaxSizeMb());
+        assertEquals("map2", mapConfig2.getName());
+        assertEquals(2, mapConfig2.getMaxSizeMb());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.config;
 
 import com.google.common.collect.ImmutableSet;
 import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
+import com.hazelcast.config.cp.CPMapConfig;
 import com.hazelcast.config.tpc.TpcConfig;
 import com.hazelcast.config.tpc.TpcSocketConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
@@ -4207,7 +4208,12 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "      lock1:\n"
                 + "        lock-acquire-limit: 1\n"
                 + "      lock2:\n"
-                + "        lock-acquire-limit: 2\n";
+                + "        lock-acquire-limit: 2\n"
+                + "    maps:\n"
+                + "      map1:\n"
+                + "        max-size-mb: 1\n"
+                + "      map2:\n"
+                + "        max-size-mb: 2\n";
         Config config = buildConfig(yaml);
         CPSubsystemConfig cpSubsystemConfig = config.getCPSubsystemConfig();
         assertEquals(10, cpSubsystemConfig.getCPMemberCount());
@@ -4242,6 +4248,14 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertNotNull(lockConfig2);
         assertEquals(1, lockConfig1.getLockAcquireLimit());
         assertEquals(2, lockConfig2.getLockAcquireLimit());
+        CPMapConfig mapConfig1 = cpSubsystemConfig.findCPMapConfig("map1");
+        CPMapConfig mapConfig2 = cpSubsystemConfig.findCPMapConfig("map2");
+        assertNotNull(mapConfig1);
+        assertNotNull(mapConfig2);
+        assertEquals("map1", mapConfig1.getName());
+        assertEquals(1, mapConfig1.getMaxSizeMb());
+        assertEquals("map2", mapConfig2.getName());
+        assertEquals(2, mapConfig2.getMaxSizeMb());
     }
 
     @Override


### PR DESCRIPTION
Adds some small missing tests w.r.t. XML/YAML parsing for CPMap config that should have been present in #25881.

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
