### PR TITLE
Forbid optimized plans to be analyzed [HZ-3838]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
@@ -618,6 +618,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
 
         if (physicalRel instanceof SelectByKeyMapPhysicalRel) {
             assert !isCreateJob;
+            checkQueryAnalyzed(analyze);
             SelectByKeyMapPhysicalRel select = (SelectByKeyMapPhysicalRel) physicalRel;
             SqlRowMetadata rowMetadata = createRowMetadata(
                     fieldNames,
@@ -636,6 +637,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
             );
         } else if (physicalRel instanceof InsertMapPhysicalRel) {
             assert !isCreateJob;
+            checkQueryAnalyzed(analyze);
             InsertMapPhysicalRel insert = (InsertMapPhysicalRel) physicalRel;
             return new IMapInsertPlan(
                     planKey,
@@ -649,6 +651,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
             );
         } else if (physicalRel instanceof SinkMapPhysicalRel) {
             assert !isCreateJob;
+            checkQueryAnalyzed(analyze);
             SinkMapPhysicalRel sink = (SinkMapPhysicalRel) physicalRel;
             return new IMapSinkPlan(
                     planKey,
@@ -661,6 +664,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
             );
         } else if (physicalRel instanceof UpdateByKeyMapPhysicalRel) {
             assert !isCreateJob;
+            checkQueryAnalyzed(analyze);
             UpdateByKeyMapPhysicalRel update = (UpdateByKeyMapPhysicalRel) physicalRel;
             return new IMapUpdatePlan(
                     planKey,
@@ -693,6 +697,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
                     analyzeJobConfig);
         } else if (physicalRel instanceof DeleteByKeyMapPhysicalRel) {
             assert !isCreateJob;
+            checkQueryAnalyzed(analyze);
             DeleteByKeyMapPhysicalRel delete = (DeleteByKeyMapPhysicalRel) physicalRel;
             return new IMapDeletePlan(
                     planKey,
@@ -1028,6 +1033,13 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
         }
 
         return result;
+    }
+
+    static void checkQueryAnalyzed(boolean isAnalyzed) {
+        if (isAnalyzed) {
+            throw QueryException.error("ANALYZE statement is not applicable for key-based optimized IMap access plans." +
+                    " Consider to submit the same query without ANALYZE statement.");
+        }
     }
 
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
@@ -618,7 +618,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
 
         if (physicalRel instanceof SelectByKeyMapPhysicalRel) {
             assert !isCreateJob;
-            checkQueryAnalyzed(analyze);
+            checkIMapByKeyPlanIsAnalyzed(analyze);
             SelectByKeyMapPhysicalRel select = (SelectByKeyMapPhysicalRel) physicalRel;
             SqlRowMetadata rowMetadata = createRowMetadata(
                     fieldNames,
@@ -637,7 +637,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
             );
         } else if (physicalRel instanceof InsertMapPhysicalRel) {
             assert !isCreateJob;
-            checkQueryAnalyzed(analyze);
+            checkIMapByKeyPlanIsAnalyzed(analyze);
             InsertMapPhysicalRel insert = (InsertMapPhysicalRel) physicalRel;
             return new IMapInsertPlan(
                     planKey,
@@ -651,7 +651,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
             );
         } else if (physicalRel instanceof SinkMapPhysicalRel) {
             assert !isCreateJob;
-            checkQueryAnalyzed(analyze);
+            checkIMapByKeyPlanIsAnalyzed(analyze);
             SinkMapPhysicalRel sink = (SinkMapPhysicalRel) physicalRel;
             return new IMapSinkPlan(
                     planKey,
@@ -664,7 +664,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
             );
         } else if (physicalRel instanceof UpdateByKeyMapPhysicalRel) {
             assert !isCreateJob;
-            checkQueryAnalyzed(analyze);
+            checkIMapByKeyPlanIsAnalyzed(analyze);
             UpdateByKeyMapPhysicalRel update = (UpdateByKeyMapPhysicalRel) physicalRel;
             return new IMapUpdatePlan(
                     planKey,
@@ -697,7 +697,7 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
                     analyzeJobConfig);
         } else if (physicalRel instanceof DeleteByKeyMapPhysicalRel) {
             assert !isCreateJob;
-            checkQueryAnalyzed(analyze);
+            checkIMapByKeyPlanIsAnalyzed(analyze);
             DeleteByKeyMapPhysicalRel delete = (DeleteByKeyMapPhysicalRel) physicalRel;
             return new IMapDeletePlan(
                     planKey,
@@ -1035,7 +1035,12 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
         return result;
     }
 
-    static void checkQueryAnalyzed(boolean isAnalyzed) {
+    /**
+     * Check should be used during the optimized IMapByKey plan construction.
+     * It throws {@link QueryException} of query is analyzed for optimized IMapByKey plans.
+     * @param isAnalyzed is query analyzed
+     */
+    static void checkIMapByKeyPlanIsAnalyzed(boolean isAnalyzed) {
         if (isAnalyzed) {
             throw QueryException.error("ANALYZE statement is not applicable for key-based optimized IMap access plans." +
                     " Consider to submit the same query without ANALYZE statement.");

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/CalciteSqlOptimizer.java
@@ -1042,8 +1042,8 @@ public class CalciteSqlOptimizer implements SqlOptimizer {
      */
     static void checkIMapByKeyPlanIsAnalyzed(boolean isAnalyzed) {
         if (isAnalyzed) {
-            throw QueryException.error("ANALYZE statement is not applicable for key-based optimized IMap access plans." +
-                    " Consider to submit the same query without ANALYZE statement.");
+            throw QueryException.error("This query uses key-based optimized IMap access plan. " +
+                    "ANALYZE is unable to produce meaningful execution statistics for it.");
         }
     }
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/AnalyzeStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/AnalyzeStatementTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.sql.impl.QueryException;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -108,7 +109,7 @@ public class AnalyzeStatementTest extends SqlEndToEndTestSupport {
     @Test
     public void test_select() {
         createMapping("test", Long.class, String.class);
-        instance().getSql().execute("INSERT INTO test VALUES (1, 'testVal')");
+        instance().getMap("test").put(1L, "testVal");
         assertRowsAnyOrder("ANALYZE SELECT * FROM test WHERE TRUE", rows(2, 1L, "testVal"));
         final Job job = instance().getJet().getJobs()
                 .stream()
@@ -120,6 +121,11 @@ public class AnalyzeStatementTest extends SqlEndToEndTestSupport {
                 .orElse(null);
         assertNotNull(job);
         assertFalse(job.isLightJob());
+
+        // Check optimized plan failure with ANALYZE statement
+        assertThatThrownBy(() -> sqlService.execute("ANALYZE SELECT * FROM test WHERE __key = 1"))
+                .hasCauseInstanceOf(QueryException.class)
+                .hasMessageContaining(" Consider to submit the same query without ANALYZE statement.");
     }
 
     @Test
@@ -129,6 +135,11 @@ public class AnalyzeStatementTest extends SqlEndToEndTestSupport {
         final String insertQuery = "INSERT INTO test SELECT v, v from table(generate_series(1,2))";
         assertJobIsAnalyzed(insertQuery);
         assertEquals(2, instance().getMap("test").size());
+
+        // Check optimized plan failure with ANALYZE statement
+        assertThatThrownBy(() -> sqlService.execute("ANALYZE INSERT INTO test VALUES(3, 3)"))
+                .hasCauseInstanceOf(QueryException.class)
+                .hasMessageContaining(" Consider to submit the same query without ANALYZE statement.");
     }
 
     @Test
@@ -139,6 +150,11 @@ public class AnalyzeStatementTest extends SqlEndToEndTestSupport {
         final String updateQuery = "UPDATE test SET this = 3 WHERE this = 1 AND this IS NOT NULL";
         assertJobIsAnalyzed(updateQuery);
         assertEquals(3L, instance().getMap("test").get(1L));
+
+        // Check optimized plan failure with ANALYZE statement
+        assertThatThrownBy(() -> sqlService.execute("ANALYZE UPDATE test SET this = 3 WHERE __key = 1"))
+                .hasCauseInstanceOf(QueryException.class)
+                .hasMessageContaining(" Consider to submit the same query without ANALYZE statement.");
     }
 
     @Test
@@ -149,6 +165,10 @@ public class AnalyzeStatementTest extends SqlEndToEndTestSupport {
         final String deleteQuery = "DELETE FROM test WHERE this = 1 AND this IS NOT NULL";
         assertJobIsAnalyzed(deleteQuery);
         assertTrue(instance().getMap("test").isEmpty());
+
+        assertThatThrownBy(() -> sqlService.execute("ANALYZE DELETE FROM test WHERE __key = 1"))
+                .hasCauseInstanceOf(QueryException.class)
+                .hasMessageContaining(" Consider to submit the same query without ANALYZE statement.");
     }
 
     @Test

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/AnalyzeStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/AnalyzeStatementTest.java
@@ -125,7 +125,7 @@ public class AnalyzeStatementTest extends SqlEndToEndTestSupport {
         // Check optimized plan failure with ANALYZE statement
         assertThatThrownBy(() -> sqlService.execute("ANALYZE SELECT * FROM test WHERE __key = 1"))
                 .hasCauseInstanceOf(QueryException.class)
-                .hasMessageContaining(" Consider to submit the same query without ANALYZE statement.");
+                .hasMessageContaining("This query uses key-based optimized IMap access plan.");
     }
 
     @Test
@@ -139,7 +139,7 @@ public class AnalyzeStatementTest extends SqlEndToEndTestSupport {
         // Check optimized plan failure with ANALYZE statement
         assertThatThrownBy(() -> sqlService.execute("ANALYZE INSERT INTO test VALUES(3, 3)"))
                 .hasCauseInstanceOf(QueryException.class)
-                .hasMessageContaining(" Consider to submit the same query without ANALYZE statement.");
+                .hasMessageContaining("This query uses key-based optimized IMap access plan.");
     }
 
     @Test
@@ -154,7 +154,7 @@ public class AnalyzeStatementTest extends SqlEndToEndTestSupport {
         // Check optimized plan failure with ANALYZE statement
         assertThatThrownBy(() -> sqlService.execute("ANALYZE UPDATE test SET this = 3 WHERE __key = 1"))
                 .hasCauseInstanceOf(QueryException.class)
-                .hasMessageContaining(" Consider to submit the same query without ANALYZE statement.");
+                .hasMessageContaining("This query uses key-based optimized IMap access plan.");
     }
 
     @Test
@@ -168,7 +168,7 @@ public class AnalyzeStatementTest extends SqlEndToEndTestSupport {
 
         assertThatThrownBy(() -> sqlService.execute("ANALYZE DELETE FROM test WHERE __key = 1"))
                 .hasCauseInstanceOf(QueryException.class)
-                .hasMessageContaining(" Consider to submit the same query without ANALYZE statement.");
+                .hasMessageContaining("This query uses key-based optimized IMap access plan.");
     }
 
     @Test


### PR DESCRIPTION
For `IMapByKey` plans - we return an error with the suggestion to run the usual query without ANALYZE