### PR TITLE
Disable log4j2 shutdown hook [HZ-3543]

### DIFF
--- a/distribution/src/bin-regular/common.bat
+++ b/distribution/src/bin-regular/common.bat
@@ -67,6 +67,8 @@ IF %JAVA_VERSION% GEQ 9 (
     	set JAVA_OPTS=%JAVA_OPTS% --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED
     )
 )
+REM Disable the log4j2 shutdown hook, otherwise log lines during node shutdown might be lost
+set JAVA_OPTS=%JAVA_OPTS% -Dlog4j.shutdownHookEnabled=false
 
 :: HAZELCAST_CONFIG holds path to the configuration file. The path is relative to the Hazelcast installation (HAZELCAST_HOME).
 if "x%HAZELCAST_CONFIG%" == "x" (

--- a/distribution/src/bin-regular/common.bat
+++ b/distribution/src/bin-regular/common.bat
@@ -68,7 +68,7 @@ IF %JAVA_VERSION% GEQ 9 (
     )
 )
 REM Disable the log4j2 shutdown hook, otherwise log lines during node shutdown might be lost
-set JAVA_OPTS=%JAVA_OPTS% -Dlog4j.shutdownHookEnabled=false
+set JAVA_OPTS=%JAVA_OPTS% -Dlog4j.shutdownHookEnabled=false -Dhazelcast.logging.shutdown=true
 
 :: HAZELCAST_CONFIG holds path to the configuration file. The path is relative to the Hazelcast installation (HAZELCAST_HOME).
 if "x%HAZELCAST_CONFIG%" == "x" (

--- a/distribution/src/bin-regular/common.sh
+++ b/distribution/src/bin-regular/common.sh
@@ -57,6 +57,8 @@ if [ "$JAVA_VERSION" -ge "9" ]; then
         JDK_OPTS="$JDK_OPTS --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED"
     fi
 fi
+# Disable the log4j2 shutdown hook, otherwise log lines during node shutdown might be lost
+JDK_OPTS="$JDK_OPTS -Dlog4j.shutdownHookEnabled=false"
 
 # ensure CLASSPATH_DEFAULT is unix style + trimmed
 if [ -n "${CLASSPATH_DEFAULT}" ]; then

--- a/distribution/src/bin-regular/common.sh
+++ b/distribution/src/bin-regular/common.sh
@@ -58,7 +58,7 @@ if [ "$JAVA_VERSION" -ge "9" ]; then
     fi
 fi
 # Disable the log4j2 shutdown hook, otherwise log lines during node shutdown might be lost
-JDK_OPTS="$JDK_OPTS -Dlog4j.shutdownHookEnabled=false"
+JDK_OPTS="$JDK_OPTS -Dlog4j.shutdownHookEnabled=false -Dhazelcast.logging.shutdown=true"
 
 # ensure CLASSPATH_DEFAULT is unix style + trimmed
 if [ -n "${CLASSPATH_DEFAULT}" ]; then

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientLoggingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientLoggingService.java
@@ -45,15 +45,17 @@ public class ClientLoggingService implements LoggingService {
     private final BuildInfo buildInfo;
     private final String instanceName;
     private final boolean detailsEnabled;
+    private final boolean shouldShutdownLoggingOnHazelcastShutdown;
     private volatile String versionMessage;
 
     public ClientLoggingService(
-            String clusterName, String loggingType, BuildInfo buildInfo, String instanceName, boolean detailsEnabled
-    ) {
+            String clusterName, String loggingType, BuildInfo buildInfo, String instanceName, boolean detailsEnabled,
+            boolean shutdownLoggingEnabled) {
         this.loggerFactory = Logger.newLoggerFactory(loggingType);
         this.buildInfo = buildInfo;
         this.instanceName = instanceName;
         this.detailsEnabled = detailsEnabled;
+        this.shouldShutdownLoggingOnHazelcastShutdown = shutdownLoggingEnabled;
         updateClusterName(clusterName);
     }
 
@@ -85,7 +87,7 @@ public class ClientLoggingService implements LoggingService {
 
     @Override
     public void shutdown() {
-        if (loggerFactory instanceof InternalLoggerFactory) {
+        if (shouldShutdownLoggingOnHazelcastShutdown && loggerFactory instanceof InternalLoggerFactory) {
             ((InternalLoggerFactory) loggerFactory).shutdown();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientLoggingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/ClientLoggingService.java
@@ -25,6 +25,7 @@ import com.hazelcast.logging.LogListener;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.logging.LoggerFactory;
 import com.hazelcast.logging.LoggingService;
+import com.hazelcast.logging.impl.InternalLoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.ConcurrentHashMap;
@@ -80,6 +81,13 @@ public class ClientLoggingService implements LoggingService {
     public ILogger getLogger(@Nonnull Class clazz) {
         checkNotNull(clazz, "class must not be null");
         return getOrPutIfAbsent(mapLoggers, clazz.getName(), loggerConstructor);
+    }
+
+    @Override
+    public void shutdown() {
+        if (loggerFactory instanceof InternalLoggerFactory) {
+            ((InternalLoggerFactory) loggerFactory).shutdown();
+        }
     }
 
     private class DefaultLogger extends AbstractLogger {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -229,8 +229,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         HazelcastProperties props = new HazelcastProperties(config.getProperties());
         String loggingType = props.getString(ClusterProperty.LOGGING_TYPE);
         boolean detailsEnabled = props.getBoolean(ClusterProperty.LOGGING_ENABLE_DETAILS);
+        boolean shutdownLoggingEnabled = props.getBoolean(ClusterProperty.LOGGING_SHUTDOWN);
         this.loggingService = new ClientLoggingService(config.getClusterName(),
-                loggingType, BuildInfoProvider.getBuildInfo(), instanceName, detailsEnabled);
+                loggingType, BuildInfoProvider.getBuildInfo(), instanceName, detailsEnabled, shutdownLoggingEnabled);
 
         if (clientConfig != null) {
             MetricsConfigHelper.overrideClientMetricsConfig(clientConfig,

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/Node.java
@@ -570,6 +570,7 @@ public class Node {
             if (state != NodeState.SHUT_DOWN) {
                 shuttingDown.compareAndSet(true, false);
             }
+            loggingService.shutdown();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/logging/Log4j2Factory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Log4j2Factory.java
@@ -36,6 +36,11 @@ public class Log4j2Factory extends LoggerFactorySupport {
         return new Log4j2Logger(LogManager.getContext(false).getLogger(name));
     }
 
+    @Override
+    public void shutdown() {
+        LogManager.shutdown();
+    }
+
     @PrivateApi
     public static class Log4j2Logger extends AbstractLogger implements InternalLogger {
 

--- a/hazelcast/src/main/java/com/hazelcast/logging/LoggingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LoggingService.java
@@ -28,4 +28,6 @@ public interface LoggingService {
     @Nonnull ILogger getLogger(@Nonnull String name);
 
     @Nonnull ILogger getLogger(@Nonnull Class type);
+
+    void shutdown();
 }

--- a/hazelcast/src/main/java/com/hazelcast/logging/impl/InternalLoggerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/impl/InternalLoggerFactory.java
@@ -41,4 +41,10 @@ public interface InternalLoggerFactory {
      */
     void resetLevel();
 
+    /**
+     * Shutdown the logger factory.
+     */
+    default void shutdown() {
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/logging/impl/LoggingServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/impl/LoggingServiceImpl.java
@@ -179,6 +179,13 @@ public class LoggingServiceImpl implements LoggingService {
         listeners.remove(new LogListenerRegistration(Level.ALL, logListener));
     }
 
+    @Override
+    public void shutdown() {
+        if (loggerFactory instanceof InternalLoggerFactory) {
+            ((InternalLoggerFactory) loggerFactory).shutdown();
+        }
+    }
+
     void handleLogEvent(LogEvent logEvent) {
         for (LogListenerRegistration logListenerRegistration : listeners) {
             if (logEvent.getLogRecord().getLevel().intValue() >= logListenerRegistration.getLevel().intValue()) {

--- a/hazelcast/src/main/java/com/hazelcast/logging/impl/LoggingServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/impl/LoggingServiceImpl.java
@@ -30,6 +30,7 @@ import com.hazelcast.logging.LogListener;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.logging.LoggerFactory;
 import com.hazelcast.logging.LoggingService;
+import com.hazelcast.spi.properties.ClusterProperty;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -53,6 +54,7 @@ public class LoggingServiceImpl implements LoggingService {
 
     private final LoggerFactory loggerFactory;
     private final boolean detailsEnabled;
+    private final boolean shouldShutdownLoggingOnHazelcastShutdown;
     private final Node node;
     private final String versionMessage;
 
@@ -67,6 +69,7 @@ public class LoggingServiceImpl implements LoggingService {
         this.detailsEnabled = detailsEnabled;
         this.node = node;
         versionMessage = "[" + clusterName + "] [" + buildInfo.getVersion() + "] ";
+        this.shouldShutdownLoggingOnHazelcastShutdown = node.getProperties().getBoolean(ClusterProperty.LOGGING_SHUTDOWN);
     }
 
     public void setThisMember(MemberImpl thisMember) {
@@ -181,7 +184,7 @@ public class LoggingServiceImpl implements LoggingService {
 
     @Override
     public void shutdown() {
-        if (loggerFactory instanceof InternalLoggerFactory) {
+        if (shouldShutdownLoggingOnHazelcastShutdown && loggerFactory instanceof InternalLoggerFactory) {
             ((InternalLoggerFactory) loggerFactory).shutdown();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1634,6 +1634,20 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.logging.details.enabled", true);
 
     /**
+     * Controls whether Hazelcast will explicitly shutdown the logging implementation as part of
+     * Hazelcast graceful shutdown procedure. Default value is {@code false}.
+     * <p/>
+     * This property can be enabled when Hazelcast is the only application being executed in the JVM,
+     * for example, when running a Hazelcast cluster member in its own process.
+     * If the JVM process is expected to continue executing other application bits after Hazelcast is shut down, then
+     * if this property is {@code true}, logging may be disrupted.
+     *
+     * @since 5.4.0
+     */
+    public static final HazelcastProperty LOGGING_SHUTDOWN
+            = new HazelcastProperty("hazelcast.logging.shutdown", false);
+
+    /**
      * All locks which are acquired without an explicit lease time use this value
      * (in seconds) as the lease time. When you want to set an explicit lease
      * time for your locks, you cannot set it to a longer time than this value.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientExecutionServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/ClientExecutionServiceImplTest.java
@@ -49,7 +49,7 @@ public class ClientExecutionServiceImplTest {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         HazelcastProperties properties = new HazelcastProperties(new Config());
         ClientLoggingService loggingService = new ClientLoggingService(
-                name, "jdk", BuildInfoProvider.getBuildInfo(), name, true
+                name, "jdk", BuildInfoProvider.getBuildInfo(), name, true, false
         );
 
         executionService = new ClientExecutionServiceImpl(name, classLoader, properties, loggingService);


### PR DESCRIPTION
A common issue, especially when Hazelcast runs in Kubernetes pods with log4j2 logging,
is that shutdown logs are missing. The reason is that log4j2 registers its own shutdown
hook, alongside Hazelcast's own shutdown hook. Since the JVM does not guarantee
any ordering of shutdown hook execution, it can be the case that the log4j shutdown
hook shuts down loggers while Hazelcast is still performing shut down activities.

This results in missing important logs from the shutdown of Hazelcast members that
can be useful for troubleshooting.

This change introduces explicit shutdown of the log4j2 LogManager after Hazelcast Node
has been shut down: this does no harm when the log4j shutdown hook is enabled (as far as
I navigated the log4j code & tested the changes locally). When the shutdown hook is disabled,
it allows for clean logging of shutdown information.

Example of Hazelcast shutdown logging with `GRACEFUL` shutdown hook policy:

- without this change:
```
$ bin/hz start
...
2023-11-20 16:25:56,816 [ INFO] [main] [c.h.c.LifecycleService]: [127.0.0.1]:5701 [dev] [5.4.0-SNAPSHOT] [127.0.0.1]:5701 is STARTED
 ^C2023-11-20 16:26:02,988 [ INFO] [hz.ShutdownThread] [c.h.i.i.Node]: [127.0.0.1]:5701 [dev] [5.4.0-SNAPSHOT] Running shutdown hook... Current node state: ACTIVE
 ```

 - with this change:
 ```
 ^C2023-11-20 16:26:31,183 [ INFO] [hz.ShutdownThread] [c.h.i.i.Node]: [127.0.0.1]:5701 [dev] [5.4.0-SNAPSHOT] Running shutdown hook... Current node state: ACTIVE
 2023-11-20 16:26:31,185 [ INFO] [hz.ShutdownThread] [c.h.c.LifecycleService]: [127.0.0.1]:5701 [dev] [5.4.0-SNAPSHOT] [127.0.0.1]:5701 is SHUTTING_DOWN
 2023-11-20 16:26:31,191 [ INFO] [hz.ShutdownThread] [c.h.i.i.Node]: [127.0.0.1]:5701 [dev] [5.4.0-SNAPSHOT] Shutting down connection manager...
 2023-11-20 16:26:31,195 [ INFO] [hz.ShutdownThread] [c.h.i.i.Node]: [127.0.0.1]:5701 [dev] [5.4.0-SNAPSHOT] Shutting down node engine...
 2023-11-20 16:26:31,205 [ INFO] [hz.ShutdownThread] [c.h.i.i.NodeExtension]: [127.0.0.1]:5701 [dev] [5.4.0-SNAPSHOT] Destroying node NodeExtension.
 2023-11-20 16:26:31,206 [ INFO] [hz.ShutdownThread] [c.h.i.i.Node]: [127.0.0.1]:5701 [dev] [5.4.0-SNAPSHOT] Hazelcast Shutdown is completed in 18 ms.
```