### PR TITLE
Add required getters for FailoverClusterMembershipEventTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -309,6 +309,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return new Diagnostics(name, loggingService, instanceName, properties);
     }
 
+    ClientClusterViewListenerService getClientClusterViewListenerService() {
+        return clientClusterViewListenerService;
+    }
+
     private MetricsRegistryImpl initMetricsRegistry() {
         ILogger logger = loggingService.getLogger(MetricsRegistryImpl.class);
         return new MetricsRegistryImpl(getName(), logger, clientMetricsLevel(properties,


### PR DESCRIPTION
This adds required internal getters used in the test FailoverClusterMembershipEventTest in the EE PR https://github.com/hazelcast/hazelcast-enterprise/pull/6874