### PR TITLE
Continue trying if initial membership event retrieval fails and client is failover [API-2171]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -309,6 +309,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return new Diagnostics(name, loggingService, instanceName, properties);
     }
 
+    ClientClusterViewListenerService getClientClusterViewListenerService() {
+        return clientClusterViewListenerService;
+    }
+
     private MetricsRegistryImpl initMetricsRegistry() {
         ILogger logger = loggingService.getLogger(MetricsRegistryImpl.class);
         return new MetricsRegistryImpl(getName(), logger, clientMetricsLevel(properties,


### PR DESCRIPTION
As reported in https://hazelcast.atlassian.net/browse/API-2171, the client was not continuing trying next clusters if the connected cluster fails to send initial membership event in time. I added a check about client being failover in the conn. manager and conditionally handle the case.

This PR also adds required internal getters/APIs used in the test FailoverClusterMembershipEventTest in the EE PR https://github.com/hazelcast/hazelcast-enterprise/pull/6874