### PR TITLE
Remove redundant `Projection` test implementations

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapProjectSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapProjectSerializationTest.java
@@ -18,11 +18,11 @@ package com.hazelcast.client.map;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.AbstractMapQueryIterableTest.GetValueProjection;
 import com.hazelcast.map.IMap;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.projection.Projection;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -34,10 +34,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
@@ -57,16 +55,6 @@ public class ClientMapProjectSerializationTest extends HazelcastTestSupport {
         hazelcastFactory.terminateAll();
     }
 
-
-    public static class ValuesProjection
-            implements Projection<Map.Entry<Integer, OnlyDeserializedTwiceObject>, OnlyDeserializedTwiceObject>, Serializable {
-
-        @Override
-        public OnlyDeserializedTwiceObject transform(Map.Entry<Integer, OnlyDeserializedTwiceObject> input) {
-            return input.getValue();
-        }
-    }
-
     @Test
     public void testProjectObjectShouldDeserializedOnlyTwice() {
         // One deserialization on server when object is accessed from transform
@@ -77,7 +65,7 @@ public class ClientMapProjectSerializationTest extends HazelcastTestSupport {
         IMap<Integer, OnlyDeserializedTwiceObject> map = client.getMap("test");
         OnlyDeserializedTwiceObject value = new OnlyDeserializedTwiceObject("test");
         map.put(1, value);
-        Collection<OnlyDeserializedTwiceObject> result = map.project(new ValuesProjection());
+        Collection<OnlyDeserializedTwiceObject> result = map.project(new GetValueProjection<>());
 
         assertEquals(Collections.singletonList(value), result);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/AbstractMapQueryIterableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AbstractMapQueryIterableTest.java
@@ -255,16 +255,16 @@ public abstract class AbstractMapQueryIterableTest extends HazelcastTestSupport 
         }
     }
 
-    private static class TestProjection implements Projection<Entry<String, String>, String> {
+    public static class TestProjection implements Projection<Entry<String, String>, String> {
         @Override
         public String transform(Entry<String, String> input) {
             return "dummy" + input.getValue();
         }
     }
 
-    private static class GetValueProjection<T> implements Projection<Entry<String, T>, T> {
+    public static class GetValueProjection<K, V> implements Projection<Entry<K, V>, V> {
         @Override
-        public T transform(Entry<String, T> input) {
+        public V transform(Entry<K, V> input) {
             return input.getValue();
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/AbstractMapQueryPartitionIterableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AbstractMapQueryPartitionIterableTest.java
@@ -18,6 +18,8 @@ package com.hazelcast.map;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.AbstractMapQueryIterableTest.GetValueProjection;
+import com.hazelcast.map.AbstractMapQueryIterableTest.TestProjection;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicate;
@@ -224,20 +226,6 @@ public abstract class AbstractMapQueryPartitionIterableTest extends HazelcastTes
         @Override
         public boolean apply(Entry<String, Integer> mapEntry) {
             return mapEntry.getValue() % 2 == 0;
-        }
-    }
-
-    private static class TestProjection implements Projection<Entry<String, String>, String> {
-        @Override
-        public String transform(Entry<String, String> input) {
-            return "dummy" + input.getValue();
-        }
-    }
-
-    private static class GetValueProjection<T> implements Projection<Entry<String, T>, T> {
-        @Override
-        public T transform(Entry<String, T> input) {
-            return input.getValue();
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/AbstractMapQueryPartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AbstractMapQueryPartitionIteratorTest.java
@@ -18,6 +18,8 @@ package com.hazelcast.map;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.AbstractMapQueryIterableTest.GetValueProjection;
+import com.hazelcast.map.AbstractMapQueryIterableTest.TestProjection;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicate;
@@ -237,20 +239,6 @@ public abstract class AbstractMapQueryPartitionIteratorTest extends HazelcastTes
         @Override
         public boolean apply(Entry<String, Integer> mapEntry) {
             return mapEntry.getValue() % 2 == 0;
-        }
-    }
-
-    private static class TestProjection implements Projection<Entry<String, String>, String> {
-        @Override
-        public String transform(Entry<String, String> input) {
-            return "dummy" + input.getValue();
-        }
-    }
-
-    private static class GetValueProjection<T> implements Projection<Entry<String, T>, T> {
-        @Override
-        public T transform(Entry<String, T> input) {
-            return input.getValue();
         }
     }
 }


### PR DESCRIPTION
Several of the `Projection` implementations in the test scope are duplications and should be consolidated.