### PR TITLE
Unify serialization of Subject [HZ-3388]

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtil.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceAware;
 import com.hazelcast.internal.services.NodeAware;
+import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.jet.sql.impl.connector.keyvalue.KvRowProjector;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -282,14 +283,14 @@ public final class QueryUtil {
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeObject(rightRowProjectorSupplier);
             out.writeObject(arguments);
-            out.writeObject(subject);
+            ImdgUtil.writeSubject(out, subject);
         }
 
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             rightRowProjectorSupplier = in.readObject();
             arguments = in.readObject();
-            subject = in.readObject();
+            subject = ImdgUtil.readSubject(in);
         }
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/UpdatingEntryProcessor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/UpdatingEntryProcessor.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceAware;
 import com.hazelcast.internal.services.NodeAware;
+import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.jet.sql.impl.connector.keyvalue.KvRowProjector;
 import com.hazelcast.jet.sql.impl.inject.UpsertTargetDescriptor;
 import com.hazelcast.map.EntryProcessor;
@@ -118,7 +119,7 @@ public final class UpdatingEntryProcessor
         out.writeObject(rowProjectorSupplier);
         out.writeObject(valueProjectorSupplier);
         out.writeObject(arguments);
-        out.writeObject(subject);
+        ImdgUtil.writeSubject(out, subject);
     }
 
     @Override
@@ -126,7 +127,7 @@ public final class UpdatingEntryProcessor
         rowProjectorSupplier = in.readObject();
         valueProjectorSupplier = in.readObject();
         arguments = in.readObject();
-        subject = in.readObject();
+        subject = ImdgUtil.readSubject(in);
     }
 
     public static Supplier supplier(

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtilTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtilTest.java
@@ -16,7 +16,11 @@
 
 package com.hazelcast.jet.sql.impl.connector.map;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -25,10 +29,22 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
+
+import javax.security.auth.Subject;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.LinkedList;
 
 import static com.hazelcast.jet.core.JetTestSupport.TEST_SS;
 import static com.hazelcast.jet.sql.impl.connector.map.QueryUtil.toPredicate;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -40,5 +56,47 @@ public class QueryUtilTest {
                 toPredicate(new JetSqlRow(TEST_SS, new Object[1]), new int[]{0}, new int[]{0}, new QueryPath[]{QueryPath.KEY_PATH});
 
         assertThat(predicate).isNull();
+    }
+
+    @Test
+    public void writeAndReadJoinProjection() throws IOException {
+        final var evalContextWithSubjectMock = mock(ExpressionEvalContext.class);
+        when(evalContextWithSubjectMock.getSerializationService()).thenReturn(mock());
+        when(evalContextWithSubjectMock.getArguments()).thenReturn(singletonList("value"));
+        final var subject = new Subject(true, singleton(mock(Principal.class)), emptySet(), emptySet());
+        when(evalContextWithSubjectMock.subject()).thenReturn(subject);
+
+        final var evalContextNoSubjectMock = mock(ExpressionEvalContext.class);
+        when(evalContextNoSubjectMock.getSerializationService()).thenReturn(mock());
+
+        final var queue = new LinkedList<>();
+        final var output = mock(ObjectDataOutput.class, (Answer<Void>) invocation -> {
+            queue.add(invocation.getArguments()[0]);
+            return null;
+        });
+        final var input = mock(ObjectDataInput.class, (Answer<Object>) invocation -> queue.poll());
+
+        DataSerializable writer = (DataSerializable) QueryUtil.toProjection(mock(), evalContextWithSubjectMock);
+        DataSerializable reader = (DataSerializable) QueryUtil.toProjection(mock(), evalContextNoSubjectMock);
+
+        writer.writeData(output);
+        reader.readData(input);
+
+        assertThat(reader)
+                .usingRecursiveComparison()
+                .comparingOnlyFields("rowProjectorSupplier", "arguments", "subject")
+                .ignoringFields("subject.pubCredentials", "subject.privCredentials")
+                .isEqualTo(writer);
+    }
+
+    @Test
+    public void readDataFailedIfUnexpectedObjectInInput() {
+        final var evalContextMock = mock(ExpressionEvalContext.class);
+        when(evalContextMock.getSerializationService()).thenReturn(mock());
+
+        final var input = mock(ObjectDataInput.class, (Answer<Object>) invocation -> "some unexpected object");
+
+        DataSerializable reader = (DataSerializable) QueryUtil.toProjection(mock(), evalContextMock);
+        assertThatThrownBy(() -> reader.readData(input)).isInstanceOf(ClassCastException.class);
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtilTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtilTest.java
@@ -16,39 +16,34 @@
 
 package com.hazelcast.jet.sql.impl.connector.map;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.instance.impl.TestUtil;
+import com.hazelcast.internal.serialization.impl.AbstractSerializationService;
+import com.hazelcast.jet.sql.SqlTestSupport;
+import com.hazelcast.jet.sql.impl.connector.keyvalue.KvRowProjector;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.extract.QueryPath;
 import com.hazelcast.sql.impl.row.JetSqlRow;
+import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.mockito.stubbing.Answer;
 
 import javax.security.auth.Subject;
-import java.io.IOException;
-import java.security.Principal;
-import java.util.LinkedList;
 
-import static com.hazelcast.jet.core.JetTestSupport.TEST_SS;
 import static com.hazelcast.jet.sql.impl.connector.map.QueryUtil.toPredicate;
 import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
-public class QueryUtilTest {
+public class QueryUtilTest extends SqlTestSupport {
 
     @Test
     public void when_leftValueIsNull_then_returnsNull() {
@@ -59,44 +54,32 @@ public class QueryUtilTest {
     }
 
     @Test
-    public void writeAndReadJoinProjection() throws IOException {
-        final var evalContextWithSubjectMock = mock(ExpressionEvalContext.class);
-        when(evalContextWithSubjectMock.getSerializationService()).thenReturn(mock());
-        when(evalContextWithSubjectMock.getArguments()).thenReturn(singletonList("value"));
-        final var subject = new Subject(true, singleton(mock(Principal.class)), emptySet(), emptySet());
-        when(evalContextWithSubjectMock.subject()).thenReturn(subject);
+    public void when_serializedObject_then_deserializedCorrect() {
+        initialize(1, null);
+        AbstractSerializationService service = (AbstractSerializationService) TestUtil.getNode(instance()).getSerializationService();
 
-        final var evalContextNoSubjectMock = mock(ExpressionEvalContext.class);
-        when(evalContextNoSubjectMock.getSerializationService()).thenReturn(mock());
+        var evalContextMock = mock(ExpressionEvalContext.class);
+        when(evalContextMock.getSerializationService()).thenReturn(mock());
+        var subject = new Subject(true, emptySet(), emptySet(), emptySet());
+        when(evalContextMock.subject()).thenReturn(subject);
 
-        final var queue = new LinkedList<>();
-        final var output = mock(ObjectDataOutput.class, (Answer<Void>) invocation -> {
-            queue.add(invocation.getArguments()[0]);
-            return null;
-        });
-        final var input = mock(ObjectDataInput.class, (Answer<Object>) invocation -> queue.poll());
+        var supplier = KvRowProjector.supplier(
+                new QueryPath[]{},
+                new QueryDataType[]{},
+                null,
+                null,
+                null,
+                null
+        );
+        DataSerializable projection = (DataSerializable) QueryUtil.toProjection(supplier, evalContextMock);
 
-        DataSerializable writer = (DataSerializable) QueryUtil.toProjection(mock(), evalContextWithSubjectMock);
-        DataSerializable reader = (DataSerializable) QueryUtil.toProjection(mock(), evalContextNoSubjectMock);
+        var data = service.toData(projection);
+        var actual = service.toObject(data);
 
-        writer.writeData(output);
-        reader.readData(input);
-
-        assertThat(reader)
+        assertThat(actual)
                 .usingRecursiveComparison()
                 .comparingOnlyFields("rowProjectorSupplier", "arguments", "subject")
                 .ignoringFields("subject.pubCredentials", "subject.privCredentials")
-                .isEqualTo(writer);
-    }
-
-    @Test
-    public void readDataFailedIfUnexpectedObjectInInput() {
-        final var evalContextMock = mock(ExpressionEvalContext.class);
-        when(evalContextMock.getSerializationService()).thenReturn(mock());
-
-        final var input = mock(ObjectDataInput.class, (Answer<Object>) invocation -> "some unexpected object");
-
-        DataSerializable reader = (DataSerializable) QueryUtil.toProjection(mock(), evalContextMock);
-        assertThatThrownBy(() -> reader.readData(input)).isInstanceOf(ClassCastException.class);
+                .isEqualTo(projection);
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtilTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/QueryUtilTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,6 +46,11 @@ import static org.mockito.Mockito.when;
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class QueryUtilTest extends SqlTestSupport {
 
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        initialize(1, null);
+    }
+
     @Test
     public void when_leftValueIsNull_then_returnsNull() {
         Predicate<Object, Object> predicate =
@@ -55,7 +61,6 @@ public class QueryUtilTest extends SqlTestSupport {
 
     @Test
     public void when_serializedObject_then_deserializedCorrect() {
-        initialize(1, null);
         AbstractSerializationService service = (AbstractSerializationService) TestUtil.getNode(instance()).getSerializationService();
 
         var evalContextMock = mock(ExpressionEvalContext.class);

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorTest.java
@@ -23,7 +23,11 @@ import com.hazelcast.jet.sql.impl.inject.PrimitiveUpsertTargetDescriptor;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.sql.impl.QueryUtils;
-import com.hazelcast.sql.impl.expression.*;
+import com.hazelcast.sql.impl.expression.ColumnExpression;
+import com.hazelcast.sql.impl.expression.ConstantExpression;
+import com.hazelcast.sql.impl.expression.Expression;
+import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.expression.ParameterExpression;
 import com.hazelcast.sql.impl.expression.math.PlusFunction;
 import com.hazelcast.sql.impl.extract.GenericQueryTargetDescriptor;
 import com.hazelcast.sql.impl.extract.QueryPath;
@@ -156,7 +160,9 @@ public class UpdateProcessorTest extends SqlTestSupport {
         final var evalContextMock = mock(ExpressionEvalContext.class);
         when(evalContextMock.getSerializationService()).thenReturn(mock());
 
-        var queue = new LinkedList<>(){{ add("some unexpected object");}};
+        var queue = new LinkedList<>();
+        queue.add("some unexpected object");
+
         final var input = mock(ObjectDataInput.class, (Answer<Object>) invocation -> queue.poll());
         final var supplier = UpdatingEntryProcessor.supplier(
                 mock(),

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorTest.java
@@ -160,10 +160,7 @@ public class UpdateProcessorTest extends SqlTestSupport {
         final var evalContextMock = mock(ExpressionEvalContext.class);
         when(evalContextMock.getSerializationService()).thenReturn(mock());
 
-        var queue = new LinkedList<>();
-        queue.add("some unexpected object");
-
-        final var input = mock(ObjectDataInput.class, (Answer<Object>) invocation -> queue.poll());
+        final var input = mock(ObjectDataInput.class, (Answer<Object>) invocation -> "some unexpected object");
         final var supplier = UpdatingEntryProcessor.supplier(
                 mock(),
                 mock(),


### PR DESCRIPTION
Unify subject serialization/deserialization in the UpdatingEntryProcessor and QueryUtil.JoinProjection classes.
Subject serialization/deserialization should be the same as in ImdgUtil.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible