### PR TITLE
Do not log whole config in CDC [HZ-3861]

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSourceP.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSourceP.java
@@ -250,7 +250,11 @@ public abstract class CdcSourceP<T> extends AbstractProcessor {
     }
 
     private SourceTask startNewTask() {
-        logger.info("starting new task with config: " + taskConfig);
+        if (taskConfig.containsKey("name")) {
+            logger.info("starting new task: " + taskConfig.get("name"));
+        } else {
+            logger.info("starting new task");
+        }
         SourceTask task = newInstance(connector.taskClass().getName(), "task");
         task.initialize(new JetSourceTaskContext());
 


### PR DESCRIPTION
Avoid logging all config, as it may contain passwords
Fixes #26003


Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
