### PR TITLE
Avoid parsing internal Debezium messages [HZ-3863]

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordCdcSourceP.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordCdcSourceP.java
@@ -54,7 +54,8 @@ public class ChangeRecordCdcSourceP extends CdcSourceP<ChangeRecord> {
     @Nullable
     @Override
     protected ChangeRecord map(SourceRecord record) {
-        if (record == null || record.topic().startsWith("__debezium")) { // internal Debezium messages
+        if (record == null || record.topic().startsWith("__debezium")) {
+            // internal Debezium messages about e.g. Heartbeat uses such topics
             return null;
         }
 
@@ -65,7 +66,9 @@ public class ChangeRecordCdcSourceP extends CdcSourceP<ChangeRecord> {
         Schema valueSchema = record.valueSchema();
 
         if (valueSchema.name().startsWith("io.debezium.")) {
-            return null; // internal Debezium messages
+            // internal Debezium messages, e.g. transaction metadata uses topic ${database.server.name}.transaction
+            // so it won't be filtered out earlier
+            return null;
         }
         Struct source = (Struct) value.get("source");
 

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordCdcSourceP.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordCdcSourceP.java
@@ -54,7 +54,7 @@ public class ChangeRecordCdcSourceP extends CdcSourceP<ChangeRecord> {
     @Nullable
     @Override
     protected ChangeRecord map(SourceRecord record) {
-        if (record == null) {
+        if (record == null || record.topic().startsWith("__debezium")) { // internal Debezium messages
             return null;
         }
 

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -264,6 +264,7 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
                     .setProperty("database.password", "postgres")
                     .setProperty("database.dbname", "postgres")
                     .setProperty("table.whitelist", "inventory.customers")
+                    .setProperty("heartbeat.interval.ms", "1000") // this will add Heartbeat messages to the stream
                     .build();
 
             Pipeline pipeline = Pipeline.create();


### PR DESCRIPTION
Adding e.g. heartbeat config adds  messages with value schema's name `io.debezium.connector.common.Heartbeat`

It's also under `__debezium*` topics, so easy to filter out

Fixes #26005

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
