### PR TITLE
[BACKPORT] Fix the `ReliableTopicConfig.setName` method to allow empty names [HZ-2274] [API-2172] (#26010)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -31,9 +31,9 @@ import java.util.concurrent.Executor;
 
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readNullableList;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeNullableList;
-import static com.hazelcast.internal.util.Preconditions.checkHasText;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
+import static com.hazelcast.internal.util.Preconditions.isNotNull;
 import static com.hazelcast.topic.TopicOverloadPolicy.BLOCK;
 
 /**
@@ -74,7 +74,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
     private int readBatchSize = DEFAULT_READ_BATCH_SIZE;
     private String name;
     private boolean statisticsEnabled = DEFAULT_STATISTICS_ENABLED;
-    private List<ListenerConfig> listenerConfigs = new LinkedList<ListenerConfig>();
+    private List<ListenerConfig> listenerConfigs = new LinkedList<>();
     private TopicOverloadPolicy topicOverloadPolicy = DEFAULT_TOPIC_OVERLOAD_POLICY;
 
     public ReliableTopicConfig() {
@@ -111,10 +111,10 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      *
      * @param name the name of the reliable topic
      * @return the updated ReliableTopicConfig
-     * @throws IllegalArgumentException if name is {@code null} or an empty string
+     * @throws IllegalArgumentException if name is {@code null}
      */
     public ReliableTopicConfig setName(String name) {
-        this.name = checkHasText(name, "name must contain text");
+        this.name = isNotNull(name, "name");
         return this;
     }
 
@@ -263,7 +263,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      * @return this updated topic configuration
      */
     public ReliableTopicConfig setMessageListenerConfigs(List<ListenerConfig> listenerConfigs) {
-        this.listenerConfigs = listenerConfigs != null ? listenerConfigs : new LinkedList<ListenerConfig>();
+        this.listenerConfigs = listenerConfigs != null ? listenerConfigs : new LinkedList<>();
         return this;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.List;
 import java.util.concurrent.Executor;
 
 import static com.hazelcast.config.ReliableTopicConfig.DEFAULT_READ_BATCH_SIZE;
@@ -34,10 +35,10 @@ import static com.hazelcast.config.ReliableTopicConfig.DEFAULT_STATISTICS_ENABLE
 import static com.hazelcast.config.ReliableTopicConfig.DEFAULT_TOPIC_OVERLOAD_POLICY;
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static com.hazelcast.topic.TopicOverloadPolicy.DISCARD_NEWEST;
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -54,6 +55,19 @@ public class ReliableTopicConfigTest {
         assertEquals("foo", config.getName());
         assertEquals(DEFAULT_TOPIC_OVERLOAD_POLICY, config.getTopicOverloadPolicy());
         assertEquals(DEFAULT_STATISTICS_ENABLED, config.isStatisticsEnabled());
+    }
+
+    @Test
+    public void testConstructorWithEmptyName() {
+        ReliableTopicConfig config = new ReliableTopicConfig("");
+        assertTrue(config.getName().isEmpty());
+    }
+
+    @Test
+    public void testSetEmptyName() {
+        ReliableTopicConfig config = new ReliableTopicConfig("abc");
+        config.setName("");
+        assertTrue(config.getName().isEmpty());
     }
 
     @Test
@@ -150,7 +164,7 @@ public class ReliableTopicConfigTest {
         ListenerConfig listenerConfig = new ListenerConfig("foobar");
         config.addMessageListenerConfig(listenerConfig);
 
-        assertEquals(asList(listenerConfig), config.getMessageListenerConfigs());
+        assertEquals(List.of(listenerConfig), config.getMessageListenerConfigs());
     }
 
     // ==================== setExecutor =============================
@@ -190,31 +204,31 @@ public class ReliableTopicConfigTest {
         try {
             readOnly.setExecutor(null);
             fail();
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException ignored) {
         }
 
         try {
             readOnly.setReadBatchSize(3);
             fail();
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException ignored) {
         }
 
         try {
             readOnly.setStatisticsEnabled(true);
             fail();
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException ignored) {
         }
 
         try {
             readOnly.addMessageListenerConfig(new ListenerConfig("foobar"));
             fail();
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException ignored) {
         }
 
         try {
             readOnly.setTopicOverloadPolicy(null);
             fail();
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException ignored) {
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.concurrent.Executor;
 
 import static com.hazelcast.config.ReliableTopicConfig.DEFAULT_READ_BATCH_SIZE;
@@ -164,7 +164,7 @@ public class ReliableTopicConfigTest {
         ListenerConfig listenerConfig = new ListenerConfig("foobar");
         config.addMessageListenerConfig(listenerConfig);
 
-        assertEquals(List.of(listenerConfig), config.getMessageListenerConfigs());
+        assertEquals(Collections.singletonList(listenerConfig), config.getMessageListenerConfigs());
     }
 
     // ==================== setExecutor =============================


### PR DESCRIPTION
Fixed the `ReliableTopicConfig.setName` method to allow empty namesThe method is also inline with the constructor which accepts empty name.

backports #26010 