### PR TITLE
[TPC] Fixing performance regression [HZ-3909]

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/Reactor.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/Reactor.java
@@ -30,6 +30,7 @@ import com.hazelcast.internal.util.ThreadAffinityHelper;
 import org.jctools.queues.MpmcArrayQueue;
 
 import java.util.BitSet;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -321,6 +322,64 @@ public abstract class Reactor implements Executor {
      * This method is thread-safe.
      */
     public abstract void wakeup();
+
+    /**
+     * Executes a Callable on the Reactor and returns a CompletableFuture with
+     * its content.
+     * <p/>
+     * Warning: This method is very inefficient because it creates a lot of
+     * litter. It should not be run too frequent because performance will tank.
+     *
+     * @param callable the Callable to submit
+     * @param <E> the type of the callable
+     * @return the CompletableFuture that is linked to the callable.
+     */
+    public final <E> CompletableFuture<E> submit(Callable<E> callable) {
+        CompletableFuture future = new CompletableFuture();
+        Runnable task = () -> {
+            try {
+                future.complete(callable.call());
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        };
+
+        if (!offer(task)) {
+            future.completeExceptionally(new RejectedExecutionException("Task " + callable.toString()
+                    + " rejected from " + this));
+        }
+
+        return future;
+    }
+
+    /**
+     * Executes a Callable on the Reactor and returns a CompletableFuture with
+     * its content.
+     * <p/>
+     * Warning: This method is very inefficient because it creates a lot of litter.
+     * It should not be run too frequent because performance will tank.
+     *
+     * @param cmd the command to submit.
+     * @return a CompletableFuture that is linked to the cmd.
+     */
+    public final CompletableFuture<Void> submit(Runnable cmd) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        Runnable task = () -> {
+            try {
+                cmd.run();
+                future.complete(null);
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        };
+
+        if (!offer(task)) {
+            future.completeExceptionally(new RejectedExecutionException("Task " + cmd.toString()
+                    + " rejected from " + this));
+        }
+
+        return future;
+    }
 
     @Override
     public void execute(Runnable command) {

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocket.java
@@ -17,11 +17,9 @@
 package com.hazelcast.internal.tpcengine.net;
 
 import com.hazelcast.internal.tpcengine.Reactor;
-import com.hazelcast.internal.tpcengine.iobuffer.IOBuffer;
 
 import java.io.IOException;
 import java.net.SocketAddress;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -33,7 +31,7 @@ public abstract class AsyncSocket extends AbstractAsyncSocket {
 
     protected volatile SocketAddress remoteAddress;
     protected volatile SocketAddress localAddress;
-    protected AsyncSocketMetrics metrics = new AsyncSocketMetrics();
+    protected final AsyncSocketMetrics metrics = new AsyncSocketMetrics();
     protected final boolean clientSide;
 
     protected AsyncSocket(boolean clientSide) {
@@ -137,10 +135,10 @@ public abstract class AsyncSocket extends AbstractAsyncSocket {
     public abstract void start();
 
     /**
-     * Ensures that any scheduled IOBuffers are flushed to the socket.
+     * Ensures that any scheduled messages are flushed to the socket.
      * <p>
      * What happens under the hood is that the AsyncSocket is scheduled in the
-     * {@link Reactor} where at some point in the future the IOBuffers get written
+     * {@link Reactor} where at some point in the future the messages get written
      * to the socket.
      * <p>
      * This method is thread-safe.
@@ -150,46 +148,44 @@ public abstract class AsyncSocket extends AbstractAsyncSocket {
     public abstract void flush();
 
     /**
-     * Writes a {@link IOBuffer} to this AsyncSocket without scheduling the AsyncSocket
+     * Writes a message to this AsyncSocket without scheduling the AsyncSocket
      * in the {@link Reactor}.
      * <p>
-     * This call can be used to buffer a series of IOBuffers and then call
+     * This call can be used to buffer a series of messages and then call
      * {@link #flush()} to trigger the actual writing to the socket.
      * <p>
-     * There is no guarantee that IOBuffer is actually going to be received by the caller after
-     * the AsyncSocket has accepted the IOBuffer. E.g. when the TCP/IP connection is dropped.
+     * There is no guarantee that message is actually going to be received by the caller after
+     * the AsyncSocket has accepted the message. E.g. when the TCP/IP connection is dropped.
      * <p>
      * This method is thread-safe.
      *
-     * @param buf the IOBuffer to write.
-     * @return true if the IOBuffer was accepted, false otherwise.
+     * @param msg the message to write.
+     * @return true if the msg was accepted, false otherwise.
      */
-    public abstract boolean write(IOBuffer buf);
-
-    public abstract boolean writeAll(Collection<IOBuffer> bufs);
+    public abstract boolean write(Object msg);
 
     /**
-     * Writes a {@link IOBuffer} to this AsyncSocket and flushes it. Flushing causes the AsyncSocket
+     * Writes a  message to this AsyncSocket and flushes it. Flushing causes the AsyncSocket
      * to be scheduled in the {@link Reactor}.
      * <p>
-     * This is the same as calling {@link #write(IOBuffer)} followed by a {@link #flush()}.
+     * This is the same as calling {@link #write(Object)} followed by a {@link #flush()}.
      * <p>
-     * There is no guarantee that IOBuffer is actually going to be received by the caller if
-     * the AsyncSocket has accepted the IOBuffer. E.g. when the connection closes.
+     * There is no guarantee that message is actually going to be received by the caller if
+     * the AsyncSocket has accepted the message. E.g. when the connection closes.
      * <p>
      * This method is thread-safe.
      *
-     * @param buf the IOBuffer to write.
-     * @return true if the IOBuffer was accepted, false otherwise.
+     * @param msg the message to write.
+     * @return true if the msg was accepted, false otherwise.
      */
-    public abstract boolean writeAndFlush(IOBuffer buf);
+    public abstract boolean writeAndFlush(Object msg);
 
     /**
-     * Writes an {@link IOBuffer} and ensure it gets written.
+     * Writes a message.
      * <p>
      * Should only be called from the reactor-thread.
      */
-    public abstract boolean unsafeWriteAndFlush(IOBuffer buf);
+    public abstract boolean unsafeWriteAndFlush(Object msg);
 
     /**
      * Connects asynchronously to some address.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocketBuilder.java
@@ -76,6 +76,16 @@ public interface AsyncSocketBuilder {
     AsyncSocketBuilder setReader(AsyncSocketReader reader);
 
     /**
+     * Sets the AsyncSocketWriter.
+     *
+     * @param writer the AsyncSocketWriter
+     * @return this
+     * @throws NullPointerException  if reader is null.
+     * @throws IllegalStateException when build already has been called.
+     */
+    AsyncSocketBuilder setWriter(AsyncSocketWriter writer);
+
+    /**
      * Builds the {@link AsyncSocket}.
      *
      * @return the opened AsyncSocket.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocketWriter.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/net/AsyncSocketWriter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpcengine.net;
+
+import com.hazelcast.internal.tpcengine.Eventloop;
+import com.hazelcast.internal.tpcengine.Reactor;
+
+import java.nio.ByteBuffer;
+import java.util.Queue;
+
+import static com.hazelcast.internal.tpcengine.util.Preconditions.checkNotNull;
+
+/**
+ * The {@link AsyncSocketWriter} is called to convert messages from the writeQueue to
+ * bytes so they can be send over the socket.
+ * <p/>
+ * A writer is specific to a {@link AsyncSocket} and can't be shared between
+ * multiple AsyncSocket instances.
+ */
+public abstract class AsyncSocketWriter {
+    protected AsyncSocket socket;
+    protected Reactor reactor;
+    protected Eventloop eventloop;
+    protected Queue writeQueue;
+
+    /**
+     * Initializes the Reader. This method is called once and from the
+     * eventloop thread that owns the socket.
+     *
+     * @param socket the socket this Reader belongs to.
+     */
+    public void init(AsyncSocket socket, Queue writeQueue) {
+        this.socket = checkNotNull(socket);
+        this.writeQueue = writeQueue;
+        this.reactor = socket.reactor();
+        this.eventloop = reactor.eventloop();
+    }
+
+    /**
+     * Is called when data needs to be written to the socket.
+     *
+     * @return true if the Writer is clean, false if dirty. It is dirty
+     * when it could not manage to write all data to the dst buffer.
+     */
+    public abstract boolean onWrite(ByteBuffer dst);
+}

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/IOVector.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/IOVector.java
@@ -38,6 +38,10 @@ public final class IOVector {
         return length == 0;
     }
 
+    public boolean hasRemaining() {
+        return length > 0;
+    }
+
     public int length() {
         return length;
     }

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.tpcengine.net.AsyncSocket;
 import com.hazelcast.internal.tpcengine.net.AsyncSocketMetrics;
 import com.hazelcast.internal.tpcengine.net.AsyncSocketOptions;
 import com.hazelcast.internal.tpcengine.net.AsyncSocketReader;
+import com.hazelcast.internal.tpcengine.net.AsyncSocketWriter;
 import com.hazelcast.internal.tpcengine.util.BufferUtil;
 import com.hazelcast.internal.tpcengine.util.CircularQueue;
 import org.jctools.queues.MpmcArrayQueue;
@@ -34,7 +35,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.CancelledKeyException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -55,17 +55,17 @@ public final class NioAsyncSocket extends AsyncSocket {
 
     private final NioAsyncSocketOptions options;
     private final AtomicReference<Thread> flushThread = new AtomicReference<>(currentThread());
-    private final MpmcArrayQueue<IOBuffer> writeQueue;
+    private final MpmcArrayQueue writeQueue;
     private final Handler handler;
     private final SocketChannel socketChannel;
     private final NioReactor reactor;
     private final Thread eventloopThread;
     private final SelectionKey key;
-    private final IOVector ioVector = new IOVector();
-    private final boolean regularSchedule;
-    private final boolean writeThrough;
+    private final IOVector ioVector;
     private final AsyncSocketReader reader;
     private final CircularQueue localTaskQueue;
+    private final AsyncSocketWriter writer;
+    private boolean ioVectorWriteAllowed;
 
     // only accessed from eventloop thread
     private boolean started;
@@ -73,6 +73,7 @@ public final class NioAsyncSocket extends AsyncSocket {
     private boolean connecting;
     private volatile CompletableFuture<Void> connectFuture;
 
+    @SuppressWarnings("checkstyle:executablestatementcount")
     NioAsyncSocket(NioAsyncSocketBuilder builder) {
         super(builder.clientSide);
 
@@ -88,13 +89,19 @@ public final class NioAsyncSocket extends AsyncSocket {
                 this.localAddress = socketChannel.getLocalAddress();
                 this.remoteAddress = socketChannel.getRemoteAddress();
             }
-            this.writeThrough = builder.writeThrough;
-            this.regularSchedule = builder.regularSchedule;
             this.writeQueue = new MpmcArrayQueue<>(builder.writeQueueCapacity);
             this.handler = new Handler(builder);
             this.key = socketChannel.register(reactor.selector, 0, handler);
             this.reader = builder.reader;
             reader.init(this);
+            this.writer = builder.writer;
+            if (writer != null) {
+                this.writer.init(this, writeQueue);
+                this.ioVector = null;
+            } else {
+                this.ioVector = new IOVector();
+            }
+            this.ioVectorWriteAllowed = ioVector != null;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -271,20 +278,22 @@ public final class NioAsyncSocket extends AsyncSocket {
     @Override
     public void flush() {
         Thread currentThread = currentThread();
-        if (flushThread.compareAndSet(null, currentThread)) {
-            if (currentThread == eventloopThread) {
-                localTaskQueue.add(handler);
-            } else if (writeThrough) {
-                handler.run();
-            } else if (regularSchedule) {
-                // todo: return value
-                reactor.offer(handler);
-            } else {
-                key.interestOps(key.interestOps() | OP_WRITE);
-                // we need to call the select wakeup because the interest set will only take
-                // effect after a select operation.
-                reactor.wakeup();
-            }
+
+        if (flushThread.get() != null) {
+            // the socket is already flushed, we are done.
+            return;
+        }
+
+        // The socket is not flushed, so we are going to try to flush it.
+        if (!flushThread.compareAndSet(null, currentThread)) {
+            // A different thread triggered a flush, we are done.
+            return;
+        }
+
+        if (currentThread == eventloopThread) {
+            localTaskQueue.add(handler);
+        } else {
+            reactor.offer(handler);
         }
     }
 
@@ -300,52 +309,78 @@ public final class NioAsyncSocket extends AsyncSocket {
     }
 
     @Override
-    public boolean write(IOBuffer buf) {
-        return writeQueue.add(buf);
+    public boolean write(Object msg) {
+        checkNotNull(msg, "msg");
+
+        if (writer == null && !(msg instanceof IOBuffer)) {
+            throw new IllegalArgumentException("Message needs to be an IOBuffer if no writer is configured.");
+        }
+
+        if (writeQueue.add(msg)) {
+            return true;
+        } else {
+            // lets trigger a flush since the writeQueue is full.
+            flush();
+            return false;
+        }
     }
 
     @Override
-    public boolean writeAll(Collection<IOBuffer> bufs) {
-        return writeQueue.addAll(bufs);
-    }
-
-    @Override
-    public boolean writeAndFlush(IOBuffer buf) {
-        boolean result = write(buf);
+    public boolean writeAndFlush(Object msg) {
+        boolean result = write(msg);
         flush();
         return result;
     }
 
     @Override
-    public boolean unsafeWriteAndFlush(IOBuffer buf) {
-        Thread currentFlushThread = flushThread.get();
+    public boolean unsafeWriteAndFlush(Object msg) {
+        checkNotNull(msg, "msg");
+
+        if (writer == null && !(msg instanceof IOBuffer)) {
+            throw new IllegalArgumentException(
+                    "Only accepting IOBuffers if writer isn't set.");
+        }
+
         Thread currentThread = currentThread();
+        if (currentThread != eventloopThread) {
+            throw new IllegalStateException(
+                    "insideWriteAndFlush can only be made from eventloop thread, "
+                            + "found " + currentThread);
+        }
 
-        assert currentThread == eventloopThread;
+        boolean triggeredFlush;
 
-        boolean result;
+        Thread currentFlushThread = flushThread.get();
         if (currentFlushThread == null) {
-            if (flushThread.compareAndSet(null, currentThread)) {
-                localTaskQueue.add(handler);
-                if (ioVector.offer(buf)) {
-                    result = true;
-                } else {
-                    result = writeQueue.offer(buf);
-                }
+            // the socket isn't flushed, lets try to flush it.
+            triggeredFlush = flushThread.compareAndSet(null, currentThread);
+            // At this point we know for sure that the socket was flushed; either
+            // by the current thread or by a different one.
+        } else {
+            // the socket was already flushed
+            triggeredFlush = false;
+        }
+
+        boolean offered = unsafeWrite(msg);
+
+        if (triggeredFlush && offered) {
+            reactor.execute(handler);
+        }
+
+        return offered;
+    }
+
+    private boolean unsafeWrite(Object msg) {
+        if (ioVectorWriteAllowed) {
+            if (ioVector.offer((IOBuffer) msg)) {
+                return true;
             } else {
-                result = writeQueue.offer(buf);
-            }
-        } else if (currentFlushThread == eventloopThread) {
-            if (ioVector.offer(buf)) {
-                result = true;
-            } else {
-                result = writeQueue.offer(buf);
+                ioVectorWriteAllowed = false;
+                return writeQueue.offer(msg);
             }
         } else {
-            result = writeQueue.offer(buf);
-            flush();
+            return writeQueue.offer(msg);
         }
-        return result;
     }
 
     @Override
@@ -359,10 +394,18 @@ public final class NioAsyncSocket extends AsyncSocket {
     private final class Handler implements NioHandler, Runnable {
         private final ByteBuffer rcvBuffer;
         private final AsyncSocketMetrics metrics = NioAsyncSocket.this.metrics;
+        private final ByteBuffer sndBuffer;
 
         private Handler(NioAsyncSocketBuilder builder) throws SocketException {
             int receiveBufferSize = builder.socketChannel.socket().getReceiveBufferSize();
             this.rcvBuffer = BufferUtil.allocate(builder.directBuffers, receiveBufferSize);
+
+            if (ioVector == null) {
+                int sndBufferSize = builder.socketChannel.socket().getSendBufferSize();
+                this.sndBuffer = BufferUtil.allocate(builder.directBuffers, sndBufferSize);
+            } else {
+                this.sndBuffer = null;
+            }
         }
 
         @Override
@@ -423,28 +466,48 @@ public final class NioAsyncSocket extends AsyncSocket {
             compactOrClear(rcvBuffer);
         }
 
+        // todo: temp notes.
+        // In netty there is logic in the NioSocketChannel.doWrite
+        // 1) all the collected messages are IOBUffers, do a writev.
+        // 2) if there is only 1 message and it an IOBuffer, then do a write
+        // 3) if at least one of the messages is a non IOBuffer, then fallback
+        // to a normal write.
         private void handleWrite() throws IOException {
-            // typically this method is called with the flushThread being set.
-            // but in case of cancellation of the key, this method is also
-            // called without the flushThread being set.
-            // So we can't do an assert flushThread!=null.
-
             metrics.incWriteEvents();
 
-            ioVector.populate(writeQueue);
+            // todo: Netty has a write spin option we need to investigate.
 
-            ByteBuffer[] srcs = ioVector.array();
-            int length = ioVector.length();
-            long written = length == 1
-                    ? socketChannel.write(srcs[0])
-                    : socketChannel.write(srcs, 0, length);
+            long bytesWritten;
+            boolean clean;
+            if (writer == null) {
+                // the writeQueue is guaranteed to have only IOBuffers
+                // if the writer isn't set.
+                ioVector.populate(writeQueue);
 
-            ioVector.compact(written);
+                if (writeQueue.isEmpty()) {
+                    ioVectorWriteAllowed = true;
+                }
 
-            metrics.incBytesWritten(written);
-            //System.out.println(NioAsyncSocket.this + " bytes written:" + written);
+                int ioVectorLength = ioVector.length();
+                ByteBuffer[] srcs = ioVector.array();
+                bytesWritten = ioVectorLength == 1
+                        ? socketChannel.write(srcs[0])
+                        : socketChannel.write(srcs, 0, ioVectorLength);
+                ioVector.compact(bytesWritten);
+                clean = ioVector.isEmpty();
+            } else {
+                boolean writerClean = writer.onWrite(sndBuffer);
+                sndBuffer.flip();
+                bytesWritten = socketChannel.write(sndBuffer);
+                boolean sndBufferClean = !sndBuffer.hasRemaining();
+                clean = writerClean && sndBufferClean;
+                compactOrClear(sndBuffer);
+            }
 
-            if (ioVector.isEmpty()) {
+            metrics.incBytesWritten(bytesWritten);
+            //System.out.println(socket + " bytes written:" + bytesWritten);
+
+            if (clean) {
                 // everything got written
                 int interestOps = key.interestOps();
 
@@ -455,10 +518,13 @@ public final class NioAsyncSocket extends AsyncSocket {
 
                 resetFlushed();
             } else {
-                // We need to register for the OP_WRITE because not everything got written
+                // not everything got written, therefor we need to register
+                // for the OP_WRITE so that we get an event as soon as space
+                // is available in the send buffer of the socket.
                 key.interestOps(key.interestOps() | OP_WRITE);
             }
         }
+
 
         // Is called when side of the socket that initiates the connect
         // gets the event that the connection is completed.

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketBuilder.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocketBuilder.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.tpcengine.Option;
 import com.hazelcast.internal.tpcengine.net.AsyncSocket;
 import com.hazelcast.internal.tpcengine.net.AsyncSocketBuilder;
 import com.hazelcast.internal.tpcengine.net.AsyncSocketReader;
+import com.hazelcast.internal.tpcengine.net.AsyncSocketWriter;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -63,11 +64,11 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
     final SocketChannel socketChannel;
     final NioAcceptRequest acceptRequest;
     final boolean clientSide;
-    boolean regularSchedule = true;
-    boolean writeThrough;
     boolean directBuffers = true;
     int writeQueueCapacity = DEFAULT_WRITE_QUEUE_CAPACITY;
     AsyncSocketReader reader;
+    AsyncSocketWriter writer;
+
     NioAsyncSocketOptions options;
     private boolean built;
 
@@ -118,31 +119,19 @@ public class NioAsyncSocketBuilder implements AsyncSocketBuilder {
         return this;
     }
 
-    public NioAsyncSocketBuilder setRegularSchedule(boolean regularSchedule) {
-        verifyNotBuilt();
-
-        this.regularSchedule = regularSchedule;
-        return this;
-    }
-
-    public NioAsyncSocketBuilder setWriteThrough(boolean writeThrough) {
-        verifyNotBuilt();
-
-        this.writeThrough = writeThrough;
-        return this;
-    }
-
-    /**
-     * Sets the read handler. Should be called before this AsyncSocket is started.
-     *
-     * @param reader the ReadHandler
-     * @return this
-     * @throws NullPointerException if readHandler is null.
-     */
+    @Override
     public final NioAsyncSocketBuilder setReader(AsyncSocketReader reader) {
         verifyNotBuilt();
 
         this.reader = checkNotNull(reader);
+        return this;
+    }
+
+    @Override
+    public AsyncSocketBuilder setWriter(AsyncSocketWriter writer) {
+        verifyNotBuilt();
+
+        this.writer = checkNotNull(writer);
         return this;
     }
 

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/TpcTestSupport.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/TpcTestSupport.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.tpcengine;
 import com.hazelcast.internal.tpcengine.util.OS;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -47,6 +48,14 @@ public class TpcTestSupport {
 
     public static void assertCompletesEventually(final Future future) {
         assertTrueEventually(() -> assertTrue("Future has not completed", future.isDone()));
+    }
+
+    public static void assertCompletesEventually(final List<Future> futures, long timeoutSeconds) {
+        assertTrueEventually(() -> {
+            for (Future future : futures) {
+                assertTrue(future.isDone());
+            }
+        }, timeoutSeconds);
     }
 
     public static void terminateAll(Collection<? extends Reactor> reactors) {

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocket_LargePayloadTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocket_LargePayloadTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import com.hazelcast.internal.tpcengine.iobuffer.IOBuffer;
 import com.hazelcast.internal.tpcengine.iobuffer.IOBufferAllocator;
 import com.hazelcast.internal.tpcengine.iobuffer.NonConcurrentIOBufferAllocator;
+import com.hazelcast.internal.tpcengine.util.BufferUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,27 +30,36 @@ import org.junit.Test;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
-import java.util.concurrent.CountDownLatch;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.ASSERT_TRUE_EVENTUALLY_TIMEOUT;
-import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertOpenEventually;
+import static com.hazelcast.internal.tpcengine.TpcTestSupport.assertCompletesEventually;
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.terminate;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_RCVBUF;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_SNDBUF;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.TCP_NODELAY;
 import static com.hazelcast.internal.tpcengine.util.BitUtil.SIZEOF_INT;
 import static com.hazelcast.internal.tpcengine.util.BitUtil.SIZEOF_LONG;
-import static com.hazelcast.internal.tpcengine.util.BufferUtil.put;
+import static java.lang.Math.max;
 
 public abstract class AsyncSocket_LargePayloadTest {
+    // payloadSize (int) + round (long) + hash (int)
+    private static final int SIZEOF_HEADER = SIZEOF_INT + SIZEOF_LONG + SIZEOF_INT;
+    private static final boolean USE_DIRECT_BYTEBUFFERS = true;
     // use small buffers to cause a lot of network scheduling overhead (and shake down problems)
-    public static final int SOCKET_BUFFER_SIZE = 16 * 1024;
+    private static final int SOCKET_BUFFER_SIZE = 16 * 1024;
+
     public int iterations = 20;
     public long testTimeoutMs = ASSERT_TRUE_EVENTUALLY_TIMEOUT;
 
     private final AtomicLong iteration = new AtomicLong();
-    private final PrintAtomicLongThread printThread = new PrintAtomicLongThread("at:", iteration);
+    private final PrintAtomicLongThread monitorThread = new PrintAtomicLongThread("at:", iteration);
+    private final List<Future> futures = new ArrayList<>();
     private Reactor clientReactor;
     private Reactor serverReactor;
 
@@ -65,161 +75,337 @@ public abstract class AsyncSocket_LargePayloadTest {
     public void before() {
         clientReactor = newReactorBuilder().build().start();
         serverReactor = newReactorBuilder().build().start();
-        printThread.start();
+        monitorThread.start();
     }
 
     @After
     public void after() throws InterruptedException {
         terminate(clientReactor);
         terminate(serverReactor);
-        printThread.shutdown();
+        monitorThread.shutdown();
     }
 
     @Test
-    public void test_concurrency_1_payload_0B() throws InterruptedException {
-        test(0, 1);
+    public void test_concurrency_1_payload_0B_withoutWriter() throws Exception {
+        test(0, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_1B() throws InterruptedException {
-        test(1, 1);
+    public void test_concurrency_1_payload_1B_withoutWriter() throws Exception {
+        test(1, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_1KB() throws InterruptedException {
-        test(1024, 1);
+    public void test_concurrency_1_payload_1KB_withoutWriter() throws Exception {
+        test(1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_2KB() throws InterruptedException {
-        test(2 * 1024, 1);
+    public void test_concurrency_1_payload_2KB_withoutWriter() throws Exception {
+        test(2 * 1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_4KB() throws InterruptedException {
-        test(4 * 1024, 1);
+    public void test_concurrency_1_payload_4KB_withoutWriter() throws Exception {
+        test(4 * 1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_16KB() throws InterruptedException {
-        test(16 * 1024, 1);
+    public void test_concurrency_1_payload_16KB_withoutWriter() throws Exception {
+        test(16 * 1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_32KB() throws InterruptedException {
-        test(32 * 1024, 1);
+    public void test_concurrency_1_payload_32KB_withoutWriter() throws Exception {
+        test(32 * 1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_64KB() throws InterruptedException {
-        test(64 * 1024, 1);
+    public void test_concurrency_1_payload_64KB_withoutWriter() throws Exception {
+        test(64 * 1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_128KB() throws InterruptedException {
-        test(128 * 1024, 1);
+    public void test_concurrency_1_payload_128KB_withoutWriter() throws Exception {
+        test(128 * 1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_256KB() throws InterruptedException {
-        test(256 * 1024, 1);
+    public void test_concurrency_1_payload_256KB_withoutWriter() throws Exception {
+        test(256 * 1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_512KB() throws InterruptedException {
-        test(512 * 1024, 1);
+    public void test_concurrency_1_payload_512KB_withoutWriter() throws Exception {
+        test(512 * 1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_1MB() throws InterruptedException {
-        test(1024 * 1024, 1);
+    public void test_concurrency_1_payload_1MB_withoutWriter() throws Exception {
+        test(1024 * 1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_1_payload_2MB() throws InterruptedException {
-        test(2048 * 1024, 1);
+    public void test_concurrency_1_payload_2MB_withoutWriter() throws Exception {
+        test(2048 * 1024, 1, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_0B() throws InterruptedException {
-        test(0, 10);
+    public void test_concurrency_10_payload_0B_withoutWriter() throws Exception {
+        test(0, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_1B() throws InterruptedException {
-        test(1, 10);
+    public void test_concurrency_10_payload_1B_withoutWriter() throws Exception {
+        test(1, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_1KB() throws InterruptedException {
-        test(1024, 10);
+    public void test_concurrency_10_payload_1KB_withoutWriter() throws Exception {
+        test(1024, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_2KB() throws InterruptedException {
-        test(2 * 1024, 10);
+    public void test_concurrency_10_payload_2KB_withoutWriter() throws Exception {
+        test(2 * 1024, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_4KB() throws InterruptedException {
-        test(4 * 1024, 10);
+    public void test_concurrency_10_payload_4KB_withoutWriter() throws Exception {
+        test(4 * 1024, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_16KB() throws InterruptedException {
-        test(16 * 1024, 10);
+    public void test_concurrency_10_payload_16KB_withoutWriter() throws Exception {
+        test(16 * 1024, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_32KB() throws InterruptedException {
-        test(32 * 1024, 10);
+    public void test_concurrency_10_payload_32KB_withoutWriter() throws Exception {
+        test(32 * 1024, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_64KB() throws InterruptedException {
-        test(64 * 1024, 10);
+    public void test_concurrency_10_payload_64KB_withoutWriter() throws Exception {
+        test(64 * 1024, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_128KB() throws InterruptedException {
-        test(128 * 1024, 10);
+    public void test_concurrency_10_payload_128KB_withoutWriter() throws Exception {
+        test(128 * 1024, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_256KB() throws InterruptedException {
-        test(256 * 1024, 10);
+    public void test_concurrency_10_payload_256KB_withoutWriter() throws Exception {
+        test(256 * 1024, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_512KB() throws InterruptedException {
-        test(512 * 1024, 10);
+    public void test_concurrency_10_payload_512KB_withoutWriter() throws Exception {
+        test(512 * 1024, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_1MB() throws InterruptedException {
-        test(1024 * 1024, 10);
+    public void test_concurrency_10_payload_1MB_withoutWriter() throws Exception {
+        test(1024 * 1024, 10, false);
     }
 
     @Test
-    public void test_concurrency_10_payload_2MB() throws InterruptedException {
-        test(2048 * 1024, 10);
+    public void test_concurrency_10_payload_2MB_withoutWriter() throws Exception {
+        test(2 * 1024 * 1024, 10, false);
     }
 
-    public void test(int payloadSize, int concurrency) throws InterruptedException {
-        AsyncServerSocket serverSocket = newServer();
+    @Test
+    public void test_concurrency_10_payload_4MB_withoutWriter() throws Exception {
+        test(4 * 1024 * 1024, 10, false);
+    }
 
-        CountDownLatch completionLatch = new CountDownLatch(concurrency);
+    @Test
+    public void test_concurrency_10_payload_8MB_withoutWriter() throws Exception {
+        test(8 * 1024 * 1024, 10, false);
+    }
 
-        AsyncSocket clientSocket = newClient(serverSocket.getLocalAddress(), completionLatch);
+    @Test
+    public void test_concurrency_10_payload_16MB_withoutWriter() throws Exception {
+        test(16 * 1024 * 1024, 10, false);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_32MB_withoutWriter() throws Exception {
+        test(32 * 1024 * 1024, 10, false);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_0B_withWriter() throws Exception {
+        test(0, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_1B_withWriter() throws Exception {
+        test(1, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_1KB_withWriter() throws Exception {
+        test(1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_2KB_withWriter() throws Exception {
+        test(2 * 1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_4KB_withWriter() throws Exception {
+        test(4 * 1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_16KB_withWriter() throws Exception {
+        test(16 * 1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_32KB_withWriter() throws Exception {
+        test(32 * 1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_64KB_withWriter() throws Exception {
+        test(64 * 1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_128KB_withWriter() throws Exception {
+        test(128 * 1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_256KB_withWriter() throws Exception {
+        test(256 * 1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_512KB_withWriter() throws Exception {
+        test(512 * 1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_1MB_withWriter() throws Exception {
+        test(1024 * 1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_1_payload_2MB_withWriter() throws Exception {
+        test(2048 * 1024, 1, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_0B_withWriter() throws Exception {
+        test(0, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_1B_withWriter() throws Exception {
+        test(1, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_1KB_withWriter() throws Exception {
+        test(1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_2KB_withWriter() throws Exception {
+        test(2 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_4KB_withWriter() throws Exception {
+        test(4 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_16KB_withWriter() throws Exception {
+        test(16 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_32KB_withWriter() throws Exception {
+        test(32 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_64KB_withWriter() throws Exception {
+        test(64 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_128KB_withWriter() throws Exception {
+        test(128 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_256KB_withWriter() throws Exception {
+        test(256 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_512KB_withWriter() throws Exception {
+        test(512 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_1MB_withWriter() throws Exception {
+        test(1024 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_2MB_withWriter() throws Exception {
+        test(2 * 1024 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_4MB_withWriter() throws Exception {
+        test(4 * 1024 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_8MB_withWriter() throws Exception {
+        test(8 * 1024 * 1024, 10, true);
+    }
+
+    @Test
+    public void test_concurrency_10_payload_16MB_withWriter() throws Exception {
+        test(16 * 1024 * 1024, 10, true);
+    }
+
+//    @Test
+//    public void test_concurrency_10_payload_32MB_withWriter() throws Exception {
+//        test(32 * 1024 * 1024, 10, true);
+//    }
+
+    public void test(int payloadSize, int concurrency, boolean useWriter) throws Exception {
+        AsyncServerSocket serverSocket = newServer(useWriter);
+
+        AsyncSocket clientSocket = newClient(serverSocket.getLocalAddress(), useWriter);
 
         System.out.println("Starting");
+        int rounds = max(1, iterations / concurrency);
 
+        Random random = new Random();
+        byte[] payload = new byte[payloadSize];
         for (int k = 0; k < concurrency; k++) {
-            byte[] payload = new byte[payloadSize];
-            IOBuffer buf = new IOBuffer(SIZEOF_INT + SIZEOF_LONG + payload.length, true);
+            random.nextBytes(payload);
+            IOBuffer buf = new IOBuffer(SIZEOF_HEADER + payload.length, USE_DIRECT_BYTEBUFFERS);
             buf.writeInt(payload.length);
-            buf.writeLong(iterations / concurrency);
+            buf.writeLong(rounds);
+            int pos = buf.position();
+            // hash placeholder
+            buf.writeInt(0);
             buf.writeBytes(payload);
+            // and now we write the hash
+            buf.putInt(pos, hash(buf, payloadSize));
             buf.flip();
             if (!clientSocket.write(buf)) {
                 throw new RuntimeException();
@@ -227,15 +413,29 @@ public abstract class AsyncSocket_LargePayloadTest {
         }
         clientSocket.flush();
 
-        assertOpenEventually(completionLatch, testTimeoutMs);
+        assertCompletesEventually(futures, testTimeoutMs);
+
+        System.out.println("iterations:" + iteration.get());
+
+        for (Future future : futures) {
+            future.get();
+        }
     }
 
-    private AsyncSocket newClient(SocketAddress serverAddress, CountDownLatch completionLatch) {
+    private AsyncSocket newClient(SocketAddress serverAddress, boolean useWriter) {
+        CompletableFuture future = new CompletableFuture();
+        futures.add(future);
+
         AsyncSocketBuilder asyncSocketBuilder = clientReactor.newAsyncSocketBuilder()
                 .set(TCP_NODELAY, true)
                 .set(SO_SNDBUF, SOCKET_BUFFER_SIZE)
                 .set(SO_RCVBUF, SOCKET_BUFFER_SIZE)
-                .setReader(new ClientAsyncSocketReader(completionLatch));
+                .setReader(new ClientReader(future));
+
+        if (useWriter) {
+            asyncSocketBuilder.setWriter(new IOBufferWriter());
+        }
+
         customizeClientSocketBuilder(asyncSocketBuilder);
         AsyncSocket clientSocket = asyncSocketBuilder.build();
 
@@ -244,7 +444,7 @@ public abstract class AsyncSocket_LargePayloadTest {
         return clientSocket;
     }
 
-    private AsyncServerSocket newServer() {
+    private AsyncServerSocket newServer(boolean useWriter) {
         AsyncServerSocket serverSocket = serverReactor.newAsyncServerSocketBuilder()
                 .set(SO_RCVBUF, SOCKET_BUFFER_SIZE)
                 .setAcceptConsumer(acceptRequest -> {
@@ -252,7 +452,10 @@ public abstract class AsyncSocket_LargePayloadTest {
                             .set(TCP_NODELAY, true)
                             .set(SO_SNDBUF, SOCKET_BUFFER_SIZE)
                             .set(SO_RCVBUF, SOCKET_BUFFER_SIZE)
-                            .setReader(new ServerAsyncSocketReader());
+                            .setReader(new ServerReader());
+                    if (useWriter) {
+                        asyncSocketBuilder.setWriter(new IOBufferWriter());
+                    }
                     customizeServerSocketBuilder(asyncSocketBuilder);
                     asyncSocketBuilder
                             .build()
@@ -264,98 +467,141 @@ public abstract class AsyncSocket_LargePayloadTest {
         return serverSocket;
     }
 
-    private static class ServerAsyncSocketReader extends AsyncSocketReader {
-        private ByteBuffer payloadBuffer;
-        private long round;
-        private int payloadSize = -1;
-        private final IOBufferAllocator responseAllocator = new NonConcurrentIOBufferAllocator(8, true);
+    /**
+     * This writer isn't very interesting; it just writes the IOBuffer
+     * on the socket send buffer.
+     */
+    private class IOBufferWriter extends AsyncSocketWriter {
+        private IOBuffer current;
+
+        @Override
+        public boolean onWrite(ByteBuffer dst) {
+            if (current == null) {
+                current = (IOBuffer) writeQueue.poll();
+            }
+
+            while (current != null) {
+                BufferUtil.put(dst, current.byteBuffer());
+                if (current.byteBuffer().hasRemaining()) {
+                    // The current message was not fully written
+                    return false;
+                }
+
+                current.release();
+                current = (IOBuffer) writeQueue.poll();
+            }
+
+            return true;
+        }
+    }
+
+    private static int hash(IOBuffer buffer, int payloadSize) {
+        int hash = 1;
+        for (int k = SIZEOF_HEADER; k < SIZEOF_HEADER + payloadSize; k++) {
+            byte element = buffer.getByte(k);
+            hash = 31 * hash + element;
+        }
+        return hash;
+    }
+
+    private static class ServerReader extends AsyncSocketReader {
+        private final IOBufferAllocator bufferAllocator = new NonConcurrentIOBufferAllocator(SIZEOF_HEADER, USE_DIRECT_BYTEBUFFERS);
+        private IOBuffer message;
 
         @Override
         public void onRead(ByteBuffer src) {
             for (; ; ) {
-                if (payloadSize == -1) {
-                    if (src.remaining() < SIZEOF_INT + SIZEOF_LONG) {
+                if (message == null) {
+                    if (src.remaining() < SIZEOF_HEADER) {
                         break;
                     }
-                    payloadSize = src.getInt();
-                    round = src.getLong();
-                    if (round < 0) {
-                        throw new RuntimeException("round can't be smaller than 0, found:" + round);
-                    }
-                    payloadBuffer = ByteBuffer.allocate(payloadSize);
+                    int payloadSize = src.getInt();
+                    long round = src.getLong();
+                    int hash = src.getInt();
+                    message = bufferAllocator.allocate(SIZEOF_HEADER + payloadSize);
+                    message.byteBuffer().limit(SIZEOF_HEADER + payloadSize);
+                    message.writeInt(payloadSize);
+                    message.writeLong(round - 1);
+                    message.writeInt(hash);
                 }
 
-                put(payloadBuffer, src);
-                if (payloadBuffer.remaining() > 0) {
+                BufferUtil.put(message.byteBuffer(), src);
+                //response.write(src);
+
+                if (message.remaining() > 0) {
                     // not all bytes have been received.
                     break;
                 }
+                message.flip();
 
-                payloadBuffer.flip();
-                IOBuffer responseBuf = responseAllocator.allocate(SIZEOF_INT + SIZEOF_LONG + payloadSize);
-                responseBuf.writeInt(payloadSize);
-                responseBuf.writeLong(round - 1);
-                responseBuf.write(payloadBuffer);
-                responseBuf.flip();
-                if (!socket.unsafeWriteAndFlush(responseBuf)) {
+                if (!socket.unsafeWriteAndFlush(message)) {
                     throw new RuntimeException("Socket has no space");
                 }
-                payloadSize = -1;
+                message = null;
             }
         }
     }
 
-    private class ClientAsyncSocketReader extends AsyncSocketReader {
-        private final CountDownLatch latch;
-        private ByteBuffer payloadBuffer;
+    private class ClientReader extends AsyncSocketReader {
+        private final CompletableFuture future;
         private long round;
         private int payloadSize;
-        private final IOBufferAllocator responseAllocator;
+        private final IOBufferAllocator bufferAllocator = new NonConcurrentIOBufferAllocator(SIZEOF_HEADER, USE_DIRECT_BYTEBUFFERS);
+        private IOBuffer message;
+        private int hash;
 
-        ClientAsyncSocketReader(CountDownLatch latch) {
-            this.latch = latch;
-            payloadSize = -1;
-            responseAllocator = new NonConcurrentIOBufferAllocator(8, true);
+        ClientReader(CompletableFuture future) {
+            this.future = future;
         }
 
         @Override
         public void onRead(ByteBuffer src) {
             for (; ; ) {
-                if (payloadSize == -1) {
-                    if (src.remaining() < SIZEOF_INT + SIZEOF_LONG) {
+                if (message == null) {
+                    if (src.remaining() < SIZEOF_HEADER) {
                         break;
                     }
 
                     payloadSize = src.getInt();
                     round = src.getLong();
+                    hash = src.getInt();
                     if (round < 0) {
                         throw new RuntimeException("round can't be smaller than 0, found:" + round);
                     }
-                    payloadBuffer = ByteBuffer.allocate(payloadSize);
+                    message = bufferAllocator.allocate(SIZEOF_HEADER + payloadSize);
+                    message.byteBuffer().limit(SIZEOF_HEADER + payloadSize);
+                    message.writeInt(payloadSize);
+                    message.writeLong(round);
+                    message.writeInt(hash);
                 }
 
-                put(payloadBuffer, src);
+                BufferUtil.put(message.byteBuffer(), src);
+                //response.write(src);
 
-                if (payloadBuffer.remaining() > 0) {
+                if (message.remaining() > 0) {
                     // not all bytes have been received.
                     break;
                 }
-                payloadBuffer.flip();
+                message.flip();
+
+                int foundHash = hash(message, payloadSize);
+                if (foundHash != hash) {
+                    src.clear();
+                    future.completeExceptionally(new IllegalStateException("Hash mismatch, datastream is corrupted"));
+                    socket.close();
+                    return;
+                }
+
                 iteration.incrementAndGet();
 
                 if (round == 0) {
-                    latch.countDown();
+                    future.complete(null);
                 } else {
-                    IOBuffer responseBuf = responseAllocator.allocate(SIZEOF_INT + SIZEOF_LONG + payloadSize);
-                    responseBuf.writeInt(payloadSize);
-                    responseBuf.writeLong(round);
-                    responseBuf.write(payloadBuffer);
-                    responseBuf.flip();
-                    if (!socket.unsafeWriteAndFlush(responseBuf)) {
+                    if (!socket.unsafeWriteAndFlush(message)) {
                         throw new RuntimeException();
                     }
                 }
-                payloadSize = -1;
+                message = null;
             }
         }
     }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocket_RpcTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncSocket_RpcTest.java
@@ -20,8 +20,7 @@ import com.hazelcast.internal.tpcengine.PrintAtomicLongThread;
 import com.hazelcast.internal.tpcengine.Reactor;
 import com.hazelcast.internal.tpcengine.ReactorBuilder;
 import com.hazelcast.internal.tpcengine.iobuffer.IOBuffer;
-import com.hazelcast.internal.tpcengine.iobuffer.IOBufferAllocator;
-import com.hazelcast.internal.tpcengine.iobuffer.NonConcurrentIOBufferAllocator;
+import com.hazelcast.internal.tpcengine.util.BufferUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,8 +41,6 @@ import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.SO_SNDBUF;
 import static com.hazelcast.internal.tpcengine.net.AsyncSocketOptions.TCP_NODELAY;
 import static com.hazelcast.internal.tpcengine.util.BitUtil.SIZEOF_INT;
 import static com.hazelcast.internal.tpcengine.util.BitUtil.SIZEOF_LONG;
-import static com.hazelcast.internal.tpcengine.util.BufferUtil.put;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Mimics an RPC call. So there are worker threads that send request with a call id and a payload. This request is
@@ -53,12 +50,16 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * and notified. And then the worker thread will send another request.
  */
 public abstract class AsyncSocket_RpcTest {
+    private static final int SIZEOF_HEADER = SIZEOF_INT + SIZEOF_LONG;
+
     // use small buffers to cause a lot of network scheduling overhead (and shake down problems)
     public static final int SOCKET_BUFFER_SIZE = 16 * 1024;
-    public int iterations = 200;
-    public long testTimeoutSeconds = ASSERT_TRUE_EVENTUALLY_TIMEOUT;
-    private final AtomicLong iteration = new AtomicLong();
-    private final PrintAtomicLongThread printThread = new PrintAtomicLongThread("at:", iteration);
+    public long durationMillis = 500;
+    public long testTimeoutMs = ASSERT_TRUE_EVENTUALLY_TIMEOUT;
+    public boolean localWrite;
+    public boolean tcpNoDelay = true;
+    private final AtomicLong counter = new AtomicLong();
+    private final PrintAtomicLongThread printThread = new PrintAtomicLongThread("at:", counter);
 
     private final ConcurrentMap<Long, CompletableFuture> futures = new ConcurrentHashMap<>();
     private Reactor clientReactor;
@@ -87,203 +88,187 @@ public abstract class AsyncSocket_RpcTest {
     }
 
     @Test
-    public void test_concurrency_1_payload_0B() throws InterruptedException {
-        test(0, 1);
+    public void test_threads_1_payload_0B() throws InterruptedException {
+        test(1, 0);
     }
 
     @Test
-    public void test_concurrency_1_payload_1B() throws InterruptedException {
+    public void test_threads_1_payload_1B() throws InterruptedException {
         test(1, 1);
     }
 
     @Test
-    public void test_concurrency_1_payload_1KB() throws InterruptedException {
-        test(1024, 1);
+    public void test_threads_1_payload_1KB() throws InterruptedException {
+        test(1, 1024);
     }
 
     @Test
-    public void test_concurrency_1_payload_2KB() throws InterruptedException {
-        test(2 * 1024, 1);
+    public void test_threads_1_payload_2KB() throws InterruptedException {
+        test(1, 2 * 1024);
     }
 
     @Test
-    public void test_concurrency_1_payload_4KB() throws InterruptedException {
-        test(4 * 1024, 1);
+    public void test_threads_1_payload_4KB() throws InterruptedException {
+        test(1, 4 * 1024);
     }
 
     @Test
-    public void test_concurrency_1_payload_16KB() throws InterruptedException {
-        test(16 * 1024, 1);
+    public void test_threads_1_payload_16KB() throws InterruptedException {
+        test(1, 16 * 1024);
     }
 
     @Test
-    public void test_concurrency_1_payload_32KB() throws InterruptedException {
-        test(32 * 1024, 1);
+    public void test_threads_1_payload_32KB() throws InterruptedException {
+        test(1, 32 * 1024);
     }
 
     @Test
-    public void test_concurrency_1_payload_64KB() throws InterruptedException {
-        test(64 * 1024, 1);
+    public void test_threads_1_payload_64KB() throws InterruptedException {
+        test(1, 64 * 1024);
     }
 
     @Test
-    public void test_concurrency_1_payload_128KB() throws InterruptedException {
-        test(128 * 1024, 1);
+    public void test_threads_1_payload_128KB() throws InterruptedException {
+        test(1, 128 * 1024);
     }
 
     @Test
-    public void test_concurrency_1_payload_256KB() throws InterruptedException {
-        test(256 * 1024, 1);
+    public void test_threads_1_payload_256KB() throws InterruptedException {
+        test(1, 256 * 1024);
     }
 
     @Test
-    public void test_concurrency_1_payload_512KB() throws InterruptedException {
-        test(512 * 1024, 1);
+    public void test_threads_1_payload_512KB() throws InterruptedException {
+        test(1, 512 * 1024);
     }
 
     @Test
-    public void test_concurrency_1_payload_1MB() throws InterruptedException {
-        test(1024 * 1024, 1);
+    public void test_threads_1_payload_1MB() throws InterruptedException {
+        test(1, 1024 * 1024);
     }
 
     @Test
-    public void test_concurrency_1_payload_2MB() throws InterruptedException {
-        test(2 * 1024 * 1024, 1);
+    public void test_threads_10_payload_0B() throws InterruptedException {
+        test(10, 0);
     }
 
     @Test
-    public void test_concurrency_1_payload_16MB() throws InterruptedException {
-        test(16 * 1024 * 1024, 1);
+    public void test_threads_10_payload_1B() throws InterruptedException {
+        test(10, 1);
     }
 
     @Test
-    public void test_concurrency_10_payload_0B() throws InterruptedException {
-        test(0, 10);
+    public void test_threads_10_payload_1KB() throws InterruptedException {
+        test(10, 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_1B() throws InterruptedException {
-        test(1, 10);
+    public void test_threads_10_payload_2KB() throws InterruptedException {
+        test(10, 2 * 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_1KB() throws InterruptedException {
-        test(1024, 10);
+    public void test_threads_10_payload_4KB() throws InterruptedException {
+        test(10, 4 * 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_2KB() throws InterruptedException {
-        test(2 * 1024, 10);
+    public void test_threads_10_payload_16KB() throws InterruptedException {
+        test(10, 16 * 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_4KB() throws InterruptedException {
-        test(4 * 1024, 10);
+    public void test_threads_10_payload_32KB() throws InterruptedException {
+        test(10, 32 * 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_16KB() throws InterruptedException {
-        test(16 * 1024, 10);
+    public void test_threads_10_payload_64KB() throws InterruptedException {
+        test(10, 64 * 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_32KB() throws InterruptedException {
-        test(32 * 1024, 10);
+    public void test_threads_10_payload_128KB() throws InterruptedException {
+        test(10, 128 * 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_64KB() throws InterruptedException {
-        test(64 * 1024, 10);
+    public void test_threads_10_payload_256KB() throws InterruptedException {
+        test(10, 256 * 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_128KB() throws InterruptedException {
-        test(128 * 1024, 10);
+    public void test_threads_10_payload_512KB() throws InterruptedException {
+        test(10, 512 * 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_256KB() throws InterruptedException {
-        test(256 * 1024, 10);
+    public void test_threads_10_payload_1MB() throws InterruptedException {
+        test(10, 1024 * 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_512KB() throws InterruptedException {
-        test(512 * 1024, 10);
+    public void test_threads_100_payload_0B() throws InterruptedException {
+        test(100, 0);
     }
 
     @Test
-    public void test_concurrency_10_payload_1MB() throws InterruptedException {
-        test(1024 * 1024, 10);
+    public void test_threads_100_payload_1KB() throws InterruptedException {
+        test(100, 1024);
     }
 
     @Test
-    public void test_concurrency_10_payload_2MB() throws InterruptedException {
-        test(2 * 1024 * 1024, 10);
+    public void test_threads_100_payload_2KB() throws InterruptedException {
+        test(100, 2 * 1024);
     }
 
     @Test
-    public void test_concurrency_100_payload_1KB() throws InterruptedException {
-        test(1024, 100);
+    public void test_threads_100_payload_4KB() throws InterruptedException {
+        test(100, 4 * 1024);
     }
 
     @Test
-    public void test_concurrency_100_payload_2KB() throws InterruptedException {
-        test(2 * 1024, 100);
+    public void test_threads_100_payload_16KB() throws InterruptedException {
+        test(100, 16 * 1024);
     }
 
     @Test
-    public void test_concurrency_100_payload_4KB() throws InterruptedException {
-        test(4 * 1024, 100);
+    public void test_threads_100_payload_32KB() throws InterruptedException {
+        test(100, 32 * 1024);
     }
 
     @Test
-    public void test_concurrency_100_payload_16KB() throws InterruptedException {
-        test(16 * 1024, 100);
+    public void test_threads_100_payload_64KB() throws InterruptedException {
+        test(100, 64 * 1024);
     }
 
     @Test
-    public void test_concurrency_100_payload_32KB() throws InterruptedException {
-        test(32 * 1024, 100);
+    public void test_threads_100_payload_128KB() throws InterruptedException {
+        test(100, 128 * 1024);
     }
 
-    @Test
-    public void test_concurrency_100_payload_64KB() throws InterruptedException {
-        test(64 * 1024, 100);
-    }
-
-    @Test
-    public void test_concurrency_100_payload_128KB() throws InterruptedException {
-        test(128 * 1024, 100);
-    }
-
-    @Test
-    public void test_concurrency_100_payload_1MB() throws InterruptedException {
-        test(1024 * 1024, 100);
-    }
-
-    public void test(int payloadSize, int concurrency) throws InterruptedException {
+    public void test(int threadCount, int payloadSize) throws InterruptedException {
         AsyncServerSocket serverSocket = newServer();
 
         AsyncSocket clientSocket = newClient(serverSocket.getLocalAddress());
 
         AtomicLong callIdGenerator = new AtomicLong();
-        LoadGeneratorThread[] threads = new LoadGeneratorThread[concurrency];
-        int requestPerThread = iterations / concurrency;
-        for (int k = 0; k < concurrency; k++) {
-            LoadGeneratorThread thread = new LoadGeneratorThread(requestPerThread, payloadSize, callIdGenerator, clientSocket);
+        LoadGeneratorThread[] threads = new LoadGeneratorThread[threadCount];
+        for (int k = 0; k < threadCount; k++) {
+            LoadGeneratorThread thread = new LoadGeneratorThread(payloadSize, callIdGenerator, clientSocket);
             threads[k] = thread;
             thread.start();
         }
 
-        assertJoinable(testTimeoutSeconds, threads);
+        assertJoinable(testTimeoutMs, threads);
     }
 
     private AsyncSocket newClient(SocketAddress serverAddress) {
         AsyncSocketBuilder clientSocketBuilder = clientReactor.newAsyncSocketBuilder()
-                .set(TCP_NODELAY, true)
+                .set(TCP_NODELAY, tcpNoDelay)
                 .set(SO_SNDBUF, SOCKET_BUFFER_SIZE)
                 .set(SO_RCVBUF, SOCKET_BUFFER_SIZE)
-                .setReader(new ClientAsyncSocketReader());
+                .setReader(new RpcReader(true));
         customizeClientSocketBuilder(clientSocketBuilder);
         AsyncSocket clientSocket = clientSocketBuilder.build();
 
@@ -297,10 +282,10 @@ public abstract class AsyncSocket_RpcTest {
                 .set(SO_RCVBUF, SOCKET_BUFFER_SIZE)
                 .setAcceptConsumer(acceptRequest -> {
                     AsyncSocketBuilder socketBuilder = serverReactor.newAsyncSocketBuilder(acceptRequest)
-                            .set(TCP_NODELAY, true)
+                            .set(TCP_NODELAY, tcpNoDelay)
                             .set(SO_SNDBUF, SOCKET_BUFFER_SIZE)
                             .set(SO_RCVBUF, SOCKET_BUFFER_SIZE)
-                            .setReader(new ServerAsyncSocketReader());
+                            .setReader(new RpcReader(false));
                     customizeServerSocketBuilder(socketBuilder);
                     socketBuilder.build()
                             .start();
@@ -312,64 +297,14 @@ public abstract class AsyncSocket_RpcTest {
         return serverSocket;
     }
 
-    private static class ServerAsyncSocketReader extends AsyncSocketReader {
-        private ByteBuffer payloadBuffer;
-        private long callId;
-        private int payloadSize = -1;
-        private final IOBufferAllocator responseAllocator = new NonConcurrentIOBufferAllocator(8, true);
-        private long nextPrintMs = System.currentTimeMillis() + SECONDS.toMillis(1);
-        private long round;
-
-        @Override
-        public void onRead(ByteBuffer src) {
-            if (nextPrintMs < System.currentTimeMillis()) {
-                nextPrintMs += SECONDS.toMillis(1);
-                System.out.println(socket + " round " + round);
-            }
-            for (; ; ) {
-                if (payloadSize == -1) {
-                    if (src.remaining() < SIZEOF_INT + SIZEOF_LONG) {
-                        break;
-                    }
-                    payloadSize = src.getInt();
-                    callId = src.getLong();
-                    // todo:can be pooled
-                    payloadBuffer = ByteBuffer.allocate(payloadSize);
-                }
-
-                put(payloadBuffer, src);
-                if (payloadBuffer.remaining() > 0) {
-                    // System.out.println(socket + " not all bytes received");
-                    // not all bytes have been received.
-                    break;
-                }
-
-                round++;
-                // System.out.println(socket + "  all bytes received");
-
-                payloadBuffer.flip();
-                IOBuffer responseBuf = responseAllocator.allocate(SIZEOF_INT + SIZEOF_LONG + payloadSize);
-                responseBuf.writeInt(payloadSize);
-                responseBuf.writeLong(callId);
-                responseBuf.write(payloadBuffer);
-                responseBuf.flip();
-
-                if (!socket.unsafeWriteAndFlush(responseBuf)) {
-                    throw new RuntimeException("Socket has no space");
-                }
-                payloadSize = -1;
-            }
-        }
-    }
-
     public class LoadGeneratorThread extends Thread {
-        private final int requests;
         private final byte[] payload;
         private final AtomicLong callIdGenerator;
         private final AsyncSocket clientSocket;
 
-        public LoadGeneratorThread(int requests, int payloadSize, AtomicLong callIdGenerator, AsyncSocket clientSocket) {
-            this.requests = requests;
+        private LoadGeneratorThread(int payloadSize,
+                                    AtomicLong callIdGenerator,
+                                    AsyncSocket clientSocket) {
             this.payload = new byte[payloadSize];
             this.callIdGenerator = callIdGenerator;
             this.clientSocket = clientSocket;
@@ -377,7 +312,8 @@ public abstract class AsyncSocket_RpcTest {
 
         @Override
         public void run() {
-            for (int k = 0; k < requests; k++) {
+            long endMs = System.currentTimeMillis() + durationMillis;
+            while (System.currentTimeMillis() < endMs) {
                 IOBuffer buf = new IOBuffer(SIZEOF_INT + SIZEOF_LONG + payload.length, true);
 
                 long callId = callIdGenerator.incrementAndGet();
@@ -388,6 +324,7 @@ public abstract class AsyncSocket_RpcTest {
                 buf.writeLong(callId);
                 buf.writeBytes(payload);
                 buf.flip();
+
                 if (!clientSocket.writeAndFlush(buf)) {
                     throw new RuntimeException();
                 }
@@ -397,52 +334,56 @@ public abstract class AsyncSocket_RpcTest {
         }
     }
 
-    private class ClientAsyncSocketReader extends AsyncSocketReader {
-        private ByteBuffer payloadBuffer;
+    private class RpcReader extends AsyncSocketReader {
+        private IOBuffer response;
+        private final boolean clientSide;
         private long callId;
-        private int payloadSize = -1;
-        private long nextPrintMs = System.currentTimeMillis() + SECONDS.toMillis(1);
-        private long round;
+
+        private RpcReader(boolean clientSide) {
+            this.clientSide = clientSide;
+        }
 
         @Override
         public void onRead(ByteBuffer src) {
-            if (nextPrintMs < System.currentTimeMillis()) {
-                nextPrintMs += SECONDS.toMillis(1);
-                System.out.println(socket + " round " + round);
-            }
-
             for (; ; ) {
-                if (payloadSize == -1) {
-                    if (src.remaining() < SIZEOF_INT + SIZEOF_LONG) {
+                if (response == null) {
+                    if (src.remaining() < SIZEOF_HEADER) {
                         break;
                     }
-
-                    payloadSize = src.getInt();
+                    int payloadSize = src.getInt();
                     callId = src.getLong();
-                    //todo: can be pooled
-                    payloadBuffer = ByteBuffer.allocate(payloadSize);
+
+                    response = new IOBuffer(SIZEOF_HEADER + payloadSize, true);
+                    response.byteBuffer().limit(SIZEOF_HEADER + payloadSize);
+                    response.writeInt(payloadSize);
+                    response.writeLong(callId);
                 }
 
-                put(payloadBuffer, src);
+                BufferUtil.put(response.byteBuffer(), src);
 
-                if (payloadBuffer.remaining() > 0) {
-                    //System.out.println(socket + " not all bytes received");
+                if (response.remaining() > 0) {
                     // not all bytes have been received.
                     break;
                 }
+                response.flip();
 
-                round++;
+                if (clientSide) {
+                    counter.incrementAndGet();
+                    CompletableFuture<IOBuffer> future = futures.remove(callId);
+                    if (future == null) {
+                        throw new IllegalStateException("Can't find future for callId:" + callId);
+                    }
+                    future.complete(response);
+                } else {
+                    boolean offered = localWrite
+                            ? socket.unsafeWriteAndFlush(response)
+                            : socket.writeAndFlush(response);
 
-                //System.out.println(socket + " all bytes received");
-                payloadBuffer.flip();
-
-                iteration.incrementAndGet();
-                CompletableFuture future = futures.remove(callId);
-                if (future == null) {
-                    throw new RuntimeException();
+                    if (!offered) {
+                        throw new RuntimeException("Socket has no space");
+                    }
                 }
-                future.complete(null);
-                payloadSize = -1;
+                response = null;
             }
         }
     }

--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_RpcTest_Nightly.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket_RpcTest_Nightly.java
@@ -20,13 +20,15 @@ package com.hazelcast.internal.tpcengine.nio;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.experimental.categories.Category;
 
+import java.util.concurrent.TimeUnit;
+
 import static com.hazelcast.internal.tpcengine.TpcTestSupport.ASSERT_TRUE_EVENTUALLY_TIMEOUT_NIGHTLY;
 
 @Category(NightlyTest.class)
 public class NioAsyncSocket_RpcTest_Nightly extends NioAsyncSocket_RpcTest {
 
     public NioAsyncSocket_RpcTest_Nightly() {
-        iterations = 20000;
-        testTimeoutSeconds = ASSERT_TRUE_EVENTUALLY_TIMEOUT_NIGHTLY;
+        durationMillis = TimeUnit.SECONDS.toMillis(60);
+        testTimeoutMs = ASSERT_TRUE_EVENTUALLY_TIMEOUT_NIGHTLY;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/tpc/ClientAsyncSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/tpc/ClientAsyncSocketWriter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.tpc;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.ClientMessageWriter;
+import com.hazelcast.internal.tpcengine.net.AsyncSocketWriter;
+
+import java.nio.ByteBuffer;
+
+public class ClientAsyncSocketWriter extends AsyncSocketWriter {
+
+    private final ClientMessageWriter writer = new ClientMessageWriter();
+    private ClientMessage current;
+
+    @Override
+    public boolean onWrite(ByteBuffer dst) {
+        if (current == null) {
+            current = (ClientMessage) writeQueue.poll();
+        }
+
+        while (current != null) {
+            if (!writer.writeTo(dst, current)) {
+                // The current message was not fully written
+                return false;
+            }
+
+            current = (ClientMessage) writeQueue.poll();
+        }
+
+        return true;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/tpc/TpcServerBootstrap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/tpc/TpcServerBootstrap.java
@@ -149,7 +149,7 @@ public class TpcServerBootstrap {
             }
         });
 
-        reactorBuilder.setSchedulerSupplier(() -> new TpcOperationScheduler(1));
+        reactorBuilder.setSchedulerSupplier(TpcOperationScheduler::new);
         tpcEngineBuilder.setReactorBuilder(reactorBuilder);
         tpcEngineBuilder.setReactorCount(loadEventloopCount());
         return tpcEngineBuilder.build();
@@ -258,6 +258,7 @@ public class TpcServerBootstrap {
                 .setAcceptConsumer(acceptRequest -> {
                     AsyncSocketBuilder socketBuilder = reactor.newAsyncSocketBuilder(acceptRequest)
                             .setReader(readHandlerSuppliers.get(reactor).get())
+                            .setWriter(new ClientAsyncSocketWriter())
                             .set(SO_SNDBUF, clientSocketConfig.getSendBufferSizeKB() * KILO_BYTE)
                             .set(SO_RCVBUF, clientSocketConfig.getReceiveBufferSizeKB() * KILO_BYTE)
                             .set(TCP_NODELAY, tcpNoDelay)

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/TpcOperationScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/TpcOperationScheduler.java
@@ -19,7 +19,7 @@ package com.hazelcast.spi.impl.operationexecutor.impl;
 import com.hazelcast.internal.tpcengine.Eventloop;
 import com.hazelcast.internal.tpcengine.Scheduler;
 
-import static com.hazelcast.internal.util.Preconditions.checkPositive;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
 /**
  * The Scheduler for TPC. So each reactor contains an partition-operation thread
@@ -30,12 +30,16 @@ import static com.hazelcast.internal.util.Preconditions.checkPositive;
  */
 public class TpcOperationScheduler implements Scheduler {
 
-    private final int batchSize;
+    private static final int TIME_SLICE_US_DEFAULT = 500;
+    private static final String TIME_SLICE_US_NAME = "hazelcast.internal.tpc.timeSliceUs";
+
     private TpcPartitionOperationThread operationThread;
     private OperationQueue queue;
+    private final long timeSliceNs;
 
-    public TpcOperationScheduler(int batchSize) {
-        this.batchSize = checkPositive("batchSize", batchSize);
+    public TpcOperationScheduler() {
+        long timeSliceUs = Integer.getInteger(TIME_SLICE_US_NAME, TIME_SLICE_US_DEFAULT);
+        this.timeSliceNs = MICROSECONDS.toNanos(timeSliceUs);
     }
 
     @Override
@@ -50,9 +54,10 @@ public class TpcOperationScheduler implements Scheduler {
     public boolean tick() {
         final TpcPartitionOperationThread operationThread0 = operationThread;
         final OperationQueue queue0 = queue;
-        final int batchSize0 = batchSize;
+        final long timeSliceNs0 = timeSliceNs;
 
-        for (int k = 0; k < batchSize0; k++) {
+        long startNs = System.nanoTime();
+        do {
             if (operationThread0.isShutdown()) {
                 return false;
             }
@@ -63,7 +68,7 @@ public class TpcOperationScheduler implements Scheduler {
             }
 
             operationThread0.process(task);
-        }
+        } while (System.nanoTime() - startNs < timeSliceNs0);
 
         return !queue0.isEmpty();
     }


### PR DESCRIPTION
Fixes TPC performance regression compared to the tpc-engine-advanced branch.

There are 2 fixes:
1) Allow for passing any object to the AsyncSocket instead of requiring IOBuffer. THis will reduce the amount of litter/data copying. For this purpose the AsyncSocketWriter was introduced so that an arbitrary object can be passed to the sendBuffer. It will also reduce TCP overhead on small packets because instead of writing an array of buffers, they are first merged into the write buffer.

2) TPCOperationScheduler didn't do any batching (batch size is 1). Now batching is done based on a time period of 500us. 

For enterprise PR see:
https://github.com/hazelcast/hazelcast-enterprise/pull/6906