### PR TITLE
Remove duplicate `mockito-junit-jupiter` dependency declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2048,12 +2048,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
                 <version>${reflections.version}</version>


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/26034