### PR TITLE
Resolve `PagingPredicate` `ClassCastException`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/SortingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/SortingUtil.java
@@ -223,31 +223,30 @@ public final class SortingUtil {
                                                                              PagingPredicate pagingPredicate,
                                                                              IterationType iterationType) {
         if (list.isEmpty()) {
-            return new AbstractMap.SimpleImmutableEntry<Integer, Integer>(-1, -1);
+            return new AbstractMap.SimpleImmutableEntry<>(-1, -1);
         }
-        PagingPredicateImpl pagingPredicateImpl = (PagingPredicateImpl) pagingPredicate;
-        Comparator<Map.Entry> comparator = SortingUtil.newComparator(pagingPredicateImpl.getComparator(), iterationType);
+        Comparator<Map.Entry> comparator = SortingUtil.newComparator(pagingPredicate.getComparator(), iterationType);
         Collections.sort(list, comparator);
 
-        Map.Entry<Integer, Map.Entry> nearestAnchorEntry = pagingPredicateImpl.getNearestAnchorEntry();
+        Map.Entry<Integer, Map.Entry<?, ?>> nearestAnchorEntry = pagingPredicate.getNearestAnchorEntry();
         int nearestPage = nearestAnchorEntry.getKey();
-        int page = pagingPredicateImpl.getPage();
-        int pageSize = pagingPredicateImpl.getPageSize();
+        int page = pagingPredicate.getPage();
+        int pageSize = pagingPredicate.getPageSize();
         long begin = pageSize * ((long) page - nearestPage - 1);
         int size = list.size();
         if (begin > size) {
-            return new AbstractMap.SimpleImmutableEntry<Integer, Integer>(-1, -1);
+            return new AbstractMap.SimpleImmutableEntry<>(-1, -1);
         }
         long end = begin + pageSize;
         if (end > size) {
             end = size;
         }
-        setAnchor(list, pagingPredicateImpl, nearestPage);
+        setAnchor(list, pagingPredicate, nearestPage);
         // it's safe to cast begin and end back to int here since they are limited by the list size
-        return new AbstractMap.SimpleImmutableEntry<Integer, Integer>((int) begin, (int) end);
+        return new AbstractMap.SimpleImmutableEntry<>((int) begin, (int) end);
     }
 
-    private static void setAnchor(List<? extends Map.Entry> list, PagingPredicateImpl pagingPredicate, int nearestPage) {
+    private static void setAnchor(List<? extends Map.Entry> list, PagingPredicate<?, ?> pagingPredicate, int nearestPage) {
         if (list.isEmpty()) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
@@ -110,7 +110,7 @@ public interface PagingPredicate<K, V> extends Predicate<K, V> {
      *
      * @return Map.Entry the anchor object which is the last value object on the previous page
      */
-    Map.Entry<K, V> getAnchor(); 
+    Map.Entry<K, V> getAnchor();
 
     /**
      * After each query, an anchor entry is set for that page. The anchor entry is the last entry of the query.

--- a/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.BinaryInterface;
 
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * This interface is a special Predicate which helps to get a page-by-page result of a query.
@@ -109,6 +110,14 @@ public interface PagingPredicate<K, V> extends Predicate<K, V> {
      *
      * @return Map.Entry the anchor object which is the last value object on the previous page
      */
-    Map.Entry<K, V> getAnchor();
+    Map.Entry<K, V> getAnchor(); 
 
+    /**
+     * After each query, an anchor entry is set for that page. The anchor entry is the last entry of the query.
+     *
+     * @param anchor the last entry of the query
+     */
+    void setAnchor(int page, Map.Entry<K, V> anchor);
+
+    Entry<Integer, Map.Entry> getNearestAnchorEntry();
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
@@ -293,14 +293,9 @@ public class PagingPredicateImpl<K, V>
         return anchorEntry == null ? null : anchorEntry.getValue();
     }
 
-    /**
-     * After each query, an anchor entry is set for that page.
-     * The anchor entry is the last entry of the query.
-     *
-     * @param anchor the last entry of the query
-     */
-    public void setAnchor(int page, Map.Entry anchor) {
-        SimpleImmutableEntry anchorEntry = new SimpleImmutableEntry(page, anchor);
+    @Override
+    public void setAnchor(int page, Map.Entry<K, V> anchor) {
+        SimpleImmutableEntry<Integer, Map.Entry<K, V>> anchorEntry = new SimpleImmutableEntry<>(page, anchor);
         int anchorCount = anchorList.size();
         if (page < anchorCount) {
             anchorList.set(page, anchorEntry);
@@ -319,6 +314,7 @@ public class PagingPredicateImpl<K, V>
         return anchorList;
     }
 
+    @Override
     public Map.Entry<Integer, Map.Entry> getNearestAnchorEntry() {
         int anchorCount = anchorList.size();
         if (page == 0 || anchorCount == 0) {

--- a/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.map.impl.query.AlwaysTruePagingPredicate;
 import com.hazelcast.map.listener.NoopMapListener;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.PagingPredicate;
@@ -55,6 +56,7 @@ import java.util.Random;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -540,6 +542,16 @@ public class PagingPredicateTest extends HazelcastTestSupport {
             predicate.nextPage();
         }
     }
+
+    /**
+     * @see <a href="https://github.com/hazelcast/hazelcast/issues/26036">non-`PagingPredicateImpl` `PagingPredicate` throws
+     *      `ClassCastException`</a>
+     */
+    @Test
+    public void testIssue123() {
+        assertFalse(map.values(new AlwaysTruePagingPredicate<>()).isEmpty());
+    }
+
 
     // Paging predicate validation tests
     @Test(expected = IllegalArgumentException.class)

--- a/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
@@ -548,7 +548,7 @@ public class PagingPredicateTest extends HazelcastTestSupport {
      *      `ClassCastException`</a>
      */
     @Test
-    public void testIssue123() {
+    public void testIssue26036() {
         assertFalse(map.values(new AlwaysTruePagingPredicate<>()).isEmpty());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
@@ -552,7 +552,6 @@ public class PagingPredicateTest extends HazelcastTestSupport {
         assertFalse(map.values(new AlwaysTruePagingPredicate<>()).isEmpty());
     }
 
-
     // Paging predicate validation tests
     @Test(expected = IllegalArgumentException.class)
     public void testAddLocalEntryListenerThrowsWithPagingPredicate() {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/AlwaysTruePagingPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/AlwaysTruePagingPredicate.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.query.PagingPredicate;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Comparator;
+import java.util.Map.Entry;
+
+public class AlwaysTruePagingPredicate<K, V> implements PagingPredicate<K, V> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public boolean apply(Entry<K, V> mapEntry) {
+        return true;
+    }
+
+    @Override
+    public void reset() {
+    }
+
+    @Override
+    public void nextPage() {
+    }
+
+    @Override
+    public void previousPage() {
+    }
+
+    @Override
+    public int getPage() {
+        return 1;
+    }
+
+    @Override
+    public void setPage(int page) {
+    }
+
+    @Override
+    public int getPageSize() {
+        return 1;
+    }
+
+    @Override
+    public Comparator<Entry<K, V>> getComparator() {
+        return null;
+    }
+
+    @Override
+    public Entry<K, V> getAnchor() {
+        return null;
+    }
+
+    @Override
+    public void setAnchor(int page, Entry<K, V> anchor) {
+    }
+
+    @Override
+    public Entry<Integer, Entry> getNearestAnchorEntry() {
+        return new SimpleImmutableEntry<>(0, null);
+    }
+}


### PR DESCRIPTION
`SortingUtil.getPageIndexesAndUpdateAnchor(List<? extends Entry>, PagingPredicate, IterationType)` casts the `PagingPredicate` to a `PagingPredicateImpl`, but if it isn't one, a `ClassCastException` is thrown.

From what I can tell, this cast is done to access the `getAnchor` / `getNearestAnchorEntry` methods - if these are required for a `PagingPredicate` to be properly used, they should instead be part of the `PagingPredicate` interface to ensure they are available.

`PagingPredicate`s constructed via `Predicates#pagingPredicate` are instances of `PagingPredicateImpl`, this is probably why this hasn't been reported before.

Fixes https://github.com/hazelcast/hazelcast/issues/26039

Changes:
- Don't cast to `PagingPredicateImpl` in `SortingUtil`
- Add `getAnchor` / `getNearestAnchorEntry` to `PagingPredicate` interface, moving up existing documentation if present
- Address some warnings in the changed areas about missing/redudant generic types