### PR TITLE
Updates CPMap UnsupportedOperationException Message [HZ-3833]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/CPSubsystemImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/CPSubsystemImpl.java
@@ -57,7 +57,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.cp.internal.CPSubsystemImpl.CPMAP_LICENSE_MESASGE;
+import static com.hazelcast.cp.internal.CPSubsystemImpl.CPMAP_LICENSE_MESSAGE;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
@@ -151,7 +151,7 @@ public class CPSubsystemImpl implements CPSubsystem {
 
     @Override
     public <K, V> CPMap<K, V> getMap(@Nonnull String name) {
-        throw new UnsupportedOperationException(CPMAP_LICENSE_MESASGE);
+        throw new UnsupportedOperationException(CPMAP_LICENSE_MESSAGE);
     }
 
     private static class CPMembershipEventHandler extends CPSubsystemAddMembershipListenerCodec.AbstractEventHandler

--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/CPSubsystemImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/CPSubsystemImpl.java
@@ -57,6 +57,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.cp.internal.CPSubsystemImpl.CPMAP_LICENSE_MESASGE;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 
 /**
@@ -150,7 +151,7 @@ public class CPSubsystemImpl implements CPSubsystem {
 
     @Override
     public <K, V> CPMap<K, V> getMap(@Nonnull String name) {
-        throw new UnsupportedOperationException("CPMap is not included in your license");
+        throw new UnsupportedOperationException(CPMAP_LICENSE_MESASGE);
     }
 
     private static class CPMembershipEventHandler extends CPSubsystemAddMembershipListenerCodec.AbstractEventHandler

--- a/hazelcast/src/main/java/com/hazelcast/client/cp/internal/CPSubsystemImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/cp/internal/CPSubsystemImpl.java
@@ -150,7 +150,7 @@ public class CPSubsystemImpl implements CPSubsystem {
 
     @Override
     public <K, V> CPMap<K, V> getMap(@Nonnull String name) {
-        throw new UnsupportedOperationException("CPMap is not supported in Open Source");
+        throw new UnsupportedOperationException("CPMap is not included in your license");
     }
 
     private static class CPMembershipEventHandler extends CPSubsystemAddMembershipListenerCodec.AbstractEventHandler

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/CPSubsystemImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/CPSubsystemImpl.java
@@ -171,7 +171,7 @@ public class CPSubsystemImpl implements CPSubsystem {
     @Nonnull
     @Override
     public <K, V> CPMap<K, V> getMap(@Nonnull String name) {
-        throw new UnsupportedOperationException("CPMap is not supported in Open Source");
+        throw new UnsupportedOperationException("CPMap is not included in your license");
     }
 
     private static class CPSubsystemManagementServiceImpl implements CPSubsystemManagementService {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/CPSubsystemImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/CPSubsystemImpl.java
@@ -54,7 +54,7 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
  * Provides access to CP Subsystem utilities
  */
 public class CPSubsystemImpl implements CPSubsystem {
-    public static final String CPMAP_LICENSE_MESASGE = "CPMap is not included in your license";
+    public static final String CPMAP_LICENSE_MESSAGE = "CPMap is not included in your license";
 
     protected final boolean cpSubsystemEnabled;
     private final NodeEngine nodeEngine;
@@ -172,7 +172,7 @@ public class CPSubsystemImpl implements CPSubsystem {
     @Nonnull
     @Override
     public <K, V> CPMap<K, V> getMap(@Nonnull String name) {
-        throw new UnsupportedOperationException(CPMAP_LICENSE_MESASGE);
+        throw new UnsupportedOperationException(CPMAP_LICENSE_MESSAGE);
     }
 
     private static class CPSubsystemManagementServiceImpl implements CPSubsystemManagementService {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/CPSubsystemImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/CPSubsystemImpl.java
@@ -54,6 +54,7 @@ import static com.hazelcast.internal.util.Preconditions.checkNotNull;
  * Provides access to CP Subsystem utilities
  */
 public class CPSubsystemImpl implements CPSubsystem {
+    public static final String CPMAP_LICENSE_MESASGE = "CPMap is not included in your license";
 
     protected final boolean cpSubsystemEnabled;
     private final NodeEngine nodeEngine;
@@ -171,7 +172,7 @@ public class CPSubsystemImpl implements CPSubsystem {
     @Nonnull
     @Override
     public <K, V> CPMap<K, V> getMap(@Nonnull String name) {
-        throw new UnsupportedOperationException("CPMap is not included in your license");
+        throw new UnsupportedOperationException(CPMAP_LICENSE_MESASGE);
     }
 
     private static class CPSubsystemManagementServiceImpl implements CPSubsystemManagementService {

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/CPSubsystemImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/CPSubsystemImplTest.java
@@ -31,7 +31,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.cp.internal.CPSubsystemImpl.CPMAP_LICENSE_MESASGE;
+import static com.hazelcast.cp.internal.CPSubsystemImpl.CPMAP_LICENSE_MESSAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -212,6 +212,6 @@ public class CPSubsystemImplTest extends HazelcastTestSupport {
 
         Throwable t = assertThrows(UnsupportedOperationException.class, () -> client.getCPSubsystem().getMap("map"));
         assertNotNull(t);
-        assertEquals(CPMAP_LICENSE_MESASGE, t.getMessage());
+        assertEquals(CPMAP_LICENSE_MESSAGE, t.getMessage());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/CPSubsystemImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/CPSubsystemImplTest.java
@@ -31,6 +31,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.cp.internal.CPSubsystemImpl.CPMAP_LICENSE_MESASGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -211,6 +212,6 @@ public class CPSubsystemImplTest extends HazelcastTestSupport {
 
         Throwable t = assertThrows(UnsupportedOperationException.class, () -> client.getCPSubsystem().getMap("map"));
         assertNotNull(t);
-        assertEquals("CPMap is not included in your license", t.getMessage());
+        assertEquals(CPMAP_LICENSE_MESASGE, t.getMessage());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/cp/internal/CPSubsystemImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/cp/internal/CPSubsystemImplTest.java
@@ -211,6 +211,6 @@ public class CPSubsystemImplTest extends HazelcastTestSupport {
 
         Throwable t = assertThrows(UnsupportedOperationException.class, () -> client.getCPSubsystem().getMap("map"));
         assertNotNull(t);
-        assertEquals("CPMap is not supported in Open Source", t.getMessage());
+        assertEquals("CPMap is not included in your license", t.getMessage());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPSubsystemImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPSubsystemImplTest.java
@@ -186,6 +186,6 @@ public class CPSubsystemImplTest extends HazelcastTestSupport {
         factory.newHazelcastInstance(config);
         HazelcastInstance instance = factory.newHazelcastInstance(config);
         Throwable t = assertThrows(UnsupportedOperationException.class, () -> instance.getCPSubsystem().getMap("myMap"));
-        assertEquals("CPMap is not supported in Open Source", t.getMessage());
+        assertEquals("CPMap is not included in your license", t.getMessage());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPSubsystemImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPSubsystemImplTest.java
@@ -31,7 +31,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.cp.internal.CPSubsystemImpl.CPMAP_LICENSE_MESASGE;
+import static com.hazelcast.cp.internal.CPSubsystemImpl.CPMAP_LICENSE_MESSAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -187,6 +187,6 @@ public class CPSubsystemImplTest extends HazelcastTestSupport {
         factory.newHazelcastInstance(config);
         HazelcastInstance instance = factory.newHazelcastInstance(config);
         Throwable t = assertThrows(UnsupportedOperationException.class, () -> instance.getCPSubsystem().getMap("myMap"));
-        assertEquals(CPMAP_LICENSE_MESASGE, t.getMessage());
+        assertEquals(CPMAP_LICENSE_MESSAGE, t.getMessage());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPSubsystemImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPSubsystemImplTest.java
@@ -31,6 +31,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.cp.internal.CPSubsystemImpl.CPMAP_LICENSE_MESASGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -186,6 +187,6 @@ public class CPSubsystemImplTest extends HazelcastTestSupport {
         factory.newHazelcastInstance(config);
         HazelcastInstance instance = factory.newHazelcastInstance(config);
         Throwable t = assertThrows(UnsupportedOperationException.class, () -> instance.getCPSubsystem().getMap("myMap"));
-        assertEquals("CPMap is not included in your license", t.getMessage());
+        assertEquals(CPMAP_LICENSE_MESASGE, t.getMessage());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/AbstractAtomicRegisterSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/AbstractAtomicRegisterSnapshotTest.java
@@ -42,7 +42,11 @@ public abstract class AbstractAtomicRegisterSnapshotTest<T> extends HazelcastRaf
 
     @Before
     public void setup() {
+        setLicense();
         instances = newInstances(3);
+    }
+
+    protected void setLicense() {
     }
 
     protected CPSubsystem getCPSubsystem() {


### PR DESCRIPTION
Updates the `UnsupportedOperationException` message to simplify feature implementation in Enterprise Edition.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6890

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
