### PR TITLE
Add IsolatedJVMTest category for parallel tests which needs fresh JVM (not reused)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/IsolatedJVMTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/IsolatedJVMTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.annotation;
+
+/**
+ * Annotates tests which has to be run in isolated (forked and fresh) JVM by surefire plugin in parallel profile.
+ * By default ParallelJVMTest are reusing forked JVMs and this can lead to problems with a static context.
+ * Combination of ParallelJVMTest (for example from parent class) and IsolatedJVMTest categories will prevent issue
+ * with a static context.
+ */
+public final class IsolatedJVMTest {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -885,7 +885,8 @@
                                     </groups>
                                     <excludedGroups>
                                         com.hazelcast.test.annotation.SlowTest,
-                                        com.hazelcast.test.annotation.NightlyTest
+                                        com.hazelcast.test.annotation.NightlyTest,
+                                        com.hazelcast.test.annotation.IsolatedJVMTest
                                     </excludedGroups>
                                     <systemPropertyVariables>
                                         <multipleJVM>true</multipleJVM>
@@ -921,8 +922,52 @@
                                     <excludedGroups>
                                         com.hazelcast.test.annotation.SlowTest,
                                         com.hazelcast.test.annotation.NightlyTest,
-                                        com.hazelcast.test.annotation.ParallelJVMTest
+                                        com.hazelcast.test.annotation.ParallelJVMTest,
+                                        com.hazelcast.test.annotation.IsolatedJVMTest
                                     </excludedGroups>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>isolated-jvms</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration combine.self="override">
+                                    <useFile>false</useFile>
+                                    <trimStackTrace>false</trimStackTrace>
+                                    <!-- 0.5C means half as many forks as cpu cores -->
+                                    <forkCount>0.5C</forkCount>
+                                    <reuseForks>false</reuseForks>
+                                    <argLine>
+                                        ${vmHeapSettings}
+                                        ${javaModuleArgs}
+                                        -ea
+                                        -Dhazelcast.phone.home.enabled=false
+                                        -Dhazelcast.logging.type=none
+                                        -Dhazelcast.test.use.network=false
+                                        -Dhazelcast.test.multiple.jvm=true
+                                        -Dlog4j.configurationFile=log4j2.xml
+                                        -Dlog4j.skipJansi=true
+                                        ${extraVmArgs}
+                                    </argLine>
+                                    <includes>
+                                        <include>**/**.java</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>**/jsr/**.java</exclude>
+                                        <exclude>**/**IT.java</exclude>
+                                    </excludes>
+                                    <groups>
+                                        com.hazelcast.test.annotation.IsolatedJVMTest
+                                    </groups>
+                                    <excludedGroups>
+                                        com.hazelcast.test.annotation.SlowTest,
+                                        com.hazelcast.test.annotation.NightlyTest
+                                    </excludedGroups>
+                                    <systemPropertyVariables>
+                                        <multipleJVM>true</multipleJVM>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -948,7 +993,8 @@
                             <useSystemClassLoader>true</useSystemClassLoader>
                             <excludedGroups>
                                 com.hazelcast.test.annotation.SlowTest,
-                                com.hazelcast.test.annotation.NightlyTest
+                                com.hazelcast.test.annotation.NightlyTest,
+                                com.hazelcast.test.annotation.IsolatedJVMTest
                             </excludedGroups>
                         </configuration>
                         <executions>


### PR DESCRIPTION
Using this `IsolatedJVMTest` category moves tests with `ParallelJVMTest` to separate execution of surefire, still parallel but with not reused forked JVM.

I tried this with my own version of #26032 (where we meet such issue with static context and pr builder) and it passed here:
Jenkins: https://jenkins.hazelcast.com/job/Hazelcast-pr-builder-sql-patryk/3/
Branch: https://github.com/Patras3/hazelcast/tree/fix/5.4/small-opt-perf

I think we should rewrite our categories and way of running tests in a future as some of tests without any category are invoked more than once, but this PR is just to fix issues with reused static context for some tests.

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [X] Request reviewers if possible