### PR TITLE
Revert "Bump com.googlecode.maven-download-plugin:download-maven-plugin from 1.6.8 to 1.7.1"

### DIFF
--- a/extensions/kafka-connect/pom.xml
+++ b/extensions/kafka-connect/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.7.1</version>
+                <version>1.6.8</version>
                 <executions>
                     <execution>
                         <id>download-zip-file</id>


### PR DESCRIPTION
Reverts hazelcast/hazelcast#25503

As per the comment in the file:
```<!--version 1.7.1 is buggy and does not use the cache properly-->```

https://github.com/maven-download-plugin/maven-download-plugin/issues/260