### PR TITLE
Remove usages JVMUtil.upcast(Buffer).

### DIFF
--- a/extensions/s3/src/main/java/com/hazelcast/jet/s3/S3Sinks.java
+++ b/extensions/s3/src/main/java/com/hazelcast/jet/s3/S3Sinks.java
@@ -33,8 +33,6 @@ import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import static com.hazelcast.internal.util.JVMUtil.upcast;
-
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -200,7 +198,7 @@ public final class S3Sinks {
             int newCapacity = (int) (minimumLength * BUFFER_SCALE);
             ByteBuffer newBuffer = ByteBuffer.allocateDirect(newCapacity);
             if (buffer != null) {
-                upcast(buffer).flip();
+                buffer.flip();
                 newBuffer.put(buffer);
             }
             buffer = newBuffer;
@@ -226,7 +224,7 @@ public final class S3Sinks {
 
         private void flushBuffer(boolean isLastPart) {
             if (buffer.position() > 0) {
-                upcast(buffer).flip();
+                buffer.flip();
                 UploadPartRequest req = UploadPartRequest
                         .builder()
                         .bucket(bucketName)
@@ -238,7 +236,7 @@ public final class S3Sinks {
                 String eTag = s3Client.uploadPart(req, RequestBody.fromByteBuffer(buffer)).eTag();
                 completedParts.add(CompletedPart.builder().partNumber(partNumber).eTag(eTag).build());
                 partNumber++;
-                upcast(buffer).clear();
+                buffer.clear();
             }
 
             if (isLastPart) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageReader.java
@@ -25,7 +25,6 @@ import java.nio.ByteBuffer;
 
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.SIZE_OF_FRAME_LENGTH_AND_FLAGS;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public final class ClientMessageReader {
 
@@ -90,9 +89,9 @@ public final class ClientMessageReader {
                 sumUntrustedMessageLength += frameLength;
             }
 
-            upcast(src).position(src.position() + Bits.INT_SIZE_IN_BYTES);
+            src.position(src.position() + Bits.INT_SIZE_IN_BYTES);
             int flags = Bits.readShortL(src, src.position()) & INT_MASK;
-            upcast(src).position(src.position() + Bits.SHORT_SIZE_IN_BYTES);
+            src.position(src.position() + Bits.SHORT_SIZE_IN_BYTES);
 
             int size = frameLength - SIZE_OF_FRAME_LENGTH_AND_FLAGS;
             byte[] bytes = new byte[size];

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageWriter.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.SIZE_OF_FRAME_LENGTH_AND_FLAGS;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public class ClientMessageWriter {
 
@@ -58,14 +57,14 @@ public class ClientMessageWriter {
         if (writeOffset == -1) {
             if (bytesWritable >= SIZE_OF_FRAME_LENGTH_AND_FLAGS) {
                 Bits.writeIntL(dst, dst.position(), frameContentLength + SIZE_OF_FRAME_LENGTH_AND_FLAGS);
-                upcast(dst).position(dst.position() + Bits.INT_SIZE_IN_BYTES);
+                dst.position(dst.position() + Bits.INT_SIZE_IN_BYTES);
 
                 if (isLastFrame) {
                     Bits.writeShortL(dst, dst.position(), (short) (frame.flags | IS_FINAL_FLAG));
                 } else {
                     Bits.writeShortL(dst, dst.position(), (short) frame.flags);
                 }
-                upcast(dst).position(dst.position() + Bits.SHORT_SIZE_IN_BYTES);
+                dst.position(dst.position() + Bits.SHORT_SIZE_IN_BYTES);
                 writeOffset = 0;
             } else {
                 return false;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
@@ -39,7 +39,6 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.FRAGMENTATION_ID_
 import static com.hazelcast.client.impl.protocol.ClientMessage.UNFRAGMENTED_MESSAGE;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * Builds {@link ClientMessage}s from byte chunks.
@@ -74,7 +73,7 @@ public class ClientMessageDecoder extends InboundHandlerWithCounters<ByteBuffer,
 
     @Override
     public HandlerStatus onRead() {
-        upcast(src).flip();
+        src.flip();
         try {
             while (src.hasRemaining()) {
                 boolean trusted = isEndpointTrusted();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoder.java
@@ -27,7 +27,6 @@ import java.util.function.Supplier;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * A {@link OutboundHandler} for the new-client. It writes ClientMessages to the ByteBuffer.
@@ -65,7 +64,7 @@ public class ClientMessageEncoder extends OutboundHandler<Supplier<ClientMessage
                 }
             }
         } finally {
-            upcast(dst).flip();
+            dst.flip();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommand.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public class BulkGetCommand extends AbstractTextCommand {
 
@@ -62,6 +61,6 @@ public class BulkGetCommand extends AbstractTextCommand {
             byteBuffer.put(bytes);
         }
         byteBuffer.put(TextCommandConstants.END);
-        upcast(byteBuffer).flip();
+        byteBuffer.flip();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
@@ -27,7 +27,6 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.SERVER_ERROR;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_SERVER;
 import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class ErrorCommand extends AbstractTextCommand {
@@ -59,7 +58,7 @@ public class ErrorCommand extends AbstractTextCommand {
             response.put(msg);
         }
         response.put(TextCommandConstants.RETURN);
-        upcast(response).flip();
+        response.flip();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
@@ -20,7 +20,6 @@ import com.hazelcast.internal.ascii.AbstractTextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 
 import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 import java.nio.ByteBuffer;
 
@@ -51,7 +50,7 @@ public class SetCommand extends AbstractTextCommand {
             while (src.hasRemaining()) {
                 char c = (char) src.get();
                 if (c == '\n') {
-                    upcast(bbValue).flip();
+                    bbValue.flip();
                     return true;
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
@@ -22,7 +22,6 @@ import com.hazelcast.internal.ascii.TextCommandConstants;
 import java.nio.ByteBuffer;
 
 import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class StatsCommand extends AbstractTextCommand {
@@ -79,7 +78,7 @@ public class StatsCommand extends AbstractTextCommand {
         putLong(DECR_HITS, stats.getDecrHits());
         putLong(DECR_MISSES, stats.getDecrMisses());
         response.put(TextCommandConstants.END);
-        upcast(response).flip();
+        response.flip();
     }
 
     private void putInt(byte[] name, int value) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -34,7 +34,6 @@ import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_404;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_500;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_503;
 import static com.hazelcast.internal.nio.IOUtil.copyFromHeapBuffer;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 @SuppressFBWarnings({"EI_EXPOSE_REP", "MS_MUTABLE_ARRAY", "MS_PKGPROTECT"})
@@ -160,7 +159,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
             }
         }
         response.put(TextCommandConstants.RETURN);
-        upcast(response).flip();
+        response.flip();
         setStatusCode(statusCode.code);
     }
 
@@ -218,7 +217,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
         if (value != null) {
             response.put(value);
         }
-        upcast(response).flip();
+        response.flip();
         setStatusCode(statusCode.code);
     }
 
@@ -262,7 +261,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
         if (value != null) {
             response.put(value);
         }
-        upcast(response).flip();
+        response.flip();
         setStatusCode(statusCode.code);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_POST;
 import static com.hazelcast.internal.ascii.rest.HttpStatusCode.SC_100;
 import static com.hazelcast.internal.nio.IOUtil.copyToHeapBuffer;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 public class HttpPostCommand extends HttpCommand {
@@ -76,7 +75,7 @@ public class HttpPostCommand extends HttpCommand {
         }
         if (complete) {
             if (data != null) {
-                upcast(data).flip();
+                data.flip();
             }
         }
         return complete;
@@ -148,7 +147,7 @@ public class HttpPostCommand extends HttpCommand {
         if (b == CARRIAGE_RETURN) {
             readLF(src);
         } else {
-            upcast(src).position(src.position() - 1);
+            src.position(src.position() - 1);
         }
     }
 
@@ -171,7 +170,7 @@ public class HttpPostCommand extends HttpCommand {
         } else {
             result = new String(bb.array(), 0, bb.position(), StandardCharsets.UTF_8);
         }
-        upcast(bb).clear();
+        bb.clear();
         return result;
     }
 
@@ -225,7 +224,7 @@ public class HttpPostCommand extends HttpCommand {
         int capacity = lineBuffer.capacity() << 1;
 
         ByteBuffer newBuffer = ByteBuffer.allocate(capacity);
-        upcast(lineBuffer).flip();
+        lineBuffer.flip();
         newBuffer.put(lineBuffer);
         lineBuffer = newBuffer;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
@@ -47,7 +47,6 @@ import static com.hazelcast.internal.nio.IOUtil.deleteQuietly;
 import static com.hazelcast.internal.nio.IOUtil.readFullyOrNothing;
 import static com.hazelcast.internal.nio.IOUtil.rename;
 import static com.hazelcast.internal.nio.IOUtil.toFileName;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.nio.ByteBuffer.allocate;
@@ -277,18 +276,18 @@ public class NearCachePreloader<K> {
             return;
         }
         fos.write(buf.array());
-        upcast(buf).position(0);
+        buf.position(0);
     }
 
     private void flushLocalBuffer(FileChannel outChannel) throws IOException {
         if (buf.position() == 0) {
             return;
         }
-        upcast(buf).flip();
+        buf.flip();
         while (buf.hasRemaining()) {
             outChannel.write(buf);
         }
-        upcast(buf).clear();
+        buf.clear();
     }
 
     private static String getFilename(String directory, String nearCacheName) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/OutboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/OutboundHandler.java
@@ -23,7 +23,6 @@ import java.nio.ByteBuffer;
 import static com.hazelcast.internal.networking.ChannelOption.DIRECT_BUF;
 import static com.hazelcast.internal.networking.ChannelOption.SO_SNDBUF;
 import static com.hazelcast.internal.nio.IOUtil.newByteBuffer;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * The {@link OutboundHandler} is a {@link ChannelHandler} for outbound
@@ -120,7 +119,7 @@ public abstract class OutboundHandler<S, D> extends ChannelHandler<OutboundHandl
         if (bytes != null) {
             buffer.put(bytes);
         }
-        upcast(buffer).flip();
+        buffer.flip();
         dst = (D) buffer;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/IOUtil.java
@@ -84,7 +84,6 @@ import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
 import static com.hazelcast.internal.tpcengine.util.ReflectionUtil.findStaticFieldValue;
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static java.lang.String.format;
 import static java.nio.channels.FileChannel.open;
 import static java.nio.file.FileVisitResult.CONTINUE;
@@ -125,7 +124,7 @@ public final class IOUtil {
         if (bb.hasRemaining()) {
             bb.compact();
         } else {
-            upcast(bb).clear();
+            bb.clear();
         }
     }
 
@@ -374,7 +373,7 @@ public final class IOUtil {
         int n = Math.min(src.remaining(), dst.remaining());
         int srcPosition = src.position();
         dst.put(src.array(), srcPosition, n);
-        upcast(src).position(srcPosition + n);
+        src.position(srcPosition + n);
         return n;
     }
 
@@ -398,7 +397,7 @@ public final class IOUtil {
         int n = Math.min(src.remaining(), dst.remaining());
         int dstPosition = dst.position();
         src.get(dst.array(), dstPosition, n);
-        upcast(dst).position(dstPosition + n);
+        dst.position(dstPosition + n);
         return n;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextDecoder.java
@@ -36,7 +36,6 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.UNKNOWN;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
 
@@ -84,7 +83,7 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
 
     @Override
     public HandlerStatus onRead() throws Exception {
-        upcast(src).flip();
+        src.flip();
         try {
             while (src.hasRemaining()) {
                 doRead(src);
@@ -147,14 +146,14 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
         }
 
         ByteBuffer newBuffer = ByteBuffer.allocate(capacity);
-        upcast(commandLineBuffer).flip();
+        commandLineBuffer.flip();
         newBuffer.put(commandLineBuffer);
         commandLineBuffer = newBuffer;
     }
 
     private void reset() {
         command = null;
-        upcast(commandLineBuffer).clear();
+        commandLineBuffer.clear();
         commandLineRead = false;
     }
 
@@ -168,7 +167,7 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
         } else {
             result = new String(bb.array(), 0, bb.position(), StandardCharsets.UTF_8);
         }
-        upcast(bb).clear();
+        bb.clear();
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ascii/TextEncoder.java
@@ -29,7 +29,6 @@ import java.util.function.Supplier;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 public class TextEncoder extends OutboundHandler<Supplier<TextCommand>, ByteBuffer> {
     public static final String TEXT_ENCODER = "textencoder";
@@ -97,7 +96,7 @@ public class TextEncoder extends OutboundHandler<Supplier<TextCommand>, ByteBuff
                 }
             }
         } finally {
-            upcast(dst).flip();
+            dst.flip();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
@@ -24,8 +24,6 @@ import com.hazelcast.internal.nio.BufferObjectDataInput;
 import com.hazelcast.query.impl.getters.JsonPathCursor;
 import com.hazelcast.spi.impl.operationexecutor.impl.OperationThread;
 
-import static com.hazelcast.internal.util.JVMUtil.upcast;
-
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.ByteBuffer;
@@ -107,7 +105,7 @@ public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
         UTF8Reader(BufferObjectDataInput input) {
             byte[] data = obtainBytes(input);
             inputBuffer = ByteBuffer.wrap(data);
-            upcast(inputBuffer).position(input.position());
+            inputBuffer.position(input.position());
             decoder = Thread.currentThread() instanceof OperationThread
                     ? DECODER_THREAD_LOCAL.get()
                     : StandardCharsets.UTF_8.newDecoder();

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/MemberProtocolEncoder.java
@@ -30,7 +30,6 @@ import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.Protocols.CLUSTER;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 /**
@@ -70,7 +69,7 @@ public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
 
             return DIRTY;
         } finally {
-            upcast(dst).flip();
+            dst.flip();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/PacketDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/PacketDecoder.java
@@ -29,7 +29,6 @@ import java.util.function.Consumer;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.Packet.FLAG_URGENT;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * The {@link InboundHandler} for member to member communication.
@@ -57,7 +56,7 @@ public class PacketDecoder extends InboundHandlerWithCounters<ByteBuffer, Consum
 
     @Override
     public HandlerStatus onRead() throws Exception {
-        upcast(src).flip();
+        src.flip();
         try {
             while (src.hasRemaining()) {
                 Packet packet = packetReader.readFrom(src);

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/PacketEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/PacketEncoder.java
@@ -27,7 +27,6 @@ import java.util.function.Supplier;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * A {@link OutboundHandler} that for member to member communication.
@@ -74,7 +73,7 @@ public class PacketEncoder extends OutboundHandler<Supplier<Packet>, ByteBuffer>
                 }
             }
         } finally {
-            upcast(dst).flip();
+            dst.flip();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolDecoder.java
@@ -30,7 +30,6 @@ import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
 import static com.hazelcast.internal.nio.Protocols.UNEXPECTED_PROTOCOL;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 
 /**
  * Checks if the correct protocol is received then swaps itself with the next
@@ -89,7 +88,7 @@ public class SingleProtocolDecoder
 
     @Override
     public HandlerStatus onRead() {
-        upcast(src).flip();
+        src.flip();
 
         try {
             if (src.remaining() < PROTOCOL_LENGTH) {
@@ -107,7 +106,7 @@ public class SingleProtocolDecoder
                     // previous handler may get stuck in a DIRTY loop even if the
                     // channel closes. We observed this behavior in TLSDecoder
                     // before.
-                    upcast(src).position(src.limit());
+                    src.position(src.limit());
                 }
                 return CLEAN;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/SingleProtocolEncoder.java
@@ -28,7 +28,6 @@ import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.nio.IOUtil.compactOrClear;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
 import static com.hazelcast.internal.nio.Protocols.UNEXPECTED_PROTOCOL;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 
 /**
@@ -83,7 +82,7 @@ public class SingleProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
             // destination buffer). We can now throw exception in the pipeline to close the channel.
             throw new ProtocolException(exceptionMessage);
         } finally {
-            upcast(dst).flip();
+            dst.flip();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TextHandshakeDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TextHandshakeDecoder.java
@@ -21,8 +21,6 @@ import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.nio.ascii.MemcacheTextDecoder;
 import com.hazelcast.internal.nio.ascii.RestApiTextDecoder;
 
-import static com.hazelcast.internal.util.JVMUtil.upcast;
-
 import java.nio.ByteBuffer;
 
 public class TextHandshakeDecoder
@@ -60,7 +58,7 @@ public class TextHandshakeDecoder
         // we need to restore whatever is read
         ByteBuffer src = this.src;
         ByteBuffer dst = (ByteBuffer) inboundHandlers[0].src();
-        upcast(src).flip();
+        src.flip();
         dst.put(src);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolDecoder.java
@@ -48,7 +48,6 @@ import static com.hazelcast.internal.nio.Protocols.CLIENT_BINARY;
 import static com.hazelcast.internal.nio.Protocols.CLUSTER;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
 import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 import static com.hazelcast.jet.impl.util.Util.CONFIG_CHANGE_TEMPLATE;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_CLIENT_RECEIVE_BUFFER_SIZE;
@@ -83,7 +82,7 @@ public class UnifiedProtocolDecoder
 
     @Override
     public HandlerStatus onRead() throws Exception {
-        upcast(src).flip();
+        src.flip();
 
         try {
             if (src.remaining() < PROTOCOL_LENGTH) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/UnifiedProtocolEncoder.java
@@ -36,7 +36,6 @@ import static com.hazelcast.internal.nio.Protocols.CLUSTER;
 import static com.hazelcast.internal.nio.Protocols.PROTOCOL_LENGTH;
 import static com.hazelcast.internal.nio.ascii.TextEncoder.TEXT_ENCODER;
 import static com.hazelcast.internal.server.ServerContext.KILO_BYTE;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.StringUtil.stringToBytes;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_CLIENT_SEND_BUFFER_SIZE;
 import static com.hazelcast.spi.properties.ClusterProperty.SOCKET_SEND_BUFFER_SIZE;
@@ -128,7 +127,7 @@ public class UnifiedProtocolEncoder
 
             return CLEAN;
         } finally {
-            upcast(dst).flip();
+            dst.flip();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamSocketP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/StreamSocketP.java
@@ -32,7 +32,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.util.concurrent.locks.LockSupport;
 
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.security.permission.ActionConstants.ACTION_READ;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -73,8 +72,8 @@ public final class StreamSocketP extends AbstractProcessor {
             LockSupport.parkNanos(MILLISECONDS.toNanos(1));
         }
         getLogger().info("Connected to socket " + hostAndPort());
-        upcast(byteBuffer).limit(0);
-        upcast(charBuffer).limit(0);
+        byteBuffer.limit(0);
+        charBuffer.limit(0);
     }
 
     @Override
@@ -98,10 +97,10 @@ public final class StreamSocketP extends AbstractProcessor {
             return;
         }
         socketDone = socketChannel.read(byteBuffer) < 0;
-        upcast(byteBuffer).flip();
-        upcast(charBuffer).clear();
+        byteBuffer.flip();
+        charBuffer.clear();
         charsetDecoder.decode(byteBuffer, charBuffer, socketDone);
-        upcast(charBuffer).flip();
+        charBuffer.flip();
         byteBuffer.compact();
         assert byteBuffer.position() < MAX_BYTES_PER_CHAR - 1 : "position=" + byteBuffer.position();
     }

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/IMapOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/IMapOutputStream.java
@@ -24,7 +24,6 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static java.lang.Math.min;
 
 public class IMapOutputStream extends OutputStream {
@@ -99,6 +98,6 @@ public class IMapOutputStream extends OutputStream {
             throw new IOException("Writing to chunked IMap failed: " + e, e);
         }
         currentChunkIndex++;
-        upcast(currentChunk).clear();
+        currentChunk.clear();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoderAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoderAbstractTest.java
@@ -30,7 +30,6 @@ import org.junit.runner.RunWith;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -84,7 +83,7 @@ public abstract class HyperLogLogEncoderAbstractTest {
             int toCount = random.nextInt();
             actualCount.add(toCount);
 
-            upcast(bb).clear();
+            bb.clear();
             bb.putInt(toCount);
             encoder.add(HashUtil.MurmurHash3_x64_64(bb.array(), 0, bb.array().length));
 

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImplTest.java
@@ -35,7 +35,6 @@ import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Random;
 
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -112,7 +111,7 @@ public class HyperLogLogImplTest {
             int toCount = random.nextInt();
             actualCount.add(toCount);
 
-            upcast(bb).clear();
+            bb.clear();
             bb.putInt(toCount);
             hyperLogLog.add(HashUtil.MurmurHash3_x64_64(bb.array(), 0, bb.array().length));
 

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoderDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageEncoderDecoderTest.java
@@ -53,7 +53,6 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.UNFRAGMENTED_MESSAGE;
 import static com.hazelcast.client.impl.protocol.util.ClientMessageSplitter.getFragments;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -73,7 +72,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         encoder.src(() -> reference.getAndSet(null));
 
         ByteBuffer buffer = ByteBuffer.allocate(1000);
-        upcast(buffer).flip();
+        buffer.flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -84,7 +83,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        upcast(buffer).position(buffer.limit());
+        buffer.position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -106,7 +105,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         encoder.src(() -> reference.getAndSet(null));
 
         ByteBuffer buffer = ByteBuffer.allocate(1000);
-        upcast(buffer).flip();
+        buffer.flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -117,7 +116,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        upcast(buffer).position(buffer.limit());
+        buffer.position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -148,7 +147,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         encoder.src(() -> reference.getAndSet(null));
 
         ByteBuffer buffer = ByteBuffer.allocate(1000);
-        upcast(buffer).flip();
+        buffer.flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -159,7 +158,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        upcast(buffer).position(buffer.limit());
+        buffer.position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -206,7 +205,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         encoder.src(() -> reference.getAndSet(null));
 
         ByteBuffer buffer = ByteBuffer.allocate(1000);
-        upcast(buffer).flip();
+        buffer.flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -217,7 +216,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        upcast(buffer).position(buffer.limit());
+        buffer.position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -273,7 +272,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         encoder.src(() -> reference.getAndSet(null));
 
         ByteBuffer buffer = ByteBuffer.allocate(1000);
-        upcast(buffer).flip();
+        buffer.flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -284,7 +283,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        upcast(buffer).position(buffer.limit());
+        buffer.position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -323,7 +322,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         });
 
         ByteBuffer buffer = ByteBuffer.allocate(200);
-        upcast(buffer).flip();
+        buffer.flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -334,7 +333,7 @@ public class ClientMessageEncoderDecoderTest extends HazelcastTestSupport {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessageRef::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        upcast(buffer).position(buffer.limit());
+        buffer.position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageReaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageReaderTest.java
@@ -29,7 +29,6 @@ import org.junit.runner.RunWith;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -176,14 +175,14 @@ public class ClientMessageReaderTest {
         int capacity = buffer.capacity();
         // Set limit to a small value so that we can simulate
         // that the frame length and flags are not read yet.
-        upcast(buffer).limit(4);
+        buffer.limit(4);
 
         ClientMessageReader reader = new ClientMessageReader(-1);
 
         // should not be able to read with just 4 bytes of data
         assertFalse(reader.readFrom(buffer, true));
 
-        upcast(buffer).limit(capacity);
+        buffer.limit(capacity);
 
         // should be able to read when the rest of the data comes
         assertTrue(reader.readFrom(buffer, true));
@@ -208,7 +207,7 @@ public class ClientMessageReaderTest {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[message.getFrameLength()]);
         ClientMessageWriter writer = new ClientMessageWriter();
         writer.writeTo(buffer, message);
-        upcast(buffer).flip();
+        buffer.flip();
         return buffer;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitAndBuildTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitAndBuildTest.java
@@ -42,7 +42,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.client.impl.protocol.util.ClientMessageSplitter.getFragments;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.test.HazelcastTestSupport.generateRandomString;
 import static groovy.util.GroovyTestCase.assertEquals;
 
@@ -88,7 +87,7 @@ public class ClientMessageSplitAndBuildTest {
         encoder.src(outputQueue::poll);
 
         ByteBuffer buffer = ByteBuffer.allocate(100000);
-        upcast(buffer).flip();
+        buffer.flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -99,7 +98,7 @@ public class ClientMessageSplitAndBuildTest {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        upcast(buffer).position(buffer.limit());
+        buffer.position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -137,7 +136,7 @@ public class ClientMessageSplitAndBuildTest {
         encoder.src(outputQueue::poll);
 
         ByteBuffer buffer = ByteBuffer.allocate(100000);
-        upcast(buffer).flip();
+        buffer.flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -148,7 +147,7 @@ public class ClientMessageSplitAndBuildTest {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, inputQueue::offer, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        upcast(buffer).position(buffer.limit());
+        buffer.position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();
@@ -173,7 +172,7 @@ public class ClientMessageSplitAndBuildTest {
         encoder.src(outputQueue::poll);
 
         ByteBuffer buffer = ByteBuffer.allocate(100000);
-        upcast(buffer).flip();
+        buffer.flip();
         encoder.dst(buffer);
 
         HandlerStatus result = encoder.onWrite();
@@ -184,7 +183,7 @@ public class ClientMessageSplitAndBuildTest {
         ClientMessageDecoder decoder = new ClientMessageDecoder(null, resultingMessage::set, null);
         decoder.setNormalPacketsRead(SwCounter.newSwCounter());
 
-        upcast(buffer).position(buffer.limit());
+        buffer.position(buffer.limit());
 
         decoder.src(buffer);
         decoder.onRead();

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/TestUtil.java
@@ -37,7 +37,6 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.hazelcast.internal.util.EmptyStatement.ignore;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
 import static java.lang.reflect.Proxy.isProxyClass;
 import static org.junit.Assert.fail;
@@ -255,7 +254,7 @@ public final class TestUtil {
     }
 
     public static byte[] byteBufferToBytes(ByteBuffer buffer) {
-        upcast(buffer).flip();
+        buffer.flip();
         byte[] requestBytes = new byte[buffer.limit()];
         buffer.get(requestBytes);
         return requestBytes;

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/operations/JoinShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/operations/JoinShutdownTest.java
@@ -48,7 +48,6 @@ import java.util.Collections;
 
 import static com.hazelcast.instance.impl.TestUtil.getNode;
 import static com.hazelcast.instance.impl.TestUtil.toData;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfigWithoutJetAndMetrics;
 import static org.junit.Assert.assertTrue;
@@ -107,10 +106,10 @@ public class JoinShutdownTest {
 
         ByteBuffer buffer = toBuffer(op);
         int position = buffer.position();
-        upcast(buffer).position(286);
+        buffer.position(286);
         buffer.putInt(42_000_000);
-        upcast(buffer).position(position);
-        upcast(buffer).flip();
+        buffer.position(position);
+        buffer.flip();
 
         if (joinedBefore) {
             node.getClusterService().resetJoinState();
@@ -153,7 +152,7 @@ public class JoinShutdownTest {
     }
 
     private static void send(Operation operation, InetSocketAddress address) throws Exception {
-        send((ByteBuffer) upcast(toBuffer(operation)).flip(), address);
+        send(toBuffer(operation).flip(), address);
     }
 
     private static void send(ByteBuffer buffer, InetSocketAddress address) throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapterTest.java
@@ -34,7 +34,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 
 import static com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder.DEFAULT_BYTE_ORDER;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.test.HazelcastTestSupport.ignore;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -175,8 +174,8 @@ public class DataInputNavigableJsonAdapterTest {
             buffer.append((char) next);
             next = reader.read();
         }
-        upcast(buffer).limit(buffer.position());
-        upcast(buffer).rewind();
+        buffer.limit(buffer.position());
+        buffer.rewind();
         String actual = buffer.toString();
         assertEquals(expected, actual);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/PacketEncoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/server/tcp/PacketEncoderTest.java
@@ -37,7 +37,6 @@ import java.util.function.Supplier;
 
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -57,7 +56,7 @@ public class PacketEncoderTest extends HazelcastTestSupport {
     public void whenPacketFullyWritten() {
         final Packet packet = new Packet(serializationService.toBytes("foobar"));
         ByteBuffer dst = ByteBuffer.allocate(1000);
-        upcast(dst).flip();
+        dst.flip();
 
         PacketSupplier src = new PacketSupplier();
         src.queue.add(packet);
@@ -78,7 +77,7 @@ public class PacketEncoderTest extends HazelcastTestSupport {
     public void whenNotEnoughSpace() {
         final Packet packet = new Packet(serializationService.toBytes(new byte[2000]));
         ByteBuffer dst = ByteBuffer.allocate(1000);
-        upcast(dst).flip();
+        dst.flip();
 
         PacketSupplier src = new PacketSupplier();
         src.queue.add(packet);

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -81,7 +81,6 @@ import static com.hazelcast.internal.nio.IOUtil.writeObject;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createObjectDataInputStream;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createObjectDataOutputStream;
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static java.lang.Integer.min;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
@@ -665,8 +664,8 @@ public class IOUtilTest extends HazelcastTestSupport {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[SIZE]);
         buffer.put((byte) 0xFF);
         buffer.put((byte) 0xFF);
-        upcast(buffer).flip();
-        upcast(buffer).position(1);
+        buffer.flip();
+        buffer.position(1);
         compactOrClear(buffer);
         assertEquals("Buffer position invalid", 1, buffer.position());
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/PacketIOHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/PacketIOHelperTest.java
@@ -43,7 +43,6 @@ import static com.hazelcast.internal.serialization.impl.SerializationConcurrency
 import static com.hazelcast.internal.serialization.impl.SerializationConcurrencyTest.Person;
 import static com.hazelcast.internal.serialization.impl.SerializationConcurrencyTest.PortableAddress;
 import static com.hazelcast.internal.serialization.impl.SerializationConcurrencyTest.PortablePerson;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -106,7 +105,7 @@ public class PacketIOHelperTest extends HazelcastTestSupport {
         ByteBuffer buffer = ByteBuffer.allocate(originalPayload.length * 2);
         Packet originalPacket = new Packet(originalPayload);
         assertTrue(packetWriter.writeTo(originalPacket, buffer));
-        upcast(buffer).flip();
+        buffer.flip();
 
         SerializationService ss2 = createSerializationServiceBuilder().build();
         Packet clonedPacket = packetReader.readFrom(buffer);
@@ -133,9 +132,9 @@ public class PacketIOHelperTest extends HazelcastTestSupport {
         boolean writeCompleted;
         do {
             writeCompleted = packetWriter.writeTo(originalPacket, bb);
-            upcast(bb).flip();
+            bb.flip();
             clonedPacket = packetReader.readFrom(bb);
-            upcast(bb).clear();
+            bb.clear();
         } while (!writeCompleted);
 
         assertNotNull(clonedPacket);
@@ -160,9 +159,9 @@ public class PacketIOHelperTest extends HazelcastTestSupport {
             boolean writeCompleted;
             do {
                 writeCompleted = packetWriter.writeTo(originalPacket, bb);
-                upcast(bb).flip();
+                bb.flip();
                 clonedPacket = packetReader.readFrom(bb);
-                upcast(bb).clear();
+                bb.clear();
             } while (!writeCompleted);
 
             assertNotNull(clonedPacket);
@@ -181,7 +180,7 @@ public class PacketIOHelperTest extends HazelcastTestSupport {
         boolean written = packetWriter.writeTo(originalPacket, bb);
         assertTrue(written);
 
-        upcast(bb).flip();
+        bb.flip();
 
         Packet clonedPacket = packetReader.readFrom(bb);
         assertNotNull(clonedPacket);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockServerConnection.java
@@ -36,7 +36,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
-import static com.hazelcast.internal.util.JVMUtil.upcast;
 import static com.hazelcast.test.mocknetwork.MockServer.isTargetLeft;
 import static org.junit.Assert.assertNotNull;
 
@@ -157,12 +156,12 @@ public class MockServerConnection implements ServerConnection {
         boolean writeDone;
         do {
             writeDone = packetWriter.writeTo(packet, buffer);
-            upcast(buffer).flip();
+            buffer.flip();
             newPacket = packetReader.readFrom(buffer);
             if (buffer.hasRemaining()) {
                 throw new IllegalStateException("Buffer should be empty! " + buffer);
             }
-            upcast(buffer).clear();
+            buffer.clear();
         } while (!writeDone);
 
         assertNotNull(newPacket);


### PR DESCRIPTION
JVMUtils.upcast(Buffer) was introduced so that code compiled with Java 9+ runs on a Java 8 JVM. But we don't support Java 8 any longer, so we can get rid of this noise.

The JVMUtil.upcast method was not yet removed to prevent breaking EE. Once EE has been fixed, I will remove this method.

For Enterprise PR see: https://github.com/hazelcast/hazelcast-enterprise/pull/6905