### PR TITLE
Make `JVMUtil#getPid` use `ProcessHandle`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JVMUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JVMUtil.java
@@ -70,25 +70,11 @@ public final class JVMUtil {
     }
 
     /**
-     * Returns the process ID. The algorithm does not guarantee it will be able
-     * to get the correct process ID, in which case it returns {@code -1}.
+     * @return the process ID
+     * @see ProcessHandle#pid()
      */
     public static long getPid() {
-        String name = ManagementFactory.getRuntimeMXBean().getName();
-
-        if (name == null) {
-            return -1;
-        }
-        int separatorIndex = name.indexOf("@");
-        if (separatorIndex < 0) {
-            return -1;
-        }
-        String potentialPid = name.substring(0, separatorIndex);
-        try {
-            return Long.parseLong(potentialPid);
-        } catch (NumberFormatException e) {
-            return -1;
-        }
+        return ProcessHandle.current().pid();
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/JVMUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/JVMUtilTest.java
@@ -23,9 +23,8 @@ import com.hazelcast.test.annotation.QuickTest;
 
 import java.lang.management.ManagementFactory;
 
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -73,7 +72,7 @@ public class JVMUtilTest extends HazelcastTestSupport {
     public void testGetPid() {
        long legacyPidResult = getPidLegacy();
 
-       assumeThat(legacyPidResult, not(-1L));
+       assumeThat(legacyPidResult).isNotEqualTo(-1);
        assertEquals(legacyPidResult, JVMUtil.getPid());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/JVMUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/JVMUtilTest.java
@@ -20,6 +20,13 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+
+import java.lang.management.ManagementFactory;
+
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeThat;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -60,6 +67,36 @@ public class JVMUtilTest extends HazelcastTestSupport {
     @Test
     public void testIsObjectLayoutCompressedOopsOrNull() {
         JVMUtil.isObjectLayoutCompressedOopsOrNull();
+    }
+
+    @Test
+    public void testGetPid() {
+       long legacyPidResult = getPidLegacy();
+
+       assumeThat(legacyPidResult, not(-1L));
+       assertEquals(legacyPidResult, JVMUtil.getPid());
+    }
+
+    /**
+     * Returns the process ID. The algorithm does not guarantee it will be able
+     * to get the correct process ID, in which case it returns {@code -1}.
+     */
+    private static long getPidLegacy() {
+        String name = ManagementFactory.getRuntimeMXBean().getName();
+
+        if (name == null) {
+            return -1;
+        }
+        int separatorIndex = name.indexOf("@");
+        if (separatorIndex < 0) {
+            return -1;
+        }
+        String potentialPid = name.substring(0, separatorIndex);
+        try {
+            return Long.parseLong(potentialPid);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
     }
 
     // Prints the size of object reference as calculated by JVMUtil.


### PR DESCRIPTION
Java 9 introduced a new `ProcessHandle`, which allows easier access to the process ID than the current `ManagementFactory#getRuntimeMXBean()` implementation.

Swapped implementation to use `ProcessHandle`, test added to assert functional equivalence.