### PR TITLE
Replace `CollectionUtil#hasNonEmptyIntersection` with `Collections.disjoint`

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/StreamToStreamJoinP.java
@@ -59,7 +59,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.Streams.mapWithIndex;
-import static com.hazelcast.internal.util.CollectionUtil.hasNonEmptyIntersection;
 import static com.hazelcast.jet.Traversers.traverseStream;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.core.BroadcastKey.broadcastKey;
@@ -144,7 +143,7 @@ public class StreamToStreamJoinP extends AbstractProcessor {
         }
 
         // no key must be on both sides
-        if (hasNonEmptyIntersection(leftTimeExtractors.keySet(), rightTimeExtractors.keySet())) {
+        if (!Collections.disjoint(leftTimeExtractors.keySet(), rightTimeExtractors.keySet())) {
             throw new IllegalArgumentException("Some watermark key is found on both inputs. Left="
                     + leftTimeExtractors.keySet() + ", right=" + rightTimeExtractors.keySet());
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/CollectionUtil.java
@@ -156,14 +156,9 @@ public final class CollectionUtil {
     }
 
     /**
-     * Returns true, if the two collections contain any common item.
+     * @return {@code true}, if the two collections contain any common item.
      */
     public static <T> boolean hasNonEmptyIntersection(@Nonnull Collection<T> a, @Nonnull Collection<T> b) {
-        for (T t : a) {
-            if (b.contains(t)) {
-                return true;
-            }
-        }
-        return false;
+        return !Collections.disjoint(a, b);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/CollectionUtil.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.util;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 
-import javax.annotation.Nonnull;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -153,12 +152,5 @@ public final class CollectionUtil {
     /** Returns an empty Collection if argument is null. **/
     public static <T> Collection<T> nullToEmpty(Collection<T> collection) {
         return collection == null ? Collections.<T>emptyList() : collection;
-    }
-
-    /**
-     * @return {@code true}, if the two collections contain any common item.
-     */
-    public static <T> boolean hasNonEmptyIntersection(@Nonnull Collection<T> a, @Nonnull Collection<T> b) {
-        return !Collections.disjoint(a, b);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
@@ -23,15 +23,18 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.hazelcast.internal.util.CollectionUtil.asIntegerList;
 import static com.hazelcast.internal.util.CollectionUtil.getItemAtPositionOrNull;
@@ -224,5 +227,22 @@ public class CollectionUtilTest extends HazelcastTestSupport {
     public void testNullToEmpty_whenNotNull() {
         List<Integer> result = asList(1, 2, 3, 4, 5);
         assertEquals(result, nullToEmpty(result));
+    }
+
+    @Test
+    public void testHasNonEmptyIntersection() {
+        testHasNonEmptyIntersection(false, Collections.emptySet(), Collections.emptySet());
+        testHasNonEmptyIntersection(false, Set.of(1), Collections.emptySet());
+
+        testHasNonEmptyIntersection(true, Set.of(1), Set.of(1));
+        testHasNonEmptyIntersection(true, Set.of(1, 2), Set.of(1));
+
+        testHasNonEmptyIntersection(false, Set.of(1), Set.of(3));
+        testHasNonEmptyIntersection(false, Set.of(1, 2), Set.of(3));
+    }
+
+    public <T> void testHasNonEmptyIntersection(boolean expected, Collection<T> a, Collection<T> b) {
+        assertEquals(expected, CollectionUtil.hasNonEmptyIntersection(a, b));
+        assertEquals(expected, CollectionUtil.hasNonEmptyIntersection(b, a));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/CollectionUtilTest.java
@@ -29,11 +29,9 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import static com.hazelcast.internal.util.CollectionUtil.asIntegerList;
 import static com.hazelcast.internal.util.CollectionUtil.getItemAtPositionOrNull;
@@ -226,22 +224,5 @@ public class CollectionUtilTest extends HazelcastTestSupport {
     public void testNullToEmpty_whenNotNull() {
         List<Integer> result = asList(1, 2, 3, 4, 5);
         assertEquals(result, nullToEmpty(result));
-    }
-
-    @Test
-    public void testHasNonEmptyIntersection() {
-        testHasNonEmptyIntersection(false, Collections.emptySet(), Collections.emptySet());
-        testHasNonEmptyIntersection(false, Set.of(1), Collections.emptySet());
-
-        testHasNonEmptyIntersection(true, Set.of(1), Set.of(1));
-        testHasNonEmptyIntersection(true, Set.of(1, 2), Set.of(1));
-
-        testHasNonEmptyIntersection(false, Set.of(1), Set.of(3));
-        testHasNonEmptyIntersection(false, Set.of(1, 2), Set.of(3));
-    }
-
-    public <T> void testHasNonEmptyIntersection(boolean expected, Collection<T> a, Collection<T> b) {
-        assertEquals(expected, CollectionUtil.hasNonEmptyIntersection(a, b));
-        assertEquals(expected, CollectionUtil.hasNonEmptyIntersection(b, a));
     }
 }


### PR DESCRIPTION
The same behaviour can be achieved using a built-in Collections method, and is ~50% faster in a simple test case (2.6ns vs 1.78ns)

Utility method removed (as already contained in JDK), sole caller updated.