### PR TITLE
Update JobConfig#addJar(URL) Javadoc

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -350,7 +350,8 @@ public class JobConfig implements IdentifiedDataSerializable {
      * <p>
      * This variant identifies the JAR with a URL, which must contain at least one
      * path segment. The last path segment ("filename") will be used as the resource
-     * ID, so two JARs with the same filename will be in conflict.
+     * ID - if there's already a resource with that ID, it will <strong>not be
+     * replaced</strong>.
      * <p>
      * Cannot be used for {@linkplain JetService#newLightJob(Pipeline) light
      * jobs}.


### PR DESCRIPTION
To explain behavior when overlapping `JAR` names.

Addresses query on [community slack](https://hazelcastcommunity.slack.com/archives/C015Q2TUBKL/p1701068088454909).