### PR TITLE
Removed JVMUtil.upcast(ByteBuffer).

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JVMUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JVMUtil.java
@@ -22,7 +22,6 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeDataSupport;
 import java.lang.management.ManagementFactory;
-import java.nio.Buffer;
 
 import static com.hazelcast.internal.memory.impl.UnsafeUtil.UNSAFE;
 import static com.hazelcast.internal.memory.impl.UnsafeUtil.UNSAFE_AVAILABLE;
@@ -111,36 +110,6 @@ public final class JVMUtil {
         } while (totalBegin != totalEnd);
 
         return used;
-    }
-
-    /**
-     * Explicit cast to {@link Buffer} parent buffer type. It resolves issues with covariant return types in Java 9+ for
-     * {@link java.nio.ByteBuffer} and {@link java.nio.CharBuffer}. Explicit casting resolves the NoSuchMethodErrors (e.g
-     * java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer) when the project is compiled with newer
-     * Java version and run on Java 8.
-     * <p/>
-     * <a href="https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html">Java 8</a> doesn't provide override the
-     * following Buffer methods in subclasses:
-     *
-     * <pre>
-     * Buffer clear​()
-     * Buffer flip​()
-     * Buffer limit​(int newLimit)
-     * Buffer mark​()
-     * Buffer position​(int newPosition)
-     * Buffer reset​()
-     * Buffer rewind​()
-     * </pre>
-     *
-     * <a href="https://docs.oracle.com/javase/9/docs/api/java/nio/ByteBuffer.html">Java 9</a> introduces the overrides in child
-     * classes (e.g the ByteBuffer), but the return type is the specialized one and not the abstract {@link Buffer}. So the code
-     * compiled with newer Java is not working on Java 8 unless a workaround with explicit casting is used.
-     *
-     * @param buf buffer to cast to the abstract {@link Buffer} parent type
-     * @return the provided buffer
-     */
-    public static Buffer upcast(Buffer buf) {
-        return buf;
     }
 
     // not private for testing


### PR DESCRIPTION
Method isn't used any longer, so goodbye.
