### PR TITLE
Fix: UpdatingEntryProcessor can be created by malicious user with tampered ExpressionEvalContext

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/PlanExecutor.java
@@ -88,6 +88,7 @@ import com.hazelcast.sql.impl.SqlErrorCode;
 import com.hazelcast.sql.impl.UpdateSqlResultImpl;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.expression.UntrustedExpressionEvalContext;
 import com.hazelcast.sql.impl.row.EmptyRow;
 import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.sql.impl.schema.dataconnection.DataConnectionCatalogEntry;
@@ -683,7 +684,7 @@ public class PlanExecutor {
 
         Object key = plan.keyCondition().eval(EmptyRow.INSTANCE, evalContext);
         CompletableFuture<Long> future = hazelcastInstance.getMap(plan.mapName())
-                .submitToKey(key, plan.updaterSupplier().get(evalContext))
+                .submitToKey(key, plan.updaterSupplier().get(UntrustedExpressionEvalContext.from(evalContext)))
                 .toCompletableFuture();
         await(future, timeout);
         directIMapQueriesExecuted.getAndIncrement();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorSupplier.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorSupplier.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.security.impl.function.SecuredFunctions;
 import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.expression.UntrustedExpressionEvalContext;
 import com.hazelcast.sql.impl.row.JetSqlRow;
 
 import javax.annotation.Nonnull;
@@ -103,7 +104,7 @@ final class UpdateProcessorSupplier implements ProcessorSupplier, DataSerializab
             assert row.getFieldCount() == 1;
             keys.add(row.get(0));
         }
-        return map.submitToKeys(keys, updaterSupplier.get(evalContext))
+        return map.submitToKeys(keys, updaterSupplier.get(UntrustedExpressionEvalContext.from(evalContext)))
                 .toCompletableFuture()
                 .thenApply(m -> Traversers.empty());
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/UpdatingEntryProcessor.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/UpdatingEntryProcessor.java
@@ -35,6 +35,7 @@ import com.hazelcast.sql.impl.expression.ColumnExpression;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.Expression;
 import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
+import com.hazelcast.sql.impl.expression.UntrustedExpressionEvalContext;
 import com.hazelcast.sql.impl.row.JetSqlRow;
 import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.schema.map.MapTableField;
@@ -75,13 +76,13 @@ public final class UpdatingEntryProcessor
     private UpdatingEntryProcessor(
             KvRowProjector.Supplier rowProjectorSupplier,
             Projector.Supplier valueProjectorSupplier,
-            ExpressionEvalContext evalContext) {
+            UntrustedExpressionEvalContext evalContext) {
         this.rowProjectorSupplier = rowProjectorSupplier;
         this.valueProjectorSupplier = valueProjectorSupplier;
         this.evalContext = evalContext;
         this.extractors = Extractors.newBuilder(evalContext.getSerializationService()).build();
         this.arguments = evalContext.getArguments();
-        this.subject = evalContext.subject();
+        //   this.subject = evalContext.subject();
     }
 
     @Override
@@ -197,7 +198,7 @@ public final class UpdatingEntryProcessor
             this.valueProjectorSupplier = valueProjectorSupplier;
         }
 
-        public EntryProcessor<Object, Object, Long> get(ExpressionEvalContext eec) {
+        public EntryProcessor<Object, Object, Long> get(UntrustedExpressionEvalContext eec) {
             return new UpdatingEntryProcessor(rowProjectorSupplier, valueProjectorSupplier, eec);
         }
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/UntrustedExpressionEvalContext.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/sql/impl/expression/UntrustedExpressionEvalContext.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.sql.impl.expression;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.spi.impl.NodeEngine;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.security.auth.Subject;
+import java.security.Permission;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Specifies an untrusted context for assessing expressions.
+ * Contains identical information as the trusted context {@code ExpressionEvalContextImpl}, except for the security context.
+ * If an attempt is made to acquire a security context, an exception will be raised,
+ * indicating that the context lacks trust.
+ * This class is utilized in scenarios where obtaining a trusted security context is unfeasible.
+ */
+public class UntrustedExpressionEvalContext
+        implements ExpressionEvalContext {
+    private final List<Object> arguments;
+    private final transient InternalSerializationService serializationService;
+    private final transient NodeEngine nodeEngine;
+
+    private UntrustedExpressionEvalContext(
+            @Nonnull List<Object> arguments,
+            @Nonnull InternalSerializationService serializationService,
+            @Nonnull NodeEngine nodeEngine) {
+        this.arguments = requireNonNull(arguments);
+        this.serializationService = requireNonNull(serializationService);
+        this.nodeEngine = requireNonNull(nodeEngine);
+    }
+
+    public static UntrustedExpressionEvalContext from(ExpressionEvalContext context) {
+        return new UntrustedExpressionEvalContext(
+                context.getArguments(),
+                context.getSerializationService(),
+                context.getNodeEngine()
+        );
+    }
+
+    @Override
+    public Object getArgument(int index) {
+        return arguments.get(index);
+    }
+
+    @Override
+    public List<Object> getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public InternalSerializationService getSerializationService() {
+        return serializationService;
+    }
+
+    @Override
+    public UntrustedExpressionEvalContext withSerializationService(@Nonnull InternalSerializationService newService) {
+        if (serializationService == newService) {
+            return this;
+        }
+        return new UntrustedExpressionEvalContext(
+                arguments,
+                newService,
+                nodeEngine
+        );
+    }
+
+    @Override
+    public NodeEngine getNodeEngine() {
+        return nodeEngine;
+    }
+
+    @Override
+    public void checkPermission(Permission permission) {
+        throw new SecurityException("Unable to employ sensitive functions in untrusted invocations.");
+    }
+
+    @Override
+    @Nullable
+    public Subject subject() {
+        throw new SecurityException("Unable to employ sensitive functions in untrusted invocations.");
+    }
+}

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/UpdateProcessorTest.java
@@ -26,8 +26,8 @@ import com.hazelcast.sql.impl.QueryUtils;
 import com.hazelcast.sql.impl.expression.ColumnExpression;
 import com.hazelcast.sql.impl.expression.ConstantExpression;
 import com.hazelcast.sql.impl.expression.Expression;
-import com.hazelcast.sql.impl.expression.ExpressionEvalContext;
 import com.hazelcast.sql.impl.expression.ParameterExpression;
+import com.hazelcast.sql.impl.expression.UntrustedExpressionEvalContext;
 import com.hazelcast.sql.impl.expression.math.PlusFunction;
 import com.hazelcast.sql.impl.extract.GenericQueryTargetDescriptor;
 import com.hazelcast.sql.impl.extract.QueryPath;
@@ -119,7 +119,7 @@ public class UpdateProcessorTest extends SqlTestSupport {
     public void when_serializedObject_then_deserializedCorrect() {
         AbstractSerializationService service = (AbstractSerializationService) TestUtil.getNode(instance()).getSerializationService();
 
-        var evalContextMock = mock(ExpressionEvalContext.class);
+        var evalContextMock = mock(UntrustedExpressionEvalContext.class);
         when(evalContextMock.getSerializationService()).thenReturn(mock());
         var subject = new Subject(true, emptySet(), emptySet(), emptySet());
         when(evalContextMock.subject()).thenReturn(subject);


### PR DESCRIPTION
…sor uses untrusted context.

<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.pinpointhq.com/
-->

INSERT_PR_DESCRIPTION_HERE

Fixes INSERT_LINK_TO_THE_ISSUE_HERE

Backport of: INSERT_LINK_TO_THE_ORIGINAL_PR_HERE

EE PR: INSERT_LINK_TO_THE_EE_PR_HERE

Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
