### PR TITLE
Update data-migration-5.3 to 5.3.6

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extensions/avro/pom.xml
+++ b/extensions/avro/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/extensions/csv/pom.xml
+++ b/extensions/csv/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/elasticsearch/elasticsearch-6/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-6/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions/elasticsearch/elasticsearch-7/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-7/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions/grpc/pom.xml
+++ b/extensions/grpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hadoop-dist/files-azure/pom.xml
+++ b/extensions/hadoop-dist/files-azure/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-hadoop-dist</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hadoop-dist/files-gcs/pom.xml
+++ b/extensions/hadoop-dist/files-gcs/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-hadoop-dist</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hadoop-dist/files-s3/pom.xml
+++ b/extensions/hadoop-dist/files-s3/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>hazelcast-jet-hadoop-dist</artifactId>
         <groupId>com.hazelcast.jet</groupId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extensions/hadoop-dist/hadoop-all/pom.xml
+++ b/extensions/hadoop-dist/hadoop-all/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-hadoop-dist</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hadoop-dist/hadoop/pom.xml
+++ b/extensions/hadoop-dist/hadoop/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-hadoop-dist</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hadoop-dist/pom.xml
+++ b/extensions/hadoop-dist/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/extensions/hadoop/pom.xml
+++ b/extensions/hadoop/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-common/pom.xml
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hazelcast-3-connector-root</artifactId>
         <groupId>com.hazelcast</groupId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <artifactId>hazelcast-3-connector-common</artifactId>

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-impl/pom.xml
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hazelcast-3-connector-root</artifactId>
         <groupId>com.hazelcast</groupId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <artifactId>hazelcast-3-connector-impl</artifactId>

--- a/extensions/hazelcast-3-connector/hazelcast-3-connector-interface/pom.xml
+++ b/extensions/hazelcast-3-connector/hazelcast-3-connector-interface/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hazelcast-3-connector-root</artifactId>
         <groupId>com.hazelcast</groupId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <artifactId>hazelcast-3-connector-interface</artifactId>

--- a/extensions/hazelcast-3-connector/pom.xml
+++ b/extensions/hazelcast-3-connector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions/kafka-connect/pom.xml
+++ b/extensions/kafka-connect/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/kinesis/pom.xml
+++ b/extensions/kinesis/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/mapstore/pom.xml
+++ b/extensions/mapstore/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/mongodb/pom.xml
+++ b/extensions/mongodb/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/extensions/protobuf/pom.xml
+++ b/extensions/protobuf/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/python/pom.xml
+++ b/extensions/python/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/s3/pom.xml
+++ b/extensions/s3/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-build-utils/pom.xml
+++ b/hazelcast-build-utils/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-coverage-report/pom.xml
+++ b/hazelcast-coverage-report/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>hazelcast-root</artifactId>
         <groupId>com.hazelcast</groupId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/hazelcast-it/distribution-it/pom.xml
+++ b/hazelcast-it/distribution-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-it</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <artifactId>distribution-it</artifactId>

--- a/hazelcast-it/jdk17-tests/pom.xml
+++ b/hazelcast-it/jdk17-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-it</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdk17-tests</artifactId>

--- a/hazelcast-it/pom.xml
+++ b/hazelcast-it/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
     </parent>
 
     <artifactId>hazelcast-it</artifactId>

--- a/hazelcast-spring-tests/pom.xml
+++ b/hazelcast-spring-tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-tpc-engine/pom.xml
+++ b/hazelcast-tpc-engine/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -468,7 +468,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-tpc-engine</artifactId>
-            <version>5.3.5-DM-SNAPSHOT</version>
+            <version>5.3.6-DM-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1124,7 +1124,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                 //  changed data and use that. Since this only matters for WAN-received merge events, we can avoid
                 //  additional overhead by checking provenance. Fixes HZ-3392, Backlog for merge changes: HZ-3397
                 boolean shouldMergeExpiration = provenance != CallerProvenance.WAN
-                        || valueComparator.isEqual(oldValue, mergingEntry.getValue(), serializationService);
+                        || valueComparator.isEqual(existingEntry.getRawValue(), mergingEntry.getRawValue(), serializationService);
                 if (shouldMergeExpiration) {
                     mergeRecordExpiration(key, record, mergingEntry, now);
                 }

--- a/hazelcast/src/main/resources/release_notes.txt
+++ b/hazelcast/src/main/resources/release_notes.txt
@@ -1,27 +1,5 @@
-This document lists the enhancements, fixed issues, and removed or deprecated features for Hazelcast Platform 5.3.5 release. The numbers in the square brackets refer to the issues and pull requests in Hazelcast's GitHub repository.
-
-NOTE: Due to an error in the tooling, the Platform releases 5.3.3 and 5.3.4 needed to be skipped numerically.
-
-## Enhancements
-
-* Improved the permission checks by fixing the [CVE-2023-45859](https://nvd.nist.gov/vuln/detail/CVE-2023-45859) and [CVE-2023-45860](https://nvd.nist.gov/vuln/detail/CVE-2023-45860) vulnerabilities.
-* Changed the exception type from `CancellationException` to `CancellationByUserException` in case the user cancels a job before it is initialized. [#25452]
-* Updated the versions of following dependencies
-  ** gRPC to 1.57.0
-  ** Netty to 4.1.100
-  ** Avro to 1.1.13
-  ** Snappy Java to 1.1.10.5
-  ** Elasticsearch to 7.17.13
-  [#25430], [#25670], [#25659]
-* Renamed the service port for Hazelcast clusters deployed in Kubernetes environments as `hazelcast`.
-Previously, the name was `hazelcast-service-port` causing the member auto-discovery (for embedded deployments) to fail. [#24834]
+This document lists the enhancements, fixed issues, and removed or deprecated features for Hazelcast Platform 5.3.6 release. The numbers in the square brackets refer to the issues and pull requests in Hazelcast's GitHub repository.
 
 ## Fixes
 
-* Fixed an issue where the map entries' metadata, such as time-to-live and expiration, was not replicated correctly over WAN after updating existing entries. [#25505]
-* Fixed an issue where the member list was not updated after a cluster failover scenario. [#25504]
-* Fixed a memory leak issue happening in Hazelcast members and clients while destroying fenced locks. [#25421]
-
-## Removed/Deprecated Features
-
-* Removed the evaluation tool (to try out Platform 5.x features for IMDG 3.x users) and the relevant IMDG 3.x JAR libraries from Hazelcast Platform distributions. [#25663]
+* Fixed a WAN replication failure - when using maps with WAN replication enabled, and BINARY or NATIVE in-memory formats for the entries, WAN replication was failing when an entry is updated with the same key/value pair, and the cluster members lack serialization information. [#25899]

--- a/modulepath-tests/pom.xml
+++ b/modulepath-tests/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.3.5-DM-SNAPSHOT</version>
+        <version>5.3.6-DM-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-root</artifactId>
     <packaging>pom</packaging>
-    <version>5.3.5-DM-SNAPSHOT</version>
+    <version>5.3.6-DM-SNAPSHOT</version>
     <name>Hazelcast Root</name>
     <description>Hazelcast In-Memory DataGrid</description>
     <url>http://www.hazelcast.com/</url>


### PR DESCRIPTION
As per the discussion in the phase 2 requirements elaboration meeting, I merged v5.3.6 tag into data-migration-5.3 

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6917

