### PR TITLE
Minimise the chance of using unavailable member during leaderships transfer [HZ-3913]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
@@ -658,7 +658,10 @@ class RaftGroupMembershipManager {
             CPGroupId groupId = null;
             int min = maxLeaderships;
             for (CPGroupSummary group : groups) {
-                for (CPMember member : group.members()) {
+                List<CPMember> groupMembers = new ArrayList<>(group.members());
+                // If the destination member is unavailable minimise the probability of using it next time
+                Collections.shuffle(groupMembers);
+                for (CPMember member : groupMembers) {
                     Collection<CPGroupId> g = leaderships.get(member);
                     if (g == null) {
                         continue;

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/AbstractAtomicRegisterSnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/AbstractAtomicRegisterSnapshotTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractAtomicRegisterSnapshotTest<T> extends HazelcastRaf
         }
 
         SnapshotEntry snapshotEntry = leaderNode.state().log().snapshot();
-        assertEquals(SNAPSHOT_THRESHOLD, snapshotEntry.index());
+        assertGreaterOrEquals("snapshot size", snapshotEntry.index(), SNAPSHOT_THRESHOLD);
 
         // shutdown the last instance
         instances[instances.length - 1].shutdown();
@@ -106,7 +106,7 @@ public abstract class AbstractAtomicRegisterSnapshotTest<T> extends HazelcastRaf
 
         RaftNodeImpl raftNode = getRaftNode(instance, getGroupId());
         SnapshotEntry newNodeSnapshotEntry = raftNode.state().log().snapshot();
-        assertEquals(SNAPSHOT_THRESHOLD, newNodeSnapshotEntry.index());
+        assertGreaterOrEquals("snapshot size", newNodeSnapshotEntry.index(), SNAPSHOT_THRESHOLD);
     }
 
     protected T getValue(InternalCompletableFuture<Object> future) {


### PR DESCRIPTION
The new leader-to-transfer should be selected randomly, if several CP members have the same cpMemberPriority priority. It should minimise the chance of constantly using the same overloaded/unavailable member to transfer the leadership.

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
