### PR TITLE
Improve `SortingUtil` `PagingPredicate` `ClassCastException` exception message

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/SortingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/SortingUtil.java
@@ -135,7 +135,8 @@ public final class SortingUtil {
         if (pagingPredicate == null || list.isEmpty()) {
             return list;
         }
-        PagingPredicateImpl pagingPredicateImpl = PredicateUtils.convertToPagingPredicateImpl(pagingPredicate, "getSortedSubList");
+        PagingPredicateImpl pagingPredicateImpl =
+                PredicateUtils.convertToPagingPredicateImpl(pagingPredicate, "getSortedSubList");
         Comparator<QueryableEntry> comparator = newComparator(pagingPredicateImpl);
         Collections.sort(list, comparator);
         int nearestPage = nearestAnchorEntry.getKey();
@@ -165,7 +166,8 @@ public final class SortingUtil {
         if (anchor == null) {
             return true;
         }
-        PagingPredicateImpl pagingPredicateImpl = PredicateUtils.convertToPagingPredicateImpl(pagingPredicate, "getSortedSubList");
+        PagingPredicateImpl pagingPredicateImpl =
+                PredicateUtils.convertToPagingPredicateImpl(pagingPredicate, "getSortedSubList");
         Comparator<Map.Entry> comparator = pagingPredicate.getComparator();
         IterationType iterationType = pagingPredicateImpl.getIterationType();
         return SortingUtil.compare(comparator, iterationType, anchor, queryEntry) < 0;
@@ -226,7 +228,8 @@ public final class SortingUtil {
         if (list.isEmpty()) {
             return new AbstractMap.SimpleImmutableEntry<>(-1, -1);
         }
-        PagingPredicateImpl pagingPredicateImpl = PredicateUtils.convertToPagingPredicateImpl(pagingPredicate, "getPageIndexesAndUpdateAnchor");
+        PagingPredicateImpl pagingPredicateImpl =
+                PredicateUtils.convertToPagingPredicateImpl(pagingPredicate, "getPageIndexesAndUpdateAnchor");
         Comparator<Map.Entry> comparator = SortingUtil.newComparator(pagingPredicateImpl.getComparator(), iterationType);
         Collections.sort(list, comparator);
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
@@ -80,22 +80,36 @@ public final class PredicateUtils {
     }
 
     /**
-     * This method is used for checking a predicate that it is not/does not contain a {@link com.hazelcast.query.PagingPredicate}
+     * This method is used for checking a predicate that it is not/does not contain a {@link PagingPredicate}
      *
-     * @throws IllegalArgumentException if the predicate is a {@link com.hazelcast.query.PagingPredicate} or is a
-     *                                  {@link com.hazelcast.query.PartitionPredicate} that includes a
-     *                                  {@link com.hazelcast.query.PagingPredicate}
+     * @throws IllegalArgumentException if the predicate is a {@link PagingPredicate} or is a {@link PartitionPredicate} that
+     *         includes a {@link PagingPredicate}
      */
-    public static void checkDoesNotContainPagingPredicate(Predicate predicate, String methodName)
+    public static void checkDoesNotContainPagingPredicate(Predicate<?, ?> predicate, String methodName)
             throws IllegalArgumentException {
-        if (PredicateUtils.containsPagingPredicate(predicate)) {
+        if (containsPagingPredicate(predicate)) {
             throw new IllegalArgumentException("Paging predicate is not supported in " + methodName + " method");
         }
     }
 
     /**
-     * Returns true if the predicate passed is a {@link com.hazelcast.query.PagingPredicate}
-     * or is a {@link com.hazelcast.query.PartitionPredicate} that includes a {@link com.hazelcast.query.PagingPredicate}
+     * Safely casts {@code predicate} to a {@link PagingPredicateImpl}
+     * 
+     * @throws IllegalArgumentException if the predicate is not a {@link PagingPredicateImpl}
+     */
+    public static <K, V> PagingPredicateImpl<K, V> convertToPagingPredicateImpl(Predicate<K, V> predicate, String methodName)
+            throws IllegalArgumentException {
+        if (predicate instanceof PagingPredicateImpl) {
+            return (PagingPredicateImpl<K, V>) predicate;
+        } else {
+            throw new IllegalArgumentException(
+                    "Only " + PagingPredicateImpl.class.getSimpleName() + " is supported in " + methodName + " method");
+        }
+    }
+
+    /**
+     * @return {@code true} if the predicate passed is a {@link PagingPredicate} or is a {@link PartitionPredicate} that
+     *         includes a {@link PagingPredicate}
      */
     public static boolean containsPagingPredicate(Predicate predicate) {
         if (predicate instanceof PagingPredicateImpl) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
@@ -94,7 +94,7 @@ public final class PredicateUtils {
 
     /**
      * Safely casts {@code predicate} to a {@link PagingPredicateImpl}
-     * 
+     *
      * @throws IllegalArgumentException if the predicate is not a {@link PagingPredicateImpl}
      */
     public static <K, V> PagingPredicateImpl<K, V> convertToPagingPredicateImpl(Predicate<K, V> predicate, String methodName)

--- a/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
@@ -643,7 +643,7 @@ public class PagingPredicateTest extends HazelcastTestSupport {
     public void testExecuteOnEntriesThrowsWithPredicateIncludingPagingPredicate() {
         map.executeOnEntries(entry -> 1, PREDICATE_INCLUDING_PAGING_PREDICATE);
     }
-    
+
     /**
      * @see <a href="https://github.com/hazelcast/hazelcast/issues/26036">non-`PagingPredicateImpl` `PagingPredicate` throws
      *      `ClassCastException`</a>

--- a/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.map.impl.query.AlwaysTruePagingPredicate;
 import com.hazelcast.map.listener.NoopMapListener;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.PagingPredicate;
@@ -641,6 +642,15 @@ public class PagingPredicateTest extends HazelcastTestSupport {
     @Test(expected = IllegalArgumentException.class)
     public void testExecuteOnEntriesThrowsWithPredicateIncludingPagingPredicate() {
         map.executeOnEntries(entry -> 1, PREDICATE_INCLUDING_PAGING_PREDICATE);
+    }
+    
+    /**
+     * @see <a href="https://github.com/hazelcast/hazelcast/issues/26036">non-`PagingPredicateImpl` `PagingPredicate` throws
+     *      `ClassCastException`</a>
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testIssue26036() {
+        map.values(new AlwaysTruePagingPredicate<>());
     }
 
     private IMap<Integer, Employee> makeEmployeeMap(int maxEmployees) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/AlwaysTruePagingPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/AlwaysTruePagingPredicate.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.query.PagingPredicate;
+
+import java.util.Comparator;
+import java.util.Map.Entry;
+
+public class AlwaysTruePagingPredicate<K, V> implements PagingPredicate<K, V> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public boolean apply(Entry<K, V> mapEntry) {
+        return true;
+    }
+
+    @Override
+    public void reset() {
+    }
+
+    @Override
+    public void nextPage() {
+    }
+
+    @Override
+    public void previousPage() {
+    }
+
+    @Override
+    public int getPage() {
+        return 1;
+    }
+
+    @Override
+    public void setPage(int page) {
+    }
+
+    @Override
+    public int getPageSize() {
+        return 1;
+    }
+
+    @Override
+    public Comparator<Entry<K, V>> getComparator() {
+        return null;
+    }
+
+    @Override
+    public Entry<K, V> getAnchor() {
+        return null;
+    }
+}


### PR DESCRIPTION
`SortingUtil.getPageIndexesAndUpdateAnchor(List<? extends Entry>, PagingPredicate, IterationType)` casts the `PagingPredicate` to a `PagingPredicateImpl`, but if it isn't one, a `ClassCastException` is thrown.

This [mismatch between parameter and execution type is intentional](https://github.com/hazelcast/hazelcast/pull/26040#issuecomment-1831364729), but this isn't immediately obvious when then the exception is thrown - instead, a better exception should be thrown.

Fixes https://github.com/hazelcast/hazelcast/issues/26039

Changes:
- Utility method added to `PredicateUtils` to handle this scenario
- `SortingUtil` casts replaced with utility method reference
- Address some warnings in the changed areas about missing/redundant generic types