### PR TITLE
Fix SecuredFunctionTest.test_updateWithEntryProcessorFn [HZ-3946]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AbstractHazelcastConnectorSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/AbstractHazelcastConnectorSupplier.java
@@ -107,8 +107,18 @@ public abstract class AbstractHazelcastConnectorSupplier implements ProcessorSup
 
     protected abstract Processor createProcessor(HazelcastInstance instance, SerializationService serializationService);
 
+    /**
+     * Return if ProcessorSupplier is for local cluster or not
+     */
     boolean isLocal() {
         return (clientXml == null) && (dataConnectionName == null);
+    }
+
+    /**
+     * Return if ProcessorSupplier is for remote cluster or not
+     */
+    boolean isRemote() {
+        return !isLocal();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
@@ -192,7 +192,9 @@ public final class WriteMapP<T, K, V> extends AsyncHazelcastWriterP {
 
         @Override
         public List<Permission> permissions() {
-            return singletonList(mapPutPermission(clientXml, mapName));
+            // Return permissions for this ProcessorSupplier
+            Permission permission = mapPutPermission(isRemote(), mapName);
+            return singletonList(permission);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/security/PermissionsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/PermissionsUtil.java
@@ -71,9 +71,19 @@ public final class PermissionsUtil {
                 new MapPermission(name, ACTION_CREATE, ACTION_PUT, ACTION_REMOVE, ACTION_READ));
     }
 
+    @Nonnull
+    public static Permission mapUpdatePermission(@Nonnull String name) {
+        return new MapPermission(name, ACTION_CREATE, ACTION_PUT, ACTION_REMOVE, ACTION_READ);
+    }
+
     @Nullable
     public static Permission mapPutPermission(boolean isRemote, @Nonnull String name) {
         return checkRemote(isRemote, new MapPermission(name, ACTION_CREATE, ACTION_PUT));
+    }
+
+    @Nonnull
+    public static Permission mapPutPermission(@Nonnull String name) {
+        return new MapPermission(name, ACTION_CREATE, ACTION_PUT);
     }
 
     @Nullable

--- a/hazelcast/src/main/java/com/hazelcast/security/PermissionsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/PermissionsUtil.java
@@ -44,7 +44,7 @@ public final class PermissionsUtil {
     }
 
     @Nullable
-    public static Permission checkRemote(@Nullable String clientXml, @Nonnull Permission permission) {
+    private static Permission checkRemote(@Nullable String clientXml, @Nonnull Permission permission) {
         if (clientXml == null) {
             return permission;
         }
@@ -52,7 +52,7 @@ public final class PermissionsUtil {
     }
 
     @Nullable
-    public static Permission checkRemote(boolean isRemote, @Nonnull Permission permission) {
+    private static Permission checkRemote(boolean isRemote, @Nonnull Permission permission) {
         if (isRemote) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/security/PermissionsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/PermissionsUtil.java
@@ -51,6 +51,13 @@ public final class PermissionsUtil {
         return null;
     }
 
+    @Nullable
+    public static Permission checkRemote(boolean isRemote, @Nonnull Permission permission) {
+        if (isRemote) {
+            return null;
+        }
+        return permission;
+    }
 
     @Nullable
     public static Permission mapUpdatePermission(@Nullable String clientXml, @Nonnull String name) {
@@ -59,8 +66,14 @@ public final class PermissionsUtil {
     }
 
     @Nullable
-    public static Permission mapPutPermission(@Nullable String clientXml, @Nonnull String name) {
-        return checkRemote(clientXml, new MapPermission(name, ACTION_CREATE, ACTION_PUT));
+    public static Permission mapUpdatePermission(boolean isRemote, @Nonnull String name) {
+        return checkRemote(isRemote,
+                new MapPermission(name, ACTION_CREATE, ACTION_PUT, ACTION_REMOVE, ACTION_READ));
+    }
+
+    @Nullable
+    public static Permission mapPutPermission(boolean isRemote, @Nonnull String name) {
+        return checkRemote(isRemote, new MapPermission(name, ACTION_CREATE, ACTION_PUT));
     }
 
     @Nullable

--- a/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunctions.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/impl/function/SecuredFunctions.java
@@ -356,7 +356,7 @@ public final class SecuredFunctions {
 
     public static <T, K, V> FunctionEx<HazelcastInstance, Processor> updateMapProcessorFn(
             String name,
-            String clientXml,
+            boolean isRemote,
             FunctionEx<? super T, ? extends K> toKeyFn,
             BiFunctionEx<? super V, ? super T, ? extends V> updateFn
     ) {
@@ -370,7 +370,8 @@ public final class SecuredFunctions {
 
             @Override
             public List<Permission> permissions() {
-                return singletonList(mapUpdatePermission(clientXml, name));
+                Permission permission = mapUpdatePermission(isRemote, name);
+                return singletonList(permission);
             }
         };
     }
@@ -378,7 +379,7 @@ public final class SecuredFunctions {
     public static <T, R, K, V> FunctionEx<HazelcastInstance, Processor> updateWithEntryProcessorFn(
             int maxParallelAsyncOps,
             String name,
-            String clientXml,
+            boolean isRemote,
             FunctionEx<? super T, ? extends K> toKeyFn,
             FunctionEx<? super T, ? extends EntryProcessor<K, V, R>> toEntryProcessorFn
     ) {
@@ -393,7 +394,8 @@ public final class SecuredFunctions {
 
             @Override
             public List<Permission> permissions() {
-                return singletonList(mapUpdatePermission(clientXml, name));
+                Permission permission = mapUpdatePermission(isRemote, name);
+                return singletonList(permission);
             }
         };
     }


### PR DESCRIPTION
The test is failing because HazelcastWriters was not setting the permission correctly.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
