### PR TITLE
[CN-296] Increase Kubernetes auto-discovery test timeout

### DIFF
--- a/.github/workflows/k8s-terraform-integration-tests.yml
+++ b/.github/workflows/k8s-terraform-integration-tests.yml
@@ -101,5 +101,5 @@ jobs:
       - name: Run Tests
         working-directory: auto-discovery-suite/terraform/test
         run: |
-          go test -v -timeout 60m -run TestSuite -suite ${{ matrix.suite }} -member-image ${{ needs.build.outputs.HZ_IMG }} 
+          go test -v -timeout 120m -run TestSuite -suite ${{ matrix.suite }} -member-image ${{ needs.build.outputs.HZ_IMG }} 
           -client-image ${{ needs.build.outputs.CL_IMG }}


### PR DESCRIPTION
It increases the Kubernetes auto-discovery test timeout.

Checklist:
- [X] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [X] Request reviewers if possible
