### PR TITLE
Resolve `HazelcastServerCommandLineTest.test_log4j2_exception` system property mutation causing unrelated test failures

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRule.java
@@ -24,6 +24,9 @@ import org.junit.runners.model.Statement;
  * Sets or clears a property before running a test. The property will be restored once the test is finished.
  * <p>
  * Can be used for finer control of the scope of a System property.
+ * <p>
+ * Consider using {@link uk.org.webcompere.systemstubs.jupiter.SystemStub}'s
+ * {@link uk.org.webcompere.systemstubs.properties.SystemProperties}
  */
 public final class OverridePropertyRule implements TestRule {
 

--- a/pom.xml
+++ b/pom.xml
@@ -2136,6 +2136,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <version>2.1.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
The `HazelcastServerCommandLineTest.test_log4j2_exception()` test is setting system properties to force an exception to occur, but not unsetting those properties afterwards, causing downstream tests to fail.

This property mutation should be isolated to the test.

Changes:
- `system-stubs` dependency added
   - similar functionality to `OverridePropertyRule`, but for JUnit5
- Added `hazelcast:tests` dependency to `distribution/pom.xml`
   - Allows access to `system-stubs`
- Replaced `System.setProperty` calls with new `SystemProperties` dependency

Fixes: https://github.com/hazelcast/hazelcast/issues/26088