### PR TITLE
Add a warning about `nexus-staging-maven-plugin` deploy behaviour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1553,6 +1553,10 @@
     <distributionManagement>
         <repository>
             <id>release-repository</id>
+            <!-- Irrespective of this configuration, nexus-staging-maven-plugin
+            will *also* deploy to it's own staging destination, configured in
+            //project//plugin[artifactId='nexus-staging-maven-plugin']/configuration/nexusUrl
+            (i.e. Maven central) -->
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
         <snapshotRepository>


### PR DESCRIPTION
`nexus-staging-maven-plugin` deploys to an additional repository outside of `distributionManagement`, which is what lead to an accidental public release of `5.3.4`.

Documentation added to help catch this in future.