### PR TITLE
Always build extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <module>hazelcast-spring-tests</module>
         <module>hazelcast-build-utils</module>
         <module>hazelcast-sql</module>
+        <module>extensions</module>
     </modules>
 
     <properties>
@@ -1509,7 +1510,6 @@
                 </property>
             </activation>
             <modules>
-                <module>extensions</module>
                 <module>distribution</module>
                 <module>hazelcast-it</module>
             </modules>


### PR DESCRIPTION
It's needed as extensions are now necessary to be rebuild due to shading & sql connectors outside hazelcast-sql.

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
