### PR TITLE
Litter reduction in CompositeMessageTaskFactory.create

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/CompositeMessageTaskFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/CompositeMessageTaskFactory.java
@@ -32,14 +32,13 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.lang.reflect.Constructor;
 import java.util.Iterator;
-import java.util.Map;
 
 public class CompositeMessageTaskFactory implements MessageTaskFactory {
     private static final String FACTORY_ID = "com.hazelcast.client.impl.protocol.MessageTaskFactoryProvider";
 
     private final Node node;
     private final NodeEngine nodeEngine;
-    private final Map<Integer, MessageTaskFactory> factories;
+    private final Int2ObjectHashMap<MessageTaskFactory> factories;
 
     public CompositeMessageTaskFactory(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;


### PR DESCRIPTION
The factories hashtable is of type Int2ObjectHashMap; which is great because no litter is created based on the 'int' key.

But the field is of type Map and Map doesn't have a Map.get(int) only Map.get(Object). So there is still boxing going on which causes litter. So effectively the Int2ObjectHashMap is in vain.

This PR fixes that by changing the type of the factories field to Int2ObjectHashMap.
