### PR TITLE
Litter reduction in TcpServerConnection.hashCode.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/server/tcp/TcpServerConnection.java
@@ -242,7 +242,9 @@ public class TcpServerConnection implements ServerConnection {
 
     @Override
     public int hashCode() {
-        return Objects.hash(acceptorSide, connectionId);
+        int result = acceptorSide ? 1231 : 1237;
+        result = 31 * result + connectionId;
+        return result;
     }
 
     @Override


### PR DESCRIPTION
The problem is that an Objects.hash is called which creates an array and leads to autoboxing of both the acceptorSide and connectionId primitives. Apart from the litter, the calculation of the hashcode takes a lot of time which is not needed.

The problem has been solved by implementing a manual hashCode.

The TcpServerConnection.hashCode is called for every ClientMessageTask that is created, so a lot of unwanted litter is created.

![image](https://github.com/hazelcast/hazelcast/assets/105243/591c408a-4896-45c6-b530-d6382c31af18)
