### PR TITLE
Fix Vulnerability in elasticsearch 7.17.13 CVE [HZ-3988] [5.3.z]

### DIFF
--- a/extensions/elasticsearch/elasticsearch-7/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-7/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>7.17.13</version>
+            <version>7.17.15</version>
         </dependency>
 
         <!-- TEST -->

--- a/pom.xml
+++ b/pom.xml
@@ -1916,8 +1916,10 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
+                <artifactId>log4j-bom</artifactId>
                 <version>${log4j2.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.jline</groupId>


### PR DESCRIPTION
Upgrade elastic client to 7.17.15.
Use  Log4j BOM because of Dependency convergence error coming from new elastic client

Fixes : https://github.com/hazelcast/hazelcast/issues/26117

See : https://discuss.elastic.co/t/elasticsearch-7-17-14-8-10-3-security-update-esa-2023-24/347708
In the  

> Solutions and Mitigations:
> The issue is resolved in versions 8.10.3 and 7.17.14.
> 

HZ 5.4 is using 7.17.15. So I have upgraded 5.3.x to 7.17.15

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
