### PR TITLE
[TPC] Added BufferUtil.allocate.

### DIFF
--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/iobuffer/ConcurrentIOBufferAllocator.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/iobuffer/ConcurrentIOBufferAllocator.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.tpcengine.iobuffer;
 
 
+import com.hazelcast.internal.tpcengine.util.BufferUtil;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpmcArrayQueue;
 
@@ -100,7 +101,7 @@ public class ConcurrentIOBufferAllocator implements IOBufferAllocator {
             for (int k = count; k < pool.bufs.length; k++) {
                 //newAllocations.incrementAndGet();
                 //System.out.println(" new buf");
-                ByteBuffer buffer = direct ? ByteBuffer.allocateDirect(minSize) : ByteBuffer.allocate(minSize);
+                ByteBuffer buffer = BufferUtil.allocate(direct, minSize);
                 IOBuffer buf = new IOBuffer(buffer);
                 buf.concurrent = true;
                 buf.allocator = this;

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/iobuffer/NonConcurrentIOBufferAllocator.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/iobuffer/NonConcurrentIOBufferAllocator.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.tpcengine.iobuffer;
 
+import com.hazelcast.internal.tpcengine.util.BufferUtil;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -49,7 +51,7 @@ public final class NonConcurrentIOBufferAllocator implements IOBufferAllocator {
             for (int k = 0; k < bufs.length; k++) {
                 //newAllocations.incrementAndGet();
                 //System.out.println(" new buf");
-                ByteBuffer buffer = direct ? ByteBuffer.allocateDirect(minSize) : ByteBuffer.allocate(minSize);
+                ByteBuffer buffer = BufferUtil.allocate(direct, minSize);
                 IOBuffer buf = new IOBuffer(buffer);
                 buf.concurrent = false;
                 newAllocateCnt++;

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/nio/NioAsyncSocket.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.tpcengine.net.AsyncSocket;
 import com.hazelcast.internal.tpcengine.net.AsyncSocketMetrics;
 import com.hazelcast.internal.tpcengine.net.AsyncSocketOptions;
 import com.hazelcast.internal.tpcengine.net.AsyncSocketReader;
+import com.hazelcast.internal.tpcengine.util.BufferUtil;
 import com.hazelcast.internal.tpcengine.util.CircularQueue;
 import org.jctools.queues.MpmcArrayQueue;
 
@@ -361,9 +362,7 @@ public final class NioAsyncSocket extends AsyncSocket {
 
         private Handler(NioAsyncSocketBuilder builder) throws SocketException {
             int receiveBufferSize = builder.socketChannel.socket().getReceiveBufferSize();
-            this.rcvBuffer = builder.directBuffers
-                    ? ByteBuffer.allocateDirect(receiveBufferSize)
-                    : ByteBuffer.allocate(receiveBufferSize);
+            this.rcvBuffer = BufferUtil.allocate(builder.directBuffers, receiveBufferSize);
         }
 
         @Override

--- a/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/util/BufferUtil.java
+++ b/hazelcast-tpc-engine/src/main/java/com/hazelcast/internal/tpcengine/util/BufferUtil.java
@@ -35,7 +35,18 @@ public final class BufferUtil {
         }
     }
 
-     public static void put(ByteBuffer dst, ByteBuffer src) {
+    /**
+     * Allocates a new {@link ByteBuffer}.
+     *
+     * @param direct if the ByteBuffer should be a direct ByteBuffer.
+     * @param capacity the capacity of the ByteBuffer to allocate
+     * @return the allocated ByteBuffer.
+     */
+    public static ByteBuffer allocate(boolean direct, int capacity) {
+        return direct ? ByteBuffer.allocateDirect(capacity) : ByteBuffer.allocate(capacity);
+    }
+
+    public static void put(ByteBuffer dst, ByteBuffer src) {
         if (src.remaining() <= dst.remaining()) {
             // there is enough space in the dst buffer to copy the src
             dst.put(src);


### PR DESCRIPTION
Makes allocating buffers a bit less verbose.

Especially in the TLS code where many more buffers are created, the lack of this method makes the code too long.