### PR TITLE
Bump kafka version

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -19,11 +19,11 @@ package com.hazelcast.jet.kafka.impl;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.jet.kafka.HazelcastKafkaAvroSerializer;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
@@ -265,13 +265,14 @@ public abstract class KafkaTestSupport {
         return schemaRegistryServer.getURI();
     }
 
-    public int registerSchema(String subject, Schema schema) throws SchemaRegistryException {
-        return schemaRegistry.register(subject, new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(
-                subject, -1, -1, AvroSchema.TYPE, emptyList(), schema.toString()));
+    public int registerSchema(String subject, org.apache.avro.Schema avroSchema) throws SchemaRegistryException {
+        Schema schema = new Schema(subject, -1, -1, AvroSchema.TYPE, emptyList(), avroSchema.toString());
+        Schema registeredSchema = schemaRegistry.register(subject, schema);
+        return registeredSchema.getId();
     }
 
     public int getLatestSchemaVersion(String subject) throws SchemaRegistryException {
-        return Optional.ofNullable(schemaRegistry.getLatestVersion(subject)).map(s -> s.getVersion())
+        return Optional.ofNullable(schemaRegistry.getLatestVersion(subject)).map(Schema::getVersion)
                 .orElseThrow(() -> new SchemaRegistryException("No schema found in subject '" + subject + "'"));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <json-surfer.version>0.11</json-surfer.version>
         <jsr107.api.version>1.1.1</jsr107.api.version> <!-- JCache -->
         <jsr250.api.version>1.2</jsr250.api.version> <!-- javax.annotations -->
-        <kafka.version>3.4.1</kafka.version>
+        <kafka.version>3.6.0</kafka.version>
         <kotlin.version>1.9.21</kotlin.version>
         <reload4j.version>1.2.25</reload4j.version>
         <mssql.version>12.4.2.jre11</mssql.version>
@@ -145,7 +145,7 @@
         <commons-codec.version>1.16.0</commons-codec.version>
         <commons-io.version>2.15.1</commons-io.version>
         <commons-lang3.version>3.14.0</commons-lang3.version>
-        <confluent.version>7.4.0</confluent.version>
+        <confluent.version>7.5.1</confluent.version>
         <felix.utils.version>1.11.6</felix.utils.version>
         <findbugs.annotations.version>3.0.1u2</findbugs.annotations.version>
         <http.core.version>4.4.16</http.core.version>


### PR DESCRIPTION
Kafka version can not be upgraded because schema registry tests were failing.  The failure can be see from dependabot PR
https://github.com/hazelcast/hazelcast/pull/25600

1. This commit upgrades schema registry and changes tests for API changes in the schema registry.
2. This commit upgrades Kafka version

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
