### PR TITLE
Revert "Bump google-api-client from 1.32.2 to 2.2.0 (#23624)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1994,7 +1994,7 @@
             <dependency>
                 <groupId>com.google.api-client</groupId>
                 <artifactId>google-api-client</artifactId>
-                <version>2.2.0</version>
+                <version>1.32.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.api.grpc</groupId>


### PR DESCRIPTION
This reverts commit 30fb9ececfb55ab37327e23847a1ec5f17efc620, PR #23624.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/6635

Checklist:
- [x] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
