### PR TITLE
Add `heapDataComparator` to align on-heap and off-heap comparators for index scans [HZ-3093]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchIndexOperation.java
@@ -32,7 +32,6 @@ import com.hazelcast.query.impl.Comparison;
 import com.hazelcast.query.impl.GlobalIndexPartitionTracker.PartitionStamp;
 import com.hazelcast.query.impl.IndexKeyEntries;
 import com.hazelcast.query.impl.InternalIndex;
-import com.hazelcast.query.impl.OrderedIndexStore;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.operationservice.ReadonlyOperation;
@@ -153,9 +152,8 @@ public class MapFetchIndexOperation extends MapOperation implements ReadonlyOper
                 logger.finest("Processing pointer: " + pointer);
             }
 
-            Comparator<Data> comparator = pointer.isDescending()
-                    ? OrderedIndexStore.DATA_COMPARATOR_REVERSED
-                    : OrderedIndexStore.DATA_COMPARATOR;
+            Comparator<Data> comparator = index.getComparator(pointer.isDescending());
+            assert comparator != null : "Comparator should be present for sorted index";
 
             Iterator<IndexKeyEntries> entryIterator = getEntryIterator(index, pointer);
             while (entryIterator.hasNext()) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AbstractIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AbstractIndex.java
@@ -31,6 +31,7 @@ import com.hazelcast.query.impl.getters.MultiResult;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -300,6 +301,11 @@ public abstract class AbstractIndex implements InternalIndex {
     @Override
     public PerIndexStats getPerIndexStats() {
         return stats;
+    }
+
+    @Override
+    public Comparator getComparator(boolean isDescending) {
+        return indexStore.getComparator(isDescending);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexStore.java
@@ -21,6 +21,8 @@ import com.hazelcast.internal.monitor.impl.IndexOperationStats;
 import com.hazelcast.query.Predicate;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -300,4 +302,13 @@ public interface IndexStore {
      * @see Index#getRecords(Comparable, boolean, Comparable, boolean)
      */
     Set<QueryableEntry> getRecords(Comparable from, boolean fromInclusive, Comparable to, boolean toInclusive);
+
+    /**
+     * @param isDescending is the index used in descending order.
+     * @return corresponding comparator for this index.
+     */
+    @Nullable
+    default Comparator getComparator(boolean isDescending) {
+        return null;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexStore.java
@@ -305,7 +305,8 @@ public interface IndexStore {
 
     /**
      * @param isDescending is the index used in descending order.
-     * @return corresponding comparator for this index.
+     * @return             comparator ordering IMap keys stored for given index key.
+     *                     {@code null} indicates that index store is not ordered.
      */
     @Nullable
     default Comparator getComparator(boolean isDescending) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.BitmapIndexOptions.UniqueKeyTransformation;
 import com.hazelcast.config.ConfigXmlGenerator.XmlGenerator;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
+import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.memory.Capacity;
@@ -30,6 +31,7 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -369,6 +371,26 @@ public final class IndexUtils {
         }
 
         return res;
+    }
+
+    public static Comparator heapDataComparator(boolean isDescending) {
+        Comparator comparator = (Comparator<HeapData>) (left, right) -> {
+            int leftTotalSize = left.totalSize();
+            int rightTotalSize = right.totalSize();
+            if (leftTotalSize != rightTotalSize) {
+                return leftTotalSize < rightTotalSize ? -1 : 1;
+            }
+
+            byte[] lba = left.toByteArray();
+            byte[] rba = right.toByteArray();
+            for (int i = 0; i < leftTotalSize; i++) {
+                if (lba[i] != rba[i]) {
+                    return lba[i] < rba[i] ? -1 : 1;
+                }
+            }
+            return 0;
+        };
+        return isDescending ? comparator.reversed() : comparator;
     }
 
     private static Capacity getCapacity(Node node, boolean domLevel3) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
@@ -54,6 +54,26 @@ public final class IndexUtils {
     /** Pattern to stripe away "this." prefix. */
     private static final Pattern THIS_PATTERN = Pattern.compile("^this\\.");
 
+    /**
+     * Comparator for deserialized HD index entries.
+     */
+    private static final Comparator<HeapData> DESERIALIZED_OFFHEAP_DATA_COMPARATOR = (left, right) -> {
+        int leftTotalSize = left.totalSize();
+        int rightTotalSize = right.totalSize();
+        if (leftTotalSize != rightTotalSize) {
+            return leftTotalSize < rightTotalSize ? -1 : 1;
+        }
+
+        byte[] lba = left.toByteArray();
+        byte[] rba = right.toByteArray();
+        for (int i = 0; i < leftTotalSize; i++) {
+            if (lba[i] != rba[i]) {
+                return lba[i] < rba[i] ? -1 : 1;
+            }
+        }
+        return 0;
+    };
+
     private IndexUtils() {
         // No-op.
     }
@@ -373,24 +393,9 @@ public final class IndexUtils {
         return res;
     }
 
+    @SuppressWarnings("unused")
     public static Comparator heapDataComparator(boolean isDescending) {
-        Comparator comparator = (Comparator<HeapData>) (left, right) -> {
-            int leftTotalSize = left.totalSize();
-            int rightTotalSize = right.totalSize();
-            if (leftTotalSize != rightTotalSize) {
-                return leftTotalSize < rightTotalSize ? -1 : 1;
-            }
-
-            byte[] lba = left.toByteArray();
-            byte[] rba = right.toByteArray();
-            for (int i = 0; i < leftTotalSize; i++) {
-                if (lba[i] != rba[i]) {
-                    return lba[i] < rba[i] ? -1 : 1;
-                }
-            }
-            return 0;
-        };
-        return isDescending ? comparator.reversed() : comparator;
+        return isDescending ? DESERIALIZED_OFFHEAP_DATA_COMPARATOR.reversed() : DESERIALIZED_OFFHEAP_DATA_COMPARATOR;
     }
 
     private static Capacity getCapacity(Node node, boolean domLevel3) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexUtils.java
@@ -22,7 +22,6 @@ import com.hazelcast.config.BitmapIndexOptions.UniqueKeyTransformation;
 import com.hazelcast.config.ConfigXmlGenerator.XmlGenerator;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.IndexType;
-import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.util.StringUtil;
 import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.memory.Capacity;
@@ -31,7 +30,6 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -53,26 +51,6 @@ public final class IndexUtils {
 
     /** Pattern to stripe away "this." prefix. */
     private static final Pattern THIS_PATTERN = Pattern.compile("^this\\.");
-
-    /**
-     * Comparator for deserialized HD index entries.
-     */
-    private static final Comparator<HeapData> DESERIALIZED_OFFHEAP_DATA_COMPARATOR = (left, right) -> {
-        int leftTotalSize = left.totalSize();
-        int rightTotalSize = right.totalSize();
-        if (leftTotalSize != rightTotalSize) {
-            return leftTotalSize < rightTotalSize ? -1 : 1;
-        }
-
-        byte[] lba = left.toByteArray();
-        byte[] rba = right.toByteArray();
-        for (int i = 0; i < leftTotalSize; i++) {
-            if (lba[i] != rba[i]) {
-                return lba[i] < rba[i] ? -1 : 1;
-            }
-        }
-        return 0;
-    };
 
     private IndexUtils() {
         // No-op.
@@ -391,11 +369,6 @@ public final class IndexUtils {
         }
 
         return res;
-    }
-
-    @SuppressWarnings("unused")
-    public static Comparator heapDataComparator(boolean isDescending) {
-        return isDescending ? DESERIALIZED_OFFHEAP_DATA_COMPARATOR.reversed() : DESERIALIZED_OFFHEAP_DATA_COMPARATOR;
     }
 
     private static Capacity getCapacity(Node node, boolean domLevel3) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
@@ -20,6 +20,9 @@ import com.hazelcast.internal.monitor.impl.PerIndexStats;
 import com.hazelcast.map.impl.recordstore.StepAwareStorage;
 import com.hazelcast.query.impl.GlobalIndexPartitionTracker.PartitionStamp;
 
+import javax.annotation.Nullable;
+import java.util.Comparator;
+
 /**
  * Provides the private index API.
  */
@@ -118,10 +121,19 @@ public interface InternalIndex extends Index {
 
     /**
      * @return Step-aware storage that backs the Index.
-     * By default returns {@code null} that indicates there is no
-     * Step-aware backed storage.
+     * By default, returns {@code null} that indicates
+     * there is no step-aware backed storage.
      */
     default StepAwareStorage getStepAwareStorage() {
+        return null;
+    }
+
+    /**
+     * @param isDescending whether the index is used in descending order.
+     * @return corresponding comparator for this index.
+     */
+    @Nullable
+    default Comparator getComparator(boolean isDescending) {
         return null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
@@ -130,7 +130,7 @@ public interface InternalIndex extends Index {
 
     /**
      * @param isDescending whether the index is used in descending order.
-     * @return corresponding comparator for this index.
+     * @return             comparator ordering IMap keys stored for given index key
      */
     @Nullable
     default Comparator getComparator(boolean isDescending) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/OrderedIndexStore.java
@@ -325,6 +325,11 @@ public class OrderedIndexStore extends BaseSingleValueIndexStore {
         }
     }
 
+    @Override
+    public Comparator getComparator(boolean isDescending) {
+        return isDescending ? DATA_COMPARATOR_REVERSED : DATA_COMPARATOR;
+    }
+
     /**
      * Adds entry to the given index map without copying it.
      * Needs to be invoked in a thread-safe way.


### PR DESCRIPTION
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/6969

This patch introduces a comparator for HD index entries. Previously, we used on-heap entries comparator, which is wrong and causes incorrect query output, like duplicated or missing entries, and so on.