### PR TITLE
Add Namespace service and ClassLoader backend [HZ-2576]

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -847,5 +847,11 @@
             <version>3.9.5</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 </project>

--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/DefaultNodeExtension.java
@@ -78,6 +78,7 @@ import com.hazelcast.internal.jmx.ManagementService;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
 import com.hazelcast.internal.memory.DefaultMemoryStats;
 import com.hazelcast.internal.memory.MemoryStats;
+import com.hazelcast.internal.namespace.impl.NodeEngineThreadLocalContext;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
@@ -706,5 +707,17 @@ public class DefaultNodeExtension implements NodeExtension {
     @Override
     public SSLEngineFactory createSslEngineFactory(SSLConfig sslConfig) {
         throw new IllegalStateException("SSL/TLS requires Hazelcast Enterprise Edition");
+    }
+
+    @Override
+    public void onThreadStart(Thread thread) {
+        // Setup NodeEngine context for User Code Deployment Namespacing in operations
+        NodeEngineThreadLocalContext.declareNodeEngineReference(node.getNodeEngine());
+    }
+
+    @Override
+    public void onThreadStop(Thread thread) {
+        // Destroy NodeEngine context from User Code Deployment Namespacing
+        NodeEngineThreadLocalContext.destroyNodeEngineReference();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/NamespaceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/NamespaceService.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace;
+
+import com.hazelcast.config.ConfigAccessor;
+import com.hazelcast.config.NamespaceConfig;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.concurrent.Callable;
+
+/**
+ * Primary service used to register and maintain {@code Namespace} definitions, as well
+ * as the centralised location for handling {@code Namespace} awareness.
+ *
+ * @see NamespaceUtil
+ * @since 5.4
+ */
+public interface NamespaceService {
+    /** Name of the Namespace Service */
+    String SERVICE_NAME = "hz:impl:namespaceService";
+    /**
+     * The default Namespace name to be used when a Namespace-aware execution takes place
+     * without an explicitly defined Namespace. This Namespace can be defined in the
+     * config for use, and if not defined then no Namespace awareness will be provided.
+     */
+    String DEFAULT_NAMESPACE_NAME = "default";
+
+    /**
+     * Defines a new {@code Namespace} with the provided Namespace name and available resources.
+     * If a {@code Namespace} already exists with this name, then the existing Namespace will
+     * be overwritten with this new implementation (add-or-replace functionality) and all new
+     * UDF invocations requesting Namespace awareness will be executed with the newly provided
+     * resources available instead.
+     *
+     * @param nsName    the name of the {@code Namespace}
+     * @param resources the resources to associate with the {@code Namespace}
+     */
+    void addNamespace(@Nonnull String nsName,
+                      @Nonnull Collection<ResourceDefinition> resources);
+
+    /**
+     * Removes the {@code Namespace} defined by the provided Namespace name.
+     *
+     * @param nsName the name of the {@code Namespace} to attempt to remove
+     * @return {@code true} if {@code nsName} namespace was found and removed, otherwise {@code false}.
+     */
+    boolean removeNamespace(@Nonnull String nsName);
+
+    /**
+     * Checks to see if there is a {@code Namespace} defined with the provided name.
+     *
+     * @param namespace the name of the {@code Namespace} to check for
+     * @return {@code true} if a {@code Namespace} exists with that name, otherwise {@code false}.
+     */
+    boolean hasNamespace(String namespace);
+
+    /**
+     * Fast checking method to see if the underlying implementation is a no-op implementation
+     * (<b>not enabled</b>), or an actual implementation (<b>enabled</b>).
+     *
+     * @return {@code true} if the underlying implementation is functional, otherwise {@code false}
+     */
+    boolean isEnabled();
+
+    /**
+     * In order to fail-fast, we skip Namespace-awareness handling when an object's namespace is
+     * `null` - however, if we have a default Namespace defined, we should use that in these cases.
+     * To facilitate failing fast with minimal overhead, we track this separately.
+     *
+     * @return {@code true} if a default Namespace exists, otherwise {@code false}
+     */
+    boolean isDefaultNamespaceDefined();
+
+    /**
+     * Prepares {@code Namespace} awareness context on the current thread for the provided
+     * {@code Namespace} name if available, or does nothing if there is none defined.
+     * <p>
+     * Specifically, this method will look for a defined {@code Namespace} from the passed
+     * name, and if it exists, it will set it as the {@link ThreadLocal} reference available
+     * in this thread's {@link com.hazelcast.internal.namespace.impl.NamespaceThreadLocalContext}.
+     * <p>
+     * @implNote This method will transform the provided {@code Namespace} name to be the
+     * {@link #DEFAULT_NAMESPACE_NAME} if it is passed as {@code null} and the default {@code Namespace}
+     * exists, as determined by {@link #isDefaultNamespaceDefined()}.
+     *
+     * @param namespace the {@code Namespace} name to set up awareness with.
+     */
+    void setupNamespace(@Nullable String namespace);
+
+    /**
+     * Cleans up {@code Namespace} awareness context on the current thread for the provided
+     * {@code Namespace} name if applicable, or does nothing if there is no context to clean up.
+     * <p>
+     * @implNote This method will transform the provided {@code Namespace} name to be the
+     * {@link #DEFAULT_NAMESPACE_NAME} if it is passed as {@code null} and the default {@code Namespace}
+     * exists, as determined by {@link #isDefaultNamespaceDefined()}.
+     *
+     * @param namespace the {@code Namespace} name to clean up awareness from.
+     */
+    void cleanupNamespace(@Nullable String namespace);
+
+    /**
+     * Runs the provided {@link Runnable} with the {@code Namespace} context of the {@code Namespace}
+     * context defined by the provided Namespace name if available. If there is no Namespace available
+     * then the {@link Runnable} is executed as if it was called directly by the caller.
+     * <p>
+     * Calling this method is the equivalent of running the following code:
+     * <pre>
+     * {@code
+     * NamespaceService service = node.getNamespaceService();
+     * try {
+     *     service.setupNamespace(namespace);
+     *     runnable.run();
+     * } finally {
+     *     service.cleanupNamespace(namespace);
+     * }
+     * }
+     * </pre>
+     * <p>
+     * @implNote This method will transform the provided {@code Namespace} name to be the
+     * {@link #DEFAULT_NAMESPACE_NAME} if it is passed as {@code null} and the default {@code Namespace}
+     * exists, as determined by {@link #isDefaultNamespaceDefined()}.
+     *
+     * @param namespace the {@code Namespace} name to use for finding the appropriate {@code Namespace}.
+     * @param runnable  the {@link Runnable} to execute with Namespace awareness
+     */
+    void runWithNamespace(@Nullable String namespace, Runnable runnable);
+
+    /**
+     * Runs the provided {@link Callable} with the {@code Namespace} context of the {@code Namespace}
+     * context defined by the provided Namespace name if available. If there is no Namespace available
+     * then the {@link Callable} is executed as if it was called directly by the caller.
+     * <p>
+     * Calling this method is the equivalent of running the following code:
+     * <pre>
+     * {@code
+     * NamespaceService service = node.getNamespaceService();
+     * try {
+     *     service.setupNamespace(namespace);
+     *     return callable.call();
+     * } finally {
+     *     service.cleanupNamespace(namespace);
+     * }
+     * }
+     * </pre>
+     * <p>
+     * @implNote This method will transform the provided {@code Namespace} name to be the
+     * {@link #DEFAULT_NAMESPACE_NAME} if it is passed as {@code null} and the default {@code Namespace}
+     * exists, as determined by {@link #isDefaultNamespaceDefined()}.
+     *
+     * @param namespace the {@code Namespace} name to use for finding the appropriate {@code Namespace}.
+     * @param callable  the {@link Callable} to execute with Namespace awareness.
+     * @param <V>       the {@link Callable}'s return type.
+     * @return the completed result of the provided {@link Callable}
+     */
+    <V> V callWithNamespace(@Nullable String namespace, Callable<V> callable);
+
+    /**
+     * Looks up the {@code Namespace} associated with the provided Namespace name and returns
+     * the {@link com.hazelcast.jet.impl.deployment.MapResourceClassLoader} defined for said
+     * {@code Namespace} if it exists. If it does not exist, then {@code null} is returned.
+     * <p>
+     * @implNote This method will transform the provided {@code Namespace} name to be the
+     * {@link #DEFAULT_NAMESPACE_NAME} if it is passed as {@code null} and the default {@code Namespace}
+     * exists, as determined by {@link #isDefaultNamespaceDefined()}.
+     *
+     * @param namespace the {@code Namespace} name to use looking up associated {@code Namespace}.
+     * @return the  associated{@link ClassLoader} if the {@code Namespace} exists, otherwise {@code null}.
+     */
+    ClassLoader getClassLoaderForNamespace(String namespace);
+
+    /**
+     * Convenience method for adding {@code Namespace}s directly using a
+     * {@link NamespaceConfig} instance.
+     * @param config the {@link NamespaceConfig} instance to fetch the {@code Namespace}
+     *               name from for addition via {@link #addNamespace(String, Collection)}
+     */
+    default void addNamespaceConfig(NamespaceConfig config) {
+        addNamespace(config.getName(), ConfigAccessor.getResourceDefinitions(config));
+    }
+
+    /**
+     * Convenience method for removing {@code Namespace}s directly using a
+     * {@link NamespaceConfig} instance.
+     * @param config the {@link NamespaceConfig} instance to fetch the {@code Namespace}
+     *               name from for removal via {@link #removeNamespace(String)}
+     */
+    default void removeNamespaceConfig(NamespaceConfig config) {
+        removeNamespace(config.getName());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/NamespaceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/NamespaceUtil.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace;
+
+import com.hazelcast.internal.namespace.impl.NamespaceThreadLocalContext;
+import com.hazelcast.internal.namespace.impl.NodeEngineThreadLocalContext;
+import com.hazelcast.jet.impl.deployment.MapResourceClassLoader;
+import com.hazelcast.spi.impl.NodeEngine;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.Callable;
+
+import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
+
+/**
+ * Utility to simplify accessing the NamespaceService and Namespace-aware wrapping,
+ * as well as provide some useful additional functionality on top of the service
+ * implementation, such as providing a default {@link ClassLoader} where specified.
+ *
+ * @since 5.4
+ */
+public class NamespaceUtil {
+
+    /** Private constructor to prevent instantiation **/
+    private NamespaceUtil() {
+    }
+
+    /**
+     * Obtains a {@link NodeEngine} reference from {@link NodeEngineThreadLocalContext}
+     * and uses it to call {@link NamespaceService#setupNamespace(String)} with the provided
+     * parameter.
+     *
+     * @see NamespaceService#setupNamespace(String)
+     */
+    public static void setupNamespace(@Nullable String namespace) {
+        NodeEngine engine = NodeEngineThreadLocalContext.getNamespaceThreadLocalContext();
+        setupNamespace(engine, namespace);
+    }
+
+    /**
+     * Obtains a {@link NodeEngine} reference from {@link NodeEngineThreadLocalContext}
+     * and uses it to call {@link NamespaceService#cleanupNamespace(String)} with the provided
+     * parameter.
+     *
+     * @see NamespaceService#cleanupNamespace(String)
+     */
+    public static void cleanupNamespace(@Nullable String namespace) {
+        NodeEngine engine = NodeEngineThreadLocalContext.getNamespaceThreadLocalContext();
+        cleanupNamespace(engine, namespace);
+    }
+
+    /**
+     * Convenience method for calling the same method name within the {@link NamespaceService},
+     * obtained from the provided {@link NodeEngine}.
+     *
+     * @see NamespaceService#setupNamespace(String)
+     */
+    public static void setupNamespace(NodeEngine engine, @Nullable String namespace) {
+        engine.getNamespaceService().setupNamespace(namespace);
+    }
+
+    /**
+     * Convenience method for calling the same method name within the {@link NamespaceService},
+     * obtained from the provided {@link NodeEngine}.
+     *
+     * @see NamespaceService#cleanupNamespace(String)
+     */
+    public static void cleanupNamespace(NodeEngine engine, @Nullable String namespace) {
+        engine.getNamespaceService().cleanupNamespace(namespace);
+    }
+
+    /**
+     * Obtains a {@link NodeEngine} reference from {@link NodeEngineThreadLocalContext}
+     * and uses it to call {@link NamespaceService#runWithNamespace(String, Runnable)} with
+     * the provided parameters.
+     *
+     * @see NamespaceService#runWithNamespace(String, Runnable)
+     */
+    public static void runWithNamespace(@Nullable String namespace, Runnable runnable) {
+        NodeEngine engine = NodeEngineThreadLocalContext.getNamespaceThreadLocalContext();
+        runWithNamespace(engine, namespace, runnable);
+    }
+
+    /**
+     * Convenience method for calling the same method name within the {@link NamespaceService},
+     * obtained from the provided {@link NodeEngine}.
+     *
+     * @see NamespaceService#runWithNamespace(String, Runnable)
+     */
+    public static void runWithNamespace(NodeEngine engine, @Nullable String namespace, Runnable runnable) {
+        engine.getNamespaceService().runWithNamespace(namespace, runnable);
+    }
+
+    /**
+     * Obtains a {@link NodeEngine} reference from {@link NodeEngineThreadLocalContext}
+     * and uses it to call {@link NamespaceService#callWithNamespace(String, Callable)} with
+     * the provided parameters.
+     *
+     * @see NamespaceService#callWithNamespace(String, Callable)
+     */
+    public static <V> V callWithNamespace(@Nullable String namespace, Callable<V> callable) {
+        NodeEngine engine = NodeEngineThreadLocalContext.getNamespaceThreadLocalContext();
+        return callWithNamespace(engine, namespace, callable);
+    }
+
+    /**
+     * Convenience method for calling the same method name within the {@link NamespaceService},
+     * obtained from the provided {@link NodeEngine}.
+     *
+     * @see NamespaceService#callWithNamespace(String, Callable)
+     */
+    public static <V> V callWithNamespace(NodeEngine engine, @Nullable String namespace, Callable<V> callable) {
+        return engine.getNamespaceService().callWithNamespace(namespace, callable);
+    }
+
+    /**
+     * Calls the passed {@link Callable} within the {@link ClassLoader} context
+     * of the passed {@link Object}'s own {@link ClassLoader} as defined by
+     * {@code Object#getClass#getClassLoader()}. The intention is that we can
+     * retrieve a User Code Deployment class's {@link MapResourceClassLoader}
+     * without the need for any additional references like we would need when
+     * fetching using a {@code String namespace}.
+     *
+     * @implNote This should only be used on UCD objects, as the contract is
+     * that all UCD objects are instantiated using the correct Namespace-aware
+     * {@link ClassLoader}, allowing this shortcut to work. This also allows us
+     * to handle client-executed UCD objects without fuss, as it will simply
+     * use their local {@link ClassLoader}.
+     *
+     * @see #callWithClassLoader(ClassLoader, Callable)
+     *
+     * @param ucdObject the UCD-instantiated object to retrieve the
+     *                  {@link ClassLoader} from for execution
+     * @param callable  the {@link Callable} to execute with Namespace awareness
+     */
+    public static <V> V callWithOwnClassLoader(Object ucdObject, Callable<V> callable) {
+        return callWithClassLoader(ucdObject.getClass().getClassLoader(), callable);
+    }
+
+    /**
+     * Runs the passed {@link Runnable} within the {@link ClassLoader} context
+     * of the passed {@link Object}'s own {@link ClassLoader} as defined by
+     * {@code Object#getClass#getClassLoader()}. The intention is that we can
+     * retrieve a User Code Deployment class's {@link MapResourceClassLoader}
+     * without the need for any additional references like we would need when
+     * fetching with only a {@code String namespace}.
+     *
+     * @implNote This should only be used on UCD objects, as the contract is
+     * that all UCD objects are instantiated using the correct Namespace-aware
+     * {@link ClassLoader}, allowing this shortcut to work. This also allows us
+     * to handle client-executed UCD objects without fuss, as it will simply
+     * use their local {@link ClassLoader}.
+     *
+     * @see #runWithClassLoader(ClassLoader, Runnable)
+     *
+     * @param ucdObject the UCD-instantiated object to retrieve the
+     *                  {@link ClassLoader} from for execution
+     * @param runnable  the {@link Runnable} to execute with Namespace awareness
+     */
+    public static void runWithOwnClassLoader(Object ucdObject, Runnable runnable) {
+        runWithClassLoader(ucdObject.getClass().getClassLoader(), runnable);
+    }
+
+    /**
+     * Calls the passed {@link Callable} within the {@link ClassLoader} context
+     * of the passed {@link ClassLoader}, leveraging the
+     * {@link com.hazelcast.internal.namespace.impl.NamespaceAwareClassLoader}.
+     *
+     * @implNote This is intended to be used with UCD Namespace-aware objects.
+     *
+     * @param loader    the {@link ClassLoader} to use for execution context
+     * @param callable  the {@link Callable} to execute with Namespace awareness
+     */
+    public static <V> V callWithClassLoader(ClassLoader loader, Callable<V> callable) {
+        if (loader == null) {
+            try {
+                return callable.call();
+            } catch (Exception ex) {
+                throw sneakyThrow(ex);
+            }
+        }
+
+        NamespaceThreadLocalContext.onStartNsAware(loader);
+        try {
+            return callable.call();
+        } catch (Exception exception) {
+            throw sneakyThrow(exception);
+        } finally {
+            NamespaceThreadLocalContext.onCompleteNsAware(loader);
+        }
+    }
+
+    /**
+     * Runs the passed {@link Callable} within the {@link ClassLoader} context
+     * of the passed {@link ClassLoader}, leveraging the
+     * {@link com.hazelcast.internal.namespace.impl.NamespaceAwareClassLoader}.
+     *
+     * @implNote This is intended to be used with UCD Namespace-aware objects.
+     *
+     * @param loader    the {@link ClassLoader} to use for execution context
+     * @param runnable  the {@link Runnable} to execute with Namespace awareness
+     */
+    public static void runWithClassLoader(ClassLoader loader, Runnable runnable) {
+        if (loader == null) {
+            runnable.run();
+            return;
+        }
+
+        NamespaceThreadLocalContext.onStartNsAware(loader);
+        try {
+            runnable.run();
+        } catch (Exception exception) {
+            throw sneakyThrow(exception);
+        } finally {
+            NamespaceThreadLocalContext.onCompleteNsAware(loader);
+        }
+    }
+
+    /**
+     * Looks for a Namespace associated {@link MapResourceClassLoader} defined by the provided
+     * {@code Namespace} name, and returns it if available. If not available, this method
+     * will retrieve a default {@link ClassLoader} instance to use as a fallback, as
+     * defined by {@link #getDefaultClassloader(NodeEngine)}.
+     *
+     * @param engine    the {@link NodeEngine} instance to use for accessing the {@link NamespaceService}
+     * @param namespace the {@code Namespace} name to use for looking up the Namespace {@link ClassLoader}
+     * @return the {@link ClassLoader} for the provided {@code Namespace} if it exists, or else a fallback
+     *         {@link ClassLoader} as defined by {@link #getDefaultClassloader(NodeEngine)}.
+     */
+    public static ClassLoader getClassLoaderForNamespace(NodeEngine engine, @Nullable String namespace) {
+        ClassLoader loader = engine.getNamespaceService().getClassLoaderForNamespace(namespace);
+        return loader != null ? loader : getDefaultClassloader(engine);
+    }
+
+    /**
+     * Looks for a Namespace associated {@link MapResourceClassLoader} defined by the provided
+     * {@code Namespace} name, and returns it if available. If not available, this method
+     * will return the provided {@link ClassLoader}.
+     *
+     * @param engine        the {@link NodeEngine} instance to use for accessing the {@link NamespaceService}
+     * @param namespace     the {@code Namespace} name to use for looking up the Namespace {@link ClassLoader}
+     * @param defaultLoader the fallback {@link ClassLoader} to use if a Namespace-associated one is not available.
+     * @return the {@link ClassLoader} for the provided {@code Namespace} if it exists, or else the provided
+     *         {@link ClassLoader} {@code defaultLoader}.
+     */
+    public static ClassLoader getClassLoaderForNamespace(NodeEngine engine, @Nullable String namespace,
+                                                         ClassLoader defaultLoader) {
+        ClassLoader loader = engine.getNamespaceService().getClassLoaderForNamespace(namespace);
+        return loader != null ? loader : defaultLoader;
+    }
+
+    /**
+     * Attempts to retrieve the default {@code Namespace} {@link ClassLoader} if available, otherwise
+     * retrieves the config-defined {@link ClassLoader} from {@link NodeEngine#getConfigClassLoader()}.
+     * <p>
+     * The default Namespace is retrieved by calling {@link NamespaceService#getClassLoaderForNamespace(String)}
+     * with a {@code null} Namespace name, which results in the {@link NamespaceService} checking for a
+     * default Namespace (defined with name {@link NamespaceService#DEFAULT_NAMESPACE_NAME}).
+     *
+     * @param engine the {@link NodeEngine} instance to use for accessing the {@link NamespaceService}
+     * @return the default {@code Namespace} {@link MapResourceClassLoader} if defined, or the
+     *         config-defined {@link ClassLoader} from {@link NodeEngine#getConfigClassLoader()}.
+     */
+    public static ClassLoader getDefaultClassloader(NodeEngine engine) {
+        // Call with `null` namespace, which will fallback to a default Namespace if available
+        ClassLoader loader = engine.getNamespaceService().getClassLoaderForNamespace(null);
+        return loader != null ? loader : engine.getConfigClassLoader();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/ResourceDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/ResourceDefinition.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace;
+
+import com.hazelcast.jet.config.ResourceType;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+public interface ResourceDefinition extends IdentifiedDataSerializable {
+
+    /**
+     * Returns the identifier of this resource. For example, for a {@code CLASS} type resource it can be the fully-qualified
+     * name of the class.
+     * @return the identifier of this resource.
+     */
+    String id();
+
+    /**
+     * @return the type of the resource.
+     */
+    ResourceType type();
+
+    /**
+     * @return the contents of the resource.
+     */
+    byte[] payload();
+
+    /**
+     *
+     * @return the path of the resource
+     */
+    String url();
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NamespaceAwareClassLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NamespaceAwareClassLoader.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace.impl;
+
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.internal.util.ExceptionUtil;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.net.URL;
+import java.util.Enumeration;
+
+/**
+ * A ClassLoader that's aware of the configured namespaces and their resources.
+ * The classloading scheme does not follow the recommended {@link ClassLoader} parent delegation model: instead, this
+ * {@code ClassLoader} first looks up classes and resources on its own, then delegates if not found.
+ *
+ * @see com.hazelcast.config.NamespaceConfig
+ */
+public class NamespaceAwareClassLoader extends ClassLoader {
+    private static final MethodHandle FIND_RESOURCE_METHOD_HANDLE;
+    private static final MethodHandle FIND_RESOURCES_METHOD_HANDLE;
+
+    private final NamespaceServiceImpl namespaceService;
+    // Retain Parent for faster referencing (skips permission checks)
+    private final ClassLoader parent;
+
+    static {
+        try {
+            ClassLoader.registerAsParallelCapable();
+            Lookup lookup = MethodHandles.lookup();
+
+            FIND_RESOURCE_METHOD_HANDLE = lookup.findSpecial(ClassLoader.class, "findResource",
+                    MethodType.methodType(URL.class, String.class), NamespaceAwareClassLoader.class);
+
+            FIND_RESOURCES_METHOD_HANDLE = lookup.findSpecial(ClassLoader.class, "findResources",
+                    MethodType.methodType(Enumeration.class, String.class), NamespaceAwareClassLoader.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public NamespaceAwareClassLoader(ClassLoader parent, Node node) {
+        super(parent);
+        this.parent = parent;
+        this.namespaceService = (NamespaceServiceImpl) node.getNamespaceService();
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            ClassLoader candidate = pickClassLoader();
+            Class<?> klass = candidate.loadClass(name);
+            if (resolve) {
+                resolveClass(klass);
+            }
+            return klass;
+        }
+    }
+
+    @Override
+    protected URL findResource(String name) {
+        try {
+            return (URL) FIND_RESOURCE_METHOD_HANDLE.invoke(pickClassLoader(), name);
+        } catch (Throwable t) {
+            throw ExceptionUtil.sneakyThrow(t);
+        }
+    }
+
+    @Override
+    protected Enumeration<URL> findResources(String name) throws IOException {
+        try {
+            return (Enumeration<URL>) FIND_RESOURCES_METHOD_HANDLE.invoke(pickClassLoader(), name);
+        } catch (Throwable t) {
+            throw ExceptionUtil.sneakyThrow(t);
+        }
+    }
+
+    ClassLoader pickClassLoader() {
+        ClassLoader classLoader = NamespaceThreadLocalContext.getClassLoader();
+        if (classLoader != null) {
+            return classLoader;
+        }
+        return parent;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        return pickClassLoader().getResources(name);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NamespaceAwareDriverManagerInterface.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NamespaceAwareDriverManagerInterface.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace.impl;
+
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.jet.impl.deployment.MapResourceClassLoader;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.lang.reflect.Method;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Enumeration;
+import java.util.ServiceLoader;
+
+/**
+ * A wrapper around {@link DriverManager} to allow accessing registered {@link Driver}s from a {@link ClassLoader} other than
+ * the one that registered it
+ */
+public class NamespaceAwareDriverManagerInterface {
+    private static final ILogger LOGGER = Logger.getLogger(NamespaceAwareDriverManagerInterface.class);
+
+    private final MapResourceClassLoader classLoader = (MapResourceClassLoader) getClass().getClassLoader();
+
+    public static void initializeJdbcDrivers(String nsName, MapResourceClassLoader classLoader) {
+        ServiceLoader<? extends Driver> driverLoader = ServiceLoader.load(Driver.class, classLoader);
+
+        LOGGER.finest("Initializing driverLoader=%s in namespace %s", driverLoader, nsName);
+
+        for (Driver d : driverLoader) {
+            if (d.getClass().getClassLoader() == classLoader) {
+                LOGGER.finest("Registering driver %s from classloader for namespace %s", d.getClass(), nsName);
+
+                try {
+                    DriverManager.registerDriver(d);
+                } catch (SQLException e) {
+                    LOGGER.warning("Failed to register driver " + d + " in namespace " + nsName, e);
+                }
+            } else {
+                LOGGER.finest("Skipping %s because it's classloader (%s) differs from classloader (%s)", d.getClass(),
+                        d.getClass().getClassLoader(), classLoader);
+            }
+        }
+    }
+
+    /**
+     * cleanup any JDBC drivers that were registered from that classloader
+     * <p>
+     * Reloads this class inside the supplied {@code classLoader}, so that when {@link #cleanupJdbcDrivers(String)} calls
+     * {@link DriverManager#deregisterDriver(Driver)}, it's called from within the required {@link ClassLoader} that allows it
+     * to operate correctly.
+     */
+    public static void cleanupJdbcDrivers(String nsName, MapResourceClassLoader classLoader) {
+        try {
+            // This is a "NamespaceAwareDriverManagerInterface", but from the other ClassLoader, so no casting
+            Class<?> clazz = classLoader.loadClassFromThisLoader(NamespaceAwareDriverManagerInterface.class);
+            Method cleanupJdbcDriversMethod = clazz.getDeclaredMethod("cleanupJdbcDrivers", String.class);
+            cleanupJdbcDriversMethod.invoke(clazz.getDeclaredConstructor().newInstance(), nsName);
+        } catch (ReflectiveOperationException e) {
+            throw ExceptionUtil.sneakyThrow(e);
+        }
+    }
+
+    /** Public only to allow easy reflection call - not actually sensible to call externally */
+    public void cleanupJdbcDrivers(String nsName) {
+        Enumeration<Driver> registeredDrivers = DriverManager.getDrivers();
+
+        LOGGER.finest("Cleaning up registeredDrivers=%s, in namespace %s", registeredDrivers, nsName);
+
+        while (registeredDrivers.hasMoreElements()) {
+            Driver d = registeredDrivers.nextElement();
+
+            if (d.getClass().getClassLoader() == classLoader) {
+                try {
+                    LOGGER.finest("Deregistering %s from removed classloader for namespace %s", d.getClass(), nsName);
+                    DriverManager.deregisterDriver(d);
+                } catch (SQLException e) {
+                    LOGGER.warning("Failed to deregister driver " + d + " in namespace " + nsName, e);
+                }
+            } else {
+                LOGGER.finest("Skipping %s because it's classloader (%s) differs from removedClassLoader (%s)", d.getClass(),
+                        d.getClass().getClassLoader(), classLoader);
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NamespaceServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NamespaceServiceImpl.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace.impl;
+
+import com.hazelcast.config.JavaSerializationFilterConfig;
+import com.hazelcast.config.NamespaceConfig;
+import com.hazelcast.internal.namespace.NamespaceService;
+import com.hazelcast.internal.namespace.ResourceDefinition;
+import com.hazelcast.internal.nio.ClassLoaderUtil;
+import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.serialization.SerializationClassNameFilter;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.jet.impl.JobRepository;
+import com.hazelcast.jet.impl.deployment.MapResourceClassLoader;
+import com.hazelcast.jet.impl.util.ReflectionUtils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+
+import static com.hazelcast.config.ConfigAccessor.getResourceDefinitions;
+import static com.hazelcast.jet.impl.JobRepository.classKeyName;
+import static com.hazelcast.jet.impl.util.ReflectionUtils.toClassResourceId;
+
+/**
+ * Actual implementation for {@link NamespaceService} used when Namespaces are enabled.
+ * Replaced by {@link NoOpNamespaceService} when Namespaces are disabled.
+ */
+public final class NamespaceServiceImpl implements NamespaceService {
+
+    /** Map of available {@link MapResourceClassLoader} instances, keyed by Namespace name*/
+    private final ConcurrentMap<String, MapResourceClassLoader> namespaceToClassLoader = new ConcurrentHashMap<>();
+
+    /** The fallback {@link ClassLoader} to use for awareness */
+    private final ClassLoader configClassLoader;
+    /** Config-populated filter for Namespace loaded classes */
+    private final SerializationClassNameFilter classFilter;
+    private boolean hasDefaultNamespace;
+
+    public NamespaceServiceImpl(ClassLoader configClassLoader, Map<String, NamespaceConfig> nsConfigs,
+                                JavaSerializationFilterConfig filterConfig) {
+        this.configClassLoader = configClassLoader;
+        if (filterConfig != null) {
+            this.classFilter = new SerializationClassNameFilter(filterConfig);
+        } else {
+            this.classFilter = null;
+        }
+        nsConfigs.forEach((nsName, nsConfig) -> addNamespace(nsName, getResourceDefinitions(nsConfig)));
+    }
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    public boolean isDefaultNamespaceDefined() {
+        return hasDefaultNamespace;
+    }
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    public void addNamespace(@Nonnull String nsName, @Nonnull Collection<ResourceDefinition> resources) {
+        Objects.requireNonNull(nsName, "namespace name cannot be null");
+        Objects.requireNonNull(resources, "resources cannot be null");
+
+        Map<String, byte[]> resourceMap = new ConcurrentHashMap<>();
+        for (ResourceDefinition r : resources) {
+            handleResource(r, resourceMap);
+        }
+
+        MapResourceClassLoader updated = new MapResourceClassLoader(nsName, configClassLoader, () -> resourceMap, true);
+
+        MapResourceClassLoader removed = namespaceToClassLoader.put(nsName, updated);
+        if (removed != null) {
+            cleanUpClassLoader(nsName, removed);
+        }
+        initializeClassLoader(nsName, updated);
+        if (nsName.equals(DEFAULT_NAMESPACE_NAME)) {
+            hasDefaultNamespace = true;
+        }
+    }
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    public boolean removeNamespace(@Nonnull String nsName) {
+        MapResourceClassLoader removed = namespaceToClassLoader.remove(nsName);
+        if (removed != null) {
+            cleanUpClassLoader(nsName, removed);
+            if (nsName.equals(DEFAULT_NAMESPACE_NAME)) {
+                hasDefaultNamespace = false;
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    public boolean hasNamespace(String namespace) {
+        return namespaceToClassLoader.containsKey(namespace);
+    }
+
+    // Namespace setup/cleanup handling functions
+
+    private void setupNs(@Nullable String namespace) {
+        if (namespace == null) {
+            return;
+        }
+
+        ClassLoader loader = getClassLoaderForExactNamespace(namespace);
+        if (loader == null) {
+            throw new IllegalArgumentException(String.format("There is no environment defined for provided Namespace: %s\n"
+                    + "Add a new NamespaceConfig with the name '%s' and define resources to use this Namespace.",
+                    namespace, namespace));
+        }
+
+        NamespaceThreadLocalContext.onStartNsAware(loader);
+    }
+
+    private static void cleanupNs(@Nullable String namespace) {
+        if (namespace == null) {
+            return;
+        }
+        NamespaceThreadLocalContext.onCompleteNsAware(namespace);
+    }
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    public void setupNamespace(@Nullable String namespace) {
+        setupNs(transformNamespace(namespace));
+    }
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    public void cleanupNamespace(@Nullable String namespace) {
+        cleanupNs(transformNamespace(namespace));
+    }
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    public void runWithNamespace(@Nullable String namespace, Runnable runnable) {
+        namespace = transformNamespace(namespace);
+        setupNs(namespace);
+        try {
+            runnable.run();
+        } finally {
+            cleanupNs(namespace);
+        }
+    }
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    public <V> V callWithNamespace(@Nullable String namespace, Callable<V> callable) {
+        namespace = transformNamespace(namespace);
+        setupNs(namespace);
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            throw ExceptionUtil.sneakyThrow(e);
+        } finally {
+            cleanupNs(namespace);
+        }
+    }
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    public ClassLoader getClassLoaderForNamespace(@Nullable String namespace) {
+        namespace = transformNamespace(namespace);
+        if (namespace != null) {
+            return namespaceToClassLoader.get(namespace);
+        }
+        return null;
+    }
+
+    // Internal method to transform a `null` namespace into the default namespace if available
+    private String transformNamespace(String namespace) {
+        if (namespace != null) {
+            return namespace;
+            // Check if we have a `default` environment available
+        } else if (isDefaultNamespaceDefined()) {
+            return DEFAULT_NAMESPACE_NAME;
+        } else {
+            // Namespace is null, no default Namespace is defined, fail-fast
+            return null;
+        }
+    }
+
+    // Resource/classloader handling functions
+
+    private void handleResource(ResourceDefinition resource, Map<String, byte[]> resourceMap) {
+        switch (resource.type()) {
+            case JAR:
+                 handleJar(resource.id(), resource.payload(), resourceMap);
+                break;
+            case JARS_IN_ZIP:
+                handleJarInZip(resource.id(), resource.payload(), resourceMap);
+                break;
+            case CLASS:
+                handleClass(resource.id(), resource.payload(), resourceMap);
+                break;
+            default:
+                throw new IllegalArgumentException("Cannot handle resource type " + resource.type());
+        }
+    }
+
+    /**
+     * Add classes and files in the given {@code jarBytes} to the provided {@code resourceMap}, after appropriate
+     * encoding:
+     * <ul>
+     *     <li>Payload is deflated</li>
+     *     <li>For each JAR entry in {@code jarBytes} that is a class, its class name is converted to a resource ID with the
+     *     {@code "c."} prefix followed by the class name converted to a path.</li>
+     *     <li>For other JAR entries in {@code jarBytes}, its path is converted to a resource ID with the
+     *     {@code "f."} prefix followed by the path.</li>
+     * </ul>
+     * <p>
+     * Caller is responsible for closing stream.
+     * @param id
+     * @param inputStream
+     * @param resourceMap
+     * @see     com.hazelcast.jet.impl.util.ReflectionUtils#toClassResourceId(String)
+     * @see     JobRepository#classKeyName(String)
+     * @see     JobRepository#fileKeyName(String)
+     */
+    private void handleJar(String id, InputStream inputStream, Map<String, byte[]> resourceMap) {
+        try {
+            JarInputStream jarInputStream = new JarInputStream(inputStream);
+
+            JarEntry entry;
+            do {
+                entry = jarInputStream.getNextJarEntry();
+                if (entry == null) {
+                    break;
+                }
+                String className = ClassLoaderUtil.extractClassName(entry.getName());
+                if (classFilter != null) {
+                    classFilter.filter(className);
+                }
+                byte[] payload = IOUtil.compress(jarInputStream.readAllBytes());
+                jarInputStream.closeEntry();
+                resourceMap.put(className == null ? JobRepository.fileKeyName(entry.getName())
+                        : JobRepository.classKeyName(toClassResourceId(className)), payload);
+            } while (true);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to read from JAR bytes for resource with id " + id, e);
+        }
+    }
+
+    private void handleJarInZip(String id, byte[] zipBytes, Map<String, byte[]> resourceMap) {
+        try (InputStream inputStream = new ByteArrayInputStream(zipBytes)) {
+            JobRepository.executeOnJarsInZIP(inputStream, zis -> handleJar(id, zis, resourceMap));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to read from JAR bytes for resource with id " + id, e);
+        }
+    }
+
+    /**
+     * Add the class to the {@code resourceMap}, extracting and using the class' binary name (package and class) as the
+     * {@code resourceMap} key, after performing deflate compression on its payload.
+     * @param id the resource ID, used for reference in exceptions
+     * @param classBytes the class binary content
+     * @param resourceMap resource map to add resource to
+     * @see com.hazelcast.jet.impl.util.ReflectionUtils#toClassResourceId
+     * @see com.hazelcast.jet.impl.util.ReflectionUtils#getInternalBinaryName
+     */
+    private void handleClass(String id, byte[] classBytes, Map<String, byte[]> resourceMap) {
+        try {
+            // Extract a fully qualified class name - ID can be user customized, and URL can be anything
+            String fqClassName = ReflectionUtils.getInternalBinaryName(classBytes);
+            if (classFilter != null) {
+                classFilter.filter(fqClassName);
+            }
+            // We need to append `.class` as per ReflectionUtils#toClassResourceId, but we don't need the path replacement
+            resourceMap.put(classKeyName(fqClassName + ".class"), IOUtil.compress(classBytes));
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Failed to read from CLASS bytes for resource with id " + id, ex);
+        }
+    }
+
+    /** @see #handleJar(String, InputStream, Map<String, byte[]>) */
+    private void handleJar(String id, byte[] jarBytes, Map<String, byte[]> resourceMap) {
+        try (InputStream stream = new ByteArrayInputStream(jarBytes)) {
+            handleJar(id, stream, resourceMap);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to read from JAR bytes for resource with id " + id, e);
+        }
+    }
+
+    private static void initializeClassLoader(String nsName, MapResourceClassLoader classLoader) {
+        NamespaceAwareDriverManagerInterface.initializeJdbcDrivers(nsName, classLoader);
+    }
+
+    private static void cleanUpClassLoader(String nsName, MapResourceClassLoader removedClassLoader) {
+        NamespaceAwareDriverManagerInterface.cleanupJdbcDrivers(nsName, removedClassLoader);
+    }
+
+    MapResourceClassLoader getClassLoaderForExactNamespace(@Nonnull String namespace) {
+        return namespaceToClassLoader.get(namespace);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NamespaceThreadLocalContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NamespaceThreadLocalContext.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace.impl;
+
+import com.hazelcast.jet.impl.deployment.MapResourceClassLoader;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A thread-local context that maintains a {@link ClassLoader} instance for use in providing
+ * Namespace awareness to areas of execution that require it.
+ * <p><
+ * Must be setup around user-code serde in client messages, and execution on members.
+ * Additionally, should be propagated via member-to-member operations.
+ */
+public final class NamespaceThreadLocalContext {
+    private static final ThreadLocal<NamespaceThreadLocalContext> NS_THREAD_LOCAL = new ThreadLocal<>();
+
+    private final ClassLoader classLoader;
+    private int counter = 1;
+    private NamespaceThreadLocalContext previous;
+
+    private NamespaceThreadLocalContext(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    private NamespaceThreadLocalContext(ClassLoader classLoader, NamespaceThreadLocalContext previous) {
+        this.classLoader = classLoader;
+        this.previous = previous;
+    }
+
+    private void incCounter() {
+        counter++;
+    }
+
+    private int decCounter() {
+        return --counter;
+    }
+
+    @Override
+    public String toString() {
+        return "NamespaceThreadLocalContext{"
+                + "classLoader=" + classLoader
+                + ", counter=" + counter
+                + '}';
+    }
+
+    /**
+     * Sets the provided {@link ClassLoader} as this thread's {@link ThreadLocal}
+     * loader instance, to be used for Namespace aware class loading.
+     * <p>
+     * @implNote It is important that <b>context is cleaned up after</b> by invoking
+     * either {@link #onCompleteNsAware(ClassLoader)} or {@link #onCompleteNsAware(String)}.
+     *
+     * @param classLoader the {@link ClassLoader} to use for Namespace awareness.
+     */
+    public static void onStartNsAware(ClassLoader classLoader) {
+        assert classLoader != null;
+        NamespaceThreadLocalContext tlContext = NS_THREAD_LOCAL.get();
+        if (tlContext == null) {
+            tlContext = new NamespaceThreadLocalContext(classLoader);
+            NS_THREAD_LOCAL.set(tlContext);
+        } else {
+            if (!tlContext.classLoader.equals(classLoader)) {
+                // Allow for ClassLoader overwrite, but allow for return by retaining the current context, linked list style
+                tlContext = new NamespaceThreadLocalContext(classLoader, tlContext);
+                NS_THREAD_LOCAL.set(tlContext);
+                return;
+            }
+            tlContext.incCounter();
+        }
+    }
+
+    /**
+     * Removes the currently set {@link ClassLoader} from this thread's {@link ThreadLocal}
+     * variable, if it matches the provided {@link ClassLoader} instance.
+     *
+     * @param classLoader the {@link ClassLoader} to expect when removing.
+     */
+    public static void onCompleteNsAware(ClassLoader classLoader) {
+        onCompleteNsAware(tlContext -> Objects.equals(tlContext.classLoader, classLoader),
+                tlContext -> "Attempted to complete NSTLContext for classLoader " + classLoader
+                        + " but there is an existing context: " + tlContext);
+    }
+
+    /**
+     * Removes the currently set {@link ClassLoader} from this thread's {@link ThreadLocal}
+     * variable, if it's {@link MapResourceClassLoader#getNamespace()} matches the provided
+     * {@code Namespace} ID.
+     *
+     * @param namespace the {@code Namespace} ID to expect when removing.
+     */
+    public static void onCompleteNsAware(String namespace) {
+        onCompleteNsAware(tlContext -> tlContext.classLoader instanceof MapResourceClassLoader
+                        && Objects.equals(((MapResourceClassLoader) tlContext.classLoader).getNamespace(), namespace),
+                tlContext -> "Attempted to complete NSTLContext for namespace " + namespace
+                        + " but there is an existing context: " + tlContext);
+    }
+
+    private static void onCompleteNsAware(Predicate<NamespaceThreadLocalContext> equalityFunc,
+                                          Function<NamespaceThreadLocalContext, String> errorMessageFunc) {
+        NamespaceThreadLocalContext tlContext = NS_THREAD_LOCAL.get();
+        if (tlContext != null) {
+            if (!equalityFunc.test(tlContext)) {
+                throw new IllegalStateException(errorMessageFunc.apply(tlContext));
+            }
+            int count = tlContext.decCounter();
+            if (count == 0) {
+                // Check for linked previous to revert to
+                if (tlContext.previous != null) {
+                    NS_THREAD_LOCAL.set(tlContext.previous);
+                    tlContext.previous = null;
+                } else {
+                    NS_THREAD_LOCAL.remove();
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieves the {@link ClassLoader} currently stored within this
+     * thread's {@link ThreadLocal} variable.
+     *
+     * @return the {@link ClassLoader} instance if available, or {@code null}.
+     */
+    public static ClassLoader getClassLoader() {
+        NamespaceThreadLocalContext tlContext = NS_THREAD_LOCAL.get();
+        if (tlContext == null) {
+            // No context, no namespace wrapping (not even default)
+            return null;
+        } else {
+            return tlContext.classLoader;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NoOpNamespaceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NoOpNamespaceService.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace.impl;
+
+import com.hazelcast.internal.namespace.NamespaceService;
+import com.hazelcast.internal.namespace.ResourceDefinition;
+import com.hazelcast.internal.util.ExceptionUtil;
+import com.hazelcast.spi.impl.NodeEngine;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+
+/**
+ * No-operations implementation for {@link NamespaceService} used when Namespaces are disabled.
+ * Replaced by {@link NamespaceServiceImpl} when Namespaces are enabled.
+ */
+public final class NoOpNamespaceService implements NamespaceService {
+    /**
+     * {@link NodeEngine#getConfigClassLoader()} defined {@link ClassLoader} to use in invocations
+     * where returning {@code null} would break functionality.
+     */
+    private final ClassLoader configClassLoader;
+
+    public NoOpNamespaceService(ClassLoader configClassLoader) {
+        this.configClassLoader = configClassLoader;
+    }
+
+    @Override
+    public void addNamespace(@Nonnull String nsName, @Nonnull Collection<ResourceDefinition> resources) {
+        // No-op
+    }
+
+    @Override
+    public boolean removeNamespace(@Nonnull String nsName) {
+        return false;
+    }
+
+    @Override
+    public boolean hasNamespace(String namespace) {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDefaultNamespaceDefined() {
+        return false;
+    }
+
+    @Override
+    public void setupNamespace(@Nullable String namespace) {
+        // No-op
+    }
+
+    @Override
+    public void cleanupNamespace(@Nullable String namespace) {
+        // No-op
+    }
+
+    @Override
+    public void runWithNamespace(@Nullable String namespace, Runnable runnable) {
+        runnable.run();
+    }
+
+    @Override
+    public <V> V callWithNamespace(@Nullable String namespace, Callable<V> callable) {
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            throw ExceptionUtil.sneakyThrow(e);
+        }
+    }
+
+    @Override
+    public ClassLoader getClassLoaderForNamespace(String namespace) {
+        return configClassLoader;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NodeEngineThreadLocalContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/NodeEngineThreadLocalContext.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace.impl;
+
+import com.hazelcast.spi.impl.NodeEngine;
+
+/**
+ * A thread-local context that maintains a {@link NodeEngine} instance to be retrieved in
+ * areas of execution where Namespace awareness is required, which needs a {@link NodeEngine}
+ * instance to access the {@link NodeEngine#getNamespaceService()} method, but there is
+ * no local variable available.
+ * <p>
+ * The use of this thread-local context allows us to reduce code complexity that would otherwise
+ * be introduced by passing {@link NodeEngine} references through long function chains.
+ */
+public final class NodeEngineThreadLocalContext {
+
+    private static final ThreadLocal<NodeEngine> NE_THREAD_LOCAL = new ThreadLocal<>();
+
+    private NodeEngineThreadLocalContext() {
+    }
+
+    /**
+     * Sets the provided {@link NodeEngine} reference as this thread's {@link ThreadLocal}
+     * instance for use in Namespace awareness.
+     *
+     * @param nodeEngine the {@link NodeEngine} reference to use.
+     */
+    public static void declareNodeEngineReference(NodeEngine nodeEngine) {
+        if (nodeEngine != null) {
+            NE_THREAD_LOCAL.set(nodeEngine);
+        }
+    }
+
+    /**
+     * Removes the currently set {@link NodeEngine} reference for this thread.
+     */
+    public static void destroyNodeEngineReference() {
+        NE_THREAD_LOCAL.remove();
+    }
+
+    /**
+     * Retrieves the currently set {@link NodeEngine} reference for this thread,
+     * or throws an {@link IllegalStateException} if one could not be found.
+     *
+     * @return This thread's {@link NodeEngine} reference.
+     */
+    public static NodeEngine getNamespaceThreadLocalContext() {
+        NodeEngine tlContext = NE_THREAD_LOCAL.get();
+        if (tlContext == null) {
+            throw new IllegalStateException("NodeEngine context is not available for Namespaces! Current thread: "
+                    + Thread.currentThread().getName() + " (" + Thread.currentThread().getId() + ")");
+        } else {
+            return tlContext;
+        }
+    }
+
+    /**
+     * Retrieves the currently set {@link NodeEngine} reference for this thread,
+     * or {@code null} if one could not be found.
+     *
+     * @return This thread's {@link NodeEngine} reference if available, or {@code null}.
+     */
+    public static NodeEngine getNamespaceThreadLocalContextOrNull() {
+        NodeEngine tlContext = NE_THREAD_LOCAL.get();
+        if (tlContext == null) {
+            return null;
+        } else {
+            return tlContext;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/ResourceDefinitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/impl/ResourceDefinitionImpl.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace.impl;
+
+import com.hazelcast.client.impl.protocol.task.dynamicconfig.ResourceDefinitionHolder;
+import com.hazelcast.internal.config.ConfigDataSerializerHook;
+import com.hazelcast.internal.namespace.ResourceDefinition;
+import com.hazelcast.jet.config.ResourceConfig;
+import com.hazelcast.jet.config.ResourceType;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+public class ResourceDefinitionImpl implements ResourceDefinition {
+    private String id;
+    private byte[] payload;
+    private ResourceType type;
+    private String url;
+
+    public ResourceDefinitionImpl() {
+    }
+
+    public ResourceDefinitionImpl(String id, byte[] payload, ResourceType type, String url) {
+        this.id = id;
+        this.payload = payload;
+        this.type = type;
+        this.url = url;
+    }
+
+    public ResourceDefinitionImpl(ResourceConfig resourceConfig) {
+        try (InputStream is = resourceConfig.getUrl().openStream()) {
+            id = resourceConfig.getId();
+            payload = is.readAllBytes();
+            type = resourceConfig.getResourceType();
+            url = resourceConfig.getUrl().toString();
+        } catch (IOException e) {
+            throw new IllegalArgumentException(
+                    "Could not open stream for resource id " + resourceConfig.getId() + " and URL " + resourceConfig.getUrl(),
+                    e);
+        }
+    }
+
+    public ResourceDefinitionImpl(ResourceDefinitionHolder holder) {
+        id = holder.getId();
+        payload = holder.getPayload();
+        type = ResourceType.getById(holder.getResourceType());
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public ResourceType type() {
+        return type;
+    }
+
+    @Override
+    public byte[] payload() {
+        return payload;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return ConfigDataSerializerHook.RESOURCE_DEFINITION;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeString(id);
+        out.writeByteArray(payload);
+        out.writeInt(type.getId());
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        id = in.readString();
+        payload = in.readByteArray();
+        type = ResourceType.getById(in.readInt());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String url() {
+        return url;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        ResourceDefinitionImpl other = (ResourceDefinitionImpl) obj;
+        return Objects.equals(id, other.id);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/namespace/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/namespace/package-info.java
@@ -14,18 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.jet.impl.deployment;
-
-public class JetDelegatingClassLoader extends ClassLoader {
-
-    public JetDelegatingClassLoader(ClassLoader parent) {
-        super(parent == null ? JetDelegatingClassLoader.class.getClassLoader() : parent);
-    }
-
-    public JetDelegatingClassLoader(String name, ClassLoader parent) {
-        super(name, parent == null ? JetDelegatingClassLoader.class.getClassLoader() : parent);
-    }
-
-    public void shutdown() {
-    }
-}
+/**
+ * Implementation of namespaces and resources.
+ */
+package com.hazelcast.internal.namespace;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/OsHelper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.internal.tpcengine.util.OS;
+
+/**
+ * Helper methods related to operating system on which the code is actually running.
+ */
+public final class OsHelper {
+    private OsHelper() {
+    }
+
+    /**
+     * Returns a file path string that replaces Windows `\\` file
+     * separators with the Unix equivalent `/` if the current machine
+     * is using Windows as its Operating System.
+     *
+     * @param path the file path string to convert
+     * @return the file path string, with file separators set to `/`
+     */
+    public static String ensureUnixSeparators(final String path) {
+        if (OS.isWindows()) {
+            return path.replace('\\', '/');
+        }
+        return path;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobClassLoaderService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobClassLoaderService.java
@@ -107,8 +107,8 @@ public class JobClassLoaderService {
                     if (!jetConfig.isResourceUploadEnabled()) {
                         jobClassLoader = new JetDelegatingClassLoader(parent);
                     } else {
-                        jobClassLoader = new JetClassLoader(nodeEngine, parent, config.getName(), jobId,
-                                jobRepository);
+                        jobClassLoader = new JetClassLoader(nodeEngine.getLogger(JetClassLoader.class),
+                                parent, config.getName(), jobId, jobRepository);
                     }
 
                     Map<String, ClassLoader> processorCls = createProcessorClassLoaders(

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.util.OsHelper;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
@@ -50,10 +51,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -70,10 +71,10 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
-import java.util.zip.DeflaterOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -295,15 +296,34 @@ public class JobRepository {
      * Unzips the ZIP archive and processes JAR files
      */
     private void loadJarsInZip(Map<String, byte[]> map, URL url) throws IOException {
-        try (ZipInputStream zis = new ZipInputStream(new BufferedInputStream(url.openStream()))) {
-            ZipEntry zipEntry;
-            while ((zipEntry = zis.getNextEntry()) != null) {
-                if (zipEntry.isDirectory()) {
-                    continue;
-                }
-                if (lowerCaseInternal(zipEntry.getName()).endsWith(".jar")) {
+        try (InputStream inputStream = new BufferedInputStream(url.openStream())) {
+            executeOnJarsInZIP(inputStream, zis -> {
+                try {
                     loadJarFromInputStream(map, zis);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
                 }
+            });
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    /**
+     * Extracts JARs from a ZIP, provided by an {@link InputStream}, passing them to a consumer to process.
+     * <p>
+     * Caller is responsible for closing stream.
+     */
+    public static void executeOnJarsInZIP(InputStream zip, Consumer<ZipInputStream> processor) throws IOException {
+        ZipInputStream zis = new ZipInputStream(zip);
+        ZipEntry zipEntry;
+
+        while ((zipEntry = zis.getNextEntry()) != null) {
+            if (zipEntry.isDirectory()) {
+                continue;
+            }
+            if (lowerCaseInternal(zipEntry.getName()).endsWith(".jar")) {
+                processor.accept(zis);
             }
         }
     }
@@ -323,20 +343,11 @@ public class JobRepository {
         }
     }
 
-    private void readStreamAndPutCompressedToMap(
+    private static void readStreamAndPutCompressedToMap(
             String resourceName, Map<String, byte[]> map, InputStream in
     ) throws IOException {
         // ignore duplicates: the first resource in first jar takes precedence
-        if (map.containsKey(resourceName)) {
-            return;
-        }
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (DeflaterOutputStream compressor = new DeflaterOutputStream(baos)) {
-            IOUtil.drainTo(in, compressor);
-        }
-
-        map.put(classKeyName(resourceName), baos.toByteArray());
+        map.putIfAbsent(classKeyName(resourceName), IOUtil.compress(in.readAllBytes()));
     }
 
     /**
@@ -691,14 +702,14 @@ public class JobRepository {
      * Returns the key name in the form {@code file.<id>}
      */
     public static String fileKeyName(String id) {
-        return FILE_STORAGE_KEY_NAME_PREFIX + id;
+        return OsHelper.ensureUnixSeparators(FILE_STORAGE_KEY_NAME_PREFIX + id);
     }
 
     /**
      * Returns the key name in the form {@code class.<id>}
      */
     public static String classKeyName(String id) {
-        return CLASS_STORAGE_KEY_NAME_PREFIX + id;
+        return OsHelper.ensureUnixSeparators(CLASS_STORAGE_KEY_NAME_PREFIX + id);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/MapResourceClassLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/deployment/MapResourceClassLoader.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.deployment;
+
+import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.jet.impl.util.ReflectionUtils;
+import com.hazelcast.jet.impl.util.Util;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.zip.InflaterInputStream;
+
+import static com.hazelcast.internal.util.StringUtil.isNullOrEmpty;
+import static com.hazelcast.jet.impl.JobRepository.classKeyName;
+import static com.hazelcast.jet.impl.JobRepository.fileKeyName;
+import static com.hazelcast.jet.impl.util.ReflectionUtils.toClassResourceId;
+
+/**
+ * Class loader that can be customized with:
+ * <ul>
+ *     <li>A resources supplier {@code Supplier<? extends Map<String, byte[]>>}.</li>
+ *     <li>Choice of whether it looks up classes and resources in child-first order (so this ClassLoader's resources are
+ *     first search, then, if not found, the parent ClassLoader is queried). If not child-first, then the common parent-first
+ *     hierarchical ClassLoader model is followed.</li>
+ * </ul>
+ * Resources in the {@code <? extends Map<String, byte[]>>} supplied by the resource supplier are expected to follow
+ * these conventions:
+ *  <ul>
+ *      <li>the {@code byte[]} value is the {@link IOUtil#compress(byte[]) deflated} payload of the resource</li>
+ *      <li>key of classes is composed with a {@code "c."} prefix, followed by the classname as file path and the
+ *      {@code ".class"} suffix. Assuming {@code className} is the binary name of the class, the key is formatted
+ *      as {@code classKeyName(toClassResourceId(className))}. See
+ *      {@link com.hazelcast.jet.impl.JobRepository#classKeyName(String)} and
+ *      {@link com.hazelcast.jet.impl.util.ReflectionUtils#toClassResourceId(String)}.</li>
+ *      <li>key of other classpath resources if composed of the {@code "f."} prefix and the path of the resource.
+ *      See also {@link com.hazelcast.jet.impl.JobRepository#fileKeyName(String)}.</li>
+ *  </ul>
+ */
+public class MapResourceClassLoader extends JetDelegatingClassLoader {
+    static final String PROTOCOL = "map-resource";
+
+    protected final Supplier<? extends Map<String, byte[]>> resourcesSupplier;
+    /**
+     * When {@code true}, if the requested class/resource is not found in this ClassLoader's resources, then parent
+     * is queried. Otherwise, only resources in this ClassLoader are searched.
+     */
+    protected final boolean childFirst;
+
+    protected volatile boolean isShutdown;
+    private final ILogger logger = Logger.getLogger(getClass());
+    private final @Nullable String namespace;
+
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
+    // Jet only constructor
+    MapResourceClassLoader(ClassLoader parent,
+                           @Nonnull Supplier<? extends Map<String, byte[]>> resourcesSupplier,
+                           boolean childFirst) {
+        super(parent);
+        this.namespace = null;
+        this.resourcesSupplier = Util.memoizeConcurrent(resourcesSupplier);
+        this.childFirst = childFirst;
+    }
+
+    // UCD Namespaces oriented constructor
+    public MapResourceClassLoader(@Nonnull String namespace, ClassLoader parent,
+                                  @Nonnull Supplier<? extends Map<String, byte[]>> resourcesSupplier,
+                                  boolean childFirst) {
+        super("ucd-namespace", parent);
+        this.namespace = namespace;
+        this.resourcesSupplier = Util.memoizeConcurrent(resourcesSupplier);
+        this.childFirst = childFirst;
+    }
+
+    @Nullable
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (!childFirst) {
+            return super.loadClass(name, resolve);
+        }
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> klass = findLoadedClass(name);
+            // first lookup class in own resources
+            try {
+                if (klass == null) {
+                    klass = findClass(name);
+                }
+            } catch (ClassNotFoundException ignored) {
+                if (logger.isFinestEnabled()) {
+                    logger.finest(ignored);
+                }
+            }
+            if (klass == null && getParent() != null) {
+                try {
+                    klass = getParent().loadClass(name);
+                } catch (ClassNotFoundException ex) {
+                    throw newClassNotFoundException(name);
+                }
+            }
+            if (resolve) {
+                resolveClass(klass);
+            }
+            return klass;
+        }
+    }
+
+    /**
+     * Loads the passed {@link Class} freshly from this {@link ClassLoader}, meaning that the
+     * returned class will resolve {@link Class#getClassLoader()} to this instance.
+     *
+     * @param clazz The {@link Class} to load using this {@link ClassLoader} instance
+     * @return      A {@link Class} that has its {@link ClassLoader} as this instance
+     */
+    public Class<?> loadClassFromThisLoader(Class<?> clazz) {
+        try {
+            byte[] content = ReflectionUtils.getClassContent(clazz.getName(), clazz.getClassLoader());
+            if (content == null) {
+                throw new IllegalArgumentException("Unable to read bytes for extra resource class: " + clazz);
+            }
+            definePackage(clazz.getName());
+            Class<?> result = defineClass(clazz.getName(), content, 0, content.length);
+            resolveClass(result);
+            return result;
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Unable to create extra resource class: " + clazz);
+        }
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        if (isNullOrEmpty(name)) {
+            return null;
+        }
+        byte[] classBytes = resourceBytes(toClassResourceId(name));
+        if (classBytes == null) {
+            throw newClassNotFoundException(name);
+        }
+        definePackage(name);
+        return defineClass(name, classBytes, 0, classBytes.length);
+    }
+
+    @Override
+    public void shutdown() {
+        isShutdown = true;
+    }
+
+    @Nullable
+    @Override
+    public URL getResource(@Nonnull String name) {
+        Objects.requireNonNull(name);
+        if (!childFirst) {
+            return super.getResource(name);
+        }
+        URL res = findResource(name);
+        if (res == null) {
+            res = super.getResource(name);
+        }
+        return res;
+    }
+
+    @Override
+    protected URL findResource(String name) {
+        if (checkShutdown(name) || isNullOrEmpty(name)) {
+            return null;
+        }
+
+        Map<String, byte[]> resourceMap = getResourceMap();
+        if (!resourceMap.containsKey(classKeyName(name)) && !resourceMap.containsKey(fileKeyName(name))) {
+            return null;
+        }
+
+        try {
+            return new URL(PROTOCOL, null, -1, name, new MapResourceURLStreamHandler());
+        } catch (MalformedURLException e) {
+            // this should never happen with custom URLStreamHandler
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, byte[]> getResourceMap() {
+        return resourcesSupplier.get();
+    }
+
+    @Override
+    protected Enumeration<URL> findResources(String name) throws IOException {
+        URL foundResource = findResource(name);
+        return foundResource == null
+                ? Collections.emptyEnumeration()
+                : Collections.enumeration(Collections.singleton(foundResource));
+    }
+
+    public boolean isShutdown() {
+        return isShutdown;
+    }
+
+    // argument is used in overridden implementation
+    @SuppressWarnings("java:S1172")
+    boolean checkShutdown(@SuppressWarnings("unused") String resource) {
+        return isShutdown;
+    }
+
+    @Nullable
+    InputStream resourceStream(String name) {
+        if (checkShutdown(name)) {
+            return null;
+        }
+        byte[] classData = getBytes(name);
+        if (classData == null) {
+            return null;
+        }
+        return new InflaterInputStream(new ByteArrayInputStream(classData));
+    }
+
+    @Nullable
+    byte[] resourceBytes(String name) {
+        if (checkShutdown(name)) {
+            return null;
+        }
+        byte[] classData = getBytes(name);
+        if (classData == null) {
+            return null;
+        }
+        return IOUtil.decompress(classData);
+    }
+
+    @Nullable
+    private byte[] getBytes(String name) {
+        Map<String, byte[]> resourceMap = getResourceMap();
+        byte[] classData = resourceMap.get(classKeyName(name));
+        if (classData == null) {
+            classData = resourceMap.get(fileKeyName(name));
+            if (classData == null) {
+                return null;
+            }
+        }
+        return classData;
+    }
+
+    ClassNotFoundException newClassNotFoundException(String name) {
+        // Output more detail if we're `FINEST` logging
+        if (logger.isFinestEnabled()) {
+            return new ClassNotFoundException("No resource could be identified for '" + name + "'. List of resources:\n"
+                    + getResourceMap().keySet());
+        }
+        return new ClassNotFoundException(name);
+    }
+
+    /**
+     * Defines the package if it is not already defined for the given class
+     * name.
+     *
+     * @param className the class name
+     */
+    void definePackage(String className) {
+        if (isNullOrEmpty(className)) {
+            return;
+        }
+        int lastDotIndex = className.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return;
+        }
+        String packageName = className.substring(0, lastDotIndex);
+        if (getDefinedPackage(packageName) != null) {
+            return;
+        }
+        try {
+            definePackage(packageName, null, null, null, null, null, null, null);
+        } catch (IllegalArgumentException ignored) {
+            // ignore
+        }
+    }
+
+    protected final class MapResourceURLStreamHandler extends URLStreamHandler {
+        @Override
+        protected URLConnection openConnection(URL u) throws IOException {
+            return new MapResourceURLConnection(u);
+        }
+    }
+
+    private final class MapResourceURLConnection extends URLConnection {
+        MapResourceURLConnection(URL url) {
+            super(url);
+        }
+
+        @Override
+        public void connect() throws IOException {
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return resourceStream(url.getFile());
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ReflectionUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/jet/impl/util/ReflectionUtils.java
@@ -32,6 +32,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
@@ -307,6 +310,90 @@ public final class ReflectionUtils {
         } catch (IllegalAccessException ignored) {
             return null;
         }
+    }
+
+    /**
+     * Reads only the necessary amount of bytes for the provided {@link Class} to find and return
+     * the internal binary name for this class, as determined by the {@code CONSTANT_Class} found
+     * in the constants pool at the index determined by the {@code this_class} field.
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-4.html">Java Class file format</a>
+     *
+     * @param classBytes the bytes of a Java {@link Class} to extract binary name from
+     * @return           the binary name of the class
+     */
+    @SuppressWarnings("checkstyle:magicnumber")
+    public static String getInternalBinaryName(byte[] classBytes) {
+        try {
+            ByteBuffer buffer = ByteBuffer.wrap(classBytes);
+            buffer.order(ByteOrder.BIG_ENDIAN);
+
+            // Skip magic number and major/minor versions
+            buffer.position(8);
+
+            int constantPoolCount = buffer.getShort() & 0xFFFF;
+            Object[] constantPool = new Object[constantPoolCount];
+
+            // Iterate constant pool, collecting UTF8 strings (could be our class name) and looking for CONSTANT_Class tags
+            //   to identify our desired UTF8 string representing the class name. Skips appropriate bytes for all other tags.
+            // While it is generally convention for the index referenced by a CONSTANT_Class value to already be populated in
+            //   the constant pool (forward references), it is not forbidden by JVM Spec to use backward references.
+            // We need to skip the payload of all irrelevant tags, by the amount defined in the JVM spec (see javadoc)
+            for (int i = 1; i < constantPoolCount; i++) {
+                int tag = buffer.get() & 0xFF;
+                switch (tag) {
+                    case 1: // CONSTANT_Utf8
+                        int length = buffer.getShort() & 0xFFFF;
+                        byte[] bytes = new byte[length];
+                        buffer.get(bytes);
+                        constantPool[i] = new String(bytes, StandardCharsets.UTF_8);
+                        break;
+                    case 7: // CONSTANT_Class
+                        constantPool[i] = buffer.getShort() & 0xFFFF; // Store index
+                        break;
+                    case 8: // CONSTANT_String
+                    case 16: // CONSTANT_MethodType
+                    case 19: // CONSTANT_Module
+                    case 20: // CONSTANT_Package
+                        skipBytes(buffer, 2);
+                        break;
+                    case 15: // CONSTANT_MethodHandle
+                        skipBytes(buffer, 3);
+                        break;
+                    case 3: // CONSTANT_Integer
+                    case 4: // CONSTANT_Float
+                    case 9: // CONSTANT_Fieldref
+                    case 10: // CONSTANT_Methodref
+                    case 11: // CONSTANT_InterfaceMethodref
+                    case 12: // CONSTANT_NameAndType
+                    case 18: // CONSTANT_InvokeDynamic
+                    case 17: // CONSTANT_Dynamic
+                        skipBytes(buffer, 4);
+                        break;
+                    case 5: // CONSTANT_Long
+                    case 6: // CONSTANT_Double
+                        skipBytes(buffer, 8);
+                        i++;
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Invalid constant pool tag: " + tag);
+                }
+            }
+
+            // Skip access flag
+            skipBytes(buffer, 2);
+
+            // Read this_class index which points to the constantPool index which holds the value of
+            //     the index to find the current classes' internal binary name
+            int thisClassIndex = buffer.getShort() & 0xFFFF;
+            return (String) constantPool[(int) constantPool[thisClassIndex]];
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to local package/class names from class bytes!", e);
+        }
+    }
+
+    private static void skipBytes(ByteBuffer buffer, int toSkip) {
+        buffer.position(buffer.position() + toSkip);
     }
 
     public static final class Resources {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngine.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.dataconnection.impl.InternalDataConnectionService;
 import com.hazelcast.instance.impl.NodeExtension;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.namespace.NamespaceService;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
@@ -101,6 +102,13 @@ public interface NodeEngine {
     TransactionManagerService getTransactionManagerService();
 
     /**
+     * Gets the NamespaceService.
+     *
+     * @return the NamespaceService
+     */
+    NamespaceService getNamespaceService();
+
+    /**
      * Gets the address of the master member.
      * <p>
      * This value can be null if no master is elected yet.
@@ -142,12 +150,18 @@ public interface NodeEngine {
     Config getConfig();
 
     /**
-     * Returns the Config ClassLoader. This class loader will be used for instantiation of all classes defined by the
-     * configuration (e.g. listeners, policies, stores, partitioning strategies, split brain protection functions, ...).
+     * Returns the Config ClassLoader. This class loader will be used for the instantiation of all classes defined
+     * by the configuration (e.g. listeners, policies, stores, partitioning strategies, split brain protection
+     * functions, etc.).
      * <p>
-     * TODO: add more documentation what the purpose is of the config classloader
+     * When the {@link NamespaceService} is enabled, this will return an instance of the
+     * {@link com.hazelcast.internal.namespace.impl.NamespaceAwareClassLoader}, which delegates to child loaders
+     * depending on the Namespace context of the class loading.
+     * <p>
+     * When the {@link NamespaceService} is disabled, this will return either the legacy User Code Deployment
+     * class loader if enabled, or else the {@link Config#getClassLoader()} will be returned.
      *
-     * @return the config ClassLoader.
+     * @return the config ClassLoader as defined above.
      */
     ClassLoader getConfigClassLoader();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -40,6 +40,7 @@ import com.hazelcast.internal.metrics.metricsets.GarbageCollectionMetricSet;
 import com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet;
 import com.hazelcast.internal.metrics.metricsets.RuntimeMetricSet;
 import com.hazelcast.internal.metrics.metricsets.ThreadMetricSet;
+import com.hazelcast.internal.namespace.NamespaceService;
 import com.hazelcast.internal.nio.Packet;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationInfo;
@@ -639,5 +640,10 @@ public class NodeEngineImpl implements NodeEngine {
                 throw new UnsupportedOperationException("Jet is not enabled on this node");
             };
         }
+    }
+
+    @Override
+    public NamespaceService getNamespaceService() {
+        return node.getNamespaceService();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/ConfigClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/ConfigClassLoaderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.namespace.impl.NodeEngineThreadLocalContext;
+import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.test.HazelcastTestSupport;
+
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+
+/** Stub to get a qualified instance of {@link Node#getConfigClassLoader()} */
+public abstract class ConfigClassLoaderTest extends HazelcastTestSupport {
+    protected Config config;
+    protected NodeEngine engine;
+    protected ClassLoader engineConfigClassLoader;
+
+    public ConfigClassLoaderTest() {
+        config = new Config();
+        config.setClassLoader(HazelcastInstance.class.getClassLoader());
+    }
+
+    protected void createHazelcastInstanceWithConfig() {
+        HazelcastInstance instance = createHazelcastInstance(config);
+        engine = getNodeEngineImpl(instance);
+        engineConfigClassLoader = engine.getConfigClassLoader();
+        NodeEngineThreadLocalContext.declareNodeEngineReference(engine);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NamespaceAwareClassLoaderIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NamespaceAwareClassLoaderIntegrationTest.java
@@ -1,0 +1,577 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+import com.google.common.base.CaseFormat;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.NamespaceConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.namespace.NamespaceUtil;
+import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.internal.util.OsHelper;
+import com.hazelcast.jet.impl.deployment.MapResourceClassLoader;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.IMap;
+import com.hazelcast.test.Accessors;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.NamespaceTest;
+import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.starter.MavenInterface;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.hazelcast.jet.impl.JobRepository.classKeyName;
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Test static namespace configuration, resource resolution and classloading end-to-end */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({SlowTest.class, NamespaceTest.class})
+public class NamespaceAwareClassLoaderIntegrationTest extends HazelcastTestSupport {
+    private static Path classRoot;
+    protected static MapResourceClassLoader mapResourceClassLoader;
+    private static Artifact h2V202Artifact;
+    private static Artifact h2V204Artifact;
+
+    protected Config config;
+
+    @BeforeClass
+    public static void setUpClass() throws IOException {
+        classRoot = Paths.get("src/test/class");
+        mapResourceClassLoader = generateMapResourceClassLoaderForDirectory(classRoot);
+        h2V202Artifact = new DefaultArtifact("com.h2database", "h2", null, "2.0.202");
+        h2V204Artifact = new DefaultArtifact("com.h2database", "h2", null, "2.0.204");
+    }
+
+    @Before
+    public void setUp() {
+        config = new Config();
+        config.getNamespacesConfig().setEnabled(true);
+    }
+
+    /**
+     * @see <a href="https://hazelcast.atlassian.net/browse/HZ-3301">HZ-3301 - Test case for Milestone 1 use cases</a>
+     */
+    @Test
+    public void testNamespaceClassResolution() {
+        // "I can statically configure a namespace with a java class that gets resolved at runtime"
+        for (CaseValueProcessor processor : CaseValueProcessor.values()) {
+            processor.addNamespaceToConfig(config);
+        }
+
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+
+        // "I can run a customer entry processor and configure an IMap in that namespace"
+        // "to execute that entry processor on that IMap"
+        // "I can configure N > 1 namespaces with simple Java class resources of same name and different behavior"
+        Map<CaseValueProcessor, IMap<Object, String>> processorToMap =
+                Arrays.stream(CaseValueProcessor.values()).collect(Collectors.toMap(Function.identity(),
+                        processor -> processor.createExecuteAssertOnMap(hazelcastInstance)));
+
+        // "IMaps configured in the respective namespaces will correctly load and execute the respective EntryProcessor defined
+        // in their namespace, without class name clashes."
+        processorToMap.forEach((processor, map) -> processor.assertEntryUpdated(map));
+    }
+
+    /**
+     * @see <a href="https://hazelcast.atlassian.net/browse/HZ-3357">HZ-3357 - Test case for Milestone 1 dependencies use
+     *      cases</a>
+     */
+    @Test
+    public void testJDBCDriverDependencyHandling() throws Exception {
+        String mapName = randomMapName();
+        String className = "usercodedeployment.DerbyUpperCaseStringMapLoader";
+
+        assertClassNotAccessible(className);
+
+        // Add the latest Derby version that supports Java 11 (newer versions require Java 17)
+        NamespaceConfig namespace = new NamespaceConfig("ns1").addClass(mapResourceClassLoader.loadClass(className))
+                .addJar(MavenInterface.locateArtifact(new DefaultArtifact("org.apache.derby", "derby", null, "10.15.2.0"))
+                        .toUri().toURL(), null)
+                .addJar(MavenInterface.locateArtifact(new DefaultArtifact("org.apache.derby", "derbyshared", null, "10.15.2.0"))
+                        .toUri().toURL(), null);
+
+        config.getNamespacesConfig().addNamespaceConfig(namespace);
+        config.getMapConfig(mapName).setNamespace(namespace.getName()).getMapStoreConfig().setEnabled(true)
+                .setClassName(className);
+
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+
+        String mapped = executeMapLoader(hazelcastInstance, mapName);
+        assertNotNull("Was the MapStore executed?", mapped);
+        assertEquals(getClass().getSimpleName().toUpperCase(), mapped);
+    }
+
+    /**
+     * @see <a href="https://hazelcast.atlassian.net/browse/HZ-3357">HZ-3357 - Test case for Milestone 1 dependencies use
+     *      cases</a>
+     */
+    @Test
+    public void testNamespaceClassapthIsolation() throws Exception {
+        String mapName = randomMapName();
+        String className = "usercodedeployment.H2WithDriverManagerBuildVersionMapLoader";
+
+        assertClassNotAccessible(className);
+
+        // Deliberately use an older version
+        NamespaceConfig namespace = new NamespaceConfig("ns1").addClass(mapResourceClassLoader.loadClass(className))
+                .addJar(MavenInterface.locateArtifact(h2V202Artifact).toUri().toURL(), null);
+        config.getNamespacesConfig().addNamespaceConfig(namespace);
+
+        config.getMapConfig(mapName).setNamespace(namespace.getName()).getMapStoreConfig().setEnabled(true)
+                .setClassName(className);
+
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+
+        String namespaceH2Version = executeMapLoader(hazelcastInstance, mapName);
+
+        assertNotNull("Was the MapStore executed?", namespaceH2Version);
+        assertEquals("Unexpected version of H2 found in namespace", h2V202Artifact.getVersion(), namespaceH2Version);
+        assertNotEquals("Namespaces dependencies do not appear to be isolated", org.h2.engine.Constants.VERSION,
+                namespaceH2Version);
+    }
+
+    /**
+     * @see <a href="https://hazelcast.atlassian.net/browse/HZ-3413">HZ-3413 - Test cases for Milestone 2</a>
+     */
+    @Test
+    public void testNamespaceResourceDynamicLoading() {
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+
+        CaseValueProcessor processor = CaseValueProcessor.LOWER_CASE_VALUE_ENTRY_PROCESSOR;
+
+        // Set the map up, but catch a failure because we haven't configured the processor
+        assertThrows(Exception.class, () -> processor.createExecuteAssertOnMap(hazelcastInstance));
+
+        // Then dynamically configure
+        processor.addNamespaceToConfig(hazelcastInstance.getConfig());
+
+        // And re-run the test expecting success
+        processor.createExecuteAssertOnMap(hazelcastInstance);
+
+        // And able to roll back by removing it again
+        hazelcastInstance.getConfig().getNamespacesConfig().removeNamespaceConfig(processor.namespace.getName());
+        assertThrows(Exception.class, () -> processor.createExecuteAssertOnMap(hazelcastInstance));
+    }
+
+    /**
+     * @see <a href="https://hazelcast.atlassian.net/browse/HZ-3413">HZ-3413 - Test cases for Milestone 2</a>
+     */
+    @Test
+    public void testNamespaceResourceOverwriting() {
+        CaseValueProcessor processor = CaseValueProcessor.LOWER_CASE_VALUE_ENTRY_PROCESSOR;
+        CaseValueProcessor otherProcessor = CaseValueProcessor.UPPER_CASE_VALUE_ENTRY_PROCESSOR;
+
+        processor.addNamespaceToConfig(config);
+
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+
+        // Assert the basic functionality
+        processor.createExecuteAssertOnMap(hazelcastInstance);
+
+        // Now swap the class in the namespace
+        String namespace = processor.namespace.getName();
+        hazelcastInstance.getConfig().getNamespacesConfig()
+                .addNamespaceConfig(new NamespaceConfig(namespace).addClass(otherProcessor.clazz));
+
+        // Now assert the behavior has swapped, too
+        otherProcessor.createExecuteAssertOnMap(namespace, processor.mapName, hazelcastInstance);
+    }
+
+    /**
+     * @see <a href="https://hazelcast.atlassian.net/browse/HZ-3390">HZ-3390 - Support ServiceLoader in
+     *      NamespaceAwareClassLoader</a>
+     */
+    @Test
+    public void testServiceLoader() throws Exception {
+        // Class + Map Name
+        Pair<String, String> driverManager = Pair.of("usercodedeployment.H2WithDriverManagerBuildVersionMapLoader",
+                randomMapName());
+        Pair<String, String> dataSource = Pair.of("usercodedeployment.H2WithDataSourceBuildVersionMapLoader", randomMapName());
+
+        Pair<String, String>[] classes = new Pair[] {driverManager, dataSource};
+
+        NamespaceConfig namespace = new NamespaceConfig("ns1")
+                .addJar(MavenInterface.locateArtifact(h2V202Artifact).toUri().toURL(), null);
+        config.getNamespacesConfig().addNamespaceConfig(namespace);
+
+        for (Pair<String, String> clazz : classes) {
+            namespace.addClass(mapResourceClassLoader.loadClass(clazz.getLeft()));
+            config.getMapConfig(clazz.getRight()).setNamespace(namespace.getName()).getMapStoreConfig().setEnabled(true)
+                    .setClassName(clazz.getLeft());
+        }
+
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+
+        assertEquals("Fixture setup of JDBC with explicit driver declaration", h2V202Artifact.getVersion(),
+                executeMapLoader(hazelcastInstance, dataSource.getRight()));
+
+        assertEquals("JDBC generally is working, but Driver Manager isn't - suggests Service Loader issue",
+                h2V202Artifact.getVersion(), executeMapLoader(hazelcastInstance, driverManager.getRight()));
+
+        // Now dynamically reconfigure to an alternative version of H2
+        namespace = new NamespaceConfig(namespace.getName())
+                .addJar(MavenInterface.locateArtifact(h2V204Artifact).toUri().toURL(), null);
+
+        for (Pair<String, String> clazz : classes) {
+            namespace.addClass(mapResourceClassLoader.loadClass(clazz.getLeft()));
+            // destroy maps so MapLoader will be instantiated again when IMap is recreated
+            hazelcastInstance.getMap(clazz.getRight()).destroy();
+        }
+
+        hazelcastInstance.getConfig().getNamespacesConfig().addNamespaceConfig(namespace);
+
+        assertEquals("Worked with static configuration, but did not refresh when dynamically reconfigured", h2V204Artifact.getVersion(),
+                executeMapLoader(hazelcastInstance, dataSource.getRight()));
+
+        assertEquals("JDBC generally is working, but Driver Manager isn't - suggests dynamic configuration Service Loader issue",
+                h2V204Artifact.getVersion(), executeMapLoader(hazelcastInstance, driverManager.getRight()));
+    }
+
+    /**
+     * @see <a href="https://hazelcast.atlassian.net/browse/HZ-3450">HZ-3450 - Implement message tasks for adding & removing
+     *      namespaces</a>
+     */
+    @Test
+    public void testClientToMemberConfigPropagation() {
+        TestHazelcastFactory factory = new TestHazelcastFactory();
+
+        try {
+            HazelcastInstance member = factory.newHazelcastInstance(config);
+            HazelcastInstance client = factory.newHazelcastClient();
+            CaseValueProcessor processor = CaseValueProcessor.LOWER_CASE_VALUE_ENTRY_PROCESSOR;
+
+            // Add
+            client.getConfig().getNamespacesConfig().addNamespaceConfig(processor.namespace);
+            assertTrue("Namespace configuration addition has not propagated from client to member",
+                    Accessors.getNode(member).getNamespaceService().hasNamespace(processor.namespace.getName()));
+
+            // Remove
+            client.getConfig().getNamespacesConfig().removeNamespaceConfig(processor.namespace.getName());
+            assertFalse("Namespace configuration removal has not propagated from client to member",
+                    Accessors.getNode(member).getNamespaceService().hasNamespace(processor.namespace.getName()));
+        } finally {
+            factory.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testMemberToMemberDeserialization_Simple_2Node() throws ReflectiveOperationException {
+        testMemberToMemberDeserialization(2,
+                "usercodedeployment.IncrementingStringEntryProcessor",
+                "usercodedeployment.IncrementingStringEntryProcessor");
+    }
+
+    @Test
+    public void testMemberToMemberDeserialization_Simple_5Node() throws ReflectiveOperationException {
+        testMemberToMemberDeserialization(5,
+                "usercodedeployment.IncrementingStringEntryProcessor",
+                "usercodedeployment.IncrementingStringEntryProcessor");
+    }
+
+    @Test
+    public void testMemberToMemberDeserialization_Complex_2Node() throws ReflectiveOperationException {
+        testMemberToMemberDeserialization(2,
+                "usercodedeployment.ComplexStringEntryProcessor",
+                "usercodedeployment.ComplexStringEntryProcessor",
+                "usercodedeployment.ComplexProcessor");
+    }
+
+    @Test
+    public void testMemberToMemberDeserialization_Complex_5Node() throws ReflectiveOperationException {
+        testMemberToMemberDeserialization(5,
+                "usercodedeployment.ComplexStringEntryProcessor",
+                "usercodedeployment.ComplexStringEntryProcessor",
+                "usercodedeployment.ComplexProcessor");
+    }
+
+    private void testMemberToMemberDeserialization(int nodeCount, String entryProcessClassName,
+                                                               String... resourceClassNames) throws ReflectiveOperationException {
+        assertGreaterOrEquals("nodeCount", nodeCount, 2);
+        assertClassNotAccessible(entryProcessClassName);
+
+        TestHazelcastFactory factory = new TestHazelcastFactory(nodeCount);
+        try {
+            final String mapName = randomMapName();
+            configureSimpleNodeConfig(mapName, "my-ep-ns", resourceClassNames);
+            HazelcastInstance[] instances = factory.newInstances(config, nodeCount);
+
+            // Create map on the cluster as normal, populate with data for each partition
+            IMap<String, Integer> map = instances[0].getMap(mapName);
+            for (int k = 0; k < 10; k++) {
+                int j = 1;
+                for (HazelcastInstance instance : instances) {
+                    map.put(generateKeyOwnedBy(instance), j++);
+                }
+            }
+
+            // Assert ownership distribution
+            Set<String> member1Keys = map.localKeySet();
+            assertEquals(10, member1Keys.size());
+
+            for (int k = 1; k < instances.length; k++) {
+                HazelcastInstance instance = instances[k];
+                IMap<String, Integer> memberMap = instance.getMap(mapName);
+                assertEquals(10, memberMap.localKeySet().size());
+            }
+
+            // Create a client that only communicates with member1 (unisocket)
+            HazelcastInstance client = createUnisocketClient(factory);
+
+            // Execute processor on keys owned by other members
+            IMap<String, Integer> clientMap = client.getMap(mapName);
+            EntryProcessor<String, Integer, ?> entryProcessor =
+                    (EntryProcessor<String, Integer, ?>) mapResourceClassLoader.loadClass(entryProcessClassName)
+                                                                               .getConstructor().newInstance();
+            for (int k = 0; k < instances.length; k++) {
+                HazelcastInstance instance = instances[k];
+                String key = (String) instance.getMap(mapName).localKeySet().iterator().next();
+                clientMap.executeOnKey(key, entryProcessor);
+
+                // Assert processor completed successfully
+                int expectedOutput = k + 2;
+                assertTrueEventually(() -> assertEquals(expectedOutput, clientMap.get(key).intValue()));
+            }
+        } finally {
+            factory.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testDynamicConfigMapLoaderDeserialization_2Node() throws ReflectiveOperationException {
+        testMemberToMemberMLDeserialization(2,
+                "usercodedeployment.KeyBecomesValueMapLoader",
+                "usercodedeployment.KeyBecomesValueMapLoader");
+    }
+
+    @Test
+    public void testDynamicConfigMapLoaderDeserialization_5Node() throws ReflectiveOperationException {
+        testMemberToMemberMLDeserialization(5,
+                "usercodedeployment.KeyBecomesValueMapLoader",
+                "usercodedeployment.KeyBecomesValueMapLoader");
+    }
+
+    private void testMemberToMemberMLDeserialization(int nodeCount, String mapLoaderClassName,
+                                                               String... resourceClassNames) throws ReflectiveOperationException {
+        assertGreaterOrEquals("nodeCount", nodeCount, 2);
+        assertClassNotAccessible(mapLoaderClassName);
+
+        final TestHazelcastFactory factory = new TestHazelcastFactory(nodeCount);
+        try {
+            final String mapName = randomMapName();
+            final String namespace = "my-ml-ns";
+            configureSimpleNodeConfig(null, namespace, resourceClassNames);
+            HazelcastInstance[] instances = factory.newInstances(config, nodeCount);
+
+            // Create a client that only communicates with member1 (unisocket)
+            HazelcastInstance client = createUnisocketClient(factory);
+
+            // Dynamically add a new MapConfig with a MapLoader that needs to be loaded
+            MapConfig mapConfig = new MapConfig(mapName).setNamespace(namespace);
+            mapConfig.getMapStoreConfig().setEnabled(true).setClassName(mapLoaderClassName);
+            client.getConfig().addMapConfig(mapConfig);
+
+            // Trigger map loader on all members and assert values are correct
+            for (int k = 0; k < instances.length; k++) {
+                HazelcastInstance instance = instances[k];
+                String result = executeMapLoader(instance, mapName);
+                assertEquals(getClass().getSimpleName(), result);
+            }
+        } finally {
+            factory.shutdownAll();
+        }
+    }
+
+    private static HazelcastInstance createUnisocketClient(TestHazelcastFactory factory) {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().addAddress("127.0.0.1:5701");
+        clientConfig.getNetworkConfig().setSmartRouting(false);
+        return factory.newHazelcastClient(clientConfig);
+    }
+
+    private void configureSimpleNodeConfig(String mapName, String namespaceId, String... classNames) throws ClassNotFoundException {
+        for (String className : classNames) {
+            assertClassNotAccessible(className);
+        }
+
+        NamespaceConfig namespace = new NamespaceConfig(namespaceId);
+        for (String name : classNames) {
+            namespace.addClass(mapResourceClassLoader.loadClass(name));
+        }
+        config.getNamespacesConfig().addNamespaceConfig(namespace);
+        config.getNetworkConfig().setPort(5701);
+        if (mapName != null) {
+            config.getMapConfig(mapName)
+                  .setNamespace(namespace.getName());
+        }
+    }
+
+    /** Find & load all {@code .class} files in the scope of this test */
+    protected static MapResourceClassLoader generateMapResourceClassLoaderForDirectory(Path root) throws IOException {
+        try (Stream<Path> stream = Files.walk(root.resolve("usercodedeployment"))) {
+            final Map<String, byte[]> classNameToContent = stream
+                    .filter(path -> FilenameUtils.isExtension(path.getFileName().toString(), "class"))
+                    .collect(Collectors.toMap(path -> correctResourcePath(root, path), path -> {
+                        try {
+                            return IOUtil.compress(Files.readAllBytes(path));
+                        } catch (final IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    }));
+
+            return new MapResourceClassLoader(null, NamespaceAwareClassLoaderIntegrationTest.class.getClassLoader(),
+                    () -> classNameToContent, true);
+        }
+    }
+
+    private static String correctResourcePath(Path root, Path path) {
+        String classKeyName = classKeyName(root.relativize(path).toString());
+        return OsHelper.ensureUnixSeparators(classKeyName);
+    }
+
+    private static Class<?> tryLoadClass(HazelcastInstance instance, String namespace, String className) throws ClassNotFoundException  {
+        if (namespace != null) {
+            NamespaceUtil.setupNamespace(getNodeEngineImpl(instance), namespace);
+        }
+        try {
+            return Accessors.getNode(instance).getConfigClassLoader().loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new ClassNotFoundException(
+                    MessageFormat.format("\"{0}\" class not found in \"{1}\" namespace", className, namespace), e);
+        } finally {
+            if (namespace != null) {
+                NamespaceUtil.cleanupNamespace(getNodeEngineImpl(instance), namespace);
+            }
+        }
+    }
+
+    private String executeMapLoader(HazelcastInstance hazelcastInstance, String mapName) {
+        IMap<String, String> map = hazelcastInstance.getMap(mapName);
+
+        // Ensure MapLoader is executed
+        map.loadAll(false);
+
+        return map.get(getClass().getSimpleName());
+    }
+
+    /**
+     * References to {@link EntryProcessor}s - not on the classpath - that modify the case of a {@link String} value in a map
+     */
+    private enum CaseValueProcessor {
+        UPPER_CASE_VALUE_ENTRY_PROCESSOR(String::toUpperCase), LOWER_CASE_VALUE_ENTRY_PROCESSOR(String::toLowerCase);
+
+        /** Use the same class name to assert isolation */
+        private static final String className = "usercodedeployment.ModifyCaseValueEntryProcessor";
+        private static final Object KEY = Void.TYPE;
+        private static final String VALUE = "VaLuE";
+
+        /** The operation we expect the {@link EntryProcessor} to perform - for validation purposes */
+        private final UnaryOperator<String> expectedOperation;
+        private final Class<? extends EntryProcessor<Object, String, String>>  clazz;
+        private final NamespaceConfig namespace;
+        private final String mapName = randomMapName();
+
+        /** @param expectedOperation {@link #expectedOperation} */
+        CaseValueProcessor(UnaryOperator<String> expectedOperation) {
+            this.expectedOperation = expectedOperation;
+
+            try {
+                clazz = (Class<? extends EntryProcessor<Object, String, String>>) generateMapResourceClassLoaderForDirectory(
+                        classRoot.resolve("usercodedeployment").resolve(toString())).loadClass(className);
+                namespace = new NamespaceConfig(toString()).addClass(clazz);
+            } catch (ClassNotFoundException | IOException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+
+            assertClassNotAccessible(className);
+        }
+
+        private void addNamespaceToConfig(Config config) {
+            config.getNamespacesConfig().addNamespaceConfig(namespace);
+            config.getMapConfig(mapName).setNamespace(namespace.getName());
+        }
+
+        private IMap<Object, String> createExecuteAssertOnMap(HazelcastInstance hazelcastInstance) {
+            return createExecuteAssertOnMap(namespace.getName(), mapName, hazelcastInstance);
+        }
+
+        private IMap<Object, String> createExecuteAssertOnMap(String namespace, String mapName,
+                HazelcastInstance hazelcastInstance) {
+            // Create a map
+            IMap<Object, String> map = hazelcastInstance.getMap(mapName);
+            map.put(KEY, VALUE);
+
+            try {
+                // Execute the EntryProcessor
+                Class<? extends EntryProcessor<Object, String, String>> clazz =
+                        (Class<? extends EntryProcessor<Object, String, String>>)
+                                tryLoadClass(hazelcastInstance, namespace, className);
+                map.executeOnKey(Void.TYPE, clazz.getDeclaredConstructor().newInstance());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            assertEntryUpdated(map);
+
+            return map;
+        }
+
+        private void assertEntryUpdated(IMap<Object, String> map) {
+            assertEquals(expectedOperation.apply(VALUE), map.get(KEY));
+        }
+
+        @Override
+        public String toString() {
+            return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, name());
+        }
+    }
+
+    private static void assertClassNotAccessible(String className) {
+        Assert.assertThrows("The test class should not be already accessible: " + className,
+                ClassNotFoundException.class, () -> Class.forName(className));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NamespaceAwareClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NamespaceAwareClassLoaderTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+import com.hazelcast.config.NamespaceConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.namespace.NamespaceUtil;
+import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.jet.impl.JobRepository;
+import com.hazelcast.jet.impl.deployment.MapResourceClassLoader;
+import com.hazelcast.jet.impl.util.Util;
+import com.hazelcast.test.annotation.NamespaceTest;
+import com.hazelcast.test.starter.MavenInterface;
+import org.apache.commons.io.FilenameUtils;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Driver;
+import java.text.MessageFormat;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.hazelcast.test.UserCodeUtil.fileRelativeToBinariesFolder;
+import static com.hazelcast.test.UserCodeUtil.urlFromFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/** Test static namespace configuration, resource resolution and classloading end-to-end */
+@Category(NamespaceTest.class)
+public class NamespaceAwareClassLoaderTest extends ConfigClassLoaderTest {
+    private static Path classRoot;
+    private static MapResourceClassLoader mapResourceClassLoader;
+    private static Artifact h2V202Artifact;
+
+    @BeforeClass
+    public static void setUpClass() throws IOException {
+        classRoot = Paths.get("src/test/class");
+        mapResourceClassLoader = generateMapResourceClassLoaderForDirectory(classRoot);
+        h2V202Artifact = new DefaultArtifact("com.h2database", "h2", null, "2.0.202");
+    }
+
+    @Before
+    public void prepareConfig() {
+        config.getNamespacesConfig().setEnabled(true);
+    }
+
+    @Test
+    public void whenLoadClassKnownToParent_thenIsLoaded() throws Exception {
+        createHazelcastInstanceWithConfig();
+        Class<?> klass = tryLoadClass(null, "com.hazelcast.core.HazelcastInstance");
+        assertSame(HazelcastInstance.class, klass);
+    }
+
+    @Test
+    public void whenLoadClassKnownToParent_thenIsLoadedWithNoNamespaceDefined() throws Exception {
+        createHazelcastInstanceWithConfig();
+        Class<?> klass = tryLoadClass(null, "com.hazelcast.core.HazelcastInstance");
+        assertSame(HazelcastInstance.class, klass);
+    }
+
+    @Test
+    public void whenSimpleClassInNs_thenIsLoaded() throws Exception {
+        config.getNamespacesConfig().addNamespaceConfig(
+                new NamespaceConfig("ns1").addClass(mapResourceClassLoader.loadClass("usercodedeployment.ParentClass")));
+         createHazelcastInstanceWithConfig();
+
+        Class<?> parentClass = tryLoadClass("ns1", "usercodedeployment.ParentClass");
+        assertInstanceOf(MapResourceClassLoader.class, parentClass.getClassLoader());
+    }
+
+    @Test
+    public void whenSimpleClassInNs_thenIsNotLoadedWithNoNamespaceDefined() throws Exception {
+        config.getNamespacesConfig().addNamespaceConfig(
+                new NamespaceConfig("ns1").addClass(mapResourceClassLoader.loadClass("usercodedeployment.ParentClass")));
+        createHazelcastInstanceWithConfig();
+
+        assertThrows(ClassNotFoundException.class, () -> tryLoadClass(null, "usercodedeployment.ParentClass"));
+    }
+
+    @Test
+    public void whenClassWithHierarchyInNs_thenIsLoaded() throws Exception {
+        config.getNamespacesConfig().addNamespaceConfig(
+                new NamespaceConfig("ns1").addClass(mapResourceClassLoader.loadClass("usercodedeployment.ParentClass"))
+                        .addClass(mapResourceClassLoader.loadClass("usercodedeployment.ChildClass")));
+         createHazelcastInstanceWithConfig();
+
+        Class<?> childClass = tryLoadClass("ns1", "usercodedeployment.ChildClass");
+        assertEquals("usercodedeployment.ParentClass", childClass.getSuperclass().getName());
+        // assert child & parent are loaded by same classloader
+        assertSame(childClass.getClassLoader(), childClass.getSuperclass().getClassLoader());
+    }
+
+    @Test
+    public void whenLoadInnerClassKnownToParent_thenIsLoaded() throws Exception {
+        config.getNamespacesConfig().addNamespaceConfig(new NamespaceConfig("ns1").addJar(
+                urlFromFile(fileRelativeToBinariesFolder("/usercodedeployment/EntryProcessorWithAnonymousAndInner.jar")), null));
+         createHazelcastInstanceWithConfig();
+
+        tryLoadClass("ns1", "usercodedeployment.EntryProcessorWithAnonymousAndInner");
+        tryLoadClass("ns1", "usercodedeployment.EntryProcessorWithAnonymousAndInner$Test");
+    }
+
+    private static int countSqlDriversOf(ClassLoader classLoader) {
+        Enumeration<URL> urls = Util.uncheckCall(() -> classLoader.getResources("META-INF/services/java.sql.Driver"));
+        int count = 0;
+        while (urls.hasMoreElements()) {
+            count++;
+            urls.nextElement();
+        }
+        return count;
+    }
+
+    @Test
+    public void testServiceLoader_whenMultipleServicesOnClasspath() throws Exception {
+        config.getNamespacesConfig().addNamespaceConfig(
+                new NamespaceConfig("ns1").addJar(MavenInterface.locateArtifact(h2V202Artifact).toUri().toURL(), null));
+        createHazelcastInstanceWithConfig();
+        ClassLoader testClassLoader = NamespaceAwareClassLoaderTest.class.getClassLoader();
+
+        // We need to provide NodeEngine context (as would be in place for Operations normally)
+        NamespaceUtil.runWithNamespace("ns1", () -> {
+            int countInTestClasspath = countSqlDriversOf(testClassLoader);
+            int countInNamespace = countSqlDriversOf(engineConfigClassLoader);
+            // namespace classpath contains one additional URL to META-INF/services/java.sql.Driver
+            // in the H2 JDBC driver artifact added to the namespace
+            assertEquals(countInTestClasspath + 1, countInNamespace);
+
+            ServiceLoader<Driver> loader = ServiceLoader.load(Driver.class, testClassLoader);
+            Driver h2DriverFromTestCP = null;
+            for (Driver d : loader) {
+                if (d.getClass().getName().equals("org.h2.Driver")) {
+                    h2DriverFromTestCP = d;
+                }
+            }
+            // verify driver version loaded from test classpath
+            assertSame(testClassLoader, h2DriverFromTestCP.getClass().getClassLoader());
+            assertEquals(2, h2DriverFromTestCP.getMajorVersion());
+            assertEquals(2, h2DriverFromTestCP.getMinorVersion());
+
+            Driver h2DriverFromNamespaceCP = null;
+            loader = ServiceLoader.load(Driver.class, engineConfigClassLoader);
+            List<ServiceLoader.Provider<Driver>> providers =
+                    loader.stream().filter(d -> d.type().getName().equals("org.h2.Driver")).collect(Collectors.toList());
+            assertEquals(1, providers.size());
+            h2DriverFromNamespaceCP = providers.get(0).get();
+            // verify driver is loaded from older version that is present in namespace classpath
+            assertInstanceOf(MapResourceClassLoader.class, h2DriverFromNamespaceCP.getClass().getClassLoader());
+            assertEquals(2, h2DriverFromNamespaceCP.getMajorVersion());
+            assertEquals(0, h2DriverFromNamespaceCP.getMinorVersion());
+        });
+    }
+
+    /** Find & load all .class files in the scope of this test */
+    private static MapResourceClassLoader generateMapResourceClassLoaderForDirectory(Path root) throws IOException {
+        try (Stream<Path> stream = Files.walk(root.resolve("usercodedeployment"))) {
+            final Map<String, byte[]> classNameToContent =
+                    stream.filter(path -> FilenameUtils.isExtension(path.getFileName().toString(), "class"))
+                            .collect(Collectors.toMap(path -> JobRepository.classKeyName(root.relativize(path).toString()), path -> {
+                                try {
+                                    return IOUtil.compress(Files.readAllBytes(path));
+                                } catch (final IOException e) {
+                                    throw new UncheckedIOException(e);
+                                }
+                            }));
+
+            return new MapResourceClassLoader(null, NamespaceAwareClassLoaderTest.class.getClassLoader(), () -> classNameToContent,
+                    true);
+        }
+    }
+
+    Class<?> tryLoadClass(String namespace, String className) throws Exception {
+        if (namespace != null) {
+            NamespaceUtil.setupNamespace(engine, namespace);
+        }
+        try {
+            return engineConfigClassLoader.loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new ClassNotFoundException(
+                    MessageFormat.format("\"{0}\" class not found in \"{1}\" namespace", className, namespace), e);
+        } finally {
+            if (namespace != null) {
+                NamespaceUtil.cleanupNamespace(engine, namespace);
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/NodeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance.impl;
+
+import com.hazelcast.config.NamespaceConfig;
+import com.hazelcast.internal.namespace.impl.NamespaceAwareClassLoader;
+import com.hazelcast.internal.usercodedeployment.UserCodeDeploymentClassLoader;
+import com.hazelcast.test.annotation.NamespaceTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@Category(NamespaceTest.class)
+public class NodeTest extends ConfigClassLoaderTest {
+
+    @Test
+    public void testConfigClassLoader_whenNoNamespaceExists_andUCDDisabled() {
+        createHazelcastInstanceWithConfig();
+        assertSame(config.getClassLoader(), engineConfigClassLoader);
+    }
+
+    @Test
+    public void testConfigClassLoader_whenNoNamespaceExists_andUCDEnabled_thenIsUCDClassLoader() {
+        config.getUserCodeDeploymentConfig().setEnabled(true);
+
+        createHazelcastInstanceWithConfig();
+        assertTrue(engineConfigClassLoader instanceof UserCodeDeploymentClassLoader);
+        assertSame(config.getClassLoader(), engineConfigClassLoader.getParent());
+    }
+
+    @Test
+    public void testConfigClassLoader_whenNamespaceExists_andUCDEnabled_thenIsNsAwareWithUCDParent() {
+        config.getUserCodeDeploymentConfig().setEnabled(true);
+        config.getNamespacesConfig().setEnabled(true);
+        config.getNamespacesConfig().addNamespaceConfig(new NamespaceConfig("namespace"));
+
+        createHazelcastInstanceWithConfig();
+        assertTrue(engineConfigClassLoader instanceof NamespaceAwareClassLoader);
+        assertTrue(engineConfigClassLoader.getParent() instanceof UserCodeDeploymentClassLoader);
+        assertSame(config.getClassLoader(), engineConfigClassLoader.getParent().getParent());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/namespace/impl/NamespaceServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/namespace/impl/NamespaceServiceImplTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.namespace.impl;
+
+import com.google.common.io.Files;
+import com.google.common.net.UrlEscapers;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.namespace.NamespaceService;
+import com.hazelcast.internal.namespace.ResourceDefinition;
+import com.hazelcast.internal.util.OsHelper;
+import com.hazelcast.jet.config.ResourceType;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.annotation.NamespaceTest;
+import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Constructor;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.hazelcast.test.Accessors.getNodeEngineImpl;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfigWithoutJetAndMetrics;
+import static com.hazelcast.test.UserCodeUtil.fileRelativeToBinariesFolder;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Category(NamespaceTest.class)
+public class NamespaceServiceImplTest {
+    public static Stream<Arguments> testLoadClasses() throws IOException {
+        return Stream.of(
+                Arguments.of(
+                        Named.of(ResourceType.CLASS.toString(),
+                                classResourcesFromClassPath("usercodedeployment/ChildClass.class",
+                                        "usercodedeployment/ParentClass.class")),
+                        new String[] {"usercodedeployment.ParentClass", "usercodedeployment.ChildClass"}),
+                Arguments.of(
+                        Named.of(ResourceType.JAR.toString(),
+                                singletonJarResourceFromBinaries("usercodedeployment/ChildParent.jar")),
+                        new String[] {"usercodedeployment.ParentClass", "usercodedeployment.ChildClass"}),
+                Arguments.of(
+                        Named.of(ResourceType.JARS_IN_ZIP.toString(),
+                                jarResourcesFromBinaries("/zip-resources/person-car-jar.zip")),
+                        new String[] {"com.sample.pojo.car.Car"}));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testLoadClasses(Collection<ResourceDefinition> resources, String... expectedClasses) throws Exception {
+        NamespaceServiceImpl namespaceService =
+                new NamespaceServiceImpl(NamespaceServiceImplTest.class.getClassLoader(), Collections.emptyMap(), null);
+
+        namespaceService.addNamespace("ns1", resources);
+        ClassLoader classLoader = namespaceService.getClassLoaderForExactNamespace("ns1");
+
+        for (String expectedClass : expectedClasses) {
+            Class<?> clazz = classLoader.loadClass(expectedClass);
+
+            // Workaround the fact that the "Car" class doesn't have a default constructor
+            Constructor<?> constructor = clazz.getDeclaredConstructors()[0];
+            Object[] parameters = new Object[constructor.getParameterCount()];
+
+            assertDoesNotThrow(() -> constructor.newInstance(parameters));
+        }
+    }
+
+    private static Collection<ResourceDefinition> classResourcesFromClassPath(String... classIdPaths) {
+        return Arrays.stream(classIdPaths).map(idPath -> {
+            try {
+                final byte[] bytes = Files.toByteArray(fileRelativeToBinariesFolder(idPath));
+                return new ResourceDefinitionImpl(idPath, bytes, ResourceType.CLASS, idPath);
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }).collect(Collectors.toSet());
+    }
+
+    private static Collection<ResourceDefinition> singletonJarResourceFromBinaries(final String idPath) throws IOException {
+        final byte[] bytes = Files.toByteArray(fileRelativeToBinariesFolder(idPath));
+        return Collections.singleton(new ResourceDefinitionImpl(idPath, bytes, ResourceType.JAR, idPath));
+    }
+
+    private static Collection<ResourceDefinition> jarResourcesFromBinaries(final String idPath) throws IOException {
+        try (InputStream stream = NamespaceServiceImplTest.class.getResource(idPath).openStream()) {
+            return Collections
+                    .singleton(new ResourceDefinitionImpl(idPath, stream.readAllBytes(), ResourceType.JARS_IN_ZIP, idPath));
+        }
+    }
+
+    @Test
+    void testXmlConfigDefinedFiltering_ClassBlacklist() {
+        assertThrows(SecurityException.class, () -> testXmlConfigDefinedFiltering(
+                "<class>usercodedeployment.ParentClass</class>", "<package>com.foo.bar</package>"));
+    }
+
+    @Test
+    void testXmlConfigDefinedFiltering_PackageBlacklist() {
+        assertThrows(SecurityException.class, () -> testXmlConfigDefinedFiltering(
+                "<package>usercodedeployment</package>", "<package>com.foo.bar</package>"));
+    }
+
+    @Test
+    void testXmlConfigDefinedFiltering_PrefixBlacklist() {
+        assertThrows(SecurityException.class, () -> testXmlConfigDefinedFiltering(
+                "<package>usercodedeployment.Child</package>", "<package>com.foo.bar</package>"));
+    }
+
+    @Test
+    void testXmlConfigDefinedFiltering_PrefixBlacklist_NotApplicable() {
+        assertDoesNotThrow(() -> testXmlConfigDefinedFiltering(
+                "<package>com.foo.bar</package>", null));
+    }
+
+    @Test
+    void testXmlConfigDefinedFiltering_ClassWhitelist() {
+        assertDoesNotThrow(() -> testXmlConfigDefinedFiltering(
+                "<package>com.foo.bar</package>", "<class>usercodedeployment.ParentClass</class>\n"
+                        + "<class>usercodedeployment.ChildClass</class>"));
+    }
+
+    @Test
+    void testXmlConfigDefinedFiltering_PackageWhitelist() {
+        assertDoesNotThrow(() -> testXmlConfigDefinedFiltering(
+                "<package>com.foo.bar</package>", "<package>usercodedeployment</package>"));
+    }
+
+    @Test
+    void testXmlConfigDefinedFiltering_PrefixWhitelist_NotMatching() {
+        assertThrows(SecurityException.class, () -> testXmlConfigDefinedFiltering(
+                null, "<package>com.foo.bar</package>"));
+    }
+
+    @Test
+    void testXmlConfigDefinedFiltering_PrefixWhitelist() {
+        assertDoesNotThrow(() -> testXmlConfigDefinedFiltering(
+                "<package>com.foo.bar</package>", "<prefix>usercodedeployment.</prefix>"));
+    }
+
+    @Test
+    void testXmlConfigDefinedFiltering_NoneDefined() {
+        assertDoesNotThrow(() -> testXmlConfigDefinedFiltering(
+                null, null));
+    }
+
+    // This could be programmatic in the future, but serves its purpose as-is
+    private void testXmlConfigDefinedFiltering(String blacklistLine, String whitelistLine) {
+        String stringPath =
+                getCorrectedPathString(Paths.get("src", "test", "class", "usercodedeployment", "ChildParent.jar"));
+
+        String xmlPayload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\"\n"
+                + "           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                + "           xsi:schemaLocation=\"http://www.hazelcast.com/schema/config\n"
+                + "           http://www.hazelcast.com/schema/config/hazelcast-config-5.4.xsd\">\n" + "\n"
+                + "    <cluster-name>cluster</cluster-name>\n\n"
+                + "    <namespaces enabled=\"true\">\n"
+                + "      <java-serialization-filter defaults-disabled=\"true\">\n"
+                + (blacklistLine == null ? ""
+                : "          <blacklist>\n"
+                + "              " + blacklistLine + "\n"
+                + "          </blacklist>\n")
+                + (whitelistLine == null ? ""
+                : "          <whitelist>\n"
+                + "              " + whitelistLine + "\n"
+                + "          </whitelist>\n")
+                + "      </java-serialization-filter>"
+                + "      <namespace name=\"myNamespace\">\n"
+                + "          <jar>\n"
+                + "              <url>file:///" + stringPath + "</url>\n"
+                + "          </jar>\n"
+                + "      </namespace>\n"
+                + "    </namespaces>\n"
+                + "</hazelcast>\n" + "\n";
+
+        // Start an instance & confirm that our namespaces were loaded
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(Config.loadFromString(xmlPayload));
+        try {
+            NodeEngineImpl nodeEngine = getNodeEngineImpl(instance);
+            NamespaceService service = nodeEngine.getNamespaceService();
+            assertTrue(service.isEnabled());
+            assertTrue(service.hasNamespace("myNamespace"));
+        } finally {
+            instance.shutdown();
+        }
+    }
+
+    private String getCorrectedPathString(Path path) {
+        return OsHelper.ensureUnixSeparators(UrlEscapers.urlFragmentEscaper().escape(path.toAbsolutePath().toString()));
+    }
+
+    // "No-op" implementation test
+    @Test
+    void testNoOpImplementation() {
+        // Do not enable Namespaces in any form, results in No-Op implementation being used
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(smallInstanceConfigWithoutJetAndMetrics());
+        try {
+            NodeEngineImpl nodeEngine = getNodeEngineImpl(instance);
+            NamespaceService service = nodeEngine.getNamespaceService();
+            assertFalse(service.isEnabled());
+            assertTrue(service instanceof NoOpNamespaceService);
+            assertFalse(nodeEngine.getConfigClassLoader() instanceof NamespaceAwareClassLoader);
+            assertFalse(service.isDefaultNamespaceDefined());
+        } finally {
+            instance.shutdown();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ClientDeployment_StandaloneClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/ClientDeployment_StandaloneClusterTest.java
@@ -28,11 +28,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-import static com.hazelcast.jet.impl.deployment.AbstractDeploymentTest.CLASS_DIRECTORY;
+import static com.hazelcast.test.UserCodeUtil.CLASS_DIRECTORY_FILE;
+import static com.hazelcast.test.UserCodeUtil.urlFromFile;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -40,7 +40,7 @@ public class ClientDeployment_StandaloneClusterTest extends JetTestSupport {
 
     @Test
     public void when_classAddedUsingUcd_then_visibleToJet() throws Exception {
-        URL classUrl = new File(CLASS_DIRECTORY).toURI().toURL();
+        URL classUrl = urlFromFile(CLASS_DIRECTORY_FILE);
         URLClassLoader urlClassLoader = new URLClassLoader(new URL[]{classUrl}, null);
         Class<?> personClz = urlClassLoader.loadClass("com.sample.pojo.person.Person$Appereance");
 

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassloaderCompactGenericRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/JetClassloaderCompactGenericRecordTest.java
@@ -33,10 +33,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
 
-import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.ThreadLocalRandom;
+
+import static com.hazelcast.test.UserCodeUtil.CLASS_DIRECTORY_FILE;
+import static com.hazelcast.test.UserCodeUtil.urlFromFile;
 
 
 @Category({NightlyTest.class, ParallelJVMTest.class})
@@ -78,7 +80,7 @@ public class JetClassloaderCompactGenericRecordTest extends SimpleTestInClusterS
                 .getPipeline();
 
         JobConfig jobConfig = new JobConfig();
-        URL classUrl = new File(AbstractDeploymentTest.CLASS_DIRECTORY).toURI().toURL();
+        URL classUrl = urlFromFile(CLASS_DIRECTORY_FILE);
         URLClassLoader urlClassLoader = new URLClassLoader(new URL[]{classUrl}, null);
         Class<?> appearance = urlClassLoader.loadClass("com.sample.pojo.person.Person$Appereance");
         jobConfig.addClass(appearance);

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/MapResourceClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/deployment/MapResourceClassLoaderTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.deployment;
+
+import com.hazelcast.internal.nio.ClassLoaderUtil;
+import com.hazelcast.jet.impl.JobRepository;
+import com.hazelcast.test.UserCodeUtil;
+import com.hazelcast.test.annotation.NamespaceTest;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.stream.Stream;
+
+import static com.hazelcast.internal.nio.IOUtil.closeResource;
+import static com.hazelcast.internal.nio.IOUtil.compress;
+import static com.hazelcast.internal.util.EmptyStatement.ignore;
+import static com.hazelcast.jet.impl.util.ReflectionUtils.toClassResourceId;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Category(NamespaceTest.class)
+class MapResourceClassLoaderTest {
+    private Map<String, byte[]> classBytes = new HashMap<>();
+    private MapResourceClassLoader classLoader;
+    private ClassLoader parentClassLoader;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        parentClassLoader = this.getClass().getClassLoader();
+        loadClassesFromJar("usercodedeployment/ChildParent.jar");
+        loadClassesFromJar("usercodedeployment/IncrementingEntryProcessor.jar");
+        loadClassesFromJar("usercodedeployment/ShadedClasses.jar");
+    }
+
+    @Test
+    void findClass_whenClassFromMap() throws Exception {
+        classLoader = new MapResourceClassLoader(null, null, () -> classBytes, false);
+        assertDoesNotThrow(
+                () -> classLoader.findClass("usercodedeployment.ParentClass").getDeclaredConstructor().newInstance());
+        assertDoesNotThrow(() -> classLoader.findClass("usercodedeployment.ChildClass").getDeclaredConstructor().newInstance());
+    }
+
+    @Test
+    void findClass_whenClassFromMapReferencesClassFromParent() throws Exception {
+        classLoader = new MapResourceClassLoader(null, parentClassLoader, () -> classBytes, false);
+        // IncrementingEntryProcessor implements EntryProcessor
+        assertDoesNotThrow(() -> classLoader.findClass("usercodedeployment.IncrementingEntryProcessor").getDeclaredConstructor()
+                .newInstance());
+    }
+
+    @Test
+    void loadClass_whenClassFromParentClassLoader() throws Exception {
+        classLoader = new MapResourceClassLoader(null, parentClassLoader, () -> classBytes, false);
+        assertDoesNotThrow(() -> classLoader.loadClass("com.hazelcast.map.EntryProcessor"));
+    }
+
+    @Test
+    void loadClassChildFirst_whenClassFromChild_shadesClassFromParent() throws Exception {
+        classLoader = new MapResourceClassLoader(null, parentClassLoader, () -> classBytes, true);
+        // com.hazelcast.core.HazelcastInstance loaded from ShadedClasses.jar is a concrete class with a main method
+        Class<?> klass = classLoader.loadClass("com.hazelcast.core.HazelcastInstance");
+        assertFalse(klass.isInterface());
+    }
+
+    @Test
+    void loadClassParentFirst_whenClassFromChild_shadesClassFromParent() throws Exception {
+        classLoader = new MapResourceClassLoader(null, parentClassLoader, () -> classBytes, false);
+        // expect to load com.hazelcast.core.HazelcastInstance interface from the codebase
+        Class<?> klass = classLoader.loadClass("com.hazelcast.core.HazelcastInstance");
+        assertTrue(klass.isInterface());
+    }
+
+    @Test
+    void getResource_whenResolvableFromChild() {
+        classLoader = new MapResourceClassLoader(null, parentClassLoader, () -> classBytes, true);
+        URL url = classLoader.getResource("usercodedeployment/ParentClass.class");
+        assertEquals(MapResourceClassLoader.PROTOCOL, url.getProtocol());
+        assertEquals(toClassResourceId("usercodedeployment.ParentClass"), url.getFile());
+    }
+
+    @Test
+    void getResource_whenResolvableFromParent() {
+        classLoader = new MapResourceClassLoader(null, parentClassLoader, () -> classBytes, true);
+        URL url = classLoader.getResource("com/hazelcast/map/IMap.class");
+        assertNotNull(url);
+        assertNotEquals(MapResourceClassLoader.PROTOCOL, url.getProtocol());
+    }
+
+    @Test
+    void getResource_whenResolvableFromChild_andNotChildFirst() {
+        classLoader = new MapResourceClassLoader(null, parentClassLoader, () -> classBytes, false);
+        URL url = classLoader.getResource("usercodedeployment/ParentClass.class");
+        assertEquals(MapResourceClassLoader.PROTOCOL, url.getProtocol());
+        assertEquals(toClassResourceId("usercodedeployment.ParentClass"), url.getFile());
+    }
+
+    static Stream<Arguments> findResource_negativeCases() {
+        return Stream.of(Arguments.of(Named.of("Empty String", StringUtils.EMPTY)),
+                Arguments.of(Named.of("findResource is meant to only search in this classloader's resources, not the parent",
+                        "com/hazelcast/map/IMap.class")));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @MethodSource("findResource_negativeCases")
+    void findResource_negativeCases(String name) {
+        classLoader = new MapResourceClassLoader(null, parentClassLoader, () -> classBytes, true);
+        URL url = classLoader.findResource(name);
+        assertNull(url);
+    }
+
+    private void loadClassesFromJar(String jarPath) throws IOException {
+        JarInputStream inputStream = null;
+        try {
+            inputStream = getJarInputStream(jarPath);
+            JarEntry entry;
+            do {
+                entry = inputStream.getNextJarEntry();
+                if (entry == null) {
+                    break;
+                }
+
+                String className = ClassLoaderUtil.extractClassName(entry.getName());
+                if (className == null) {
+                    continue;
+                }
+                byte[] classDefinition = compress(inputStream.readAllBytes());
+                inputStream.closeEntry();
+                classBytes.put(JobRepository.classKeyName(toClassResourceId(className)), classDefinition);
+            } while (true);
+        } finally {
+            closeResource(inputStream);
+        }
+    }
+
+    private JarInputStream getJarInputStream(String jarPath) throws IOException {
+        File file = UserCodeUtil.fileRelativeToBinariesFolder(jarPath);
+        if (file.exists()) {
+            return new JarInputStream(new FileInputStream(file));
+        }
+
+        try {
+            return new JarInputStream(new URL(jarPath).openStream());
+        } catch (MalformedURLException e) {
+            ignore(e);
+        }
+
+        InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(jarPath);
+        if (inputStream == null) {
+            throw new FileNotFoundException("File could not be found in " + jarPath + "  and resources/" + jarPath);
+        }
+        return new JarInputStream(inputStream);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ReflectionUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jet/impl/util/ReflectionUtilsTest.java
@@ -26,6 +26,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 
@@ -198,6 +201,60 @@ public class ReflectionUtilsTest {
                               .contains("file_pretty_printed.json")
                               .contains("file_list_pretty_printed.json")
                               .contains("package.properties");
+    }
+
+    @Test
+    public void testAllConstantTagsReadable_whenReadingInternalBinaryName() {
+        // To read an internal binary name, we need to read (and skip values for) all constant pool bytes
+        //    in the class file, so we need to make sure all 17 (as of JDK 21) are handled correctly
+        byte[] classBytes = generateClassFileHeaderWithAllConstants();
+        assertEquals("com.hazelcast.test.FakeClass", ReflectionUtils.getInternalBinaryName(classBytes));
+    }
+
+    private static final byte[] CONSTANT_POOL_TAGS = new byte[]      {1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 17, 18, 19, 20};
+    private static final int[] CONSTANT_POOL_PAYLOAD_SIZE = new int[]{0, 4, 4, 8, 8, 2, 2, 4, 4,  4,  4,  3,  2,  4,  4,  2,  2};
+
+    private static byte[] generateClassFileHeaderWithAllConstants() {
+        // We need to define all bytes up to the `this_class` definition
+        ByteBuffer buffer = ByteBuffer.allocate(154);
+        buffer.order(ByteOrder.BIG_ENDIAN);
+
+        // 4 bytes of magic
+        fillBuffer(buffer, 4);
+        // 4 bytes of versioning
+        fillBuffer(buffer, 4);
+        // constant pool length (for all our constants + 2 for 2x 8 byte payloads + 1 because the index starts at 1)
+        buffer.putShort((short) (CONSTANT_POOL_TAGS.length + 2 + 1));
+        // constant pool definition
+        for (int k = 0; k < CONSTANT_POOL_TAGS.length; k++) {
+            byte tagId = CONSTANT_POOL_TAGS[k];
+            buffer.put(tagId);
+            // Special handling for CONSTANT_Class to point at our Utf8 index (1)
+            if (tagId == 7) {
+                buffer.putShort((short) 1);
+            } else if (tagId == 1) {
+                // Special handling for CONSTANT_Utf8 to write our fake class name
+                byte[] bytes = "com.hazelcast.test.FakeClass".getBytes(StandardCharsets.UTF_8);
+                buffer.putShort((short) bytes.length);
+                buffer.put(bytes);
+            } else {
+                int payloadByteLength = CONSTANT_POOL_PAYLOAD_SIZE[k];
+                fillBuffer(buffer, payloadByteLength);
+            }
+        }
+        // 2 bytes of access flags
+        fillBuffer(buffer, 2);
+        // this_class definition (point to our CONSTANT_Class index)
+        buffer.putShort((short) 8);
+        // extra noise for completeness
+        fillBuffer(buffer, 32);
+        return buffer.array();
+    }
+
+    private static void fillBuffer(ByteBuffer buffer, int bytes) {
+        for (int k = 0; k < bytes; k++) {
+            buffer.put((byte) 0);
+        }
     }
 
     private static ClassResource classResource(Class<?> clazz) {

--- a/hazelcast/src/test/java/com/hazelcast/nio/ClassLoaderUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ClassLoaderUtilTest.java
@@ -16,22 +16,25 @@
 
 package com.hazelcast.nio;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.io.InputStream;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -97,10 +100,14 @@ public class ClassLoaderUtilTest extends HazelcastTestSupport {
         }
 
         // now the context class loader is reset back, new instance should fail
-        try {
-            ClassLoaderUtil.newInstance(null, "mock.Class");
-            fail("call did not fail, class probably incorrectly returned from CONSTRUCTOR_CACHE");
-        } catch (ClassNotFoundException expected) { }
+        Assert.assertThrows("call did not fail, class probably incorrectly returned from CONSTRUCTOR_CACHE",
+                ClassNotFoundException.class, () -> ClassLoaderUtil.newInstance(null, "mock.Class"));
+    }
+
+    @Test
+    public void testExtractClassName() {
+        assertEquals("org.me.package.MyClass", ClassLoaderUtil.extractClassName("org/me/package/MyClass.class"));
+        assertNull(ClassLoaderUtil.extractClassName("path/to/my/File.txt"));
     }
 
     private static class ExtendingClassImplementingSubInterface extends DirectlyImplementingSubInterfaceInterface {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -64,6 +64,9 @@ import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.function.ThrowingRunnable;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -1611,6 +1614,19 @@ public abstract class HazelcastTestSupport {
         Collection<DistributedObject> distributedObjects = hz.getDistributedObjects();
         for (DistributedObject object : distributedObjects) {
             object.destroy();
+        }
+    }
+
+    /**
+     * Returns raw byte[] of supplied file.
+     * @param testFile the file to get bytes from.
+     * @return the raw byte contents.
+     */
+    protected static byte[] getTestFileBytes(File testFile) {
+        try (InputStream is = testFile.toURI().toURL().openStream()) {
+            return is.readAllBytes();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/UserCodeUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/UserCodeUtil.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static com.hazelcast.internal.util.ExceptionUtil.sneakyThrow;
+
+/**
+ * Utility methods to facilitate referencing files from {@code src/test/class} which are not part of the classpath at
+ * test execution time.
+ */
+public class UserCodeUtil {
+
+    public static final String CLASS_DIRECTORY = "src/test/class";
+    public static final File CLASS_DIRECTORY_FILE = new File(CLASS_DIRECTORY);
+
+    private UserCodeUtil() {
+    }
+
+    /** @return a File for the given path, relative to src/test/class */
+    public static File fileRelativeToBinariesFolder(String path) {
+        return new File(CLASS_DIRECTORY_FILE, path);
+    }
+
+    /** @see #fileRelativeToBinariesFolder(String) */
+    public static String pathRelativeToBinariesFolder(String path) {
+        return fileRelativeToBinariesFolder(path).toString();
+    }
+
+    public static URL urlFromFile(File f) {
+        try {
+            return f.toURI().toURL();
+        } catch (MalformedURLException e) {
+            throw sneakyThrow(e);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
@@ -16,149 +16,38 @@
 
 package com.hazelcast.test.starter;
 
-import static com.hazelcast.internal.util.Preconditions.checkState;
-
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.internal.impl.DefaultLocalRepositoryProvider;
-import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
-import org.eclipse.aether.repository.LocalRepository;
-import org.eclipse.aether.repository.LocalRepositoryManager;
-import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
 
 import com.hazelcast.internal.cluster.Versions;
-import com.hazelcast.internal.tpcengine.util.OS;
 import com.hazelcast.version.Version;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.text.MessageFormat;
-import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class HazelcastVersionLocator {
+    private static final String GROUP_ID = "com.hazelcast";
+
     public enum Artifact {
-        OS_JAR(false, false, "hazelcast", "OS"),
-        OS_TEST_JAR(false, true, "hazelcast", "OS tests"),
-        SQL_JAR(false, false, "hazelcast-sql", "SQL"),
-        EE_JAR(true, false, "hazelcast-enterprise", "EE");
-
-        private static final String GROUP_ID = "com.hazelcast";
-        private static final Path MAVEN_REPOSITORY;
-        private static final LocalRepositoryManager REPOSITORY_MANAGER;
-
-        static {
-            try {
-                final DefaultLocalRepositoryProvider repositoryProvider = new DefaultLocalRepositoryProvider();
-
-                repositoryProvider.setLocalRepositoryManagerFactories(
-                        Collections.singletonList(new SimpleLocalRepositoryManagerFactory()));
-
-                // You can query this dynamically with the command:
-                // mvn help:evaluate -Dexpression=settings.localRepository --quiet --batch-mode -DforceStdout
-                //
-                // But can be problematic to parse when additional VM arguments print logging information to stdout as well
-                // https://github.com/hazelcast/hazelcast/issues/25451
-                MAVEN_REPOSITORY = Paths.get(System.getProperty("user.home")).resolve(".m2").resolve("repository");
-
-                if (Files.exists(MAVEN_REPOSITORY)) {
-                    final LocalRepository localRepo = new LocalRepository(MAVEN_REPOSITORY.toFile());
-                    REPOSITORY_MANAGER = repositoryProvider.newLocalRepositoryManager(MavenRepositorySystemUtils.newSession(),
-                            localRepo);
-                } else {
-                    throw new NoSuchFileException(MAVEN_REPOSITORY.toString(), null, "Maven repository");
-                }
-            } catch (final IOException | NoLocalRepositoryManagerException e) {
-                throw new RuntimeException(e);
-            }
-        }
+        OS_JAR(false, false, "hazelcast"),
+        OS_TEST_JAR(false, true, "hazelcast"),
+        SQL_JAR(false, false, "hazelcast-sql"),
+        EE_JAR(true, false, "hazelcast-enterprise");
 
         private final boolean enterprise;
         private final boolean test;
         private final String artifactId;
-        private final String label;
 
-        Artifact(final boolean enterprise, final boolean test, final String artifactId, final String label) {
+        Artifact(final boolean enterprise, final boolean test, final String artifactId) {
             this.enterprise = enterprise;
             this.test = test;
             this.artifactId = artifactId;
-            this.label = label;
         }
 
         private org.eclipse.aether.artifact.Artifact toAetherArtifact(final String version) {
             return new DefaultArtifact(GROUP_ID, artifactId, test ? "tests" : null, null, version);
-        }
-
-        /** @return a {@link Path} to the artifact in the local Maven repository, downloading if required */
-        private Path locateArtifact(final String version) {
-            final Path localCopy = MAVEN_REPOSITORY
-                    .resolve(REPOSITORY_MANAGER.getPathForLocalArtifact(toAetherArtifact(version)) + ".jar");
-
-            if (!Files.exists(localCopy)) {
-                downloadArtifact(version);
-
-                if (!Files.exists(localCopy)) {
-                    throw new UncheckedIOException(new NoSuchFileException(localCopy.toString(), null,
-                            MessageFormat.format("{0} (version \"{1}\") not found after download", this, version)));
-                }
-            }
-
-            return localCopy;
-        }
-
-        private static String getMvn() {
-            return OS.isWindows() ? "mvn.cmd" : "mvn";
-        }
-
-        private void downloadArtifact(final String version) {
-            // It's also possible to download this via Aether but I was unable to get this working
-            final ProcessBuilder builder = new ProcessBuilder(buildMavenCommand(version).toArray(String[]::new)).inheritIO();
-            try {
-                final Process process = builder.start();
-                final boolean successful = process.waitFor(2, TimeUnit.MINUTES);
-                checkState(successful, "Maven dependency:get timed out");
-                checkState(process.exitValue() == 0, "Maven dependency:get failed");
-            } catch (InterruptedException | IOException e) {
-                throw new RuntimeException(
-                        MessageFormat.format("Problem in invoking Maven dependency:get {0}:{1}", this, version), e);
-            }
-        }
-
-        private Stream<String> buildMavenCommand(final String version) {
-            final Stream.Builder<String> builder = Stream.builder();
-
-            builder.add(getMvn());
-
-            builder.add("dependency:get");
-            builder.add("-DgroupId=" + GROUP_ID);
-            builder.add("-DartifactId=" + artifactId);
-            builder.add("-Dversion=" + version);
-            builder.add("--quiet");
-            builder.add("--batch-mode");
-
-            if (test) {
-                builder.add("-Dclassifier=tests");
-            }
-
-            if (enterprise) {
-                builder.add("-DremoteRepositories=https://repository.hazelcast.com/release");
-            }
-
-            return builder.build();
-        }
-
-        @Override
-        public String toString() {
-            return label;
         }
     }
 
@@ -172,7 +61,9 @@ public class HazelcastVersionLocator {
         if (enterprise) {
             files.add(Artifact.EE_JAR);
         }
-        return files.build()
-                .collect(Collectors.toMap(Function.identity(), artifact -> artifact.locateArtifact(version).toFile()));
+        return files.build().collect(Collectors.toMap(Function.identity(),
+                artifact -> MavenInterface.locateArtifact(artifact.toAetherArtifact(version),
+                        artifact.enterprise ? new String[] {"https://repository.hazelcast.com/release"} : new String[] {})
+                        .toFile()));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/MavenInterface.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/MavenInterface.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import static com.hazelcast.internal.util.Preconditions.checkState;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
+import org.eclipse.aether.internal.impl.DefaultLocalRepositoryProvider;
+import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.LocalRepositoryManager;
+import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
+import org.h2.util.StringUtils;
+
+import com.hazelcast.internal.tpcengine.util.OS;
+import com.hazelcast.internal.util.StringUtil;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+public class MavenInterface {
+    private static final Path MAVEN_REPOSITORY;
+    private static final LocalRepositoryManager REPOSITORY_MANAGER;
+
+    static {
+        try {
+            final DefaultLocalRepositoryProvider repositoryProvider = new DefaultLocalRepositoryProvider(
+                    Collections.singleton(new SimpleLocalRepositoryManagerFactory(new DefaultLocalPathComposer())));
+
+            // You can query this dynamically with the command:
+            // mvn help:evaluate -Dexpression=settings.localRepository --quiet --batch-mode -DforceStdout
+            //
+            // But can be problematic to parse when additional VM arguments print logging information to stdout as well
+            // https://github.com/hazelcast/hazelcast/issues/25451
+            MAVEN_REPOSITORY = Paths.get(System.getProperty("user.home")).resolve(".m2").resolve("repository");
+
+            if (Files.exists(MAVEN_REPOSITORY)) {
+                final LocalRepository localRepo = new LocalRepository(MAVEN_REPOSITORY.toFile());
+                REPOSITORY_MANAGER = repositoryProvider.newLocalRepositoryManager(MavenRepositorySystemUtils.newSession(),
+                        localRepo);
+            } else {
+                throw new NoSuchFileException(MAVEN_REPOSITORY.toString(), null, "Maven repository");
+            }
+        } catch (final IOException | NoLocalRepositoryManagerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** @return a {@link Path} to the artifact in the local Maven repository, downloading if required */
+    public static Path locateArtifact(Artifact artifact, String... remoteRepositories) {
+        final Path localCopy = MAVEN_REPOSITORY
+                .resolve(REPOSITORY_MANAGER.getPathForLocalArtifact(artifact) + FilenameUtils.EXTENSION_SEPARATOR
+                        + (StringUtils.isNullOrEmpty(artifact.getExtension()) ? "jar" : artifact.getExtension()));
+
+        if (!Files.exists(localCopy)) {
+            downloadArtifact(artifact, remoteRepositories);
+
+            if (!Files.exists(localCopy)) {
+                throw new UncheckedIOException(new NoSuchFileException(localCopy.toString(), null,
+                        MessageFormat.format("{0} not found after download", artifact)));
+            }
+        }
+
+        return localCopy;
+    }
+
+    private static String getMvn() {
+        return OS.isWindows() ? "mvn.cmd" : "mvn";
+    }
+
+    private static void downloadArtifact(Artifact artifact, String... remoteRepositories) {
+        // It's also possible to download this via Aether but I was unable to get this working
+        final ProcessBuilder builder = new ProcessBuilder(
+                buildMavenCommand(artifact, remoteRepositories).toArray(String[]::new)).inheritIO();
+        try {
+            final Process process = builder.start();
+            final boolean successful = process.waitFor(2, TimeUnit.MINUTES);
+            checkState(successful, "Maven dependency:get timed out");
+            checkState(process.exitValue() == 0, "Maven dependency:get failed");
+        } catch (InterruptedException | IOException e) {
+            throw new RuntimeException(MessageFormat.format("Problem in invoking Maven dependency:get {0}", artifact), e);
+        }
+    }
+
+    private static Stream<String> buildMavenCommand(Artifact artifact, String... remoteRepositories) {
+        final Stream.Builder<String> builder = Stream.builder();
+
+        builder.add(getMvn());
+
+        builder.add("dependency:get");
+        builder.add("-DgroupId=" + artifact.getGroupId());
+        builder.add("-DartifactId=" + artifact.getArtifactId());
+        builder.add("-Dversion=" + artifact.getVersion());
+        builder.add("--quiet");
+        builder.add("--batch-mode");
+
+        if (!StringUtil.isNullOrEmpty(artifact.getClassifier())) {
+            builder.add("-Dclassifier=" + artifact.getClassifier());
+        }
+
+        if (remoteRepositories.length != 0) {
+            builder.add("-DremoteRepositories=" + String.join(",", remoteRepositories));
+        }
+
+        return builder.build();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
 
 /**
  * TODO This test doesn't force a re-download, so if an artifact is cached in the local repository, the download won't be
- * exercised. It's difficult to modify the local Maven repository as it's not encapsulated for the scope of testing
+ *      exercised. It's difficult to modify the local Maven repository as it's not encapsulated for the scope of testing
  */
 public class HazelcastVersionLocatorTest {
     private static HashFunction hashFunction;


### PR DESCRIPTION
This PR focuses on the changes required for the introduction of the `NamespaceService` and the `ClassLoader` backend implementation, leveraging the existing Jet approach.
[Namespaces feature TDD for reference](https://gist.github.com/JamesHazelcast/f25007a4e0594c491ce867c816b616a7).

_This PR is 1 of 5 pertaining to the Namespace feature addition. The other 4 PRs can be found below:_
- https://github.com/hazelcast/hazelcast/pull/26144
- https://github.com/hazelcast/hazelcast/pull/26145
- https://github.com/hazelcast/hazelcast/pull/26147
- https://github.com/hazelcast/hazelcast/pull/26148

_Due to the Namespaces feature being split into 5 pieces for easier reviewing, it is highly recommended that you clone the [UCD feature development branch](https://github.com/vbekiaris/hazelcast/tree/enhancements/5.4.0/ucd) for testing purposes, as these individual PRs are likely non-functional standalone._