### PR TITLE
Add Namespaces security support [HZ-2576]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/SecureRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/SecureRequest.java
@@ -16,11 +16,28 @@
 
 package com.hazelcast.client.impl.client;
 
+import javax.annotation.Nullable;
 import java.security.Permission;
 
 public interface SecureRequest {
 
     Permission getRequiredPermission();
+
+    /**
+     * Defines the {@link com.hazelcast.security.permission.NamespacePermission} associated
+     * with this request, if applicable. Since the majority of requests are not associated
+     * with a Namespace, this method returns {@code null} by default to reduce bloat.
+     * <p>
+     * Requests that are associated with a {@code Namespace} should implement this method
+     * and return the appropriate {@link com.hazelcast.security.permission.NamespacePermission}
+     *
+     * @return The {@link com.hazelcast.security.permission.NamespacePermission} required for
+     *         this task, or {@code null} if there is no Namespace associated with it.
+     */
+    @Nullable
+    default Permission getNamespacePermission() {
+        return null;
+    }
 
     /**
      * Used for {@link com.hazelcast.security.SecurityInterceptor}

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityInterceptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityInterceptorConstants.java
@@ -183,6 +183,8 @@ public final class SecurityInterceptorConstants {
     public static final String ADD_DISTRIBUTED_OBJECT_LISTENER = "addDistributedObjectListener";
     public static final String REMOVE_DISTRIBUTED_OBJECT_LISTENER = "removeDistributedObjectListener";
     public static final String COMPARE_AND_SET = "compareAndSet";
+    public static final String ADD_NAMESPACE_CONFIG = "addNamespaceConfig";
+    public static final String REMOVE_NAMESPACE_CONFIG = "removeNamespaceConfig";
 
     private SecurityInterceptorConstants() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
@@ -32,6 +32,7 @@ import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.internal.crdt.pncounter.PNCounterService;
 import com.hazelcast.internal.locksupport.LockSupportService;
+import com.hazelcast.internal.namespace.NamespaceService;
 import com.hazelcast.internal.usercodedeployment.UserCodeDeploymentService;
 import com.hazelcast.jet.impl.JetServiceBackend;
 import com.hazelcast.map.impl.MapService;
@@ -68,6 +69,7 @@ public final class ActionConstants {
     public static final String ACTION_AGGREGATE = "aggregate";
     public static final String ACTION_PROJECTION = "projection";
     public static final String ACTION_USER_CODE_DEPLOY = "deploy";
+    public static final String ACTION_USE = "use";
 
     public static final String ACTION_SUBMIT = "submit";
     public static final String ACTION_CANCEL = "cancel";
@@ -120,6 +122,7 @@ public final class ActionConstants {
         PERMISSION_FACTORY_MAP.put(InternalSqlService.SERVICE_NAME, SqlPermission::new);
         PERMISSION_FACTORY_MAP.put(DistributedScheduledExecutorService.SERVICE_NAME, ScheduledExecutorPermission::new);
         PERMISSION_FACTORY_MAP.put(CPMapServiceUtil.SERVICE_NAME, CPMapPermission::new);
+        PERMISSION_FACTORY_MAP.put(NamespaceService.SERVICE_NAME, NamespacePermission::new);
     }
 
     private ActionConstants() {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/NamespacePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/NamespacePermission.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.security.permission;
+
+public class NamespacePermission extends InstancePermission {
+    private static final long serialVersionUID = 1L;
+
+    private static final int USE = 4;
+    private static final int ALL = CREATE | DESTROY | USE;
+
+    public NamespacePermission(String namespace, String... actions) {
+        super(namespace, actions);
+    }
+
+    @Override
+    protected int initMask(String[] actions) {
+        int mask = NONE;
+        for (String action : actions) {
+            if (ActionConstants.ACTION_ALL.equals(action)) {
+                return ALL;
+            }
+
+            if (ActionConstants.ACTION_CREATE.equals(action)) {
+                mask |= CREATE;
+            } else if (ActionConstants.ACTION_DESTROY.equals(action)) {
+                mask |= DESTROY;
+            } else if (ActionConstants.ACTION_USE.equals(action)) {
+                mask |= USE;
+            }
+        }
+        return mask;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/ActionConstantsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/ActionConstantsTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.cp.internal.datastructures.countdownlatch.CountDownLatchSer
 import com.hazelcast.cp.internal.datastructures.cpmap.CPMapServiceUtil;
 import com.hazelcast.cp.internal.datastructures.semaphore.SemaphoreService;
 import com.hazelcast.internal.locksupport.LockSupportService;
+import com.hazelcast.internal.namespace.NamespaceService;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.map.impl.MapService;
@@ -178,5 +179,13 @@ public class ActionConstantsTest {
 
         assertNotNull(permission);
         assertTrue(permission instanceof CPMapPermission);
+    }
+
+    @Test
+    public void getPermission_NamespaceService() {
+        Permission permission = ActionConstants.getPermission("foo", NamespaceService.SERVICE_NAME);
+
+        assertNotNull(permission);
+        assertTrue(permission instanceof NamespacePermission);
     }
 }


### PR DESCRIPTION
This PR focuses on the changes required for the introduction of permissions related to Namespace actions.
[Namespaces feature TDD for reference](https://gist.github.com/JamesHazelcast/f25007a4e0594c491ce867c816b616a7).

_This PR is 1 of 5 pertaining to the Namespace feature addition. The other 4 PRs can be found below:_
- https://github.com/hazelcast/hazelcast/pull/26144
- https://github.com/hazelcast/hazelcast/pull/26145
- https://github.com/hazelcast/hazelcast/pull/26146
- https://github.com/hazelcast/hazelcast/pull/26148

_Due to the Namespaces feature being split into 5 pieces for easier reviewing, it is highly recommended that you clone the [UCD feature development branch](https://github.com/vbekiaris/hazelcast/tree/enhancements/5.4.0/ucd) for testing purposes, as these individual PRs are likely non-functional standalone._