### PR TITLE
Test Avro in pipeline api

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaAvroTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaAvroTest.java
@@ -1,5 +1,7 @@
 package com.hazelcast.jet.kafka.impl;
 
+import com.google.common.collect.ImmutableMap;
+import com.hazelcast.collection.IList;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.kafka.HazelcastKafkaAvroDeserializer;
@@ -14,9 +16,10 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -24,13 +27,19 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
+import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.kafka.impl.AbstractHazelcastAvroSerde.OPTION_KEY_AVRO_SCHEMA;
 import static com.hazelcast.jet.kafka.impl.AbstractHazelcastAvroSerde.OPTION_VALUE_AVRO_SCHEMA;
 import static java.lang.String.format;
 import static java.util.stream.IntStream.range;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -38,24 +47,32 @@ public class StreamKafkaAvroTest extends SimpleTestInClusterSupport {
 
     private static final int INITIAL_PARTITION_COUNT = 4;
 
-    static final Schema KEY_SCHEMA = SchemaBuilder.record("schema.id")
+    static final Schema KEY_SCHEMA = SchemaBuilder.record("schema.key")
             .fields()
-            .optionalInt("id")
+            .optionalInt("key")
             .endRecord();
 
-    static final Schema VALUE_SCHEMA = SchemaBuilder.record("SomeSchema").fields()
-            .optionalInt("id")
-            .optionalString("name")
-            .optionalInt("value")
+    static final Schema VALUE_SCHEMA = SchemaBuilder.record("schema.value").fields()
+            .optionalString("value")
             .endRecord();
+
     private static KafkaTestSupport kafkaTestSupport;
 
-    private String TOPIC_NAME = "topic";
+    private static String TOPIC_NAME = "topic";
+
+    private static final Map<String, String> AVRO_SCHEMA_PROPERTIES = ImmutableMap.of(
+            OPTION_KEY_AVRO_SCHEMA, KEY_SCHEMA.toString(),
+            OPTION_VALUE_AVRO_SCHEMA, VALUE_SCHEMA.toString()
+    );
 
     @BeforeClass
     public static void beforeClass() throws IOException {
         kafkaTestSupport = KafkaTestSupport.create();
         kafkaTestSupport.createKafkaCluster();
+        kafkaTestSupport.setProducerProperties(
+                TOPIC_NAME,
+                AVRO_SCHEMA_PROPERTIES
+        );
         initialize(2, null);
     }
 
@@ -70,33 +87,50 @@ public class StreamKafkaAvroTest extends SimpleTestInClusterSupport {
         kafkaTestSupport = null;
     }
 
-
-    public void read() {
+    @Test
+    public void readGenericRecord() {
+        IList<Object> sinkList = instance().getList("actual");
         Pipeline p = Pipeline.create();
         p.readFrom(KafkaSources.kafka(createProperties(KEY_SCHEMA, VALUE_SCHEMA), TOPIC_NAME))
                 .withoutTimestamps()
-                .writeTo(Sinks.list("output"));
+                .writeTo(Sinks.list(sinkList));
 
-        Job job = instance().getJet().newJob(p);
+        instance().getJet().newJob(p);
 
-        assertJobStatusEventually(job, RUNNING);
-        assertTrueAllTheTime(() -> assertEquals(RUNNING, job.getStatus()), 3);
+        produceSafe(TOPIC_NAME, keyData(1), valueData("value"));
+
+        assertTrueEventually(() -> assertThat(sinkList).contains(entry(keyData(1), valueData("value"))));
     }
 
     @Test
-    public void write() {
+    public void writeGenericRecord() {
         var mapName = "source_map";
         var map = instance().getMap(mapName);
-        range(0, 10).forEach(i -> map.put(keyData(i), valueData("llolololo", i)));
+        map.put(keyData(1), valueData("value"));
         Pipeline p = Pipeline.create();
 
         p.readFrom(Sources.map(mapName))
                 .writeTo(KafkaSinks.kafka(createProperties(KEY_SCHEMA, VALUE_SCHEMA), TOPIC_NAME));
         instance().getJet().newJob(p).join();
 
-        read();
+        kafkaTestSupport.assertTopicContentsEventually(
+                TOPIC_NAME,
+                Map.of(keyData(1), valueData("value")),
+                HazelcastKafkaAvroDeserializer.class,
+                HazelcastKafkaAvroDeserializer.class,
+                AVRO_SCHEMA_PROPERTIES
 
-        instance().getList("output").forEach(entry -> System.out.println("res: " + entry));
+        );
+    }
+
+
+    private void produceSafe(String topic, Object key, Object value) {
+        try {
+            kafkaTestSupport.produce(topic, key, value).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+
     }
 
     private Properties createProperties(Schema keySchema, Schema valueSchema) {
@@ -111,19 +145,45 @@ public class StreamKafkaAvroTest extends SimpleTestInClusterSupport {
         properties.setProperty("auto.offset.reset", "earliest");
         properties.setProperty(OPTION_KEY_AVRO_SCHEMA, keySchema.toString());
         properties.setProperty(OPTION_VALUE_AVRO_SCHEMA, valueSchema.toString());
+
+        return properties;
+    }
+
+    private Properties createStringProperties() {
+        Properties properties = new Properties();
+
+        properties.setProperty("bootstrap.servers", kafkaTestSupport.getBrokerConnectionString());
+        properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getCanonicalName());
+        properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getCanonicalName());
+        properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName());
+        properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName());
+        properties.setProperty("auto.offset.reset", "earliest");
         return properties;
     }
 
     private GenericData.Record keyData(Integer i) {
         var key = new GenericData.Record(KEY_SCHEMA);
-        key.put("id", i);
+        key.put("key", i);
         return key;
     }
 
-    private GenericData.Record valueData(String name, Integer value) {
+    private GenericData.Record valueData(String value) {
         var record = new GenericData.Record(VALUE_SCHEMA);
-        record.put("name", name);
         record.put("value", value);
         return record;
     }
+
+    private GenericData.Record valueDataAnotherSchema(String name, Integer value) {
+        var record = new GenericData.Record(RECORD_SCHEMA);
+        record.put("another_id", null);
+        record.put("another_name", null);
+        record.put("common_value", value);
+        return record;
+    }
+
+    static final Schema RECORD_SCHEMA = SchemaBuilder.record("schema.value2").fields()
+            .optionalInt("another_id")
+            .optionalString("another_name")
+            .optionalInt("common_value")
+            .endRecord();
 }

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaAvroTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaAvroTest.java
@@ -1,0 +1,125 @@
+package com.hazelcast.jet.kafka.impl;
+
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
+import com.hazelcast.jet.kafka.HazelcastKafkaAvroDeserializer;
+import com.hazelcast.jet.kafka.HazelcastKafkaAvroSerializer;
+import com.hazelcast.jet.kafka.KafkaSinks;
+import com.hazelcast.jet.kafka.KafkaSources;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import com.hazelcast.jet.pipeline.Sources;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static com.hazelcast.jet.core.JobStatus.RUNNING;
+import static com.hazelcast.jet.kafka.impl.AbstractHazelcastAvroSerde.OPTION_KEY_AVRO_SCHEMA;
+import static com.hazelcast.jet.kafka.impl.AbstractHazelcastAvroSerde.OPTION_VALUE_AVRO_SCHEMA;
+import static java.lang.String.format;
+import static java.util.stream.IntStream.range;
+import static org.junit.Assert.assertEquals;
+
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class StreamKafkaAvroTest extends SimpleTestInClusterSupport {
+
+    private static final int INITIAL_PARTITION_COUNT = 4;
+
+    static final Schema KEY_SCHEMA = SchemaBuilder.record("schema.id")
+            .fields()
+            .optionalInt("id")
+            .endRecord();
+
+    static final Schema VALUE_SCHEMA = SchemaBuilder.record("SomeSchema").fields()
+            .optionalInt("id")
+            .optionalString("name")
+            .optionalInt("value")
+            .endRecord();
+    private static KafkaTestSupport kafkaTestSupport;
+
+    private String TOPIC_NAME = "topic";
+
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        kafkaTestSupport = KafkaTestSupport.create();
+        kafkaTestSupport.createKafkaCluster();
+        initialize(2, null);
+    }
+
+    @Before
+    public void before() {
+        kafkaTestSupport.createTopic(TOPIC_NAME, INITIAL_PARTITION_COUNT);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        kafkaTestSupport.shutdownKafkaCluster();
+        kafkaTestSupport = null;
+    }
+
+
+    public void read() {
+        Pipeline p = Pipeline.create();
+        p.readFrom(KafkaSources.kafka(createProperties(KEY_SCHEMA, VALUE_SCHEMA), TOPIC_NAME))
+                .withoutTimestamps()
+                .writeTo(Sinks.list("output"));
+
+        Job job = instance().getJet().newJob(p);
+
+        assertJobStatusEventually(job, RUNNING);
+        assertTrueAllTheTime(() -> assertEquals(RUNNING, job.getStatus()), 3);
+    }
+
+    @Test
+    public void write() {
+        var mapName = "source_map";
+        var map = instance().getMap(mapName);
+        range(0, 10).forEach(i -> map.put(keyData(i), valueData("llolololo", i)));
+        Pipeline p = Pipeline.create();
+
+        p.readFrom(Sources.map(mapName))
+                .writeTo(KafkaSinks.kafka(createProperties(KEY_SCHEMA, VALUE_SCHEMA), TOPIC_NAME));
+        instance().getJet().newJob(p).join();
+
+        read();
+
+        instance().getList("output").forEach(entry -> System.out.println("res: " + entry));
+    }
+
+    private Properties createProperties(Schema keySchema, Schema valueSchema) {
+        Properties properties = new Properties();
+        properties.setProperty("bootstrap.servers", kafkaTestSupport.getBrokerConnectionString());
+        properties.setProperty("key.deserializer", HazelcastKafkaAvroDeserializer.class.getCanonicalName());
+        properties.setProperty("value.deserializer", HazelcastKafkaAvroDeserializer.class.getCanonicalName());
+        properties.setProperty("key.serializer", HazelcastKafkaAvroSerializer.class.getCanonicalName());
+        properties.setProperty("value.serializer", HazelcastKafkaAvroSerializer.class.getCanonicalName());
+        properties.setProperty("auto.offset.reset", "earliest");
+        properties.setProperty(OPTION_KEY_AVRO_SCHEMA, keySchema.toString());
+        properties.setProperty(OPTION_VALUE_AVRO_SCHEMA, valueSchema.toString());
+        return properties;
+    }
+
+    private GenericData.Record keyData(Integer i) {
+        var key = new GenericData.Record(KEY_SCHEMA);
+        key.put("id", i);
+        return key;
+    }
+
+    private GenericData.Record valueData(String name, Integer value) {
+        var record = new GenericData.Record(VALUE_SCHEMA);
+        record.put("name", name);
+        record.put("value", value);
+        return record;
+    }
+}

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaAvroTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaAvroTest.java
@@ -15,6 +15,8 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -98,12 +100,14 @@ public class StreamKafkaAvroTest extends SimpleTestInClusterSupport {
     }
 
     private Properties createProperties(Schema keySchema, Schema valueSchema) {
+
         Properties properties = new Properties();
+
         properties.setProperty("bootstrap.servers", kafkaTestSupport.getBrokerConnectionString());
-        properties.setProperty("key.deserializer", HazelcastKafkaAvroDeserializer.class.getCanonicalName());
-        properties.setProperty("value.deserializer", HazelcastKafkaAvroDeserializer.class.getCanonicalName());
-        properties.setProperty("key.serializer", HazelcastKafkaAvroSerializer.class.getCanonicalName());
-        properties.setProperty("value.serializer", HazelcastKafkaAvroSerializer.class.getCanonicalName());
+        properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, HazelcastKafkaAvroDeserializer.class.getCanonicalName());
+        properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, HazelcastKafkaAvroDeserializer.class.getCanonicalName());
+        properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, HazelcastKafkaAvroSerializer.class.getCanonicalName());
+        properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, HazelcastKafkaAvroSerializer.class.getCanonicalName());
         properties.setProperty("auto.offset.reset", "earliest");
         properties.setProperty(OPTION_KEY_AVRO_SCHEMA, keySchema.toString());
         properties.setProperty(OPTION_VALUE_AVRO_SCHEMA, valueSchema.toString());


### PR DESCRIPTION
MOVED TO MONOREP - https://github.com/hazelcast/hazelcast-mono/pull/158

Test for HazelcastKafkaAvroDeserializer/HazelcastKafkaAvroSerializer in Pipeline API.

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
