### PR TITLE
Introduce AccessControlService in security realms [CN-1108]

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -125,6 +125,7 @@ import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
+import com.hazelcast.config.security.AccessControlServiceConfig;
 import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.RealmConfig;
@@ -694,6 +695,10 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         expectedRoles.add("monitor");
         expectedRoles.add("hazelcast");
         assertEquals(expectedRoles, simpleAuthnCfg.getRoles("test"));
+        AccessControlServiceConfig acs = simpleRealm.getAccessControlServiceConfig();
+        assertNotNull(acs);
+        assertEquals("com.acme.access.AccessControlServiceFactory", acs.getFactoryClassName());
+        assertEquals("/opt/acl.xml", acs.getProperty("decisionFile"));
     }
 
     @Test

--- a/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring-tests/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -739,6 +739,11 @@
                                 </hz:user>
                             </hz:simple>
                         </hz:authentication>
+                        <hz:access-control-service factory-class-name="com.acme.access.AccessControlServiceFactory">
+                            <hz:properties>
+                                <hz:property name="decisionFile">/opt/acl.xml</hz:property>
+                            </hz:properties>
+                        </hz:access-control-service>
                     </hz:realm>
                     <hz:realm name="kerberosRealm">
                         <hz:authentication>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -123,6 +123,7 @@ import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
+import com.hazelcast.config.security.AccessControlServiceConfig;
 import com.hazelcast.config.security.JaasAuthenticationConfig;
 import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
@@ -1859,9 +1860,23 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     handleIdentity(child, realmConfigBuilder);
                 } else if ("authentication".equals(nodeName)) {
                     handleAuthentication(child, realmConfigBuilder);
+                } else if ("access-control-service".equals(nodeName)) {
+                    handleAccessControlService(child, realmConfigBuilder);
                 }
             }
             return beanDefinition;
+        }
+
+        private void handleAccessControlService(Node node, BeanDefinitionBuilder realmConfigBuilder) {
+            BeanDefinitionBuilder builder = createBeanBuilder(AccessControlServiceConfig.class);
+            fillValues(node, builder);
+            for (Node child : childElements(node)) {
+                String nodeName = cleanNodeName(child);
+                if ("properties".equals(nodeName)) {
+                    handleProperties(child, builder);
+                }
+            }
+            realmConfigBuilder.addPropertyValue("accessControlServiceConfig", builder.getBeanDefinition());
         }
 
         private void handleAuthentication(Node node, BeanDefinitionBuilder realmConfigBuilder) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-5.4.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-5.4.xsd
@@ -6102,6 +6102,7 @@
         <xs:all>
             <xs:element name="authentication" type="authentication" minOccurs="0"/>
             <xs:element name="identity" type="identity" minOccurs="0"/>
+            <xs:element name="access-control-service" type="access-control-service" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
@@ -6231,6 +6232,14 @@
             <xs:element name="use-canonical-hostname" type="xs:boolean" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
+
+    <xs:complexType name="access-control-service">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="factory-class-name" type="xs:string"/>
+    </xs:complexType>
+
 
     <xs:complexType name="realm-reference">
         <xs:attribute name="realm" type="xs:string" use="required"/>

--- a/hazelcast/src/main/java/com/hazelcast/access/AccessControlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/access/AccessControlService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.access;
+
+import javax.annotation.Nonnull;
+import javax.security.auth.login.LoginException;
+
+/**
+ * Service for pluggable authentication and authorization.
+ */
+public interface AccessControlService {
+
+    /**
+     * Authenticates user described by given {@link AuthenticationContext} and returns role names assigned.
+     *
+     * @param ctx authentication context
+     * @return array of role names assigned to authenticated user
+     * @throws LoginException authentication fails
+     */
+    @Nonnull
+    String[] authenticate(@Nonnull AuthenticationContext ctx) throws LoginException;
+
+    /**
+     * Returns {@code true} when access to resource described in the {@link AuthorizationContext} should be granted to assigned
+     * roles. The role names are typically the ones returned by the {@link #authenticate(AuthenticationContext)} method call.
+     *
+     * @param ctx authorization context
+     * @param assignedRoles role names to be checked for access to the resource
+     * @return {@code true} when the access is granted
+     */
+    boolean isAccessGranted(@Nonnull AuthorizationContext ctx, @Nonnull String... assignedRoles);
+}

--- a/hazelcast/src/main/java/com/hazelcast/access/AccessControlServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/access/AccessControlServiceFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.access;
+
+import java.util.Properties;
+
+import javax.annotation.Nonnull;
+import javax.security.auth.callback.CallbackHandler;
+
+/**
+ * Interface implemented by {@link AccessControlService} factory classes.
+ */
+public interface AccessControlServiceFactory {
+
+    /**
+     * Initializes this class with given properties. The callbackCandler can provide access to member internals.
+     *
+     * @param callbackHandler callback handler which provides access to member internals
+     * @param properties properties from the config
+     */
+    void init(@Nonnull CallbackHandler callbackHandler, @Nonnull Properties properties) throws Exception;
+
+    /**
+     * Creates the configured {@link AccessControlService} instance.
+     */
+    @Nonnull
+    AccessControlService createAccessControlService() throws Exception;
+}

--- a/hazelcast/src/main/java/com/hazelcast/access/AuthenticationContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/access/AuthenticationContext.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.access;
+
+public interface AuthenticationContext {
+}

--- a/hazelcast/src/main/java/com/hazelcast/access/AuthorizationContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/access/AuthorizationContext.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.access;
+
+public interface AuthorizationContext {
+}

--- a/hazelcast/src/main/java/com/hazelcast/access/impl/NoOpAccessControlService.java
+++ b/hazelcast/src/main/java/com/hazelcast/access/impl/NoOpAccessControlService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.access.impl;
+
+import javax.security.auth.login.LoginException;
+
+import com.hazelcast.access.AccessControlService;
+import com.hazelcast.access.AuthenticationContext;
+import com.hazelcast.access.AuthorizationContext;
+
+public class NoOpAccessControlService implements AccessControlService {
+
+    public static final NoOpAccessControlService INSTANCE = new NoOpAccessControlService();
+    private static final String[] ROLES = new String[0];
+
+    private NoOpAccessControlService() {
+    }
+
+    @Override
+    public String[] authenticate(AuthenticationContext ctx) throws LoginException {
+        return ROLES;
+    }
+
+    @Override
+    public boolean isAccessGranted(AuthorizationContext ctx, String... assignedRoles) {
+        return true;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/access/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/access/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains interfaces for Hazelcast pluggable access control.
+ */
+package com.hazelcast.access;

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractBaseFactoryWithPropertiesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractBaseFactoryWithPropertiesConfig.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import static com.hazelcast.internal.util.Preconditions.checkHasText;
+
+import java.util.Objects;
+import java.util.Properties;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Configuration base for config types with a factory class and its properties.
+ *
+ * @param <T> final child type
+ */
+public abstract class AbstractBaseFactoryWithPropertiesConfig<T extends AbstractBaseFactoryWithPropertiesConfig<T>> {
+
+    protected String factoryClassName;
+    protected Properties properties = new Properties();
+
+    /**
+     * Returns the factory class name.
+     */
+    public String getFactoryClassName() {
+        return factoryClassName;
+    }
+
+    /**
+     * Sets the factory class name.
+     */
+    public T setFactoryClassName(@Nonnull String factoryClassName) {
+        this.factoryClassName =  checkHasText(factoryClassName, "The factoryClassName cannot be null!");
+        return self();
+    }
+
+    /**
+     * Sets a single property.
+     *
+     * @param name  the name of the property to set
+     * @param value the value of the property to set
+     * @return the updated config object (self)
+     * @throws NullPointerException if name or value is {@code null}
+     */
+    public T setProperty(String name, String value) {
+        properties.put(name, value);
+        return self();
+    }
+
+    /**
+     * Gets a property.
+     *
+     * @param name the name of the property to get
+     * @return the value of the property, null if not found
+     * @throws NullPointerException if name is {@code null}
+     */
+    public String getProperty(String name) {
+        return properties.getProperty(name);
+    }
+
+    /**
+     * Gets all properties.
+     *
+     * @return the properties
+     */
+    public Properties getProperties() {
+        return properties;
+    }
+
+    /**
+     * Sets the properties.
+     *
+     * @param properties the properties to set
+     * @return the updated config object (self)
+     * @throws IllegalArgumentException if properties is {@code null}
+     */
+    public T setProperties(@Nonnull Properties properties) {
+        if (properties == null) {
+            throw new IllegalArgumentException("properties can't be null");
+        }
+        this.properties = properties;
+        return self();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{"
+                + "factoryClassName='" + factoryClassName + '\''
+                + ", properties=" + properties
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractBaseFactoryWithPropertiesConfig<?> otherConfig = (AbstractBaseFactoryWithPropertiesConfig<?>) o;
+
+        return Objects.equals(properties, otherConfig.properties)
+            && Objects.equals(factoryClassName, otherConfig.factoryClassName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(factoryClassName, properties);
+    }
+
+    protected abstract T self();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractFactoryWithPropertiesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractFactoryWithPropertiesConfig.java
@@ -16,38 +16,17 @@
 
 package com.hazelcast.config;
 
-import static com.hazelcast.internal.util.Preconditions.checkHasText;
-
 import java.util.Objects;
-import java.util.Properties;
-
-import javax.annotation.Nonnull;
 
 /**
  * Configuration base for config types with a factory class and its properties.
  *
  * @param <T> final child type
  */
-public abstract class AbstractFactoryWithPropertiesConfig<T extends AbstractFactoryWithPropertiesConfig<T>> {
+public abstract class AbstractFactoryWithPropertiesConfig<T extends AbstractFactoryWithPropertiesConfig<T>>
+        extends AbstractBaseFactoryWithPropertiesConfig<T> {
 
     protected boolean enabled;
-    protected String factoryClassName;
-    protected Properties properties = new Properties();
-
-    /**
-     * Returns the factory class name.
-     */
-    public String getFactoryClassName() {
-        return factoryClassName;
-    }
-
-    /**
-     * Sets the factory class name.
-     */
-    public T setFactoryClassName(@Nonnull String factoryClassName) {
-        this.factoryClassName =  checkHasText(factoryClassName, "The factoryClassName cannot be null!");
-        return self();
-    }
 
     /**
      * Returns if this configuration is enabled.
@@ -68,60 +47,12 @@ public abstract class AbstractFactoryWithPropertiesConfig<T extends AbstractFact
         return self();
     }
 
-    /**
-     * Sets a single property.
-     *
-     * @param name  the name of the property to set
-     * @param value the value of the property to set
-     * @return the updated config object (self)
-     * @throws NullPointerException if name or value is {@code null}
-     */
-    public T setProperty(String name, String value) {
-        properties.put(name, value);
-        return self();
-    }
-
-    /**
-     * Gets a property.
-     *
-     * @param name the name of the property to get
-     * @return the value of the property, null if not found
-     * @throws NullPointerException if name is {@code null}
-     */
-    public String getProperty(String name) {
-        return properties.getProperty(name);
-    }
-
-    /**
-     * Gets all properties.
-     *
-     * @return the properties
-     */
-    public Properties getProperties() {
-        return properties;
-    }
-
-    /**
-     * Sets the properties.
-     *
-     * @param properties the properties to set
-     * @return the updated config object (self)
-     * @throws IllegalArgumentException if properties is {@code null}
-     */
-    public T setProperties(@Nonnull Properties properties) {
-        if (properties == null) {
-            throw new IllegalArgumentException("properties can't be null");
-        }
-        this.properties = properties;
-        return self();
-    }
-
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{"
                 + "factoryClassName='" + factoryClassName + '\''
-                + ", enabled=" + enabled
                 + ", properties=" + properties
+                + ", enabled=" + enabled
                 + '}';
     }
 
@@ -137,15 +68,12 @@ public abstract class AbstractFactoryWithPropertiesConfig<T extends AbstractFact
         AbstractFactoryWithPropertiesConfig<?> otherConfig = (AbstractFactoryWithPropertiesConfig<?>) o;
 
         return Objects.equals(enabled, otherConfig.enabled)
-            && Objects.equals(properties, otherConfig.properties)
-            && Objects.equals(factoryClassName, otherConfig.factoryClassName);
+            && super.equals(otherConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, factoryClassName, properties);
+        return super.hashCode() + (enabled ? 0 : 13);
     }
-
-    protected abstract T self();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
 import com.hazelcast.config.security.AbstractClusterLoginConfig;
+import com.hazelcast.config.security.AccessControlServiceConfig;
 import com.hazelcast.config.security.JaasAuthenticationConfig;
 import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
@@ -314,6 +315,10 @@ public class ConfigXmlGenerator {
             }
             kerberosIdentityGenerator(gen, c.getKerberosIdentityConfig());
             gen.close();
+        }
+        AccessControlServiceConfig acs = c.getAccessControlServiceConfig();
+        if (acs != null) {
+            factoryWithPropertiesXmlGenerator(gen, "access-control-service", acs);
         }
         gen.close();
     }
@@ -795,8 +800,13 @@ public class ConfigXmlGenerator {
     }
 
     protected void factoryWithPropertiesXmlGenerator(XmlGenerator gen, String elementName,
-                                                     AbstractFactoryWithPropertiesConfig<?> factoryWithProps) {
-        gen.open(elementName, "enabled", factoryWithProps != null && factoryWithProps.isEnabled());
+                                                     AbstractBaseFactoryWithPropertiesConfig<?> factoryWithProps) {
+        if (factoryWithProps instanceof AbstractFactoryWithPropertiesConfig) {
+            AbstractFactoryWithPropertiesConfig cfgWithEnabled = (AbstractFactoryWithPropertiesConfig) factoryWithProps;
+            gen.open(elementName, "enabled", cfgWithEnabled.isEnabled());
+        } else {
+            gen.open(elementName);
+        }
         if (factoryWithProps != null) {
             gen.node("factory-class-name", factoryWithProps.getFactoryClassName())
                     .appendProperties(factoryWithProps.getProperties());

--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import com.hazelcast.config.security.RealmConfig;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.security.ICredentialsFactory;
 
 /**
@@ -273,6 +274,10 @@ public class SecurityConfig {
 
     private RealmConfig getRealmConfigOrDefault(String realmName) {
         RealmConfig realmConfig = realmName == null ? null : realmConfigs.get(realmName);
+        if (realmConfig == null) {
+            Logger.getLogger(getClass())
+                    .warning("Realm '" + realmName + "' is requested, but it doesn't exist in member configuration.");
+        }
         return realmConfig == null ? RealmConfig.DEFAULT_REALM : realmConfig;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/security/AccessControlServiceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/AccessControlServiceConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.security;
+
+import com.hazelcast.config.AbstractBaseFactoryWithPropertiesConfig;
+
+/**
+ * AccessControlService configuration.
+ */
+public final class AccessControlServiceConfig extends AbstractBaseFactoryWithPropertiesConfig<AccessControlServiceConfig> {
+
+    @Override
+    protected AccessControlServiceConfig self() {
+        return this;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/security/RealmConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/security/RealmConfig.java
@@ -37,6 +37,7 @@ public class RealmConfig {
 
     private AuthenticationConfig authenticationConfig = DefaultAuthenticationConfig.INSTANCE;
     private IdentityConfig identityConfig;
+    private AccessControlServiceConfig accessControlServiceConfig;
 
     public JaasAuthenticationConfig getJaasAuthenticationConfig() {
         return getIfType(authenticationConfig, JaasAuthenticationConfig.class);
@@ -138,6 +139,15 @@ public class RealmConfig {
         return this;
     }
 
+    public AccessControlServiceConfig getAccessControlServiceConfig() {
+        return accessControlServiceConfig;
+    }
+
+    public RealmConfig setAccessControlServiceConfig(AccessControlServiceConfig accessControlServiceConfig) {
+        this.accessControlServiceConfig = accessControlServiceConfig;
+        return this;
+    }
+
     public boolean isAuthenticationConfigured() {
         return authenticationConfig != null && authenticationConfig != DefaultAuthenticationConfig.INSTANCE;
     }
@@ -159,7 +169,7 @@ public class RealmConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticationConfig, identityConfig);
+        return Objects.hash(authenticationConfig, identityConfig, accessControlServiceConfig);
     }
 
     @Override
@@ -175,14 +185,18 @@ public class RealmConfig {
         }
         RealmConfig other = (RealmConfig) obj;
         return Objects.equals(authenticationConfig, other.authenticationConfig)
-                && Objects.equals(identityConfig, other.identityConfig);
+                && Objects.equals(identityConfig, other.identityConfig)
+                && Objects.equals(accessControlServiceConfig, other.accessControlServiceConfig)
+                ;
     }
 
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append("RealmConfig [authenticationConfig=").append(authenticationConfig).append(", identityConfig=")
-                .append(identityConfig).append("]");
+        builder.append("RealmConfig [authenticationConfig=").append(authenticationConfig)
+                .append(", identityConfig=").append(identityConfig)
+                .append(", accessControlServiceConfig=").append(accessControlServiceConfig)
+                .append("]");
         return builder.toString();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/AbstractDomConfigProcessor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.config;
 
+import com.hazelcast.config.AbstractBaseFactoryWithPropertiesConfig;
 import com.hazelcast.config.AbstractFactoryWithPropertiesConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.CompactSerializationConfig;
@@ -310,11 +311,8 @@ public abstract class AbstractDomConfigProcessor implements DomConfigProcessor {
         return fillFactoryWithPropertiesConfig(node, new SSLConfig());
     }
 
-    protected <T extends AbstractFactoryWithPropertiesConfig<?>> T fillFactoryWithPropertiesConfig(Node node, T factoryConfig) {
-        Node enabledNode = getNamedItemNode(node, "enabled");
-        boolean enabled = enabledNode != null && getBooleanValue(getTextContent(enabledNode));
-        factoryConfig.setEnabled(enabled);
-
+    protected <T extends AbstractBaseFactoryWithPropertiesConfig<?>> T fillBaseFactoryWithPropertiesConfig(Node node,
+            T factoryConfig) {
         for (Node n : childElements(node)) {
             String nodeName = cleanNodeName(n);
             if (matches("factory-class-name", nodeName)) {
@@ -323,6 +321,14 @@ public abstract class AbstractDomConfigProcessor implements DomConfigProcessor {
                 fillProperties(n, factoryConfig.getProperties());
             }
         }
+        return factoryConfig;
+    }
+
+    protected <T extends AbstractFactoryWithPropertiesConfig<?>> T fillFactoryWithPropertiesConfig(Node node, T factoryConfig) {
+        fillBaseFactoryWithPropertiesConfig(node, factoryConfig);
+        Node enabledNode = getNamedItemNode(node, "enabled");
+        boolean enabled = enabledNode != null && getBooleanValue(getTextContent(enabledNode));
+        factoryConfig.setEnabled(enabled);
         return factoryConfig;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -136,6 +136,7 @@ import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
 import com.hazelcast.config.security.AbstractClusterLoginConfig;
+import com.hazelcast.config.security.AccessControlServiceConfig;
 import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
@@ -3302,6 +3303,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 handleAuthentication(realmConfig, child);
             } else if (matches("identity", nodeName)) {
                 handleIdentity(realmConfig, child);
+            } else if (matches("access-control-service", nodeName)) {
+                handleAccessControlService(realmConfig, child);
             }
         }
     }
@@ -3336,6 +3339,12 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 handleKerberosIdentity(realmConfig, child);
             }
         }
+    }
+
+    private void handleAccessControlService(RealmConfig realmConfig, Node node) {
+        AccessControlServiceConfig acs = new AccessControlServiceConfig();
+        realmConfig.setAccessControlServiceConfig(acs);
+        fillBaseFactoryWithPropertiesConfig(node, acs);
     }
 
     protected void handleToken(RealmConfig realmConfig, Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/security/RealmNameCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/RealmNameCallback.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.security;
+
+import javax.security.auth.callback.Callback;
+
+/**
+ * This {@link Callback} allows retrieving the current security realm name.
+ */
+public class RealmNameCallback implements Callback {
+
+    private String realmName;
+
+    public RealmNameCallback() {
+    }
+
+    public String getRealmName() {
+        return realmName;
+    }
+
+    public void setRealmName(String realmName) {
+        this.realmName = realmName;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
@@ -20,9 +20,13 @@ import com.hazelcast.config.PermissionConfig;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.sql.impl.security.SqlSecurityContext;
 
+import javax.annotation.Nonnull;
 import javax.security.auth.Subject;
+import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+
+import java.net.InetAddress;
 import java.security.AccessControlException;
 import java.security.Permission;
 import java.util.Set;
@@ -58,6 +62,27 @@ public interface SecurityContext {
      */
     LoginContext createClientLoginContext(String clusterName, Credentials credentials, Connection connection)
             throws LoginException;
+
+    /**
+     * Creates JAAS login {@link Configuration} from given Security Realm configuration.
+     *
+     * @param realmName security realm name
+     * @return {@link Configuration} for given realm (or default authentication configuration if the realm doesn't exist).
+     */
+    Configuration createLoginConfigurationForRealm(String realmName);
+
+    /**
+     * Creates {@link LoginContext} from given JAAS Configuration.
+     *
+     * @param configuration JAAS configuration object
+     * @param clusterName cluster name
+     * @param credentials credentials
+     * @param remoteAddress address of the HTTP client
+     * @return {@link LoginContext}
+     * @throws LoginException in case of any exceptional case
+     */
+    LoginContext createLoginContext(@Nonnull Configuration configuration, String clusterName, Credentials credentials,
+            InetAddress remoteAddress) throws LoginException;
 
     /**
      * Returns current {@link ICredentialsFactory}.

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityContextCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityContextCallback.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.security;
+
+import javax.security.auth.callback.Callback;
+
+/**
+ * This JAAS {@link Callback} is used to retrieve a {@link SecurityContext} from the current member.
+ */
+public class SecurityContextCallback implements Callback {
+
+    private SecurityContext securityContext;
+
+    public SecurityContext getSecurityContext() {
+        return securityContext;
+    }
+
+    public void setSecurityContext(SecurityContext securityContext) {
+        this.securityContext = securityContext;
+    }
+}

--- a/hazelcast/src/main/resources/hazelcast-config-5.4.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.4.json
@@ -2854,6 +2854,18 @@
                     "$ref": "#/definitions/CredentialsFactoryIdentity"
                   }
                 }
+              },
+              "access-control-service": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "factory-class-name": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "type": "object"
+                  }
+                }
               }
             }
           }

--- a/hazelcast/src/main/resources/hazelcast-config-5.4.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.4.xsd
@@ -2514,7 +2514,7 @@
             </xs:element>
         </xs:all>
     </xs:complexType>
-    <xs:complexType name="factory-class-with-properties">
+    <xs:complexType name="factory-class-with-properties-base">
         <xs:all>
             <xs:element name="factory-class-name" type="xs:string" minOccurs="0">
                 <xs:annotation>
@@ -2525,13 +2525,19 @@
             </xs:element>
             <xs:element name="properties" type="properties" minOccurs="0"/>
         </xs:all>
-        <xs:attribute name="enabled" default="false" type="xs:boolean">
-            <xs:annotation>
-                <xs:documentation>
-                    True to enable this configuration element, false to disable.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="factory-class-with-properties">
+        <xs:complexContent>
+            <xs:extension base="factory-class-with-properties-base">
+                <xs:attribute name="enabled" default="false" type="xs:boolean">
+                    <xs:annotation>
+                        <xs:documentation>
+                            True to enable this configuration element, false to disable.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
     <xs:complexType name="item-listener">
         <xs:simpleContent>
@@ -5959,6 +5965,7 @@
         <xs:all>
             <xs:element name="authentication" type="authentication" minOccurs="0"/>
             <xs:element name="identity" type="identity" minOccurs="0"/>
+            <xs:element name="access-control-service" type="factory-class-with-properties-base" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2479,6 +2479,21 @@
                     </jaas>
                 </authentication>
             </realm>
+            <realm name="restRealm">
+                <authentication>
+                    <simple>
+                        <user username="restuser" password="restsecret">
+                            <role>admin</role>
+                        </user>
+                    </simple>
+                </authentication>
+                <access-control-service>
+                    <factory-class-name>com.acme.access.AccessControlServiceFactory</factory-class-name>
+                    <properties>
+                        <property name="decisionFile">/opt/acl.xml</property>
+                    </properties>
+                </access-control-service>
+            </realm>
         </realms>
         <member-authentication realm="jaasRealm"/>
         <client-authentication realm="simpleRealm"/>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -2441,6 +2441,18 @@ hazelcast:
                 storeKey: true
                 principal: hz/127.0.0.1@HAZELCAST.COM
                 keyTab: /opt/hz-localhost.keytab
+      - name: restRealm
+        authentication:
+          simple:
+            users:
+              - username: restuser
+                password: 'restpassword'
+                roles:
+                  - admin
+        access-control-service:
+          factory-class-name: com.acme.access.AccessControlServiceFactory
+          properties:
+            decisionFile: '/opt/acl.xml'
     member-authentication:
       realm: jaasRealm
     client-authentication:

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -25,6 +25,7 @@ import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
+import com.hazelcast.config.security.AccessControlServiceConfig;
 import com.hazelcast.config.security.JaasAuthenticationConfig;
 import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
@@ -1748,7 +1749,15 @@ public class ConfigCompatibilityChecker {
                     && isCompatible(c1.getUsernamePasswordIdentityConfig(), c2.getUsernamePasswordIdentityConfig())
                     && isCompatible(c1.getTokenIdentityConfig(), c2.getTokenIdentityConfig())
                     && isCompatible(c1.getKerberosIdentityConfig(), c2.getKerberosIdentityConfig())
+                    && isCompatible(c1.getAccessControlServiceConfig(), c2.getAccessControlServiceConfig())
                     ;
+        }
+
+        private static boolean isCompatible(AccessControlServiceConfig c1,
+                AccessControlServiceConfig c2) {
+            return c1 == c2 || (c1 != null && c2 != null
+                    && nullSafeEqual(c1.getFactoryClassName(), c2.getFactoryClassName())
+                    && nullSafeEqual(c1.getProperties(), c2.getProperties()));
         }
 
         private static boolean isCompatible(UsernamePasswordIdentityConfig c1, UsernamePasswordIdentityConfig c2) {

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.cp.CPMapConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
+import com.hazelcast.config.security.AccessControlServiceConfig;
 import com.hazelcast.config.security.JaasAuthenticationConfig;
 import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
@@ -726,8 +727,9 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         RealmConfig realmConfig = new RealmConfig().setSimpleAuthenticationConfig(new SimpleAuthenticationConfig()
                 .setRoleSeparator(":")
                 .addUser("test", "1234", "monitor", "hazelcast")
-                .addUser("dev", "secret", "root")
-        );
+                .addUser("dev", "secret", "root"))
+            .setAccessControlServiceConfig(new AccessControlServiceConfig()
+                .setFactoryClassName("com.acme.access.ACSFactory").setProperty("decisionFile", "/opt/acl.xml"));
         SecurityConfig expectedConfig = new SecurityConfig().setMemberRealmConfig("simpleRealm", realmConfig);
         cfg.setSecurityConfig(expectedConfig);
         SecurityConfig actualConfig = getNewConfigViaXMLGenerator(cfg, false).getSecurityConfig();

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
+import com.hazelcast.config.security.AccessControlServiceConfig;
 import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
@@ -280,6 +281,14 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "          </user>"
                 + "        </simple>"
                 + "      </authentication>"
+                + "      <access-control-service>"
+                + "        <factory-class-name>"
+                + "            com.acme.access.AccessControlServiceFactory"
+                + "        </factory-class-name>"
+                + "        <properties>"
+                + "            <property name='decisionFile'>/opt/acl.xml</property>"
+                + "        </properties>"
+                + "      </access-control-service>"
                 + "    </realm>"
                 + "  </realms>"
                 + "  <member-authentication realm='mr'/>\n"
@@ -381,6 +390,10 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         expectedRoles.add("hazelcast");
         assertEquals(expectedRoles, simpleAuthnCfg.getRoles("test"));
         assertEquals(Boolean.TRUE, simpleAuthnCfg.getSkipRole());
+        AccessControlServiceConfig acs = simpleRealm.getAccessControlServiceConfig();
+        assertNotNull(acs);
+        assertEquals("com.acme.access.AccessControlServiceFactory", acs.getFactoryClassName());
+        assertEquals("/opt/acl.xml", acs.getProperty("decisionFile"));
 
         // client-permission-policy
         PermissionPolicyConfig permissionPolicyConfig = securityConfig.getClientPolicyConfig();

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
 import com.hazelcast.config.cp.SemaphoreConfig;
+import com.hazelcast.config.security.AccessControlServiceConfig;
 import com.hazelcast.config.security.KerberosAuthenticationConfig;
 import com.hazelcast.config.security.KerberosIdentityConfig;
 import com.hazelcast.config.security.LdapAuthenticationConfig;
@@ -252,6 +253,10 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "                password: secret\n"
                 + "                roles:\n"
                 + "                  - root\n"
+                + "        access-control-service:\n"
+                + "          factory-class-name: 'com.acme.access.AccessControlServiceFactory'\n"
+                + "          properties:\n"
+                + "            decisionFile: '/opt/acl.xml'\n"
                 + "    client-permission-policy:\n"
                 + "      class-name: MyPermissionPolicy\n"
                 + "      properties:\n"
@@ -341,6 +346,10 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         expectedRoles.add("hazelcast");
         assertEquals(expectedRoles, simpleAuthnCfg.getRoles("test"));
         assertEquals(Boolean.TRUE, simpleAuthnCfg.getSkipRole());
+        AccessControlServiceConfig acs = simpleRealm.getAccessControlServiceConfig();
+        assertNotNull(acs);
+        assertEquals("com.acme.access.AccessControlServiceFactory", acs.getFactoryClassName());
+        assertEquals("/opt/acl.xml", acs.getProperty("decisionFile"));
 
         // client-permission-policy
         PermissionPolicyConfig permissionPolicyConfig = securityConfig.getClientPolicyConfig();

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -808,6 +808,21 @@
                     </jaas>
                 </authentication>
             </realm>
+            <realm name="restRealm">
+                <authentication>
+                    <simple>
+                        <user username="restuser" password="restsecret">
+                            <role>admin</role>
+                        </user>
+                    </simple>
+                </authentication>
+                <access-control-service>
+                    <factory-class-name>com.acme.access.AccessControlServiceFactory</factory-class-name>
+                    <properties>
+                        <property name="decisionFile">/opt/acl.xml</property>
+                    </properties>
+                </access-control-service>
+            </realm>
         </realms>
         <member-authentication realm="jaasRealm"/>
         <client-authentication realm="simpleRealm"/>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -766,6 +766,19 @@ hazelcast:
                 storeKey: true
                 principal: hz/127.0.0.1@HAZELCAST.COM
                 keyTab: /opt/hz-localhost.keytab
+      - name: restRealm
+        authentication:
+          simple:
+            users:
+              - username: restuser
+                password: 'restpassword'
+                roles:
+                  - admin
+        access-control-service:
+          factory-class-name: com.acme.access.AccessControlServiceFactory
+          properties:
+            decisionFile: '/opt/acl.xml'
+
     member-authentication:
       realm: jaasRealm
     client-authentication:


### PR DESCRIPTION
Extend capabilities of named security realms by the possibility of making access control decisions.
The initial usage is expected in the new REST API.

Configuration looks like this:
```xml
            <realm name="restRealm">
                <authentication>
                    <simple>
                        <user username="restuser" password="restsecret">
                            <role>admin</role>
                        </user>
                    </simple>
                </authentication>
                <access-control-service>
                    <factory-class-name>com.acme.access.AccessControlServiceFactory</factory-class-name>
                    <properties>
                        <property name="decisionFile">/opt/acl.xml</property>
                    </properties>
                </access-control-service>
            </realm>
````