### PR TITLE
Implement lazy loading of the SQL schema [HZ-3756] #24004

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.sql.impl.schema;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
+import com.hazelcast.sql.impl.schema.SqlCatalog;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.schema.Function;
@@ -44,8 +45,8 @@ import static java.util.Objects.requireNonNull;
 public class HazelcastSchema implements Schema {
 
     private final Map<String, Schema> subSchemaMap;
-    //TODO: Change this to something else.
     private final Map<String, Table> tableMap;
+    private SqlCatalog catalog;
 
     public HazelcastSchema(Map<String, Table> tableMap) {
         this(null, tableMap);
@@ -60,7 +61,7 @@ public class HazelcastSchema implements Schema {
         return subSchemaMap;
     }
 
-    final public Map<String, Table> getTableMap() {
+    public final Map<String, Table> getTableMap() {
         return tableMap;
     }
 
@@ -126,7 +127,7 @@ public class HazelcastSchema implements Schema {
     public static class Factory implements SchemaFactory {
         public static final Factory INSTANCE = new Factory();
 
-        private Factory() {}
+        private Factory() { }
 
         @Override public Schema create(SchemaPlus parentSchema, String name,
                                        Map<String, Object> operand) {

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
@@ -106,14 +106,12 @@ public class HazelcastSchema implements Schema {
         if (tableMap.containsKey(name) && tableMap.get(name) != null) {
             return tableMap.get(name);
         }
-        if (catalog == null) {
-            return null;
-        }
-        Map<String, com.hazelcast.sql.impl.schema.Table> schema = catalog.getSchemas().get(schemaName);
-        if (schema == null) {
-            return null;
-        }
-        com.hazelcast.sql.impl.schema.Table table = schema.get(name);
+        Map<String, com.hazelcast.sql.impl.schema.Table> schema = (catalog != null) ?
+                catalog.getSchemas().get(schemaName) : null;
+
+        com.hazelcast.sql.impl.schema.Table table = (schema != null) ?
+                schema.get(name) : null;
+
         if (table == null) {
             return null;
         }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
@@ -44,6 +44,7 @@ import static java.util.Objects.requireNonNull;
 public class HazelcastSchema implements Schema {
 
     private final Map<String, Schema> subSchemaMap;
+    //TODO: Change this to something else.
     private final Map<String, Table> tableMap;
 
     public HazelcastSchema(Map<String, Table> tableMap) {
@@ -77,25 +78,17 @@ public class HazelcastSchema implements Schema {
         return Schemas.subSchemaExpression(parentSchema, name, getClass());
     }
 
+    //TODO:
     @Override public final Set<String> getTableNames() {
         //noinspection RedundantCast
         return (Set<String>) getTableMap().keySet();
     }
 
+    //TODO:
     @Override public final @Nullable Table getTable(String name) {
         return getTableMap().get(name);
     }
 
-    /**
-     * Returns a map of types in this schema by name.
-     *
-     * <p>The implementations of {@link #getTypeNames()}
-     * and {@link #getType(String)} depend on this map.
-     * The default implementation of this method returns the empty map.
-     * Override this method to change their behavior.
-     *
-     * @return Map of types in this schema by name
-     */
     protected Map<String, RelProtoDataType> getTypeMap() {
         return ImmutableMap.of();
     }
@@ -109,19 +102,6 @@ public class HazelcastSchema implements Schema {
         return (Set<String>) getTypeMap().keySet();
     }
 
-    /**
-     * Returns a multi-map of functions in this schema by name.
-     * It is a multi-map because functions are overloaded; there may be more than
-     * one function in a schema with a given name (as long as they have different
-     * parameter lists).
-     *
-     * <p>The implementations of {@link #getFunctionNames()}
-     * and {@link Schema#getFunctions(String)} depend on this map.
-     * The default implementation of this method returns the empty multi-map.
-     * Override this method to change their behavior.
-     *
-     * @return Multi-map of functions in this schema by name
-     */
     protected Multimap<String, Function> getFunctionMultimap() {
         return ImmutableMultimap.of();
     }
@@ -143,8 +123,6 @@ public class HazelcastSchema implements Schema {
         return getSubSchemaMap().get(name);
     }
 
-    /** Schema factory that creates an
-     * {@link org.apache.calcite.schema.impl.AbstractSchema}. */
     public static class Factory implements SchemaFactory {
         public static final Factory INSTANCE = new Factory();
 

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
@@ -34,7 +34,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,17 +48,10 @@ public class HazelcastSchema implements Schema {
     private final Map<String, Schema> subSchemaMap;
     private Map<String, Table> tableMap;
     private SqlCatalog catalog;
-    //TODO: Maybe having a reference to pattern is a better idea?
     private String schemaName;
 
     public HazelcastSchema(Map<String, Table> tableMap) {
         this(null, tableMap);
-    }
-
-    public HazelcastSchema(SqlCatalog catalog) {
-        this.catalog = catalog;
-        this.subSchemaMap = new HashMap<>();
-        this.tableMap = new HashMap<>();
     }
 
     public HazelcastSchema(Map<String, Schema> subSchemaMap, Map<String, Table> tableMap) {
@@ -74,12 +66,10 @@ public class HazelcastSchema implements Schema {
         this.schemaName = schemaName;
     }
 
-    //CHECK: Remove that as now it might be dangerous?
     protected Map<String, Schema> getSubSchemaMap() {
         return subSchemaMap;
     }
 
-    //CHECK: Remove that as now it might be dangerous?
     protected final Map<String, Table> getTableMap() {
         return tableMap;
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
@@ -80,7 +80,7 @@ public class HazelcastSchema implements Schema {
     }
 
     //CHECK: Remove that as now it might be dangerous?
-    public final Map<String, Table> getTableMap() {
+    protected final Map<String, Table> getTableMap() {
         return tableMap;
     }
 
@@ -106,8 +106,18 @@ public class HazelcastSchema implements Schema {
         if (tableMap.containsKey(name) && tableMap.get(name) != null) {
             return tableMap.get(name);
         }
+        if (catalog == null) {
+            return null;
+        }
+        Map<String, com.hazelcast.sql.impl.schema.Table> schema = catalog.getSchemas().get(schemaName);
+        if (schema == null) {
+            return null;
+        }
+        com.hazelcast.sql.impl.schema.Table table = schema.get(name);
+        if (table == null) {
+            return null;
+        }
 
-        com.hazelcast.sql.impl.schema.Table table = catalog.getSchemas().get(schemaName).get(name);
         HazelcastTable convertedTable = new HazelcastTable(
                 table,
                 createTableStatistic(table)

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchema.java
@@ -16,18 +16,32 @@
 
 package com.hazelcast.jet.sql.impl.schema;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.Function;
 import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaFactory;
+import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.SchemaVersion;
+import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of a schema, exposing sub schemas and tables.
  */
-public class HazelcastSchema extends AbstractSchema {
+public class HazelcastSchema implements Schema {
 
     private final Map<String, Schema> subSchemaMap;
     private final Map<String, Table> tableMap;
@@ -41,18 +55,104 @@ public class HazelcastSchema extends AbstractSchema {
         this.tableMap = tableMap != null ? tableMap : Collections.emptyMap();
     }
 
-    @Override
     protected Map<String, Schema> getSubSchemaMap() {
         return subSchemaMap;
     }
 
-    @Override
-    public Map<String, Table> getTableMap() {
+    final public Map<String, Table> getTableMap() {
         return tableMap;
     }
 
     @Override
     public Schema snapshot(SchemaVersion version) {
         return this;
+    }
+
+    @Override public boolean isMutable() {
+        return true;
+    }
+
+    @Override public Expression getExpression(@Nullable SchemaPlus parentSchema, String name) {
+        requireNonNull(parentSchema, "parentSchema");
+        return Schemas.subSchemaExpression(parentSchema, name, getClass());
+    }
+
+    @Override public final Set<String> getTableNames() {
+        //noinspection RedundantCast
+        return (Set<String>) getTableMap().keySet();
+    }
+
+    @Override public final @Nullable Table getTable(String name) {
+        return getTableMap().get(name);
+    }
+
+    /**
+     * Returns a map of types in this schema by name.
+     *
+     * <p>The implementations of {@link #getTypeNames()}
+     * and {@link #getType(String)} depend on this map.
+     * The default implementation of this method returns the empty map.
+     * Override this method to change their behavior.
+     *
+     * @return Map of types in this schema by name
+     */
+    protected Map<String, RelProtoDataType> getTypeMap() {
+        return ImmutableMap.of();
+    }
+
+    @Override public @Nullable RelProtoDataType getType(String name) {
+        return getTypeMap().get(name);
+    }
+
+    @Override public Set<String> getTypeNames() {
+        //noinspection RedundantCast
+        return (Set<String>) getTypeMap().keySet();
+    }
+
+    /**
+     * Returns a multi-map of functions in this schema by name.
+     * It is a multi-map because functions are overloaded; there may be more than
+     * one function in a schema with a given name (as long as they have different
+     * parameter lists).
+     *
+     * <p>The implementations of {@link #getFunctionNames()}
+     * and {@link Schema#getFunctions(String)} depend on this map.
+     * The default implementation of this method returns the empty multi-map.
+     * Override this method to change their behavior.
+     *
+     * @return Multi-map of functions in this schema by name
+     */
+    protected Multimap<String, Function> getFunctionMultimap() {
+        return ImmutableMultimap.of();
+    }
+
+    @Override public final Collection<Function> getFunctions(String name) {
+        return getFunctionMultimap().get(name); // never null
+    }
+
+    @Override public final Set<String> getFunctionNames() {
+        return getFunctionMultimap().keySet();
+    }
+
+    @Override public final Set<String> getSubSchemaNames() {
+        //noinspection RedundantCast
+        return (Set<String>) getSubSchemaMap().keySet();
+    }
+
+    @Override public final @Nullable Schema getSubSchema(String name) {
+        return getSubSchemaMap().get(name);
+    }
+
+    /** Schema factory that creates an
+     * {@link org.apache.calcite.schema.impl.AbstractSchema}. */
+    public static class Factory implements SchemaFactory {
+        public static final Factory INSTANCE = new Factory();
+
+        private Factory() {}
+
+        @Override public Schema create(SchemaPlus parentSchema, String name,
+                                       Map<String, Object> operand) {
+            return new AbstractSchema();
+        }
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchemaUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchemaUtils.java
@@ -56,6 +56,7 @@ public final class HazelcastSchemaUtils {
      *
      * @return Top-level schema.
      */
+    //TODO: I need to change this method too.
     public static HazelcastSchema createRootSchema(SqlCatalog catalog) {
         // Create schemas.
         Map<String, Schema> schemaMap = new HashMap<>();

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchemaUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchemaUtils.java
@@ -49,36 +49,32 @@ public final class HazelcastSchemaUtils {
 
     /**
      * Construct a schema from the given table resolvers.
-     * <p>
      * Currently we assume that all tables are resolved upfront by querying a table resolver. It works well for predefined
      * objects such as IMap and ReplicatedMap as well as external tables created by Jet. This approach will not work well
      * should we need a relaxed/dynamic object resolution at some point in future.
      *
      * @return Top-level schema.
      */
-    //TODO: I need to change this method too.
     public static HazelcastSchema createRootSchema(SqlCatalog catalog) {
-        // Create schemas.
         Map<String, Schema> schemaMap = new HashMap<>();
 
+        //Filling of ROOT schema
         for (Map.Entry<String, Map<String, Table>> currentSchemaEntry : catalog.getSchemas().entrySet()) {
             String schemaName = currentSchemaEntry.getKey();
 
             Map<String, org.apache.calcite.schema.Table> schemaTables = new HashMap<>();
 
+            //Each individual Scheme
             for (Map.Entry<String, Table> tableEntry : currentSchemaEntry.getValue().entrySet()) {
+
                 String tableName = tableEntry.getKey();
                 Table table = tableEntry.getValue();
 
-                HazelcastTable convertedTable = new HazelcastTable(
-                        table,
-                        createTableStatistic(table)
-                );
-
-                schemaTables.put(tableName, convertedTable);
+                //CHECK: Maybe we shouldn't have also any names in schemaTables?
+                schemaTables.put(tableName, null);
             }
-
-            HazelcastSchema currentSchema = new HazelcastSchema(Collections.emptyMap(), schemaTables);
+            //Key -> table mapping aka schema.
+            HazelcastSchema currentSchema = new HazelcastSchema(Collections.emptyMap(), schemaTables, catalog, schemaName);
 
             schemaMap.put(schemaName, currentSchema);
         }
@@ -97,7 +93,9 @@ public final class HazelcastSchemaUtils {
      * @param table Target table.
      * @return Statistics for the table.
      */
-    private static Statistic createTableStatistic(Table table) {
+
+    //CHECK: It seems that I could move it to a different place.
+    public static Statistic createTableStatistic(Table table) {
         return new HazelcastTableStatistic(table.getStatistics().getRowCount());
     }
 }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchemaUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchemaUtils.java
@@ -49,6 +49,7 @@ public final class HazelcastSchemaUtils {
 
     /**
      * Construct a schema from the given table resolvers.
+     * <p>
      * Currently we assume that all tables are resolved upfront by querying a table resolver. It works well for predefined
      * objects such as IMap and ReplicatedMap as well as external tables created by Jet. This approach will not work well
      * should we need a relaxed/dynamic object resolution at some point in future.
@@ -56,23 +57,20 @@ public final class HazelcastSchemaUtils {
      * @return Top-level schema.
      */
     public static HazelcastSchema createRootSchema(SqlCatalog catalog) {
+        // Create schemas.
         Map<String, Schema> schemaMap = new HashMap<>();
 
-        //Filling of ROOT schema
         for (Map.Entry<String, Map<String, Table>> currentSchemaEntry : catalog.getSchemas().entrySet()) {
             String schemaName = currentSchemaEntry.getKey();
 
             Map<String, org.apache.calcite.schema.Table> schemaTables = new HashMap<>();
 
-            //Each individual Scheme
             for (Map.Entry<String, Table> tableEntry : currentSchemaEntry.getValue().entrySet()) {
 
                 String tableName = tableEntry.getKey();
 
-                //CHECK: Maybe we shouldn't have also any names in schemaTables?
                 schemaTables.put(tableName, null);
             }
-            //Key -> table mapping aka schema.
             HazelcastSchema currentSchema = new HazelcastSchema(Collections.emptyMap(), schemaTables, catalog, schemaName);
 
             schemaMap.put(schemaName, currentSchema);
@@ -92,8 +90,6 @@ public final class HazelcastSchemaUtils {
      * @param table Target table.
      * @return Statistics for the table.
      */
-
-    //CHECK: It seems that I could move it to a different place.
     public static Statistic createTableStatistic(Table table) {
         return new HazelcastTableStatistic(table.getStatistics().getRowCount());
     }

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchemaUtils.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/HazelcastSchemaUtils.java
@@ -68,7 +68,6 @@ public final class HazelcastSchemaUtils {
             for (Map.Entry<String, Table> tableEntry : currentSchemaEntry.getValue().entrySet()) {
 
                 String tableName = tableEntry.getKey();
-                Table table = tableEntry.getValue();
 
                 //CHECK: Maybe we shouldn't have also any names in schemaTables?
                 schemaTables.put(tableName, null);


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.pinpointhq.com/
-->

https://github.com/hazelcast/hazelcast/issues/24004
https://hazelcast.atlassian.net//browse/HZ-3756

Implementation of lazy loading

Breaking changes (list specific methods/types/messages):
* API, no but I wondered about removal of public getTableMap, as now during lazy loading it could have table values set to null.

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
@viliam-durina, @k-jamroz 
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
