### PR TITLE
Implement SQL connector preferredLocalParallelism option

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/SqlConnector.java
@@ -181,6 +181,11 @@ public interface SqlConnector {
     String OPTION_TYPE_AVRO_SCHEMA = "avroSchema";
 
     /**
+     * The preferred local parallelism for connectors that support configuring it.
+     */
+    String OPTION_PREFERRED_LOCAL_PARALLELISM = "preferredLocalParallelism";
+
+    /**
      * Value for {@value #OPTION_KEY_FORMAT} and {@value #OPTION_VALUE_FORMAT}
      * for Java serialization.
      */

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
@@ -21,7 +21,6 @@ import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.kafka.KafkaProcessors;
-import com.hazelcast.jet.kafka.impl.StreamKafkaP;
 import com.hazelcast.jet.pipeline.DataConnectionRef;
 import com.hazelcast.jet.sql.impl.connector.HazelcastRexNode;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
@@ -144,7 +143,7 @@ public class KafkaSqlConnector implements SqlConnector {
         return context.getDag().newUniqueVertex(
                 table.toString(),
                 ProcessorMetaSupplier.of(
-                        StreamKafkaP.PREFERRED_LOCAL_PARALLELISM,
+                        table.preferredLocalParallelism(),
                         new RowProjectorProcessorSupplier(
                                 table.kafkaConsumerProperties(),
                                 table.dataConnectionName(),

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaTable.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaTable.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.sql.impl.connector.kafka;
 
+import com.hazelcast.jet.kafka.impl.StreamKafkaP;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.jet.sql.impl.inject.UpsertTargetDescriptor;
 import com.hazelcast.jet.sql.impl.schema.JetTable;
@@ -113,6 +114,13 @@ class KafkaTable extends JetTable {
 
     QueryDataType[] types() {
         return getFields().stream().map(TableField::getType).toArray(QueryDataType[]::new);
+    }
+
+    int preferredLocalParallelism() {
+        if (options.containsKey(SqlConnector.OPTION_PREFERRED_LOCAL_PARALLELISM)) {
+            return Integer.parseInt(options.get(SqlConnector.OPTION_PREFERRED_LOCAL_PARALLELISM));
+        }
+        return StreamKafkaP.PREFERRED_LOCAL_PARALLELISM;
     }
 
     @Override

--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/PropertiesResolver.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/PropertiesResolver.java
@@ -37,6 +37,7 @@ import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMA
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_AVRO_SCHEMA;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_CLASS;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_PREFERRED_LOCAL_PARALLELISM;
 
 final class PropertiesResolver {
     static final String KEY_SERIALIZER = "key.serializer";
@@ -48,7 +49,8 @@ final class PropertiesResolver {
             OPTION_KEY_FORMAT,
             OPTION_KEY_CLASS,
             OPTION_VALUE_FORMAT,
-            OPTION_VALUE_CLASS
+            OPTION_VALUE_CLASS,
+            OPTION_PREFERRED_LOCAL_PARALLELISM
     );
 
     // using strings instead of canonical names to not fail without Kafka on the classpath

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/PropertiesResolverTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/PropertiesResolverTest.java
@@ -53,6 +53,7 @@ import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMA
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_AVRO_SCHEMA;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_CLASS;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_PREFERRED_LOCAL_PARALLELISM;
 import static com.hazelcast.jet.sql.impl.connector.kafka.PropertiesResolver.KEY_DESERIALIZER;
 import static com.hazelcast.jet.sql.impl.connector.kafka.PropertiesResolver.KEY_SERIALIZER;
 import static com.hazelcast.jet.sql.impl.connector.kafka.PropertiesResolver.VALUE_DESERIALIZER;
@@ -445,5 +446,17 @@ public class PropertiesResolverTest {
 
     private static Properties resolveProducerProperties(Map<String, String> options) {
         return PropertiesResolver.resolveProducerProperties(options, null, null);
+    }
+
+    @Test
+    public void when_consumerProperties_preferredLocalParallelismPropertyIsDefined_then_itIsIgnored() {
+        assertThat(resolveConsumerProperties(Map.of(OPTION_PREFERRED_LOCAL_PARALLELISM, "-1")))
+                .containsExactlyEntriesOf(Map.of(KEY_DESERIALIZER, ByteArrayDeserializer.class.getCanonicalName()));
+    }
+
+    @Test
+    public void when_producerProperties_preferredLocalParallelismPropertyIsDefined_then_itIsIgnored() {
+        assertThat(resolveProducerProperties(Map.of(OPTION_PREFERRED_LOCAL_PARALLELISM, "-1")))
+                .containsExactlyEntriesOf(Map.of(KEY_SERIALIZER, ByteArraySerializer.class.getCanonicalName()));
     }
 }


### PR DESCRIPTION
This PR implements a new SQL mapping option to define the preferred local parallelism for connectors that support configuring it. At the moment, only the Kafka connector supports this. See linked issue for more details.

Fixes https://github.com/hazelcast/hazelcast/issues/24357

No Breaking changes.

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
