### PR TITLE
Fix testNullValuesFromMapLoaderAreNotInsertedIntoMap failure

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -815,17 +815,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             Object loadedValue = entry.getValue();
             Data key = toData(loadedKey);
 
-            if (key == null) {
-                String msg = String.format("Key cannot be null.[mapName: %s]", name);
-                throw new NullPointerException(msg);
-            }
-
-            if (loadedValue == null) {
-                // we haven't found any matching value to load, this
-                // is a legitimate case when loading not-existing keys
-                // from a map-loader, so we can continue with the rest.
-                continue;
-            }
+            checkKeyAndValue(key, loadedValue);
 
             BiTuple<Object, Long> biTuple = getOldValueWithExpiryTupleOrNull(loadedValue, now);
             if (biTuple != null) {


### PR DESCRIPTION
Fixes failure to throw a `NullPointerException` when a null value from a `MapLoader` is inserted into a Map.

The issue appears to been have introduced in commit 7ec47491423e15436c04e4635f0e223a7b043ff9 in which the null value is chosen to be tolerated as normal rather then exceptional.

I've reused the code `DefaultRecordStore` as this was the check in the original flow of the code. The `partitionId` check is superfluous here, however.

Fixes #26184
