### PR TITLE
isAsync takes precedence over OperationHostileThread

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -520,14 +520,14 @@ public final class OperationExecutorImpl implements OperationExecutor, StaticMet
 
         Thread currentThread = Thread.currentThread();
 
-        // IO threads are not allowed to run any operation
-        if (currentThread instanceof OperationHostileThread) {
-            return false;
-        }
-
         // if it is async we don't need to check if it is PartitionOperationThread or not
         if (isAsync) {
             return true;
+        }
+
+        // IO threads are not allowed to run any operation
+        if (currentThread instanceof OperationHostileThread) {
+            return false;
         }
 
         // allowed to invoke non partition specific task

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsInvocationAllowedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsInvocationAllowedTest.java
@@ -124,7 +124,7 @@ public class OperationExecutorImpl_IsInvocationAllowedTest extends OperationExec
         DummyOperationHostileThread hostileThread = new DummyOperationHostileThread(futureTask);
         hostileThread.start();
 
-        assertEqualsEventually(futureTask, FALSE);
+        assertEqualsEventually(futureTask, TRUE);
     }
 
     // ===================== partition specific operations ========================
@@ -249,6 +249,6 @@ public class OperationExecutorImpl_IsInvocationAllowedTest extends OperationExec
         DummyOperationHostileThread thread = new DummyOperationHostileThread(futureTask);
         thread.start();
 
-        assertEqualsEventually(futureTask, FALSE);
+        assertEqualsEventually(futureTask, TRUE);
     }
 }


### PR DESCRIPTION
Fixes #24712
OperationExecutor allows async invocation of OperationHostileThread.