### PR TITLE
Implement DataSerializable on BoundedRangePredicate

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BoundedRangePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BoundedRangePredicate.java
@@ -16,13 +16,14 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.impl.Comparables;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.util.Set;
 
 import static com.hazelcast.query.impl.predicates.PredicateUtils.isNull;
@@ -35,10 +36,10 @@ import static com.hazelcast.query.impl.predicates.PredicateUtils.isNull;
  */
 public class BoundedRangePredicate extends AbstractIndexAwarePredicate implements RangePredicate {
 
-    private final Comparable from;
-    private final boolean fromInclusive;
-    private final Comparable to;
-    private final boolean toInclusive;
+    private Comparable from;
+    private boolean fromInclusive;
+    private Comparable to;
+    private boolean toInclusive;
 
     /**
      * Creates a new instance of bounded range predicate.
@@ -62,6 +63,9 @@ public class BoundedRangePredicate extends AbstractIndexAwarePredicate implement
         this.fromInclusive = fromInclusive;
         this.to = to;
         this.toInclusive = toInclusive;
+    }
+
+    public BoundedRangePredicate() {
     }
 
     @Override
@@ -93,7 +97,7 @@ public class BoundedRangePredicate extends AbstractIndexAwarePredicate implement
 
     @Override
     public int getClassId() {
-        throw new UnsupportedOperationException("can't be serialized");
+        return PredicateDataSerializerHook.BOUNDED_RANGE_PREDICATE;
     }
 
     @Override
@@ -122,12 +126,25 @@ public class BoundedRangePredicate extends AbstractIndexAwarePredicate implement
     }
 
     @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        super.writeData(out);
+        out.writeObject(from);
+        out.writeBoolean(fromInclusive);
+        out.writeObject(to);
+        out.writeBoolean(toInclusive);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        super.readData(in);
+        from = in.readObject();
+        fromInclusive = in.readBoolean();
+        to = in.readObject();
+        toInclusive = in.readBoolean();
+    }
+
+    @Override
     public String toString() {
         return from + (fromInclusive ? " >= " : " > ") + attributeName + (toInclusive ? " <= " : " < ") + to;
     }
-
-    private void writeObject(ObjectOutputStream stream) throws IOException {
-        throw new UnsupportedOperationException("can't be serialized");
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateDataSerializerHook.java
@@ -57,8 +57,9 @@ public class PredicateDataSerializerHook implements DataSerializerHook {
     public static final int NEGATIVE_INFINITY = 19;
     public static final int POSITIVE_INFINITY = 20;
     public static final int MULTI_PARTITION_PREDICATE = 21;
+    public static final int BOUNDED_RANGE_PREDICATE = 22;
 
-    public static final int LEN = MULTI_PARTITION_PREDICATE + 1;
+    public static final int LEN = BOUNDED_RANGE_PREDICATE + 1;
 
     @Override
     public int getFactoryId() {
@@ -91,6 +92,7 @@ public class PredicateDataSerializerHook implements DataSerializerHook {
         constructors[NEGATIVE_INFINITY] = () -> CompositeValue.NEGATIVE_INFINITY;
         constructors[POSITIVE_INFINITY] = () -> CompositeValue.POSITIVE_INFINITY;
         constructors[MULTI_PARTITION_PREDICATE] = MultiPartitionPredicateImpl::new;
+        constructors[BOUNDED_RANGE_PREDICATE] = BoundedRangePredicate::new;
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BasicBoundedRangePredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BasicBoundedRangePredicateTest.java
@@ -44,11 +44,6 @@ public class BasicBoundedRangePredicateTest {
         new BoundedRangePredicate("this", null, true, null, true);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testCantBeSerialized() {
-        new BoundedRangePredicate("this", 1, true, 10, true).getClassId();
-    }
-
     @Test
     public void testRangePredicateConformance() {
         assertRangePredicate(new BoundedRangePredicate("this", 1, true, 10, true), "this", 1, true, 10, true);


### PR DESCRIPTION
Implement `DataSerializable` on `BoundedRangePredicate` as it has not been supported since introduced. Implementation is a reference from `BetweenPredicate` which is nearly the same without the inclusive boolean parameters.

Breaking changes (list specific methods/types/messages):
* None


