### PR TITLE
`fireLifecycleEvent` from `OutOfMemoryHandlerHelper`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/impl/OutOfMemoryHandlerHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/impl/OutOfMemoryHandlerHelper.java
@@ -59,7 +59,8 @@ public final class OutOfMemoryHandlerHelper {
         HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
         closeSockets(factory);
         try {
-            factory.node.shutdown(true);
+            // TODO or go through LifecycleService.terminate?
+            NodeShutdownHelper.shutdownNodeByFiringEvents(factory.node, true);
         } catch (Throwable ignored) {
             ignore(ignored);
         }

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultOutOfMemoryHandlerTest.java
@@ -56,5 +56,6 @@ public class DefaultOutOfMemoryHandlerTest extends AbstractOutOfMemoryHandlerTes
         outOfMemoryHandler.onOutOfMemory(new OutOfMemoryError(), instances);
 
         assertFalse("The member should be shutdown", hazelcastInstance.getLifecycleService().isRunning());
+        // TODO assert that an event was fired like in NodeShutdownEventsTest (https://github.com/hazelcast/hazelcast/pull/3903)
     }
 }


### PR DESCRIPTION
While working on error handling scenarios in an app using 5.3.7 I found that a qualifying `OutOfMemoryError` triggers a shutdown of the member but neglects to notify `LifecycleListener`, so the app has no way of adding its own cleanup procedures other than checking the current state in a polling loop. It is not clear to me whether this lack of notification is intentional (to avoid code paths which might try to allocate more objects), or merely an oversight like the one corrected in #3903. If the latter, I can try to add test coverage.