### PR TITLE
The error encountered while starting a native image

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -89,7 +89,6 @@ public final class BuildInfoProvider {
         String build = readStaticStringField(clazz, "BUILD");
         String revision = readStaticStringField(clazz, "REVISION");
         String distribution = readStaticStringField(clazz, "DISTRIBUTION");
-        String artifactId = readStaticStringField(clazz, "ARTIFACT_ID");
         String commitId = readStaticStringField(clazz, "COMMIT_ID");
 
         revision = checkMissingExpressionValue(revision, "${git.commit.id.abbrev}");

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -26,7 +26,6 @@ import static com.hazelcast.internal.util.EmptyStatement.ignore;
 
 /**
  * Provides information about current Hazelcast build.
- * @author Omer Celik
  */
 public final class BuildInfoProvider {
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -26,6 +26,7 @@ import static com.hazelcast.internal.util.EmptyStatement.ignore;
 
 /**
  * Provides information about current Hazelcast build.
+ * @author Omer Celik
  */
 public final class BuildInfoProvider {
 


### PR DESCRIPTION
Hello,

In my Spring Boot project, I am using Hazelcast version 5.0.0. It was working without any issues, but I decided to create a native image with GraalVM(Spring Boot Project). I successfully created a native image, but I'm encountering an error during the project startup when running the native image.. Because trying to access a field using reflection, normally this field is registered in a hint for us. However,  used reflection to get the field in the code, but you haven't used it. Therefore, this unused field is not registered in the hint. But at runtime, when this field is tried to be accessed using reflection, it causes an error.

This is why I created a pull request to remove this code. Alternatively, if you want me to make improvements in another way, I can update my pull request.

![Screenshot 2024-07-30 151829](https://github.com/user-attachments/assets/316c4818-506b-4ba7-a60e-5066d61cd685)

If you want to reproduce the error, I am sharing a sample POC project.
 https://github.com/omercelikceng/native-poc-cache 

Error : 

```
Caused by: java.lang.ExceptionInInitializerError: null
        at com.hazelcast.spi.properties.ClusterProperty.<clinit>(ClusterProperty.java:1692) ~[na:na]
        at com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl.<init>(HazelcastClientInstanceImpl.java:232) ~[com.example.NativePocCacheApplication:5.5.0]
        at com.hazelcast.client.HazelcastClient.constructHazelcastClient(HazelcastClient.java:475) ~[com.example.NativePocCacheApplication:5.5.0]
        at com.hazelcast.client.HazelcastClient.newHazelcastClientInternal(HazelcastClient.java:425) ~[com.example.NativePocCacheApplication:5.5.0]
        at com.hazelcast.client.HazelcastClient.newHazelcastClient(HazelcastClient.java:142) ~[com.example.NativePocCacheApplication:5.5.0]
        at com.example.HazelcastConfiguration.hazelcastClient(HazelcastConfiguration.java:43) ~[com.example.NativePocCacheApplication:na]
        at com.example.HazelcastConfiguration$$SpringCGLIB$$0.CGLIB$hazelcastClient$1(<generated>) ~[com.example.NativePocCacheApplication:na]
        at com.example.HazelcastConfiguration$$SpringCGLIB$$FastClass$$1.invoke(<generated>) ~[com.example.NativePocCacheApplication:na]
        at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:258) ~[com.example.NativePocCacheApplication:6.1.4]
        at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:331) ~[na:na]
        at com.example.HazelcastConfiguration$$SpringCGLIB$$0.hazelcastClient(<generated>) ~[com.example.NativePocCacheApplication:na]
        at com.example.HazelcastConfiguration__BeanDefinitions.lambda$getHazelcastClientInstanceSupplier$1(HazelcastConfiguration__BeanDefinitions.java:52) ~[na:na]
        at org.springframework.util.function.ThrowingBiFunction.apply(ThrowingBiFunction.java:68) ~[com.example.NativePocCacheApplication:6.1.4]
        at org.springframework.util.function.ThrowingBiFunction.apply(ThrowingBiFunction.java:54) ~[com.example.NativePocCacheApplication:6.1.4]
        at org.springframework.beans.factory.aot.BeanInstanceSupplier.lambda$get$2(BeanInstanceSupplier.java:206) ~[na:na]
        at org.springframework.util.function.ThrowingSupplier.get(ThrowingSupplier.java:58) ~[com.example.NativePocCacheApplication:6.1.4]
        at org.springframework.util.function.ThrowingSupplier.get(ThrowingSupplier.java:46) ~[com.example.NativePocCacheApplication:6.1.4]
        at org.springframework.beans.factory.aot.BeanInstanceSupplier.invokeBeanSupplier(BeanInstanceSupplier.java:218) ~[na:na]
        at org.springframework.beans.factory.aot.BeanInstanceSupplier.get(BeanInstanceSupplier.java:206) ~[na:na]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.obtainInstanceFromSupplier(DefaultListableBeanFactory.java:949) ~[com.example.NativePocCacheApplication:6.1.4]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.obtainFromSupplier(AbstractAutowireCapableBeanFactory.java:1217) ~[com.example.NativePocCacheApplication:6.1.4]
        ... 33 common frames omitted
        
Caused by: com.hazelcast.core.HazelcastException: java.lang.NoSuchFieldException: ARTIFACT_ID
        at com.hazelcast.instance.BuildInfoProvider.readStaticStringField(BuildInfoProvider.java:112) ~[na:na]
        at com.hazelcast.instance.BuildInfoProvider.readBuildPropertiesClass(BuildInfoProvider.java:92) ~[na:na]
        at com.hazelcast.instance.BuildInfoProvider.getBuildInfoInternalVersion(BuildInfoProvider.java:71) ~[na:na]
        at com.hazelcast.instance.BuildInfoProvider.populateBuildInfoCache(BuildInfoProvider.java:48) ~[na:na]
        at com.hazelcast.instance.BuildInfoProvider.<clinit>(BuildInfoProvider.java:41) ~[na:na]
        ... 54 common frames omitted

Caused by: java.lang.NoSuchFieldException: ARTIFACT_ID
        at java.base@21.0.2/java.lang.Class.checkField(DynamicHub.java:1041) ~[com.example.NativePocCacheApplication:na]
        at java.base@21.0.2/java.lang.Class.getField(DynamicHub.java:1026) ~[com.example.NativePocCacheApplication:na]
        at com.hazelcast.instance.BuildInfoProvider.readStaticStringField(BuildInfoProvider.java:109) ~[na:na]
        ... 58 common frames omitted
```