### PR TITLE
Implementation Provided for Reflection Access to idleTimeMillis() Method at Runtime in Native Image Creation

### DIFF
--- a/hazelcast/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/hazelcast/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,14 @@
+[
+  {
+    "condition": {
+      "typeReachable": "com.hazelcast.internal.networking.nio.NioNetworking"
+    },
+    "name": "com.hazelcast.internal.networking.nio.NioOutboundPipeline",
+    "methods": [
+      {
+        "name": "idleTimeMillis",
+        "parameterTypes": []
+      }
+    ]
+  }
+]


### PR DESCRIPTION
In my **Spring Boot** project, I am using Hazelcast **version 5.0.0**. 
I am able to **create a native image successfully.** However, when I **run** the application, I get the following **error** at runtime. 
This error does not cause the application to shut down. 

I reviewed the code. A method is invoked using reflection, but the method is not registered in the hints, so the error occurs.
Method is **private long com.hazelcast.internal.networking.nio.NioOutboundPipeline.idleTimeMillis().** 
I resolved the issue by adding this method to the hints.

Here is a sample project where you can reproduce the error. After cloning the project, follow the steps in the README.md file on the **main branch**, and you will see the **error** occur. Switch to the **solution branch** and follow the steps in the README.md file there, and you will see that **the error is resolved.** You will see that the service does not throw any errors and running correctly. The relevant code fixes have been made in the solution branch.

By following the steps in the **README file**, you will see the **error** occurring in the code on the **main** branch and observe that it is **resolved** in the code on the **solution** branch. I’ve made it easier for you. Thank you.

The branch link where you can reproduce the error : https://github.com/omercelikceng/native-poc-cache-issue/tree/main 
The branch link where the error is resolved : https://github.com/omercelikceng/native-poc-cache-issue/tree/solution

Error : 

```
2024-07-30T13:38:51.976Z  WARN 1 --- [nt_1.internal-2] c.h.i.m.impl.MetricsCollectionCycle      : Collecting metrics from source com.hazelcast.internal.networking.nio.NioNetworking failed

org.graalvm.nativeimage.MissingReflectionRegistrationError: The program tried to reflectively invoke method private long com.hazelcast.internal.networking.nio.NioOutboundPipeline.idleTimeMillis() without it being registered for runtime reflection. Add private long com.hazelcast.internal.networking.nio.NioOutboundPipeline.idleTimeMillis() to the reflection metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection for help.
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.forQueriedOnlyExecutable(MissingReflectionRegistrationUtils.java:72) ~[na:na]
        at java.base@21.0.2/java.lang.reflect.Method.acquireMethodAccessor(Method.java:77) ~[com.example.NativePocCacheApplication:na]
        at java.base@21.0.2/java.lang.reflect.Method.invoke(Method.java:577) ~[com.example.NativePocCacheApplication:na]
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.methodhandles.Util_java_lang_invoke_MethodHandle.invokeInternal(Target_java_lang_invoke_MethodHandle.java:265) ~[na:na]
        at java.base@21.0.2/java.lang.invoke.MethodHandle.invokeBasic(MethodHandle.java:98) ~[com.example.NativePocCacheApplication:na]
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.methodhandles.MethodHandleIntrinsicImpl.execute(MethodHandleIntrinsicImpl.java:179) ~[na:na]
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.methodhandles.Util_java_lang_invoke_MethodHandle.invokeInternal(Target_java_lang_invoke_MethodHandle.java:186) ~[na:na]
        at java.base@21.0.2/java.lang.invoke.MethodHandle.invokeBasic(MethodHandle.java:98) ~[com.example.NativePocCacheApplication:na]
        at java.base@21.0.2/java.lang.invoke.LambdaForm$NamedFunction.invokeWithArguments(LambdaForm.java:96) ~[na:na]
        at java.base@21.0.2/java.lang.invoke.LambdaForm.interpretName(LambdaForm.java:959) ~[com.example.NativePocCacheApplication:na]
        at java.base@21.0.2/java.lang.invoke.LambdaForm.interpretWithArguments(LambdaForm.java:936) ~[com.example.NativePocCacheApplication:na]
        at java.base@21.0.2/java.lang.invoke.MethodHandle.invokeBasic(MethodHandle.java:105) ~[com.example.NativePocCacheApplication:na]
        at java.base@21.0.2/java.lang.invoke.MethodHandle.invokeBasic(MethodHandle.java:0) ~[com.example.NativePocCacheApplication:na]
        at java.base@21.0.2/java.lang.invoke.LambdaForm$MH/0x00000007c16b4800.invokeExact_MT(LambdaForm$MH) ~[na:na]
        at com.hazelcast.internal.metrics.impl.MethodProbe$LongMethodProbe.get(MethodProbe.java:197) ~[na:na]
        at com.hazelcast.internal.metrics.impl.MetricsCollectionCycle.collectLong(MetricsCollectionCycle.java:175) ~[na:na]
        at com.hazelcast.internal.metrics.impl.MetricsCollectionCycle.collect(MetricsCollectionCycle.java:153) ~[na:na]
        at com.hazelcast.internal.metrics.impl.MetricsCollectionCycle.extractAndCollectDynamicMetrics(MetricsCollectionCycle.java:128) ~[na:na]
        at com.hazelcast.internal.metrics.impl.MetricsCollectionCycle$MetricsContext.collect(MetricsCollectionCycle.java:189) ~[na:na]
        at com.hazelcast.internal.networking.nio.NioNetworking.provideDynamicMetrics(NioNetworking.java:371) ~[com.example.NativePocCacheApplication:5.5.0]
        at com.hazelcast.internal.metrics.impl.MetricsCollectionCycle.collectDynamicMetrics(MetricsCollectionCycle.java:94) ~[na:na]
        at com.hazelcast.internal.metrics.impl.MetricsRegistryImpl.collect(MetricsRegistryImpl.java:320) ~[na:na]
        at com.hazelcast.client.impl.statistics.ClientStatisticsService.collectAndSendStats(ClientStatisticsService.java:148) ~[na:na]
        at java.base@21.0.2/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[na:na]
        at java.base@21.0.2/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358) ~[com.example.NativePocCacheApplication:na]
        at java.base@21.0.2/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[na:na]
        at java.base@21.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[com.example.NativePocCacheApplication:na]
        at java.base@21.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
        at java.base@21.0.2/java.lang.Thread.runWith(Thread.java:1596) ~[com.example.NativePocCacheApplication:na]
        at java.base@21.0.2/java.lang.Thread.run(Thread.java:1583) ~[com.example.NativePocCacheApplication:na]
        at com.hazelcast.internal.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76) ~[com.example.NativePocCacheApplication:5.5.0]
        at com.hazelcast.internal.util.executor.PoolExecutorThreadFactory$ManagedThread.executeRun(PoolExecutorThreadFactory.java:74) ~[na:na]
        at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:111) ~[com.example.NativePocCacheApplication:5.5.0]
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:838) ~[com.example.NativePocCacheApplication:na]
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.posix.thread.PosixPlatformThreads.pthreadStartRoutine(PosixPlatformThreads.java:211) ~[na:na]
```