### PR TITLE
custom group factory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -329,19 +329,19 @@ public class PartitionGroupConfig {
             return false;
         }
 
-        if (areDifferent(memberGroupFactory, that.memberGroupFactory)) {
+        if (!isEqual(memberGroupFactory, that.memberGroupFactory)) {
             return false;
         }
 
         return memberGroupConfigs.equals(that.memberGroupConfigs);
     }
 
-    private boolean areDifferent(MemberGroupFactory input, MemberGroupFactory other) {
+    private boolean isEqual(MemberGroupFactory input, MemberGroupFactory other) {
         if (input == null) {
-            return other != null;
+            return other == null;
         }
 
-        return !input.equals(other);
+        return input.equals(other);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.partition.membergroup.MemberGroupFactory;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -148,6 +150,8 @@ public class PartitionGroupConfig {
 
     private final List<MemberGroupConfig> memberGroupConfigs = new LinkedList<>();
 
+    private MemberGroupFactory memberGroupFactory;
+
     /**
      * Type of member groups.
      */
@@ -160,6 +164,10 @@ public class PartitionGroupConfig {
          * Custom.
          */
         CUSTOM,
+        /**
+         * Custom factory.
+         */
+        CUSTOM_FACTORY,
         /**
          * Per member.
          */
@@ -253,6 +261,28 @@ public class PartitionGroupConfig {
     }
 
     /**
+     * Returns the MemberGroupFactory configured. Could be {@code null} if no MemberGroupFactory has been configured.
+     *
+     * @return the MemberGroupFactory
+     */
+    public MemberGroupFactory getMemberGroupFactory() {
+        return memberGroupFactory;
+    }
+
+    /**
+     * Sets the {@link MemberGroupFactory}
+     *
+     * @param memberGroupFactory the MemberGroupFactory to set
+     * @return the updated PartitionGroupConfig
+     * @throws IllegalArgumentException if memberGroupFactory is {@code null}
+     * @see #getMemberGroupFactory()
+     */
+    public PartitionGroupConfig setMemberGroupFactory(MemberGroupFactory memberGroupFactory) {
+        this.memberGroupFactory = isNotNull(memberGroupFactory, "memberGroupFactory");;
+        return this;
+    }
+
+    /**
      * Removes all the {@link MemberGroupType} instances.
      *
      * @return the updated PartitionGroupConfig
@@ -298,7 +328,20 @@ public class PartitionGroupConfig {
         if (groupType != that.groupType) {
             return false;
         }
+
+        if (areDifferent(memberGroupFactory, that.memberGroupFactory)) {
+            return false;
+        }
+
         return memberGroupConfigs.equals(that.memberGroupConfigs);
+    }
+
+    private boolean areDifferent(MemberGroupFactory input, MemberGroupFactory other) {
+        if (input == null) {
+            return other != null;
+        }
+
+        return !input.equals(other);
     }
 
     @Override
@@ -306,6 +349,7 @@ public class PartitionGroupConfig {
         int result = (enabled ? 1 : 0);
         result = 31 * result + (groupType != null ? groupType.hashCode() : 0);
         result = 31 * result + memberGroupConfigs.hashCode();
+        result = 31 * result + (memberGroupFactory != null ? memberGroupFactory.hashCode() : 0);
         return result;
     }
 
@@ -315,6 +359,7 @@ public class PartitionGroupConfig {
                 + "enabled=" + enabled
                 + ", groupType=" + groupType
                 + ", memberGroupConfigs=" + memberGroupConfigs
+                + ", memberGroupFactory=" + memberGroupFactory
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -336,14 +336,6 @@ public class PartitionGroupConfig {
         return memberGroupConfigs.equals(that.memberGroupConfigs);
     }
 
-    private boolean isEqual(MemberGroupFactory input, MemberGroupFactory other) {
-        if (input == null) {
-            return other == null;
-        }
-
-        return input.equals(other);
-    }
-
     @Override
     public final int hashCode() {
         int result = (enabled ? 1 : 0);
@@ -361,5 +353,13 @@ public class PartitionGroupConfig {
                 + ", memberGroupConfigs=" + memberGroupConfigs
                 + ", memberGroupFactory=" + memberGroupFactory
                 + '}';
+    }
+
+    private boolean isEqual(MemberGroupFactory input, MemberGroupFactory other) {
+        if (input == null) {
+            return other == null;
+        }
+
+        return input.equals(other);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/MemberGroupFactoryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/MemberGroupFactoryFactory.java
@@ -39,6 +39,8 @@ public final class MemberGroupFactoryFactory {
                 return new HostAwareMemberGroupFactory();
             case CUSTOM:
                 return new ConfigMemberGroupFactory(partitionGroupConfig.getMemberGroupConfigs());
+            case CUSTOM_FACTORY:
+                return partitionGroupConfig.getMemberGroupFactory();
             case PER_MEMBER:
                 return new SingleMemberGroupFactory();
             case ZONE_AWARE:

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/MemberGroupFactoryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/membergroup/MemberGroupFactoryFactory.java
@@ -19,6 +19,8 @@ package com.hazelcast.internal.partition.membergroup;
 import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
+import static com.hazelcast.internal.util.Preconditions.isNotNull;
+
 public final class MemberGroupFactoryFactory {
 
     private MemberGroupFactoryFactory() {
@@ -40,6 +42,7 @@ public final class MemberGroupFactoryFactory {
             case CUSTOM:
                 return new ConfigMemberGroupFactory(partitionGroupConfig.getMemberGroupConfigs());
             case CUSTOM_FACTORY:
+                isNotNull(partitionGroupConfig, "partitionGroupConfig");
                 return partitionGroupConfig.getMemberGroupFactory();
             case PER_MEMBER:
                 return new SingleMemberGroupFactory();

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -807,6 +807,8 @@ hazelcast:
   # single partition group.
   # * CUSTOM:
   # You can add different and multiple members to a group.
+  # * CUSTOM_FACTORY
+  # You can provide your own MemberGroupFactory implementation.
   # * PER_MEMBER:
   # Each member is a group of its own and primary/backup partitions are distributed
   # randomly (not on the same physical member).


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.pinpointhq.com/
-->

Create an option to provide a custom group factory. In our use case, it would be nice to provide a custom group factory to place the members together based on other Kubernetes properties.

This is my first PR for the repo, so please help me understand what else needs to be done!

Breaking changes (list specific methods/types/messages):
* No breaking changes (as far as i know)

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] Send backports/forwardports if fix needs to be applied to past/future releases
