### PR TITLE
add implementation for HazelcastCache

### DIFF
--- a/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/HazelcastCacheTest.java
+++ b/hazelcast-spring-tests/src/test/java/com/hazelcast/spring/cache/HazelcastCacheTest.java
@@ -32,8 +32,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
@@ -41,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 /**
@@ -156,6 +159,31 @@ class HazelcastCacheTest {
         for (Object result : results) {
             assertThat((Integer) result).isEqualTo(1);
         }
+    }
+
+    @Test
+    void testCacheRetrieveWithNull() {
+        assertThrows(NullPointerException.class, () -> cache.retrieve(null));
+    }
+
+    @Test
+    void testCacheRetrieveWithRandomKey() throws ExecutionException, InterruptedException {
+        String key = createRandomKey();
+        CompletableFuture<?> resultFuture = cache.retrieve(key);
+
+        assertNotNull(resultFuture);
+        assertNull(resultFuture.get());
+    }
+
+    @Test
+    void testCacheRetrieveWithExistingKey() throws ExecutionException, InterruptedException {
+        String key = createRandomKey();
+        cache.put(key, "test");
+
+        CompletableFuture<?> resultFuture = cache.retrieve(key);
+
+        assertNotNull(resultFuture);
+        assertThat(resultFuture.get()).isEqualTo("test");
     }
 
     private String createRandomKey() {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
@@ -26,6 +26,7 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.support.SimpleValueWrapper;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -99,6 +100,11 @@ public class HazelcastCache implements Cache {
         }
     }
 
+    @Override
+    public CompletableFuture<?> retrieve(Object key) {
+        return this.map.getAsync(key).toCompletableFuture();
+    }
+
     private <T> T loadValue(Object key, Callable<T> valueLoader) {
         T value;
         try {
@@ -152,7 +158,7 @@ public class HazelcastCache implements Cache {
     private Object lookup(Object key) {
         if (readTimeout > 0) {
             try {
-                return this.map.getAsync(key).toCompletableFuture().get(readTimeout, TimeUnit.MILLISECONDS);
+                return retrieve(key).get(readTimeout, TimeUnit.MILLISECONDS);
             } catch (TimeoutException te) {
                 throw new OperationTimeoutException(te.getMessage());
             } catch (InterruptedException e) {


### PR DESCRIPTION
add implementation for HazelcastCache that overrides the Cache interface default implementation 
```
    @Nullable
    default CompletableFuture<?> retrieve(Object key) {
        throw new UnsupportedOperationException(this.getClass().getName() + " does not support CompletableFuture-based retrieval");
    }
```