### PR TITLE
Update RegionValidator.java

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aws/RegionValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/RegionValidator.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
  */
 final class RegionValidator {
     private static final Pattern AWS_REGION_PATTERN =
-        Pattern.compile("\\w{2}(-gov-|-)(north|northeast|east|southeast|south|southwest|west|northwest|central)-\\d(?!.+)");
+        Pattern.compile("\\w{2}(-\\w{3}-|-)(north|northeast|east|southeast|south|southwest|west|northwest|central)-\\d(?!.+)");
 
     private RegionValidator() {
     }

--- a/hazelcast/src/test/java/com/hazelcast/aws/RegionValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/RegionValidatorTest.java
@@ -28,6 +28,7 @@ public class RegionValidatorTest {
     public void validateValidRegion() {
         RegionValidator.validateRegion("us-west-1");
         RegionValidator.validateRegion("us-gov-east-1");
+        RegionValidator.validateRegion("us-any-northeast-1");
     }
 
     @Test
@@ -48,6 +49,20 @@ public class RegionValidatorTest {
     public void validateInvalidGovRegion() {
         // given
         String region = "us-gov-wrong-1";
+        String expectedMessage = String.format("The provided region %s is not a valid AWS region.", region);
+
+        // when
+        ThrowingRunnable validateRegion = () -> RegionValidator.validateRegion(region);
+
+        //then
+        InvalidConfigurationException thrownEx = assertThrows(InvalidConfigurationException.class, validateRegion);
+        assertEquals(expectedMessage, thrownEx.getMessage());
+    }
+
+    @Test
+    public void validateInvalidAnyRegion() {
+        // given
+        String region = "us-any-wrong-1";
         String expectedMessage = String.format("The provided region %s is not a valid AWS region.", region);
 
         // when


### PR DESCRIPTION

To encompass more private/custom regions within AWS  https://aws.amazon.com/blogs/publicsector/tag/region-announcement/
Modification of Regex Validation should not affect the plugin
Fixes: https://github.com/hazelcast/hazelcast/issues/26487


Breaking changes (list specific methods/types/messages): NONE

Checklist:
- [ ] Labels (`Team:`, `Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
