### PR TITLE
HZC-7235: change-cloud-url

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudDiscovery.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudDiscovery.java
@@ -47,7 +47,7 @@ import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 
 /**
  * Discovery service that discover nodes via hazelcast.cloud
- * https://api.viridian.hazelcast.com/cluster/discovery?token=<TOKEN>
+ * https://api.cloud.hazelcast.com/cluster/discovery?token=<TOKEN>
  */
 public class HazelcastCloudDiscovery {
 
@@ -56,7 +56,7 @@ public class HazelcastCloudDiscovery {
      * Used for testing cloud discovery.
      */
     public static final HazelcastProperty CLOUD_URL_BASE_PROPERTY =
-            new HazelcastProperty("hazelcast.client.cloud.url", "https://api.viridian.hazelcast.com");
+            new HazelcastProperty("hazelcast.client.cloud.url", "https://api.cloud.hazelcast.com");
     private static final String CLOUD_URL_PATH = "/cluster/discovery?token=";
     private static final String PRIVATE_ADDRESS_PROPERTY = "private-address";
     private static final String PUBLIC_ADDRESS_PROPERTY = "public-address";

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/spi/impl/discovery/HazelcastCloudConfigTest.java
@@ -54,7 +54,7 @@ public class HazelcastCloudConfigTest extends ClientTestSupport {
         HazelcastProperties hazelcastProperties = new HazelcastProperties(config.getProperties());
         String cloudUrlBase = hazelcastProperties.getString(HazelcastCloudDiscovery.CLOUD_URL_BASE_PROPERTY);
         String urlEndpoint = HazelcastCloudDiscovery.createUrlEndpoint(cloudUrlBase, token);
-        assertEquals("https://api.viridian.hazelcast.com/cluster/discovery?token=TOKEN", urlEndpoint);
+        assertEquals("https://api.cloud.hazelcast.com/cluster/discovery?token=TOKEN", urlEndpoint);
     }
 
 }


### PR DESCRIPTION
chore: update cloud url to api.cloud.hazelcast.com as part of the deprecation of using viridian