### PR TITLE
issue# 26494: make AzureDiscoveryStrategy work for VMSS

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/azure/AzureClient.java
+++ b/hazelcast/src/main/java/com/hazelcast/azure/AzureClient.java
@@ -87,7 +87,7 @@ class AzureClient {
         LOGGER.finest("Fetching instances for subscription '%s' and resourceGroup '%s'",
                 subscriptionId, resourceGroup);
         Collection<AzureAddress> addresses = azureComputeApi.instances(subscriptionId, resourceGroup,
-                scaleSet, tag, accessToken);
+                tag, accessToken);
         LOGGER.finest("Found the following instances for project '%s' and zone '%s': %s",
                 subscriptionId, resourceGroup,
                 addresses);

--- a/hazelcast/src/main/java/com/hazelcast/azure/AzureComputeApi.java
+++ b/hazelcast/src/main/java/com/hazelcast/azure/AzureComputeApi.java
@@ -54,18 +54,21 @@ class AzureComputeApi {
         this.endpoint = endpoint;
     }
 
-    Collection<AzureAddress> instances(String subscriptionId, String resourceGroup, String scaleSet,
-                                       Tag tag, String accessToken) {
+    Collection<AzureAddress> instances(String subscriptionId, String resourceGroup, Tag tag, String accessToken) {
+        String urlForPrivateIpList = String.format("%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network"
+                + "/networkInterfaces?api-version=%s", endpoint, subscriptionId, resourceGroup, API_VERSION);
         String privateIpResponse = RestClient
-                .create(urlForPrivateIpList(subscriptionId, resourceGroup, scaleSet))
+                .create(urlForPrivateIpList)
                 .withHeader("Authorization", String.format("Bearer %s", accessToken))
                 .get()
                 .getBody();
 
         Map<String, AzureNetworkInterface> networkInterfaces = parsePrivateIpResponse(privateIpResponse);
 
+        String urlForPublicIpList = String.format("%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network"
+                + "/publicIPAddresses?api-version=%s", endpoint, subscriptionId, resourceGroup, API_VERSION);
         String publicIpResponse = RestClient
-                .create(urlForPublicIpList(subscriptionId, resourceGroup, scaleSet))
+                .create(urlForPublicIpList)
                 .withHeader("Authorization", String.format("Bearer %s", accessToken))
                 .get()
                 .getBody();
@@ -81,17 +84,6 @@ class AzureComputeApi {
         }
 
         return addresses;
-    }
-
-    private String urlForPrivateIpList(String subscriptionId, String resourceGroup, String scaleSet) {
-        if (isNullOrEmptyAfterTrim(scaleSet)) {
-            return String.format("%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network"
-                    + "/networkInterfaces?api-version=%s", endpoint, subscriptionId, resourceGroup, API_VERSION);
-        } else {
-            return String.format("%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute"
-                            + "/virtualMachineScaleSets/%s/networkInterfaces?api-version=%s",
-                    endpoint, subscriptionId, resourceGroup, scaleSet, API_VERSION_SCALE_SET);
-        }
     }
 
     private Map<String, AzureNetworkInterface> parsePrivateIpResponse(String response) {
@@ -117,17 +109,6 @@ class AzureComputeApi {
             }
         }
         return interfaces;
-    }
-
-    private String urlForPublicIpList(String subscriptionId, String resourceGroup, String scaleSet) {
-        if (isNullOrEmptyAfterTrim(scaleSet)) {
-            return String.format("%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network"
-                    + "/publicIPAddresses?api-version=%s", endpoint, subscriptionId, resourceGroup, API_VERSION);
-        } else {
-            return String.format("%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute"
-                            + "/virtualMachineScaleSets/%s/publicIPAddresses?api-version=%s",
-                    endpoint, subscriptionId, resourceGroup, scaleSet, API_VERSION_SCALE_SET);
-        }
     }
 
     private Map<String, String> parsePublicIpResponse(String response) {

--- a/hazelcast/src/test/java/com/hazelcast/azure/AzureClientTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/azure/AzureClientTest.java
@@ -64,7 +64,7 @@ public class AzureClientTest {
     @Test
     public void getAddressesCurrentSubscriptionCurrentResourceGroupCurrentScaleSetNoTag() {
         // given
-        given(azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, SCALE_SET, null, ACCESS_TOKEN)).willReturn(ADDRESSES);
+        given(azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, null, ACCESS_TOKEN)).willReturn(ADDRESSES);
 
         AzureConfig azureConfig = AzureConfig.builder().setInstanceMetadataAvailable(true).build();
         AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
@@ -79,7 +79,7 @@ public class AzureClientTest {
     @Test
     public void getAddressesCurrentSubscriptionCurrentResourceGroupCurrentScaleSetWithTag() {
         // given
-        given(azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, SCALE_SET, TAG, ACCESS_TOKEN)).willReturn(ADDRESSES);
+        given(azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, TAG, ACCESS_TOKEN)).willReturn(ADDRESSES);
 
         AzureConfig azureConfig = AzureConfig.builder().setInstanceMetadataAvailable(true).setTag(TAG).build();
         AzureClient azureClient = new AzureClient(azureMetadataApi, azureComputeApi, azureAuthenticator, azureConfig);
@@ -101,7 +101,7 @@ public class AzureClientTest {
         String subscriptionId = "subscription-2";
         String resourceGroup = "resource-group-2";
         String scaleSet = "scale-set-2";
-        given(azureComputeApi.instances(subscriptionId, resourceGroup, scaleSet, TAG, ACCESS_TOKEN)).willReturn(ADDRESSES);
+        given(azureComputeApi.instances(subscriptionId, resourceGroup, TAG, ACCESS_TOKEN)).willReturn(ADDRESSES);
 
         AzureConfig azureConfig = AzureConfig.builder()
                                        .setClientId(clientId)

--- a/hazelcast/src/test/java/com/hazelcast/azure/AzureComputeApiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/azure/AzureComputeApiTest.java
@@ -73,7 +73,7 @@ public class AzureComputeApiTest {
                 .willReturn(aResponse().withStatus(HttpURLConnection.HTTP_OK).withBody(instancesResponseForPublicIPAddresses())));
 
         // when
-        Collection<AzureAddress> result = azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, null, null, ACCESS_TOKEN);
+        Collection<AzureAddress> result = azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, null, ACCESS_TOKEN);
 
         // then
         AzureAddress address1 = new AzureAddress(INSTANCE_1_PRIVATE_IP, INSTANCE_1_PUBLIC_IP);
@@ -103,7 +103,7 @@ public class AzureComputeApiTest {
                 .willReturn(aResponse().withStatus(HttpURLConnection.HTTP_OK).withBody(instancesResponseForPublicIPAddresses())));
 
         // when
-        Collection<AzureAddress> result = azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, SCALE_SET, null, ACCESS_TOKEN);
+        Collection<AzureAddress> result = azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, null, ACCESS_TOKEN);
 
         // then
         AzureAddress address1 = new AzureAddress(INSTANCE_1_PRIVATE_IP, INSTANCE_1_PUBLIC_IP);
@@ -131,7 +131,7 @@ public class AzureComputeApiTest {
                 .willReturn(aResponse().withStatus(HttpURLConnection.HTTP_OK).withBody(instancesResponseForPublicIPAddresses())));
 
         // when
-        Collection<AzureAddress> result = azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, null, TAG, ACCESS_TOKEN);
+        Collection<AzureAddress> result = azureComputeApi.instances(SUBSCRIPTION_ID, RESOURCE_GROUP, TAG, ACCESS_TOKEN);
 
         // then
         AzureAddress address1 = new AzureAddress(INSTANCE_1_PRIVATE_IP, INSTANCE_1_PUBLIC_IP);


### PR DESCRIPTION
This PR attempts to fix  #26494 by simply using the `Microsoft.Network/networkInterfaces` resource to retrieve network interfaces when running in a VMSS (Virtual Machine Scale Set).

Fixes [#26494](https://github.com/hazelcast/hazelcast/issues/26494)

Refer to the ticket for details on setting up VMSS environment with access token and required `Reader` role

