### PR TITLE
Optional JavaX Annotation

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -332,6 +332,8 @@
                                     sun.misc;resolution:=optional,
                                     javax.cache;resolution:=optional,
                                     javax.cache.*;resolution:=optional,
+                                    javax.annotation;resolution:=optional,
+                                    javax.annotation.*;resolution:=optional,
                                     org.apache.log4j;resolution:=optional,
                                     org.apache.log4j.spi;resolution:=optional,
                                     org.apache.logging.log4j;resolution:=optional,


### PR DESCRIPTION
<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.pinpointhq.com/
-->

Resolves an OSGI dependency issue where a non-existent `javax.annotations` import is required.