### PR TITLE
 Fix memory leak in ReadMetricsOperation when requesting sequence == tail (#26463)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsService.java
@@ -56,6 +56,8 @@ import static java.util.stream.Collectors.joining;
  */
 public class MetricsService implements ManagedService, LiveOperationsTracker {
     public static final String SERVICE_NAME = "hz:impl:metricsService";
+    // Timeout for pending reads in milliseconds (60 seconds)
+    private static final long PENDING_READ_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(60);
 
     private final NodeEngine nodeEngine;
     private final ILogger logger;
@@ -184,15 +186,31 @@ public class MetricsService implements ManagedService, LiveOperationsTracker {
 
         tryCompleteRead(future, startSequence);
 
+        // Schedule timeout to prevent memory leak if metrics collection stops
+        scheduleReadTimeout(future, startSequence);
+
         return future;
+    }
+
+    private void scheduleReadTimeout(CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future, long sequence) {
+        ExecutionService executionService = nodeEngine.getExecutionService();
+        executionService.schedule(() -> {
+            if (!future.isDone()) {
+                logger.warning("Metrics read operation timed out after " + PENDING_READ_TIMEOUT_MS + "ms for sequence: "
+                        + sequence + ". Completing with empty slice to prevent memory leak.");
+                // Try to complete with current data, or use tryCompleteRead which will handle it properly
+                tryCompleteRead(future, sequence);
+            }
+        }, PENDING_READ_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
 
     private void tryCompleteRead(CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future, long sequence) {
         try {
             RingbufferSlice<Map.Entry<Long, byte[]>> slice = metricsJournal.copyFrom(sequence);
-            if (!slice.isEmpty()) {
-                future.complete(slice);
-            }
+            // Always complete the future, even with empty slice.
+            // This prevents memory leak in LiveOperationRegistry when requesting sequence == tail.
+            // Empty slice is a valid response meaning "no data available yet at this sequence".
+            future.complete(slice);
         } catch (ConcurrentArrayRingbuffer.SequenceOutOfBoundsException e) {
             logger.fine("Error reading from metrics journal, sequence: " + sequence + "."
                     + " In case of persistence-enabled member restart, this error is handled by MC gracefully.", e);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationMemoryLeakImprovedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationMemoryLeakImprovedTest.java
@@ -129,10 +129,10 @@ public class ReadMetricsOperationMemoryLeakImprovedTest extends ClientTestSuppor
         ClientMessage request = MCReadMetricsCodec.encodeRequest(memberUuid, tailSequence);
         ClientInvocation invocation = new ClientInvocation(clientImpl, request, null);
 
-        // Try to get with short timeout - should complete with empty slice or timeout
+        //sends a request to the server and returns future
         try {
-            invocation.invoke().get(500, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
+            invocation.invoke();
+        } catch (Exception e) {
             // Expected - operation is waiting for future data
         }
 
@@ -229,27 +229,5 @@ public class ReadMetricsOperationMemoryLeakImprovedTest extends ClientTestSuppor
         }
 
         return totalOperations;
-    }
-
-    private void printLiveOperationRegistryState() throws Exception {
-        // Diagnostic method for debugging - called only on test failure
-        LiveOperationRegistry registry = metricsService.getLiveOperationRegistry();
-        Field liveOperationsField = LiveOperationRegistry.class.getDeclaredField("liveOperations");
-        liveOperationsField.setAccessible(true);
-
-        @SuppressWarnings("unchecked")
-        ConcurrentHashMap<?, Map<Long, ?>> liveOperations =
-            (ConcurrentHashMap<?, Map<Long, ?>>) liveOperationsField.get(registry);
-
-        // Information will be available in test failure output
-        int totalOps = 0;
-        for (Map<Long, ?> ops : liveOperations.values()) {
-            totalOps += ops.size();
-        }
-
-        // This will appear in test logs when the test fails
-        if (totalOps > 0) {
-            fail("Found " + totalOps + " leaked operations across " + liveOperations.size() + " addresses");
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationMemoryLeakImprovedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationMemoryLeakImprovedTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.metrics.managementcenter.ConcurrentArrayRingbuffer.RingbufferSlice;
+import com.hazelcast.internal.metrics.managementcenter.ReadMetricsOperation;
+import com.hazelcast.spi.impl.InternalCompletableFuture;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.hazelcast.test.Accessors.getNode;
+import static org.junit.Assert.fail;
+
+/**
+ * Test to verify the FIX for memory leak issue #26463.
+ *
+ * Original bug scenario:
+ * 1. Client requests metrics with sequence == tail
+ * 2. ConcurrentArrayRingbuffer.copyFrom() returns EMPTY slice
+ * 3. MetricsService.tryCompleteRead() used to skip future.complete() for empty slices
+ * 4. Future never completes → doSendResponse() never called → deregister() never called
+ * 5. Operation leaks in LiveOperationRegistry
+ *
+ * Fix:
+ * - MetricsService.tryCompleteRead() now ALWAYS calls future.complete(), even with empty slice
+ * - Added timeout mechanism as safety net (60 seconds)
+ * - Empty slice is a valid response meaning "no data available yet"
+ *
+ * This test verifies the fix works correctly.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({SlowTest.class, ParallelJVMTest.class})
+public class ReadMetricsOperationMemoryLeakImprovedTest extends HazelcastTestSupport {
+
+    private HazelcastInstance instance;
+    private NodeEngineImpl nodeEngine;
+    private OperationServiceImpl operationService;
+    private MetricsService metricsService;
+
+    @Before
+    public void setUp() {
+        // Create Hazelcast instance with metrics enabled
+        // Use VERY SLOW collection to simulate the problem
+        Config config = new Config();
+        config.getMetricsConfig().setEnabled(true);
+        config.getMetricsConfig().setCollectionFrequencySeconds(3600); // 1 hour! Very slow
+        config.getMetricsConfig().getManagementCenterConfig().setEnabled(true);
+        config.getMetricsConfig().getManagementCenterConfig().setRetentionSeconds(60); // Very small - only 1 minute
+
+        instance = createHazelcastInstance(config);
+        nodeEngine = getNode(instance).getNodeEngine();
+        operationService = nodeEngine.getOperationService();
+        metricsService = nodeEngine.getService(MetricsService.SERVICE_NAME);
+    }
+
+    @After
+    public void tearDown() {
+        if (instance != null) {
+            instance.shutdown();
+        }
+    }
+
+    /**
+     * This test verifies the FIX for issue #26463.
+     *
+     * Expected behavior: NO LEAK - operations are properly cleaned up even when requesting sequence == tail
+     */
+    @Test
+    public void testMemoryLeak_whenRequestingFutureSequenceWithinRetention() throws Exception {
+        System.out.println("\n=== TEST: Verify Fix for Issue #26463 ===\n");
+
+        // Print heap size to verify VM options
+        Runtime runtime = Runtime.getRuntime();
+        long maxMemory = runtime.maxMemory() / (1024 * 1024);
+        long totalMemory = runtime.totalMemory() / (1024 * 1024);
+        System.out.println("JVM Max Memory: " + maxMemory + " MB");
+        System.out.println("JVM Total Memory: " + totalMemory + " MB");
+        System.out.println();
+
+        // Step 1: Force initial metrics collection
+        System.out.println("Step 1: Triggering initial metrics collection...");
+        forceMetricsCollection();
+        sleepSeconds(1);
+
+        // Step 2: Get current state
+        int initialSize = getLiveOperationRegistrySize();
+        System.out.println("Initial LiveOperationRegistry size: " + initialSize);
+
+        long currentTailSequence = getCurrentHeadSequence(); // This is actually tail!
+        System.out.println("Current tail sequence: " + currentTailSequence);
+
+        // Step 3: Request sequence that equals tail (empty slice, no exception)
+        // When we request sequence == tail:
+        // - copyFrom() returns empty slice (line 77)
+        // - future.complete() is NOT called (line 193-195)
+        // - Operation remains in LiveOperationRegistry forever!
+        long futureSequence = currentTailSequence; // Request tail itself
+        System.out.println("Requesting tail sequence: " + futureSequence);
+        System.out.println("(This will return empty slice without completing the future)");
+
+        int numberOfOperations = 1; // Only 1 operation to minimize memory usage
+
+        // Step 4: Send operations that will get stuck
+        for (int i = 0; i < numberOfOperations; i++) {
+            ReadMetricsOperation operation = new ReadMetricsOperation(futureSequence);
+
+            System.out.println("About to invoke operation " + i + "...");
+            InternalCompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future =
+                operationService.invokeOnTarget(
+                    MetricsService.SERVICE_NAME,
+                    operation,
+                    nodeEngine.getThisAddress()
+                );
+            System.out.println("Operation " + i + " invoked, future isDone=" + future.isDone());
+
+            // Add callback to detect when future completes
+            future.whenComplete((result, error) -> {
+                if (error != null) {
+                    System.out.println(">>> Future completed with ERROR: " + error.getClass().getSimpleName() + ": " + error.getMessage());
+                } else {
+                    System.out.println(">>> Future completed with result: " + (result != null ? result.elements().size() + " elements" : "null"));
+                }
+            });
+
+            // Try to get with short timeout - should timeout because data doesn't exist
+            try {
+                RingbufferSlice<Map.Entry<Long, byte[]>> result = future.get(500, TimeUnit.MILLISECONDS);
+                System.out.println("Operation " + i + " completed unexpectedly with " + result.elements().size() + " elements!");
+            } catch (TimeoutException e) {
+                // Expected - operation is waiting for future data
+                System.out.println("Operation " + i + " is pending (timeout - expected)");
+            } catch (Exception e) {
+                System.out.println("Operation " + i + " failed with: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
+
+        // Step 5: Wait a bit for operations to settle
+        sleepSeconds(2);
+
+        // Step 6: Check if operations leaked
+        int afterSize = getLiveOperationRegistrySize();
+        System.out.println("\nAfter " + numberOfOperations + " operations:");
+        System.out.println("LiveOperationRegistry size: " + afterSize);
+
+        int leakedOperations = afterSize - initialSize;
+        System.out.println("Leaked operations: " + leakedOperations);
+
+        // Step 7: Print diagnostic info
+        printLiveOperationRegistryState();
+
+        // Step 8: Verify the FIX - operations should be cleaned up now!
+        if (leakedOperations == 0) {
+            System.out.println("\n=== ✅ BUG FIXED! ===");
+            System.out.println("Number of operations sent: " + numberOfOperations);
+            System.out.println("Number of operations leaked: " + leakedOperations);
+            System.out.println("\nFix verification:");
+            System.out.println("1. Requested sequence=" + futureSequence + " (equals tail)");
+            System.out.println("2. ConcurrentArrayRingbuffer.copyFrom() returned EMPTY slice");
+            System.out.println("3. MetricsService.tryCompleteRead() NOW calls future.complete() even for empty slice");
+            System.out.println("4. doSendResponse() was called");
+            System.out.println("5. deregister() was executed");
+            System.out.println("6. Operations properly cleaned from LiveOperationRegistry");
+            System.out.println("\nIssue #26463 is FIXED!");
+        } else {
+            System.out.println("\n=== ❌ FIX VERIFICATION FAILED ===");
+            System.out.println("Number of operations sent: " + numberOfOperations);
+            System.out.println("Number of operations leaked: " + leakedOperations);
+            System.out.println("The fix did not work - operations are still leaking!");
+            fail("Fix verification failed: " + leakedOperations + " operations leaked. "
+                + "Expected 0 leaked operations after the fix.");
+        }
+    }
+
+    /**
+     * Test to verify that when metrics ARE collected, no leak occurs.
+     * This is the control test.
+     */
+    @Test
+    public void testNoLeak_whenMetricsAreCollected() throws Exception {
+        System.out.println("\n=== TEST: No Leak When Metrics Collected (Control) ===\n");
+
+        // Reconfigure for fast collection
+        Config config = new Config();
+        config.getMetricsConfig().setEnabled(true);
+        config.getMetricsConfig().setCollectionFrequencySeconds(2); // Fast!
+        config.getMetricsConfig().getManagementCenterConfig().setEnabled(true);
+
+        // Recreate instance with fast config
+        if (instance != null) {
+            instance.shutdown();
+        }
+        instance = createHazelcastInstance(config);
+        nodeEngine = getNode(instance).getNodeEngine();
+        operationService = nodeEngine.getOperationService();
+        metricsService = nodeEngine.getService(MetricsService.SERVICE_NAME);
+
+        // Wait for initial collection
+        System.out.println("Waiting for initial metrics collection...");
+        sleepSeconds(3);
+
+        int initialSize = getLiveOperationRegistrySize();
+        System.out.println("Initial size: " + initialSize);
+
+        // Request current metrics (should exist)
+        ReadMetricsOperation operation = new ReadMetricsOperation(0);
+        InternalCompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future =
+            operationService.invokeOnTarget(
+                MetricsService.SERVICE_NAME,
+                operation,
+                nodeEngine.getThisAddress()
+            );
+
+        RingbufferSlice<Map.Entry<Long, byte[]>> result = future.get(5, TimeUnit.SECONDS);
+        System.out.println("Received " + result.elements().size() + " metric entries - OK");
+
+        sleepSeconds(1);
+
+        int afterSize = getLiveOperationRegistrySize();
+        System.out.println("After size: " + afterSize);
+
+        if (afterSize == initialSize) {
+            System.out.println("\n=== ✅ CONTROL TEST PASSED ===");
+            System.out.println("No leak when metrics are properly collected");
+        } else {
+            fail("Unexpected leak in control test: " + (afterSize - initialSize) + " operations leaked");
+        }
+    }
+
+    // ==================== Helper Methods ====================
+
+    private long getCurrentHeadSequence() throws Exception {
+        // Try to read from sequence 0 and get the next sequence
+        ReadMetricsOperation op = new ReadMetricsOperation(0);
+        InternalCompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future =
+            operationService.invokeOnTarget(
+                MetricsService.SERVICE_NAME,
+                op,
+                nodeEngine.getThisAddress()
+            );
+
+        try {
+            RingbufferSlice<Map.Entry<Long, byte[]>> slice = future.get(2, TimeUnit.SECONDS);
+            return slice.nextSequence();
+        } catch (Exception e) {
+            // If failed, assume head is 0
+            return 0;
+        }
+    }
+
+    private void forceMetricsCollection() {
+        // Trigger metrics collection manually
+        try {
+            metricsService.collectMetrics();
+        } catch (Exception e) {
+            System.out.println("Could not force metrics collection: " + e.getMessage());
+        }
+    }
+
+    private int getLiveOperationRegistrySize() throws Exception {
+        LiveOperationRegistry registry = metricsService.getLiveOperationRegistry();
+
+        Field liveOperationsField = LiveOperationRegistry.class.getDeclaredField("liveOperations");
+        liveOperationsField.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        ConcurrentHashMap<?, Map<Long, ?>> liveOperations =
+            (ConcurrentHashMap<?, Map<Long, ?>>) liveOperationsField.get(registry);
+
+        int totalOperations = 0;
+        for (Map<Long, ?> addressOps : liveOperations.values()) {
+            totalOperations += addressOps.size();
+        }
+
+        return totalOperations;
+    }
+
+    private void printLiveOperationRegistryState() throws Exception {
+        System.out.println("\n--- LiveOperationRegistry State ---");
+
+        LiveOperationRegistry registry = metricsService.getLiveOperationRegistry();
+        Field liveOperationsField = LiveOperationRegistry.class.getDeclaredField("liveOperations");
+        liveOperationsField.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        ConcurrentHashMap<?, Map<Long, ?>> liveOperations =
+            (ConcurrentHashMap<?, Map<Long, ?>>) liveOperationsField.get(registry);
+
+        System.out.println("Number of addresses: " + liveOperations.size());
+
+        liveOperations.forEach((address, ops) -> {
+            System.out.println("  Address: " + address);
+            System.out.println("    Active operations: " + ops.size());
+            ops.forEach((callId, op) -> {
+                System.out.println("      CallId: " + callId
+                    + ", Operation: " + op.getClass().getSimpleName());
+            });
+        });
+        System.out.println("-----------------------------------\n");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationMemoryLeakImprovedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ReadMetricsOperationMemoryLeakImprovedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2025, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,29 +40,27 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.test.Accessors.getNode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test to verify the FIX for memory leak issue #26463.
- *
+ * <p>
  * Original bug scenario:
  * 1. Client requests metrics with sequence == tail
  * 2. ConcurrentArrayRingbuffer.copyFrom() returns EMPTY slice
  * 3. MetricsService.tryCompleteRead() used to skip future.complete() for empty slices
  * 4. Future never completes → doSendResponse() never called → deregister() never called
  * 5. Operation leaks in LiveOperationRegistry
- *
+ * <p>
  * Fix:
  * - MetricsService.tryCompleteRead() now ALWAYS calls future.complete(), even with empty slice
  * - Added timeout mechanism as safety net (60 seconds)
  * - Empty slice is a valid response meaning "no data available yet"
- *
+ * <p>
  * This test verifies the fix works correctly.
  */
 @RunWith(HazelcastParallelClassRunner.class)
@@ -70,10 +68,7 @@ import static org.junit.Assert.fail;
 public class ReadMetricsOperationMemoryLeakImprovedTest extends ClientTestSupport {
 
     private final TestHazelcastFactory factory = new TestHazelcastFactory();
-    private HazelcastInstance member;
-    private HazelcastInstance client;
     private HazelcastClientInstanceImpl clientImpl;
-    private NodeEngineImpl nodeEngine;
     private MetricsService metricsService;
     private UUID memberUuid;
 
@@ -87,11 +82,11 @@ public class ReadMetricsOperationMemoryLeakImprovedTest extends ClientTestSuppor
         config.getMetricsConfig().getManagementCenterConfig().setEnabled(true);
         config.getMetricsConfig().getManagementCenterConfig().setRetentionSeconds(60); // Very small - only 1 minute
 
-        member = factory.newHazelcastInstance(config);
-        client = factory.newHazelcastClient();
+        HazelcastInstance member = factory.newHazelcastInstance(config);
+        HazelcastInstance client = factory.newHazelcastClient();
 
         clientImpl = getHazelcastClientInstanceImpl(client);
-        nodeEngine = getNode(member).getNodeEngine();
+        NodeEngineImpl nodeEngine = getNode(member).getNodeEngine();
         metricsService = nodeEngine.getService(MetricsService.SERVICE_NAME);
         memberUuid = member.getCluster().getLocalMember().getUuid();
     }
@@ -103,7 +98,7 @@ public class ReadMetricsOperationMemoryLeakImprovedTest extends ClientTestSuppor
 
     /**
      * This test verifies the FIX for issue #26463.
-     *
+     * <p>
      * Expected behavior: NO LEAK - operations are properly cleaned up even when requesting sequence == tail
      */
     @Test
@@ -137,10 +132,9 @@ public class ReadMetricsOperationMemoryLeakImprovedTest extends ClientTestSuppor
         }
 
         // Wait for operations to be cleaned up deterministically
-        int expectedSize = initialSize;
         assertTrueEventually(() -> {
             int currentSize = getLiveOperationRegistrySize();
-            assertEquals("Operations should be cleaned up after the fix", expectedSize, currentSize);
+            assertEquals("Operations should be cleaned up after the fix", initialSize, currentSize);
         });
     }
 
@@ -167,10 +161,9 @@ public class ReadMetricsOperationMemoryLeakImprovedTest extends ClientTestSuppor
         assertFalse("Expected at least one metric entry", params.elements.isEmpty());
 
         // Wait for operations to be cleaned up deterministically
-        int expectedSize = initialSize;
         assertTrueEventually(() -> {
             int currentSize = getLiveOperationRegistrySize();
-            assertEquals("Operations should be cleaned up in normal scenario", expectedSize, currentSize);
+            assertEquals("Operations should be cleaned up in normal scenario", initialSize, currentSize);
         });
     }
 


### PR DESCRIPTION
 **Problem:**
  When a client requests metrics with sequence equal to tail, the operation
  would leak in LiveOperationRegistry indefinitely.

  Root cause:
  1. ConcurrentArrayRingbuffer.copyFrom() returns empty slice when sequence == tail
  2. MetricsService.tryCompleteRead() skipped future.complete() for empty slices
  3. Future never completes → doSendResponse() never called → deregister() never executed
  4. Operation remains in LiveOperationRegistry forever

  **Solution:**
  - Always call future.complete() in tryCompleteRead(), even with empty slice
  - Empty slice is now treated as valid response (no data available yet)

  **Testing:**
  Added regression test that verifies operations are properly cleaned up
  when requesting sequence == tail.

fixes #26463 