### PR TITLE
Fix CollectionConfig.setAsyncBackupCount's check #26550  

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
@@ -180,7 +180,7 @@ public abstract class CollectionConfig<T extends CollectionConfig>
      * @see #getAsyncBackupCount()
      */
     public T setAsyncBackupCount(int asyncBackupCount) {
-        this.asyncBackupCount = checkAsyncBackupCount(asyncBackupCount, asyncBackupCount);
+        this.asyncBackupCount = checkAsyncBackupCount(backupCount, asyncBackupCount);
         return (T) this;
     }
 


### PR DESCRIPTION
Fix added for the reported bug #26550

Fixes https://github.com/hazelcast/hazelcast/issues/26550

Checklist:

- [x] Labels (`Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [x] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
