### PR TITLE
Fix endpoint resolution for nonstandard AWS regions (China, ISO, ISOB, ISOF, ISOE)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aws/AwsClientConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aws/AwsClientConfigurator.java
@@ -97,23 +97,54 @@ final class AwsClientConfigurator {
         return new AwsEcsApi(ecsEndpoint, awsConfig, ecsRequestSigner, Clock.systemUTC());
     }
 
+    private static String defaultEc2Host(String region) {
+        if (region.startsWith("cn-")) {
+            return "ec2.amazonaws.com.cn";
+        } else if (region.startsWith("us-isob-")) {
+            return "ec2.sc2s.sgov.gov";
+        } else if (region.startsWith("us-isof-")) {
+            return "ec2.csp.hci.ic.gov";
+        } else if (region.startsWith("eu-isoe-")) {
+            return "ec2.cloud.adc-e.uk";
+        } else if (region.startsWith("us-iso-")) {
+            return "ec2.c2s.ic.gov";
+        }
+        return DEFAULT_EC2_HOST_HEADER;
+    }   
+
     static String resolveEc2Endpoint(AwsConfig awsConfig, String region) {
         String ec2HostHeader = awsConfig.getHostHeader();
         if (isNullOrEmptyAfterTrim(ec2HostHeader)
             || ec2HostHeader.startsWith("ecs")
             || ec2HostHeader.equals("ec2")
         ) {
-            ec2HostHeader = DEFAULT_EC2_HOST_HEADER;
+            ec2HostHeader = defaultEc2Host(region);
         }
         return ec2HostHeader.replace("ec2.", "ec2." + region + ".");
     }
+
+    private static String defaultEcsHost(String region) {
+        if (region.startsWith("cn-")) {
+            return "ecs.amazonaws.com.cn";
+        } else if (region.startsWith("us-isob-")) {
+            return "ecs.sc2s.sgov.gov";
+        } else if (region.startsWith("us-isof-")) {
+            return "ecs.csp.hci.ic.gov";
+        } else if (region.startsWith("eu-isoe-")) {
+            return "ecs.cloud.adc-e.uk";
+        } else if (region.startsWith("us-iso-")) {
+            return "ecs.c2s.ic.gov";
+        }
+        return DEFAULT_ECS_HOST_HEADER;
+    }    
+
 
     static String resolveEcsEndpoint(AwsConfig awsConfig, String region) {
         String ecsHostHeader = awsConfig.getHostHeader();
         if (isNullOrEmptyAfterTrim(ecsHostHeader)
             || ecsHostHeader.equals("ecs")
         ) {
-            ecsHostHeader = DEFAULT_ECS_HOST_HEADER;
+            ecsHostHeader = defaultEcsHost(region);
         }
         return ecsHostHeader.replace("ecs.", "ecs." + region + ".");
     }

--- a/hazelcast/src/test/java/com/hazelcast/aws/AwsClientConfiguratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aws/AwsClientConfiguratorTest.java
@@ -156,4 +156,34 @@ public class AwsClientConfiguratorTest {
         // throws exception
     }
 
+    @Test
+    public void resolveEc2EndpointsNonStandardRegions() {
+        assertEquals("ec2.cn-north-1.amazonaws.com.cn",
+            resolveEc2Endpoint(AwsConfig.builder().build(), "cn-north-1"));
+        assertEquals("ec2.cn-northwest-1.amazonaws.com.cn",
+            resolveEc2Endpoint(AwsConfig.builder().build(), "cn-northwest-1"));
+        assertEquals("ec2.us-iso-east-1.c2s.ic.gov",
+            resolveEc2Endpoint(AwsConfig.builder().build(), "us-iso-east-1"));
+        assertEquals("ec2.us-isob-east-1.sc2s.sgov.gov",
+            resolveEc2Endpoint(AwsConfig.builder().build(), "us-isob-east-1"));
+        assertEquals("ec2.eu-isoe-west-1.cloud.adc-e.uk",
+            resolveEc2Endpoint(AwsConfig.builder().build(), "eu-isoe-west-1"));        
+        assertEquals("ec2.us-isof-east-1.csp.hci.ic.gov",
+            resolveEc2Endpoint(AwsConfig.builder().build(), "us-isof-east-1"));
+    }
+    
+    @Test
+    public void resolveEcsEndpointsNonStandardRegions() {
+        assertEquals("ecs.cn-north-1.amazonaws.com.cn",
+            resolveEcsEndpoint(AwsConfig.builder().build(), "cn-north-1"));
+        assertEquals("ecs.us-iso-east-1.c2s.ic.gov",
+            resolveEcsEndpoint(AwsConfig.builder().build(), "us-iso-east-1"));
+        assertEquals("ecs.us-isob-east-1.sc2s.sgov.gov",
+            resolveEcsEndpoint(AwsConfig.builder().build(), "us-isob-east-1"));
+        assertEquals("ecs.eu-isoe-west-1.cloud.adc-e.uk",
+            resolveEcsEndpoint(AwsConfig.builder().build(), "eu-isoe-west-1"));
+        assertEquals("ecs.us-isof-east-1.csp.hci.ic.gov",
+            resolveEcsEndpoint(AwsConfig.builder().build(), "us-isof-east-1"));
+    }
+
 }


### PR DESCRIPTION

<!--
Contributing to Hazelcast and looking for a challenge? Why don't you check out our open positions?

https://hazelcast.pinpointhq.com/
-->

Fix endpoint resolution for nonstandard AWS regions (China, ISO, ISOB, ISOF).

The resolveEc2Endpoint and resolveEcsEndpoint methods used a hardcoded default 
domain (amazonaws.com) regardless of region, causing incorrect endpoints for 
nonstandard AWS partitions.

Introduces defaultEc2Host and defaultEcsHost helper methods that select the 
correct base domain based on the region prefix:
- cn-* → amazonaws.com.cn
- us-iso-* → c2s.ic.gov
- us-isob-* → sc2s.sgov.gov
- us-isof-* → csp.hci.ic.gov
- us-isoe-* → cloud.adc-e.uk

Fixes N/A

Backport of: N/A

Breaking changes (list specific methods/types/messages):

None

Checklist:

- [X] Labels (Type: bug, Module: aws)
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
