### PR TITLE
Fix wrong comment in MapUtil

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/MapUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/MapUtil.java
@@ -56,7 +56,7 @@ public final class MapUtil {
     }
 
     /**
-     * Utility method that creates an {@link java.util.LinkedHashMap} with its initialCapacity calculated
+     * Utility method that creates an {@link ConcurrentHashMap} with its initialCapacity calculated
      * to minimize rehash operations
      */
     public static <K, V> ConcurrentMap<K, V> createConcurrentHashMap(int expectedMapSize) {


### PR DESCRIPTION
Correct the JavaDoc in MapUtil regarding returned Map type.

Checklist:

- [x] Labels (`Type:`, `Source:`, `Module:`) and Milestone set
- [x] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
