### PR TITLE
Fix TransactionalList.remove() violating transactional isolation 26472

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
@@ -215,8 +215,11 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
         final Iterator<CollectionItem> iterator = getCollection().iterator();
         while (iterator.hasNext()) {
             final CollectionItem item = iterator.next();
+            TxCollectionItem existing = txMap.get(item.getItemId());
+            if (existing != null && existing.isRemoveOperation()) {
+                continue;
+            }
             if (value.equals(item.getValue())) {
-                iterator.remove();
                 txMap.put(item.getItemId(), new TxCollectionItem(item)
                         .setTransactionId(transactionId)
                         .setRemoveOperation(true));
@@ -230,7 +233,7 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
     }
 
     public void reserveRemoveBackup(long itemId, UUID transactionId) {
-        final CollectionItem item = getMap().remove(itemId);
+        final CollectionItem item = getMap().get(itemId);
         if (item == null) {
             throw new TransactionException("Transaction reservation failed on backup member. "
                     + "Reservation item ID: " + itemId);
@@ -260,19 +263,14 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
     }
 
     public void rollbackRemove(long itemId) {
-        final TxCollectionItem txItem = txMap.remove(itemId);
-        if (txItem == null) {
+        if (txMap.remove(itemId) == null) {
             logger.warning("Transaction log cannot be found for rolling back 'remove()' operation."
                     + " Missing log item ID: " + itemId);
-        } else {
-            CollectionItem item = new CollectionItem(itemId, txItem.value);
-            getCollection().add(item);
         }
     }
 
     public void rollbackRemoveBackup(long itemId) {
-        final TxCollectionItem item = txMap.remove(itemId);
-        if (item == null) {
+        if (txMap.remove(itemId) == null) {
             logger.warning("Transaction log cannot be found for rolling back 'remove()' operation on backup member."
                     + " Missing log item ID: " + itemId);
         }
@@ -295,12 +293,21 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
     }
 
     public CollectionItem commitRemove(long itemId) {
-        final CollectionItem item = txMap.remove(itemId);
-        if (item == null) {
+        if (txMap.remove(itemId) == null) {
             logger.warning("Transaction log cannot be found for committing 'remove()' operation."
                     + " Missing log item ID: " + itemId);
         }
-        return item;
+        final Iterator<CollectionItem> iterator = getCollection().iterator();
+        while (iterator.hasNext()) {
+            CollectionItem item = iterator.next();
+            if (item.getItemId() == itemId) {
+                iterator.remove();
+                return item;
+            }
+        }
+        logger.warning("Item not found in collection for committing 'remove()' operation."
+                + " Missing item ID: " + itemId);
+        return null;
     }
 
     public void commitRemoveBackup(long itemId) {
@@ -308,6 +315,7 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
             logger.warning("Transaction log cannot be found for committing 'remove()' operation on backup member."
                     + " Missing log item ID:" + itemId);
         }
+        getMap().remove(itemId);
     }
 
     public void rollbackTransaction(UUID transactionId) {
@@ -317,10 +325,6 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
             final TxCollectionItem txItem = iterator.next();
             if (transactionId.equals(txItem.getTransactionId())) {
                 iterator.remove();
-                if (txItem.isRemoveOperation()) {
-                    CollectionItem item = new CollectionItem(txItem.itemId, txItem.value);
-                    getCollection().add(item);
-                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
@@ -19,7 +19,6 @@ package com.hazelcast.collection.impl.list;
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.CollectionItem;
-import com.hazelcast.collection.impl.collection.TxCollectionItem;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.NodeEngine;
@@ -52,30 +51,6 @@ public class ListContainer extends CollectionContainer {
             config = nodeEngine.getConfig().findListConfig(name);
         }
         return config;
-    }
-
-    @Override
-    public void rollbackRemove(long itemId) {
-        TxCollectionItem txItem = txMap.remove(itemId);
-        if (txItem == null) {
-            logger.warning("Transaction log cannot be found for rolling back 'remove()' operation."
-                    + " Missing log item ID: " + itemId);
-            return;
-        }
-        CollectionItem item = new CollectionItem(itemId, txItem.getValue());
-        addTxItemOrdered(item);
-    }
-
-    private void addTxItemOrdered(CollectionItem item) {
-        ListIterator<CollectionItem> iterator = getCollection().listIterator();
-        while (iterator.hasNext()) {
-            CollectionItem collectionItem = iterator.next();
-            if (item.getItemId() < collectionItem.getItemId()) {
-                iterator.previous();
-                break;
-            }
-        }
-        iterator.add(item);
     }
 
     public CollectionItem add(int index, Data value) {

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/txnlist/TransactionListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/txnlist/TransactionListTest.java
@@ -198,7 +198,6 @@ public class TransactionListTest extends HazelcastTestSupport {
             assertEquals(i, l.get(i));
         }
     }
-
     @Test
     public void transactionShouldBeRolledBack_whenInitiatorTerminatesBeforeCommit() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
@@ -227,6 +226,171 @@ public class TransactionListTest extends HazelcastTestSupport {
         assertTrueEventually(() -> assertEquals(1, list2.size()));
 
         assertTrueAllTheTime(() -> assertEquals(1, list2.size()), 3);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests for issue #26472: TransactionalList.remove() must not affect the
+    // backing IList before commitTransaction() is called.
+    // All tests below are EXPECTED TO FAIL until the fix is applied.
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testRemove_sizeOfBackingListIsNotChangedBeforeCommit() {
+        HazelcastInstance instance = createHazelcastInstance();
+        String name = randomString();
+        String item = randomString();
+        IList<Object> list = instance.getList(name);
+        list.add(item);
+
+        TransactionContext context = instance.newTransactionContext();
+        context.beginTransaction();
+        context.getList(name).remove(item);
+
+        assertEquals("backing list size must be 1 before commit", 1, list.size());
+
+        context.commitTransaction();
+        assertEquals("backing list size must be 0 after commit", 0, list.size());
+    }
+
+    @Test
+    public void testRemove_sizeOfBackingListIsRestoredAfterRollback() {
+        HazelcastInstance instance = createHazelcastInstance();
+        String name = randomString();
+        String item = randomString();
+        IList<Object> list = instance.getList(name);
+        list.add(item);
+
+        TransactionContext context = instance.newTransactionContext();
+        context.beginTransaction();
+        context.getList(name).remove(item);
+        context.rollbackTransaction();
+
+        assertEquals("backing list size must be 1 after rollback", 1, list.size());
+    }
+
+    @Test
+    public void testRemove_containsOnBackingListReturnsTrueBeforeCommit() {
+        HazelcastInstance instance = createHazelcastInstance();
+        String name = randomString();
+        String item = randomString();
+        IList<Object> list = instance.getList(name);
+        list.add(item);
+
+        TransactionContext context = instance.newTransactionContext();
+        context.beginTransaction();
+        context.getList(name).remove(item);
+
+        assertTrue("backing list must still contain item before commit", list.contains(item));
+
+        context.commitTransaction();
+        assertFalse("backing list must not contain item after commit", list.contains(item));
+    }
+
+    @Test
+    public void testRemove_getByIndexOnBackingListReturnsItemBeforeCommit() {
+        HazelcastInstance instance = createHazelcastInstance();
+        String name = randomString();
+        String item = randomString();
+        IList<Object> list = instance.getList(name);
+        list.add(item);
+
+        TransactionContext context = instance.newTransactionContext();
+        context.beginTransaction();
+        context.getList(name).remove(item);
+
+        assertEquals("backing list must still return item at index 0 before commit", item, list.get(0));
+
+        context.commitTransaction();
+        assertEquals("backing list must be empty after commit", 0, list.size());
+    }
+
+    @Test
+    public void testRemove_indexOfOnBackingListFindsItemBeforeCommit() {
+        HazelcastInstance instance = createHazelcastInstance();
+        String name = randomString();
+        String item = randomString();
+        IList<Object> list = instance.getList(name);
+        list.add(item);
+
+        TransactionContext context = instance.newTransactionContext();
+        context.beginTransaction();
+        context.getList(name).remove(item);
+
+        assertEquals("backing list must find item at index 0 before commit", 0, list.indexOf(item));
+
+        context.commitTransaction();
+        assertEquals("backing list must not find item after commit", -1, list.indexOf(item));
+    }
+
+    @Test
+    public void testRemove_subListOnBackingListIncludesItemBeforeCommit() {
+        HazelcastInstance instance = createHazelcastInstance();
+        String name = randomString();
+        IList<Object> list = instance.getList(name);
+        list.add("A");
+        list.add("B");
+        list.add("C");
+
+        TransactionContext context = instance.newTransactionContext();
+        context.beginTransaction();
+        context.getList(name).remove("B");
+
+        assertEquals("backing list must still have 3 items before commit", 3, list.size());
+        assertEquals("subList before commit must contain all 3 items", 3, list.subList(0, 3).size());
+        assertTrue("subList before commit must contain 'B'", list.subList(0, 3).contains("B"));
+
+        context.commitTransaction();
+        assertEquals("backing list must have 2 items after commit", 2, list.size());
+        assertFalse("subList after commit must not contain 'B'", list.subList(0, 2).contains("B"));
+    }
+
+    @Test
+    public void testRemove_twoPhaseTransaction_sizeNotChangedBeforeCommit() {
+        HazelcastInstance instance = createHazelcastInstance();
+        String name = randomString();
+        String item = randomString();
+        IList<Object> list = instance.getList(name);
+        list.add(item);
+
+        TransactionOptions options = new TransactionOptions()
+                .setTransactionType(TransactionOptions.TransactionType.TWO_PHASE);
+        TransactionContext context = instance.newTransactionContext(options);
+        context.beginTransaction();
+        context.getList(name).remove(item);
+
+        assertEquals("backing list size must be 1 before commit (TWO_PHASE)", 1, list.size());
+
+        context.commitTransaction();
+        assertEquals("backing list size must be 0 after commit (TWO_PHASE)", 0, list.size());
+    }
+
+    // Reproduces the exact scenario from https://github.com/hazelcast/hazelcast/issues/26472:
+    // add + remove in the same TWO_PHASE transaction must not affect the backing IList before commit.
+    @Test
+    public void testAddAndRemove_backingListIsNotAffectedBeforeCommit() {
+        HazelcastInstance instance = createHazelcastInstance();
+        String name = randomString();
+        IList<String> list = instance.getList(name);
+        list.add("initial");
+
+        TransactionOptions options = new TransactionOptions()
+                .setTransactionType(TransactionOptions.TransactionType.TWO_PHASE);
+        TransactionContext context = instance.newTransactionContext(options);
+        context.beginTransaction();
+
+        TransactionalList<String> transactionalList = context.getList(name);
+        transactionalList.add("transactionalAdd");
+        transactionalList.remove("initial");
+
+        assertEquals("backing list size must be 1 before commit", 1, list.size());
+        assertTrue("backing list must still contain 'initial' before commit", list.contains("initial"));
+        assertFalse("backing list must not contain 'transactionalAdd' before commit", list.contains("transactionalAdd"));
+
+        context.commitTransaction();
+
+        assertEquals("backing list size must be 1 after commit", 1, list.size());
+        assertFalse("backing list must not contain 'initial' after commit", list.contains("initial"));
+        assertTrue("backing list must contain 'transactionalAdd' after commit", list.contains("transactionalAdd"));
     }
 
 }


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast/issues/26472

Problem
-------
TransactionalList.remove() immediately modified the backing IList before commitTransaction() was called, violating transactional semantics. Any non-transactional reader (IList.size(), contains(), get(index), indexOf(), subList()) could observe the removal while the transaction was still active.

Root cause: CollectionContainer.reserveRemove() called iterator.remove() on getCollection() at reservation time, physically evicting the item from the backing collection immediately. The item was only kept in txMap for potential rollback.

Comparison with TransactionalMap
---------------------------------
TransactionalMap.remove() follows the correct lock-and-defer pattern (TxnLockAndGetOperation): the entry is locked on the partition owner but remains in the record store and is visible to non-transactional readers until commitTransaction() triggers TxnDeleteOperation. The item is only physically removed at commit time.

TransactionalList used an opposite approach: physical removal at reserve time, with txMap serving only as a rollback buffer. This is the source of the bug.

Fix
---
reserveRemove() no longer removes the item from getCollection(). Instead, it only marks the item in txMap (removeOperation=true), skipping items already reserved by another transaction. The physical removal is deferred to commitRemove(), which now iterates getCollection() and removes by itemId.

Changed methods in CollectionContainer:
- reserveRemove()— no longer calls iterator.remove()
- reserveRemoveBackup()— getMap().get() instead of getMap().remove(); item stays in backup storage until commit
- commitRemove() — now physically removes from getCollection() by itemId
- commitRemoveBackup() — now calls getMap().remove(itemId) at commit time
- rollbackRemove() — only cleans txMap; item was never removed
- rollbackRemoveBackup() — only cleans txMap; item was never removed
- rollbackTransaction()— only cleans txMap; no need to restore item

ListContainer:
- Removed rollbackRemove() override (addTxItemOrdered logic) — no longer needed since the item is never evicted from the collection on reserve
- Removed unused addTxItemOrdered() private method
- Removed unused TxCollectionItem import

Tests
-----
Added 8 tests to TransactionListTest covering all affected operations observed from the backing IList (the non-transactional view) between remove() and commitTransaction():
- size() before and after commit/rollback
- contains() before and after commit
- get(index) before and after commit
- indexOf() before and after commit
- subList() before and after commit
- TWO_PHASE transaction variant
- Exact reproduction of the reported scenario: add + remove in the same TWO_PHASE transaction (mirrors the original issue code example)

Fixes https://github.com/hazelcast/hazelcast/issues/26472

 Breaking changes: none

@ihsandemir could you please take a look? This fixes a transactional isolation bug in IList.