### PR TITLE
Add PagingPredicate toString implementation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PagingPredicateImpl.java
@@ -329,6 +329,18 @@ public class PagingPredicateImpl<K, V>
         return userCodeNamespace;
     }
 
+    @Override
+    public String toString() {
+        if (predicate != null) {
+            return predicate.toString();
+        }
+        return "PagingPredicate{"
+                + "page=" + page
+                + ", pageSize=" + pageSize
+                + ", comparator=" + comparator
+                + '}';
+    }
+
     public Map.Entry<Integer, Map.Entry> getNearestAnchorEntry() {
         int anchorCount = anchorList.size();
         if (page == 0 || anchorCount == 0) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PagingPredicateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PagingPredicateImplTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.PagingPredicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class PagingPredicateImplTest {
+
+    @Test
+    public void toString_whenInnerPredicatePresent_thenReturnsInnerPredicateString() {
+        PagingPredicate<Integer, Integer> predicate = Predicates.pagingPredicate(
+                Predicates.equal("someValue", "result"), 100);
+
+        assertEquals("someValue=result", predicate.toString());
+    }
+
+    @Test
+    public void toString_whenInnerPredicateAbsent_thenReturnsPagingPredicateState() {
+        PagingPredicate<Integer, Integer> predicate = Predicates.pagingPredicate(100);
+
+        assertEquals("PagingPredicate{page=0, pageSize=100, comparator=null}", predicate.toString());
+    }
+}


### PR DESCRIPTION
Adds a string representation for `PagingPredicateImpl`, returning the wrapped predicate expression when present and a concise paging-state string otherwise.

Fixes https://github.com/hazelcast/hazelcast/issues/26468

Backport of: N/A

Breaking changes (list specific methods/types/messages):

* API: none
* client protocol format: none
* serialized form: none
* snapshot format: none

Checklist:

- [ ] Labels (`Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases