### PR TITLE
Support PostgreSQL UUID JDBC type resolution

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/HazelcastPostgresDialect.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/HazelcastPostgresDialect.java
@@ -45,6 +45,7 @@ public class HazelcastPostgresDialect extends PostgresqlSqlDialect implements Ty
             case "BPCHAR":
             case "VARCHAR":
             case "TEXT":
+            case "UUID":
                 return QueryDataType.VARCHAR;
 
             case "INT2":

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/HazelcastPostgresDialectTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/postgres/HazelcastPostgresDialectTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.jdbc.postgres;
+
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.calcite.sql.SqlDialect;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class HazelcastPostgresDialectTest {
+
+    private final HazelcastPostgresDialect dialect = new HazelcastPostgresDialect(SqlDialect.EMPTY_CONTEXT);
+
+    @Test
+    public void resolveType_whenUuid_thenReturnsVarchar() {
+        assertSame(QueryDataType.VARCHAR, dialect.resolveType("uuid", 0, 0));
+    }
+}


### PR DESCRIPTION
Resolves PostgreSQL UUID column metadata as Hazelcast `VARCHAR`, which lets JDBC mappings be created for UUID columns instead of failing with unsupported type metadata.

Fixes https://github.com/hazelcast/hazelcast/issues/26489

Backport of: N/A

Breaking changes (list specific methods/types/messages):

* API: none
* client protocol format: none
* serialized form: none
* snapshot format: none

Checklist:

- [ ] Labels (`Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases