### PR TITLE
Support MSSQL IDENTITY and NVARCHAR type resolution

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/HazelcastMSSQLDialect.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/HazelcastMSSQLDialect.java
@@ -96,6 +96,8 @@ public class HazelcastMSSQLDialect extends MssqlSqlDialect implements TypeResolv
     public QueryDataType resolveType(String columnTypeName, int precision, int scale) {
         return switch (columnTypeName.toUpperCase(Locale.ROOT)) {
             case "FLOAT" -> QueryDataType.DOUBLE;
+            case "INT IDENTITY" -> QueryDataType.INT;
+            case "NVARCHAR" -> QueryDataType.VARCHAR;
             case "DATETIME2", "SMALLDATETIME" -> QueryDataType.TIMESTAMP;
             default -> DefaultTypeResolver.resolveType(columnTypeName, precision, scale);
         };

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/HazelcastMSSQLDialectTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/jdbc/mssql/HazelcastMSSQLDialectTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.jdbc.mssql;
+
+import com.hazelcast.sql.impl.type.QueryDataType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.calcite.sql.SqlDialect;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class HazelcastMSSQLDialectTest {
+
+    private final HazelcastMSSQLDialect dialect = new HazelcastMSSQLDialect(SqlDialect.EMPTY_CONTEXT);
+
+    @Test
+    public void resolveType_whenIntIdentity_thenReturnsInt() {
+        assertSame(QueryDataType.INT, dialect.resolveType("int identity", 0, 0));
+    }
+
+    @Test
+    public void resolveType_whenNvarchar_thenReturnsVarchar() {
+        assertSame(QueryDataType.VARCHAR, dialect.resolveType("nvarchar", 0, 0));
+    }
+}


### PR DESCRIPTION
Resolves MSSQL `INT IDENTITY` columns as Hazelcast `INT` and `NVARCHAR` columns as Hazelcast `VARCHAR` in JDBC dialect metadata mapping.

Fixes https://github.com/hazelcast/hazelcast/issues/26336

Backport of: N/A

Breaking changes (list specific methods/types/messages):

* API: none
* client protocol format: none
* serialized form: none
* snapshot format: none

Checklist:

- [ ] Labels (`Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases