### PR TITLE
adding backup read for IMap.getAsync

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -449,6 +449,13 @@ abstract class MapProxySupport<K, V>
 
     protected InternalCompletableFuture<Data> getAsyncInternal(Object key) {
         Data keyData = toDataWithStrategy(key);
+        if (mapConfig.isReadBackupData()) {
+            Data fromBackup = readBackupDataOrNull(keyData);
+
+            if (fromBackup != null) {
+                return newCompletedFuture(fromBackup);
+            }
+        }
         return invokeOperationAsync(key, operationProvider.createGetOperation(name, keyData), false);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapReadBackupDataAsyncTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapReadBackupDataAsyncTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MapReadBackupDataAsyncTest extends HazelcastTestSupport {
+
+    @Test
+    public void testGetAsync_ReadsFromLocalBackup() throws Exception {
+        String mapName = randomMapName();
+        Config config = getConfig();
+
+        config.getMapConfig(mapName)
+                .setReadBackupData(true)
+                .setBackupCount(1);
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+
+        // Warm up partitions to ensure ownership is established
+        assertClusterSizeEventually(2, hz1, hz2);
+        warmUpPartitions(hz1, hz2);
+
+        IMap<String, String> map1 = hz1.getMap(mapName);
+        IMap<String, String> map2 = hz2.getMap(mapName);
+
+        String key = generateKeyOwnedBy(hz1);
+        String value = "async-backup-value";
+
+        map1.put(key, value);
+
+        //Wait for the backup to be replicated to hz2.
+        assertTrueEventually(() -> {
+            long backupEntryCount = hz2.getMap(mapName).getLocalMapStats().getBackupEntryCount();
+            assertEquals("Backup should be present on node 2", 1, backupEntryCount);
+        });
+
+        CompletionStage<String> stage = map2.getAsync(key);
+
+        String result = stage.toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+        assertEquals("Value retrieved via getAsync should match the backup data", value, result);
+        // Optional: Verify that the owner (hz1) didn't receive a GetOperation
+        // This proves the read happened locally on hz2
+        long ownerGetCount = hz1.getMap(mapName).getLocalMapStats().getGetOperationCount();
+        assertEquals("Owner should not have processed a GetOperation", 0, ownerGetCount);
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = smallInstanceConfig();
+        // Reduce partition count for faster startup in tests
+        config.setProperty("hazelcast.partition.count", "10");
+        return config;
+    }
+}


### PR DESCRIPTION
**Problem**
When MapConfig.readBackupData is enabled, IMap.get() correctly reads backup data stored on the local node to reduce network latency. However, IMap.getAsync was not implemented to check for local backup data, forcing an unnecessary remote operation to the partition owner even when a valid backup was available locally.

**Root cause**
In MapProxySupport, the synchronous getInternal(...) method included a check for mapConfig.isReadBackupData() and a call to readBackupDataOrNull(keyData). This logic was missing from the asynchronous counterpart, getAsyncInternal(...). As a result, asynchronous calls always followed the standard request-response path to the primary partition owner.

**Fix**
Updated MapProxySupport.getAsyncInternal(...) to check if backup reads are enabled. If enabled, the method now attempts to retrieve the data locally using readBackupDataOrNull(keyData). If a local backup is found, it returns a newCompletedFuture(fromBackup) immediately, bypassing the network invocation.

**Tests**
Added a new test class MapReadBackupDataAsyncTest with a focus on verifying the local read behavior:

testGetAsync_ReadsFromLocalBackup: Sets up a 2-node cluster with readBackupData enabled. It puts data on Node A, waits for the backup to sync to Node B, and then performs an asyncGet from Node B.

**The test asserts that:**
The value is correctly retrieved.
The primary owner (Node A) receives 0 GetOperations, proving the data was served entirely from the local backup on Node B.

Fixes https://github.com/hazelcast/hazelcast/issues/26435