### PR TITLE
minor: Fix comment formatting in MapStoreLazyModeLoadFailuresTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreLazyModeLoadFailuresTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreLazyModeLoadFailuresTest.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * Tests map store behaviour under key-load and value-load failures,
- * verifying that failed loads do not leave the map in a permanently broken state</li>
+ * verifying that failed loads do not leave the map in a permanently broken state
  */
 @RunWith(HazelcastParametrizedRunner.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)


### PR DESCRIPTION
minor:

`* verifying that failed loads do not leave the map in a permanently broken state</li>`

was causing 
```
[ERROR] /home/circleci/project/.ci-temp/hazelcast/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreLazyModeLoadFailuresTest.java:49: Javadoc comment at column 82 has parse error. Details: no viable alternative at input '</' while parsing HTML_ELEMENT [UnusedImports]
Audit done.
Checkstyle ends with 1 errors.
```

ref: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/46995/workflows/83865283-b7d3-4d3f-8821-b73ab2e85937/jobs/1586239