### PR TITLE
test: add regression tests for ConfigXmlGenerator

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -74,6 +74,7 @@ import java.net.Socket;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.EventListener;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -1667,5 +1668,43 @@ public class ConfigXmlGeneratorTest extends HazelcastTestSupport {
         assertEquals(expected.isFailFastOnStartup(), actual.isFailFastOnStartup());
         assertEquals(expected.isParallelMode(), actual.isParallelMode());
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testXmlGeneratorNodes() {
+        StringBuilder xml = new StringBuilder();
+
+        new ConfigXmlGenerator.XmlGenerator(xml)
+                .open("root",
+                        "escaped", "\n\r\"'&<",
+                        "omitted", null)
+                .node("omitted", null)
+                .node("self-closing", null, "attribute", "value")
+                .nodeIfContents("omitted-conditionally", null)
+                .nodeIfContents("included-conditionally", "<&")
+                .close();
+
+        assertEquals("<root escaped=\"&#10;&#13;&quot;&#39;&amp;&lt;\">"
+                + "<self-closing attribute=\"value\"/>"
+                + "<included-conditionally>&lt;&amp;</included-conditionally>"
+                + "</root>", xml.toString());
+    }
+
+    @Test
+    public void testXmlGeneratorMapProperties() {
+        StringBuilder xml = new StringBuilder();
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("escaped<&\"'\n\r", "value<&");
+        properties.put("without-value", null);
+
+        new ConfigXmlGenerator.XmlGenerator(xml)
+                .appendProperties((Map<String, String>) null)
+                .appendProperties(Map.of())
+                .appendProperties(properties);
+
+        assertEquals("<properties>"
+                + "<property name=\"escaped&lt;&amp;&quot;&#39;&#10;&#13;\">value&lt;&amp;</property>"
+                + "<property name=\"without-value\"/>"
+                + "</properties>", xml.toString());
     }
 }


### PR DESCRIPTION
This PR adds two regression tests for `ConfigXmlGenerator.XmlGenerator` around low-level XML generation.

Impact on coverage:

- Covers the relevant `ConfigXmlGenerator` logic, including [covered lines](https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java#L1351-L1432).
- Branch coverage for `ConfigXmlGenerator` increases by 4%.

Why:

These tests cover XML escaping, omitted null values, self-closing and conditional nodes, null and empty property maps, escaped property names and values, and properties without values. Both tests assert the complete generated XML.

Fixes: None

Backport of: Not applicable

Breaking changes (list specific methods/types/messages):

- API: None
- client protocol format: None
- serialized form: None
- snapshot format: None

Checklist:

- [ ] Labels (`Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Not Release Notes content` label
- [ ] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations: not applicable
- [x] New public APIs have `@since` tags in Javadoc: not applicable
- [x] Send backports/forwardports if fix needs to be applied to past/future releases: not applicable
