### PR TITLE
Pass original exception to invalid configuration exception when class…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nio/ClassLoaderUtil.java
@@ -384,6 +384,28 @@ public final class ClassLoaderUtil {
         return interfaces.toArray(new Class<?>[0]);
     }
 
+    public static String retrieveClassLoaderID(ClassLoader classLoader) {
+
+        if (classLoader == null) {
+            return "bootstrap";
+        }
+
+        return String.format("%s@%s", classLoader.getClass().getName(), Integer.toHexString(System.identityHashCode(classLoader)));
+
+    }
+
+    public static String checkStackForClassNotFound(Throwable t) {
+
+        for(; t != null; t = t.getCause()) {
+            if (t instanceof ClassNotFoundException) {
+                return t.getMessage();
+            }
+        }
+
+        return "";
+
+    }
+
     private static void addOwnInterfaces(Class<?> clazz, Collection<Class<?>> allInterfaces) {
         Class<?>[] interfaces = clazz.getInterfaces();
         Collections.addAll(allInterfaces, interfaces);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -409,8 +409,8 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
             try {
                 clazz = ClassLoaderUtil.loadClass(classLoader, className);
             } catch (ClassNotFoundException e) {
-                throw new InvalidConfigurationException("Cannot load the Compact "
-                        + "serializable class '" + className + "'.", e);
+                throw new InvalidConfigurationException(String.format("unable to load compact serializable " +
+                        "class '%s' because it was missing from the class path", className), e);
             }
 
             CompactSerializer serializer;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -378,7 +378,7 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
                 serializer = ClassLoaderUtil.newInstance(classLoader, className);
             } catch (Exception e) {
                 throw new InvalidConfigurationException("Cannot create an instance "
-                        + "of the Compact serializer '" + className + "'.");
+                        + "of the Compact serializer '" + className + "'.", e);
             }
 
             CompactSerializableRegistration registration = new CompactSerializableRegistration(
@@ -400,7 +400,7 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
                 clazz = ClassLoaderUtil.loadClass(classLoader, className);
             } catch (ClassNotFoundException e) {
                 throw new InvalidConfigurationException("Cannot load the Compact "
-                        + "serializable class '" + className + "'.");
+                        + "serializable class '" + className + "'.", e);
             }
 
             CompactSerializer serializer;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/compact/CompactStreamSerializer.java
@@ -37,6 +37,7 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.nio.serialization.compact.CompactSerializer;
 import com.hazelcast.nio.serialization.genericrecord.GenericRecord;
+import org.apache.logging.log4j.util.Strings;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -377,8 +378,17 @@ public class CompactStreamSerializer implements StreamSerializer<Object> {
             try {
                 serializer = ClassLoaderUtil.newInstance(classLoader, className);
             } catch (Exception e) {
-                throw new InvalidConfigurationException("Cannot create an instance "
-                        + "of the Compact serializer '" + className + "'.", e);
+                String baseMessage = String.format("unable to create instance of compact serializer '%s' " +
+                        "using class loader '%s'", className, ClassLoaderUtil.retrieveClassLoaderID(classLoader));
+                String classNotFoundExceptionMessage = ClassLoaderUtil.checkStackForClassNotFound(e);
+                String messageToInsert;
+                if (Strings.isBlank(classNotFoundExceptionMessage)) {
+                    messageToInsert = String.format("%s.", baseMessage);
+                } else {
+                    messageToInsert = String.format("%s because class was missing from class path: %s",
+                            baseMessage, classNotFoundExceptionMessage);
+                }
+                throw new InvalidConfigurationException(messageToInsert, e);
             }
 
             CompactSerializableRegistration registration = new CompactSerializableRegistration(

--- a/hazelcast/src/test/java/com/hazelcast/nio/ClassLoaderUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ClassLoaderUtilTest.java
@@ -16,29 +16,53 @@
 
 package com.hazelcast.nio;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClassLoaderUtilTest extends HazelcastTestSupport {
+
+    @Test
+    public void testCheckStackForClassNotFound() {
+
+        assertThat(ClassLoaderUtil.checkStackForClassNotFound(null)).isEqualTo("");
+
+        String missingClass = "the.class.everyone.told.you.would.definitely.be.present.on.the.ClassPath";
+
+        assertThat(ClassLoaderUtil.checkStackForClassNotFound(
+                new ClassNotFoundException(missingClass))).isEqualTo(missingClass);
+
+        assertThat(ClassLoaderUtil.checkStackForClassNotFound(
+                new Throwable("",
+                        new Exception(
+                                new ReflectiveOperationException(
+                                        new ClassNotFoundException(missingClass)))))).isEqualTo(missingClass);
+
+    }
+
+    @Test
+    public void testRetrieveClassLoaderID() {
+
+        assertThat(ClassLoaderUtil.retrieveClassLoaderID(null)).isEqualTo("bootstrap");
+
+        assertThat(ClassLoaderUtil.retrieveClassLoaderID(mock(ClassLoader.class))).matches("([\\w.$]+)(@\\w+)");
+
+    }
 
     @Test
     public void testConstructor() {


### PR DESCRIPTION
Hey guys, 

super small change incoming: 

Currently working on integrating a couple of maps with a custom map store implementation, and found that adding the underlying cause of class instantiation failing in the context of a declaratively configured serializer would be helpful for troubleshooting. 

This PR thus adds the causing exception to the instantiation of `InvalidConfigurationException` in the following two cases:

1. Instantiation of a declaratively configured serializer fails 
2. Instantiation of a compact serialization config fails