### PR TITLE
Remove obsolete JavadocStyle check

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -121,11 +121,6 @@
         <module name="JavadocVariable">
             <property name="accessModifiers" value="public"/>
         </module>
-        <module name="JavadocStyle">
-            <property name="checkFirstSentence" value="false"/>
-            <property name="checkHtml" value="false"/>
-        </module>
-
         <module name="TrailingComment"/>
 
         <!-- Checks for Naming Conventions.                  -->


### PR DESCRIPTION
Removes `JavadocStyle` from the Checkstyle configuration because the check is being removed from Checkstyle in PR https://github.com/checkstyle/checkstyle/pull/20582.

No replacement is added because both first-sentence and HTML checks were disabled in this config.

### Migration note

`JavadocStyle` is removed because its remaining useful validations are already covered elsewhere.

Users who relied on the first-sentence/period-at-end validation or empty Javadoc validation should use [`SummaryJavadoc`](https://checkstyle.org/checks/javadoc/summaryjavadoc.html) instead. HTML tag validation is intentionally not replaced here, as it will be handled automatically by `SummaryJavadoc` while parsing Javadoc comments.