### PR TITLE
Add Map Name To Logging In Context Of Map Store's Write Behind Functionality

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/AbstractWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/AbstractWriteBehindProcessor.java
@@ -22,9 +22,12 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapStoreWrapper;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.internal.serialization.SerializationService;
+import org.apache.logging.log4j.util.Strings;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 /**
  * Contains common functionality which is required by a {@link WriteBehindProcessor}
@@ -42,6 +45,7 @@ abstract class AbstractWriteBehindProcessor<T> implements WriteBehindProcessor<T
     protected final MapStoreWrapper mapStore;
 
     private final SerializationService serializationService;
+    private final String mapName;
 
     AbstractWriteBehindProcessor(MapStoreContext mapStoreContext) {
         this.serializationService = mapStoreContext.getSerializationService();
@@ -50,6 +54,7 @@ abstract class AbstractWriteBehindProcessor<T> implements WriteBehindProcessor<T
         MapStoreConfig mapStoreConfig = mapStoreContext.getMapStoreConfig();
         this.writeBatchSize = mapStoreConfig.getWriteBatchSize();
         this.writeCoalescing = mapStoreConfig.isWriteCoalescing();
+        this.mapName = mapStoreContext.getMapName();
     }
 
     protected Object toObject(Object obj) {
@@ -75,6 +80,28 @@ abstract class AbstractWriteBehindProcessor<T> implements WriteBehindProcessor<T
             return null;
         }
         return list.subList(start, end);
+    }
+
+    protected void logWithMapName(BiConsumer<String, Throwable> loggingConsumer, String msg, Throwable t) {
+
+        loggingConsumer.accept(addMapNameIfGiven(msg), t);
+
+    }
+
+    protected void logWithMapName(Consumer<String> loggingConsumer, String msg) {
+
+        loggingConsumer.accept(addMapNameIfGiven(msg));
+
+    }
+
+    private String addMapNameIfGiven(String msg) {
+
+        if (Strings.isBlank(mapName)) {
+            return msg;
+        }
+
+        return String.format("(in context of map '%s') %s", mapName, msg);
+
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/AbstractWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/AbstractWriteBehindProcessor.java
@@ -83,25 +83,19 @@ abstract class AbstractWriteBehindProcessor<T> implements WriteBehindProcessor<T
     }
 
     protected void logWithMapName(BiConsumer<String, Throwable> loggingConsumer, String msg, Throwable t) {
-
         loggingConsumer.accept(addMapNameIfGiven(msg), t);
-
     }
 
     protected void logWithMapName(Consumer<String> loggingConsumer, String msg) {
-
         loggingConsumer.accept(addMapNameIfGiven(msg));
-
     }
 
     private String addMapNameIfGiven(String msg) {
-
         if (Strings.isBlank(mapName)) {
             return msg;
         }
 
         return String.format("(in context of map '%s') %s", mapName, msg);
-
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -16,19 +16,12 @@
 
 package com.hazelcast.map.impl.mapstore.writebehind;
 
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.EntryLoader.MetadataAwareValue;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.mapstore.writebehind.entry.DelayedEntry;
-import com.hazelcast.internal.serialization.Data;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static com.hazelcast.internal.util.CollectionUtil.isNotEmpty;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;
@@ -289,8 +282,10 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
         for (Collection<DelayedEntry> value : values) {
             size += value.size();
         }
-        final String logMessage = String.format("Map store flush operation can not be done for %d entries", size);
-        logger.severe(logMessage);
+        logWithMapName(
+                logger::severe,
+                String.format("Map store flush operation can not be done for %d entries", size)
+        );
     }
 
     @Override
@@ -347,8 +342,12 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
                 // partition-write-behind-queues and will try to re-process
                 // them. This fail and retry cycle will be repeated indefinitely.
                 List failureList = task.failureList();
-                logger.severe("Number of entries which could not be stored is = [" + failureList.size() + "]"
-                        + ", Hazelcast will indefinitely retry to store them", exception);
+                logWithMapName(
+                        logger::severe,
+                        "Number of entries which could not be stored is = [" + failureList.size() + "]"
+                                + ", Hazelcast will indefinitely retry to store them",
+                        exception
+                );
                 return failureList;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -21,7 +21,14 @@ import com.hazelcast.map.EntryLoader.MetadataAwareValue;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.mapstore.writebehind.entry.DelayedEntry;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.hazelcast.internal.util.CollectionUtil.isNotEmpty;
 import static com.hazelcast.internal.util.MapUtil.createHashMap;


### PR DESCRIPTION
Introduces simple means in `AbstractWriteBehindProcessor` for extending classes (such as `DefaultWriteBehindProcessor`) to have their log messages enriched with map name. 

Seeing the map name in the message printed to the log stream is extremely helpful for troubleshooting map store issues, as it helps narrowing down which maps are affected, and hence which serializers and factories in the map store need to be investigated.

No breaking changes.

I don't have the rights to add any labels to this PR.
