### PR TITLE
Fix sorting after grouped index scans

### DIFF
--- a/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/AggregateBatchPhysicalRule.java
+++ b/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/physical/AggregateBatchPhysicalRule.java
@@ -23,7 +23,9 @@ import com.hazelcast.sql.impl.row.JetSqlRow;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.core.Aggregate.Group;
 import org.immutables.value.Value;
 
@@ -124,7 +126,7 @@ final class AggregateBatchPhysicalRule extends AggregateAbstractPhysicalRule {
         if (logicalAggregate.containsDistinctCall() || logicalAggregate.hasCollation()) {
             return new AggregateByKeyPhysicalRel(
                     physicalInput.getCluster(),
-                    physicalInput.getTraitSet(),
+                    withoutCollation(physicalInput),
                     physicalInput,
                     logicalAggregate.getGroupSet(),
                     logicalAggregate.getGroupSets(),
@@ -134,7 +136,7 @@ final class AggregateBatchPhysicalRule extends AggregateAbstractPhysicalRule {
         } else {
             RelNode rel = new AggregateAccumulateByKeyPhysicalRel(
                     physicalInput.getCluster(),
-                    physicalInput.getTraitSet(),
+                    withoutCollation(physicalInput),
                     physicalInput,
                     logicalAggregate.getGroupSet(),
                     aggrOp
@@ -150,5 +152,12 @@ final class AggregateBatchPhysicalRule extends AggregateAbstractPhysicalRule {
                     aggrOp
             );
         }
+    }
+
+    /**
+     * Aggregations redistribute and combine input rows, so they cannot preserve an input ordering.
+     */
+    private static RelTraitSet withoutCollation(RelNode rel) {
+        return rel.getTraitSet().replace(RelCollations.EMPTY);
     }
 }

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/ExplainStatementTest.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/ExplainStatementTest.java
@@ -122,6 +122,25 @@ public class ExplainStatementTest extends SqlTestSupport {
     }
 
     @Test
+    public void test_explainStatementSortAfterAggregationWithSortedIndex() {
+        IMap<Integer, Integer> map = instance().getMap("map");
+        map.put(1, 1);
+        map.put(2, 2);
+        map.put(3, 3);
+        map.addIndex(IndexType.SORTED, "this");
+
+        createMapping("map", Integer.class, Integer.class);
+
+        assertRowsOrdered("EXPLAIN PLAN FOR SELECT this, SUM(__key) total FROM map GROUP BY this ORDER BY this", asList(
+                new Row("SortPhysicalRel(sort0=[$0], dir0=[ASC])"),
+                new Row("  AggregateCombineByKeyPhysicalRel(group=[{0}], total=[SUM($1)])"),
+                new Row("    AggregateAccumulateByKeyPhysicalRel(group=[{0}])"),
+                new Row("      IndexScanMapPhysicalRel(table=[[hazelcast, public, map[projects=[$1, $0]]]], "
+                        + "index=[map_sorted_this], indexExp=[null], remainderExp=[null], requiresSort=[true])")
+        ));
+    }
+
+    @Test
     public void test_explainStatementLimitOffsetWithIndexScan() {
         IMap<Integer, Integer> map = instance().getMap("map");
         map.put(1, 1);


### PR DESCRIPTION
## Summary
- clear collation traits at batch aggregation boundaries
- preserve the final ORDER BY after a sorted index scan feeds GROUP BY
- add an EXPLAIN regression test

## Root cause
The batch aggregation rule propagated the sorted index scan collation through distributed accumulate/combine operators, although they do not preserve global row order. The optimizer then skipped the required final sort.

## Validation
- git diff --check
- Targeted Maven test attempted, but the partial checkout cannot resolve all required reactor modules.