### PR TITLE
Apply ManagedContext injection to MapStoreFactory instances

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
@@ -125,7 +125,7 @@ final class BasicMapStoreContext implements MapStoreContext {
         //  Namespace awareness separately as the class loader is only for instantiation, and execution
         //  of the implementation takes place in this call as well.
         final Object store = NamespaceUtil.callWithNamespace(nodeEngine, mapConfig.getUserCodeNamespace(),
-                () -> createStore(mapName, mapStoreConfig, classLoader));
+                () -> createStore(mapName, mapStoreConfig, classLoader, nodeEngine.getSerializationService().getManagedContext()));
         final MapStoreWrapper storeWrapper = new MapStoreWrapper(nodeEngine, mapName, store, mapConfig.getUserCodeNamespace());
         storeWrapper.instrument(nodeEngine);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/StoreConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/StoreConstructor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.mapstore;
 
 import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.ManagedContext;
 import com.hazelcast.map.MapStoreFactory;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.util.ExceptionUtil;
@@ -33,9 +34,10 @@ final class StoreConstructor {
     private StoreConstructor() {
     }
 
-    static Object createStore(String name, MapStoreConfig mapStoreConfig, ClassLoader classLoader) {
+    static Object createStore(String name, MapStoreConfig mapStoreConfig, ClassLoader classLoader,
+                               ManagedContext managedContext) {
         // 1. Try to create store from `store factory` class.
-        Object store = getStoreFromFactoryOrNull(name, mapStoreConfig, classLoader);
+        Object store = getStoreFromFactoryOrNull(name, mapStoreConfig, classLoader, managedContext);
 
         // 2. Try to get store from `store impl.` object.
         if (store == null) {
@@ -48,7 +50,8 @@ final class StoreConstructor {
         return store;
     }
 
-    private static Object getStoreFromFactoryOrNull(String name, MapStoreConfig mapStoreConfig, ClassLoader classLoader) {
+    private static Object getStoreFromFactoryOrNull(String name, MapStoreConfig mapStoreConfig, ClassLoader classLoader,
+                                                      ManagedContext managedContext) {
         MapStoreFactory factory = (MapStoreFactory) mapStoreConfig.getFactoryImplementation();
         if (factory == null) {
             final String factoryClassName = mapStoreConfig.getFactoryClassName();
@@ -65,6 +68,11 @@ final class StoreConstructor {
         if (factory == null) {
             return null;
         }
+
+        // Apply container-managed injection (e.g. HazelcastInstanceAware, or Spring/Guice wiring
+        // via an external ManagedContext) to the factory itself, the same way it is applied to
+        // other user-pluggable, config-instantiated objects such as listeners.
+        factory = (MapStoreFactory) managedContext.initialize(factory);
 
         final Properties properties = mapStoreConfig.getProperties();
         return factory.newMapStore(name, properties);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/StoreConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/StoreConstructorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.mapstore;
+
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.ManagedContext;
+import com.hazelcast.map.MapLoader;
+import com.hazelcast.map.MapStoreFactory;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class StoreConstructorTest extends HazelcastTestSupport {
+
+    /**
+     * Verifies the fix for a defect where a {@link MapStoreFactory} instantiated from
+     * {@link MapStoreConfig#getFactoryClassName()} never went through {@link ManagedContext#initialize(Object)},
+     * so container-managed injection (HazelcastInstanceAware, or an external Spring/Guice ManagedContext)
+     * was silently skipped for the factory.
+     */
+    @Test
+    public void createStore_appliesManagedContext_toFactoryInstantiatedFromClassName() {
+        RecordingManagedContext managedContext = new RecordingManagedContext();
+        MapStoreConfig mapStoreConfig = new MapStoreConfig()
+                .setFactoryClassName(RecordingMapStoreFactory.class.getName());
+
+        Object store = StoreConstructor.createStore("test-map", mapStoreConfig,
+                getClass().getClassLoader(), managedContext);
+
+        assertTrue("factory instantiated from class name should have been passed to ManagedContext#initialize",
+                managedContext.initializedObjects.stream().anyMatch(o -> o instanceof RecordingMapStoreFactory));
+        assertSame(RecordingMapStoreFactory.PRODUCED_STORE, store);
+    }
+
+    @Test
+    public void createStore_appliesManagedContext_toFactoryProvidedAsImplementation() {
+        RecordingManagedContext managedContext = new RecordingManagedContext();
+        RecordingMapStoreFactory factory = new RecordingMapStoreFactory();
+        MapStoreConfig mapStoreConfig = new MapStoreConfig()
+                .setFactoryImplementation(factory);
+
+        Object store = StoreConstructor.createStore("test-map", mapStoreConfig,
+                getClass().getClassLoader(), managedContext);
+
+        assertSame(factory, managedContext.initializedObjects.stream()
+                .filter(o -> o instanceof RecordingMapStoreFactory)
+                .findFirst()
+                .orElse(null));
+        assertSame(RecordingMapStoreFactory.PRODUCED_STORE, store);
+    }
+
+    @Test
+    public void createStore_returnsNull_whenNoFactoryClassOrStoreConfigured() {
+        RecordingManagedContext managedContext = new RecordingManagedContext();
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+
+        Object store = StoreConstructor.createStore("test-map", mapStoreConfig,
+                getClass().getClassLoader(), managedContext);
+
+        assertNull(store);
+        assertTrue(managedContext.initializedObjects.isEmpty());
+    }
+
+    /** No-op except for recording every object passed to {@link #initialize(Object)}, in call order. */
+    private static class RecordingManagedContext implements ManagedContext {
+
+        final java.util.List<Object> initializedObjects = new java.util.ArrayList<>();
+
+        @Override
+        public Object initialize(Object obj) {
+            initializedObjects.add(obj);
+            return obj;
+        }
+    }
+
+    /** Public no-arg constructor required for {@code ClassLoaderUtil.newInstance} reflection-based instantiation. */
+    public static class RecordingMapStoreFactory implements MapStoreFactory<Object, Object> {
+
+        static final MapLoader<Object, Object> PRODUCED_STORE = new MapLoader<>() {
+            @Override
+            public Object load(Object key) {
+                return null;
+            }
+
+            @Override
+            public Map<Object, Object> loadAll(Collection<Object> keys) {
+                return null;
+            }
+
+            @Override
+            public Iterable<Object> loadAllKeys() {
+                return null;
+            }
+        };
+
+        @Override
+        public MapLoader<Object, Object> newMapStore(String mapName, Properties properties) {
+            return PRODUCED_STORE;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #17076.

`MapStoreFactory` instances configured via `factory-class-name` or `factory-implementation` were never passed through `ManagedContext#initialize()`, unlike other user-pluggable, config-instantiated objects (e.g. listeners, see `ClientMapProxy#addPartitionLostListener`) which do go through this step elsewhere in the codebase.

Concretely, this meant:
- A `MapStoreFactory` implementing `HazelcastInstanceAware` never had `setHazelcastInstance()` called on it (this works fine today for a `MapStore`/`MapLoader` class configured directly by class name, just not for one produced via a factory).
- Factories relying on an external `ManagedContext` (Spring's `SpringManagedContext`, Guice, etc.) for field injection were silently skipped, with the only workaround being to fully construct the factory outside Hazelcast's lifecycle.

**Change:** `StoreConstructor#createStore` now accepts the `ManagedContext` obtained from the `NodeEngine`'s `SerializationService`, and applies it to the factory instance right after it's resolved (whether from `factory-class-name` via reflection or supplied directly as `factory-implementation`), before `newMapStore()` is invoked.

**Tests:** added `StoreConstructorTest` covering both instantiation paths (class-name and implementation) plus the no-factory-configured case, using a recording `ManagedContext` to assert the factory instance is passed through.

Scope is intentionally narrow - only the factory instance is initialized, matching the issue title. Happy to extend this to the produced store object as well in this same PR or a follow-up if maintainers think that's also in scope.