### PR TITLE
Suppress LeftCurly violations for ExpressionBiValue.java and ExpressionValue.java

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/ExpressionTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/ExpressionTestSupport.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@SuppressWarnings({"unchecked", "rawtypes"})
+@SuppressWarnings({"unchecked", "rawtypes", "LeftCurly"})
 @RunWith(HazelcastSerialClassRunner.class)
 public abstract class ExpressionTestSupport extends SqlTestSupport {
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/support/expressions/ExpressionBiValue.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/support/expressions/ExpressionBiValue.java
@@ -32,7 +32,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.concurrent.ConcurrentHashMap;
 
-@SuppressWarnings({"unused", "unchecked", "checkstyle:MultipleVariableDeclarations"})
+@SuppressWarnings({"unused", "unchecked", "LeftCurly", "checkstyle:MultipleVariableDeclarations"})
 public abstract class ExpressionBiValue extends ExpressionValue {
     public static Class<? extends ExpressionBiValue> createBiClass(ExpressionType<?> type1, ExpressionType<?> type2) {
         return createBiClass(type1.typeName(), type2.typeName());


### PR DESCRIPTION
While fixing false negative i LeftCurly at https://github.com/checkstyle/checkstyle/pull/20992
[ci no-error-hazelcast](https://app.circleci.com/pipelines/github/checkstyle/checkstyle/49895/workflows/324ec3d9-b76c-479f-9c16-139e688e2b46/jobs/1742798) failed