### PR TITLE
Suppress LeftCurly violations for ExpressionValue.java

### DIFF
--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/ExpressionTestSupport.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/expression/ExpressionTestSupport.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@SuppressWarnings({"unchecked", "rawtypes", "LeftCurly"})
+@SuppressWarnings({"unchecked", "rawtypes"})
 @RunWith(HazelcastSerialClassRunner.class)
 public abstract class ExpressionTestSupport extends SqlTestSupport {
 

--- a/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/support/expressions/ExpressionValue.java
+++ b/hazelcast-sql/src/test/java/com/hazelcast/jet/sql/impl/support/expressions/ExpressionValue.java
@@ -33,7 +33,7 @@ import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-@SuppressWarnings({"unused", "unchecked, checkstyle:MultipleVariableDeclarations"})
+@SuppressWarnings({"unused", "unchecked", "LeftCurly", "checkstyle:MultipleVariableDeclarations"})
 public abstract class ExpressionValue implements DataSerializable {
 
     private static final ConcurrentHashMap<String, Class<? extends ExpressionValue>> CLASS_CACHE = new ConcurrentHashMap<>();


### PR DESCRIPTION
Follow-up to e98fb3f10fcbf51f7416574b4814a3a541ed7fbc

The previous change unintentionally updated `ExpressionTestSupport.java` instead of `ExpressionValue.java`. This PR removes the unintended change from `ExpressionTestSupport.java`.