### PR TITLE
Add a PASS_THROUGH mode for QueryCache [INBOX-1214]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -417,6 +417,7 @@ public final class ClientConfigXmlGenerator {
                 gen.open("query-cache", "mapName", mapName, "name", queryCache.getName())
                         .node("include-value", queryCache.isIncludeValue())
                         .node("in-memory-format", queryCache.getInMemoryFormat())
+                        .node("mode", queryCache.getMode())
                         .node("populate", queryCache.isPopulate())
                         .node("coalesce", queryCache.isCoalesce())
                         .node("delay-seconds", queryCache.getDelaySeconds())

--- a/hazelcast/src/main/java/com/hazelcast/client/config/impl/AbstractQueryCacheConfigBuilderHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/config/impl/AbstractQueryCacheConfigBuilderHelper.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.config.QueryCacheMode;
 import com.hazelcast.internal.config.ConfigUtils;
 import com.hazelcast.internal.config.DomConfigHelper;
 import org.w3c.dom.NamedNodeMap;
@@ -78,6 +79,8 @@ abstract class AbstractQueryCacheConfigBuilderHelper implements QueryCacheConfig
             queryCacheConfig.setDelaySeconds(delaySeconds);
         } else if (matches("in-memory-format", nodeName)) {
             queryCacheConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(getTextContent(childNode))));
+        } else if (matches("mode", nodeName)) {
+            queryCacheConfig.setMode(QueryCacheMode.valueOf(upperCaseInternal(getTextContent(childNode))));
         } else if (matches("coalesce", nodeName)) {
             boolean coalesce = getBooleanValue(getTextContent(childNode));
             queryCacheConfig.setCoalesce(coalesce);

--- a/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
@@ -85,6 +85,11 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
      */
     public static final InMemoryFormat DEFAULT_IN_MEMORY_FORMAT = InMemoryFormat.BINARY;
 
+    /**
+     * By default, store matching entries locally in {@code QueryCache}.
+     */
+    public static final QueryCacheMode DEFAULT_MODE = QueryCacheMode.CACHE;
+
 
     /**
      * After reaching this minimum size, node immediately sends buffered events to {@code QueryCache}.
@@ -125,6 +130,10 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
      */
     private InMemoryFormat inMemoryFormat = DEFAULT_IN_MEMORY_FORMAT;
 
+    /**
+     * Mode used by this {@code QueryCache}.
+     */
+    private QueryCacheMode mode = DEFAULT_MODE;
 
     /**
      * The name of {@code QueryCache}.
@@ -156,7 +165,9 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
         this.includeValue = other.includeValue;
         this.populate = other.populate;
         this.coalesce = other.coalesce;
+        this.serializeKeys = other.serializeKeys;
         this.inMemoryFormat = other.inMemoryFormat;
+        this.mode = other.mode;
         this.name = other.name;
         this.predicateConfig = other.predicateConfig;
         this.evictionConfig = other.evictionConfig;
@@ -293,6 +304,32 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
         checkFalse(inMemoryFormat == InMemoryFormat.NATIVE, "InMemoryFormat." + inMemoryFormat + " is not supported.");
 
         this.inMemoryFormat = inMemoryFormat;
+        return this;
+    }
+
+    /**
+     * Returns how this {@code QueryCache} handles matching entries.
+     * <p>
+     * Default value is {@link #DEFAULT_MODE}.
+     *
+     * @return the query cache mode
+     */
+    public QueryCacheMode getMode() {
+        return mode;
+    }
+
+    /**
+     * Sets how this {@code QueryCache} handles matching entries.
+     * <p>
+     * {@link QueryCacheMode#CACHE} stores entries locally. {@link QueryCacheMode#PASS_THROUGH}
+     * publishes matching entry events without storing entries locally.
+     *
+     * @param mode the query cache mode
+     * @return this {@code QueryCacheConfig} instance
+     */
+    @Nonnull
+    public QueryCacheConfig setMode(QueryCacheMode mode) {
+        this.mode = checkNotNull(mode, "mode cannot be null");
         return this;
     }
 
@@ -488,6 +525,7 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
         writeNullableList(entryListenerConfigs, out);
         writeNullableList(indexConfigs, out);
         out.writeBoolean(serializeKeys);
+        out.writeString(mode.name());
     }
 
     @Override
@@ -505,6 +543,7 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
         entryListenerConfigs = readNullableList(in);
         indexConfigs = readNullableList(in);
         serializeKeys = in.readBoolean();
+        mode = QueryCacheMode.valueOf(in.readString());
     }
 
     @Override
@@ -541,6 +580,9 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
         if (inMemoryFormat != that.inMemoryFormat) {
             return false;
         }
+        if (mode != that.mode) {
+            return false;
+        }
         if (!Objects.equals(name, that.name)) {
             return false;
         }
@@ -567,6 +609,7 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
         result = 31 * result + (coalesce ? 1 : 0);
         result = 31 * result + (serializeKeys ? 1 : 0);
         result = 31 * result + (inMemoryFormat != null ? inMemoryFormat.hashCode() : 0);
+        result = 31 * result + (mode != null ? mode.hashCode() : 0);
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (predicateConfig != null ? predicateConfig.hashCode() : 0);
         result = 31 * result + (evictionConfig != null ? evictionConfig.hashCode() : 0);
@@ -586,6 +629,7 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
                 + ", coalesce=" + coalesce
                 + ", serializeKeys=" + serializeKeys
                 + ", inMemoryFormat=" + inMemoryFormat
+                + ", mode=" + mode
                 + ", name='" + name + '\''
                 + ", predicateConfig=" + predicateConfig
                 + ", evictionConfig=" + evictionConfig

--- a/hazelcast/src/main/java/com/hazelcast/config/QueryCacheMode.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueryCacheMode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Defines how a {@code QueryCache} handles entries that match its predicate.
+ */
+public enum QueryCacheMode {
+
+    /**
+     * Stores matching entries locally in the {@code QueryCache}.
+     */
+    CACHE,
+
+    /**
+     * Publishes query-cache events for matching entries without storing them locally.
+     */
+    PASS_THROUGH
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -90,6 +90,7 @@ import com.hazelcast.config.PersistenceConfig;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.ProbabilisticSplitBrainProtectionConfigBuilder;
 import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.config.QueryCacheMode;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QueueStoreConfig;
 import com.hazelcast.config.RecentlyActiveSplitBrainProtectionConfigBuilder;
@@ -2473,6 +2474,8 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                     queryCacheConfig.setDelaySeconds(delaySeconds);
                 } else if (matches("in-memory-format", nodeName)) {
                     queryCacheConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(getTextContent(childNode))));
+                } else if (matches("mode", nodeName)) {
+                    queryCacheConfig.setMode(QueryCacheMode.valueOf(upperCaseInternal(getTextContent(childNode))));
                 } else if (matches("coalesce", nodeName)) {
                     boolean coalesce = getBooleanValue(getTextContent(childNode));
                     queryCacheConfig.setCoalesce(coalesce);

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/QueryCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/QueryCacheConfigReadOnly.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.IndexConfig;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.config.QueryCacheMode;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -102,6 +103,12 @@ public class QueryCacheConfigReadOnly extends QueryCacheConfig {
     @Nonnull
     @Override
     public QueryCacheConfig setInMemoryFormat(InMemoryFormat inMemoryFormat) {
+        throw new UnsupportedOperationException("This config is read-only query cache: " + getName());
+    }
+
+    @Nonnull
+    @Override
+    public QueryCacheConfig setMode(QueryCacheMode mode) {
         throw new UnsupportedOperationException("This config is read-only query cache: " + getName());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigXmlGenerator.java
@@ -667,6 +667,7 @@ public final class DynamicConfigXmlGenerator {
                 gen.open("query-cache", "name", queryCacheConfig.getName());
                 gen.node("include-value", queryCacheConfig.isIncludeValue());
                 gen.node("in-memory-format", queryCacheConfig.getInMemoryFormat());
+                gen.node("mode", queryCacheConfig.getMode());
                 gen.node("populate", queryCacheConfig.isPopulate());
                 gen.node("coalesce", queryCacheConfig.isCoalesce());
                 gen.node("delay-seconds", queryCacheConfig.getDelaySeconds());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
@@ -42,8 +42,10 @@ public interface InternalQueryCache<K, V> extends QueryCache<K, V> {
      * Populate query cache with initial set of entries as {@link Data}.
      * Triggers an {@link EntryEventType#ADDED ADDED} event for each entry that
      * is added to the query cache. Note that not all events may be added
-     * to the query cache if the query cache is configured with an eviction
-     * policy with a maximum {@code ENTRY_COUNT}.
+     * to the query cache if the query cache stores entries locally and is
+     * configured with an eviction policy with a maximum {@code ENTRY_COUNT}.
+     * Pass-through query caches publish the initial events without storing
+     * entries locally.
      *
      * @param entries key-value pairs iterator.
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/PassThroughQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/PassThroughQueryCache.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.querycache.subscriber;
+
+import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.IMap;
+import com.hazelcast.map.impl.querycache.QueryCacheContext;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.map.impl.querycache.subscriber.EventPublisherHelper.publishEntryEvent;
+
+/**
+ * Query-cache implementation that publishes events for matching entries without keeping a local cache.
+ * <p>
+ * Initial population still emits {@link EntryEventType#ADDED ADDED} events for every matched entry, but the entries
+ * are not stored in the query cache and are not limited by the configured query-cache entry count. Since no local
+ * records are retained, remove-like events cannot include an old value unless that value is supplied by the publisher
+ * event itself.
+ *
+ * @param <K> the key type for this {@link InternalQueryCache}
+ * @param <V> the value type for this {@link InternalQueryCache}
+ */
+class PassThroughQueryCache<K, V> extends DefaultQueryCache<K, V> {
+
+    PassThroughQueryCache(String cacheId, String cacheName, QueryCacheConfig queryCacheConfig,
+                          IMap delegate, QueryCacheContext context) {
+        super(cacheId, cacheName, queryCacheConfig, delegate, context);
+    }
+
+    @Override
+    public void set(K key, V value, EntryEventType eventType) {
+        if (eventType == null) {
+            return;
+        }
+
+        Object queryCacheKey = recordStore.toQueryCacheKey(key);
+        Data valueData = toData(value);
+        publishEntryEvent(context, mapName, cacheId, queryCacheKey, valueData, null, eventType, extractors);
+    }
+
+    @Override
+    public void prepopulate(Iterator<Map.Entry<Data, Data>> entries) {
+        while (entries.hasNext()) {
+            Map.Entry<Data, Data> entry = entries.next();
+            publishEntryEvent(context, mapName, cacheId,
+                    entry.getKey(), entry.getValue(), null, EntryEventType.ADDED, extractors);
+        }
+    }
+
+    @Override
+    public void delete(Object key, EntryEventType eventType) {
+        checkNotNull(key, "key cannot be null");
+        if (eventType == null) {
+            return;
+        }
+
+        Object queryCacheKey = recordStore.toQueryCacheKey(key);
+        publishEntryEvent(context, mapName, cacheId, queryCacheKey, null, null, eventType, extractors);
+    }
+
+    @Override
+    public boolean reachedMaxCapacity() {
+        return false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheFactory.java
@@ -17,11 +17,12 @@
 package com.hazelcast.map.impl.querycache.subscriber;
 
 import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.config.QueryCacheMode;
+import com.hazelcast.internal.util.ConcurrencyUtil;
+import com.hazelcast.internal.util.ConstructorFunction;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.listener.MapListener;
-import com.hazelcast.internal.util.ConcurrencyUtil;
-import com.hazelcast.internal.util.ConstructorFunction;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -50,7 +51,9 @@ public class QueryCacheFactory {
             QueryCacheContext context = request.getContext();
             QueryCacheConfig queryCacheConfig = request.getQueryCacheConfig();
 
-            DefaultQueryCache queryCache = new DefaultQueryCache(cacheId, cacheName, queryCacheConfig, delegate, context);
+            DefaultQueryCache queryCache = queryCacheConfig.getMode() == QueryCacheMode.PASS_THROUGH
+                    ? new PassThroughQueryCache(cacheId, cacheName, queryCacheConfig, delegate, context)
+                    : new DefaultQueryCache(cacheId, cacheName, queryCacheConfig, delegate, context);
 
             MapListener listener = request.getListener();
             if (listener != null) {

--- a/hazelcast/src/main/resources/hazelcast-client-config-5.7.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-5.7.xsd
@@ -389,7 +389,6 @@
             <xs:enumeration value="PASS_THROUGH"/>
             <xs:enumeration value="cache"/>
             <xs:enumeration value="pass_through"/>
-            <xs:enumeration value="pass-through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-client-config-5.7.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-5.7.xsd
@@ -387,6 +387,8 @@
         <xs:restriction base="non-space-string">
             <xs:enumeration value="CACHE"/>
             <xs:enumeration value="PASS_THROUGH"/>
+            <xs:enumeration value="cache"/>
+            <xs:enumeration value="pass_through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-client-config-5.7.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-5.7.xsd
@@ -387,8 +387,6 @@
         <xs:restriction base="non-space-string">
             <xs:enumeration value="CACHE"/>
             <xs:enumeration value="PASS_THROUGH"/>
-            <xs:enumeration value="cache"/>
-            <xs:enumeration value="pass_through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-client-config-5.7.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-5.7.xsd
@@ -356,6 +356,7 @@
             <xs:element name="predicate" type="predicate"/>
             <xs:element name="entry-listeners" type="entry-listeners" minOccurs="0"/>
             <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" default="BINARY"/>
+            <xs:element name="mode" type="query-cache-mode" minOccurs="0" default="CACHE"/>
             <xs:element name="populate" type="xs:boolean" minOccurs="0" default="true"/>
             <xs:element name="coalesce" type="xs:boolean" minOccurs="0" default="false"/>
             <xs:element name="serialize-keys" type="xs:boolean" minOccurs="0" default="false"/>
@@ -382,6 +383,15 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
+    <xs:simpleType name="query-cache-mode">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="CACHE"/>
+            <xs:enumeration value="PASS_THROUGH"/>
+            <xs:enumeration value="cache"/>
+            <xs:enumeration value="pass_through"/>
+            <xs:enumeration value="pass-through"/>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:complexType name="predicate">
         <xs:simpleContent>
             <xs:extension base="xs:string">

--- a/hazelcast/src/main/resources/hazelcast-client-config-6.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-6.0.xsd
@@ -389,7 +389,6 @@
             <xs:enumeration value="PASS_THROUGH"/>
             <xs:enumeration value="cache"/>
             <xs:enumeration value="pass_through"/>
-            <xs:enumeration value="pass-through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-client-config-6.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-6.0.xsd
@@ -387,6 +387,8 @@
         <xs:restriction base="non-space-string">
             <xs:enumeration value="CACHE"/>
             <xs:enumeration value="PASS_THROUGH"/>
+            <xs:enumeration value="cache"/>
+            <xs:enumeration value="pass_through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-client-config-6.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-6.0.xsd
@@ -387,8 +387,6 @@
         <xs:restriction base="non-space-string">
             <xs:enumeration value="CACHE"/>
             <xs:enumeration value="PASS_THROUGH"/>
-            <xs:enumeration value="cache"/>
-            <xs:enumeration value="pass_through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-client-config-6.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-client-config-6.0.xsd
@@ -356,6 +356,7 @@
             <xs:element name="predicate" type="predicate"/>
             <xs:element name="entry-listeners" type="entry-listeners" minOccurs="0"/>
             <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" default="BINARY"/>
+            <xs:element name="mode" type="query-cache-mode" minOccurs="0" default="CACHE"/>
             <xs:element name="populate" type="xs:boolean" minOccurs="0" default="true"/>
             <xs:element name="coalesce" type="xs:boolean" minOccurs="0" default="false"/>
             <xs:element name="serialize-keys" type="xs:boolean" minOccurs="0" default="false"/>
@@ -382,6 +383,15 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
+    <xs:simpleType name="query-cache-mode">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="CACHE"/>
+            <xs:enumeration value="PASS_THROUGH"/>
+            <xs:enumeration value="cache"/>
+            <xs:enumeration value="pass_through"/>
+            <xs:enumeration value="pass-through"/>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:complexType name="predicate">
         <xs:simpleContent>
             <xs:extension base="xs:string">

--- a/hazelcast/src/main/resources/hazelcast-config-5.7.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.7.json
@@ -1525,9 +1525,7 @@
                   "type": "string",
                   "enum": [
                     "CACHE",
-                    "PASS_THROUGH",
-                    "cache",
-                    "pass_through"
+                    "PASS_THROUGH"
                   ],
                   "default": "CACHE",
                   "description": "Defines whether matching entries are stored locally in the query cache or only passed through to query cache listeners."

--- a/hazelcast/src/main/resources/hazelcast-config-5.7.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.7.json
@@ -1527,8 +1527,7 @@
                     "CACHE",
                     "PASS_THROUGH",
                     "cache",
-                    "pass_through",
-                    "pass-through"
+                    "pass_through"
                   ],
                   "default": "CACHE",
                   "description": "Defines whether matching entries are stored locally in the query cache or only passed through to query cache listeners."

--- a/hazelcast/src/main/resources/hazelcast-config-5.7.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.7.json
@@ -1521,6 +1521,18 @@
                 "in-memory-format": {
                   "$ref": "#/definitions/InMemoryFormat"
                 },
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "CACHE",
+                    "PASS_THROUGH",
+                    "cache",
+                    "pass_through",
+                    "pass-through"
+                  ],
+                  "default": "CACHE",
+                  "description": "Defines whether matching entries are stored locally in the query cache or only passed through to query cache listeners."
+                },
                 "populate": {
                   "type": "boolean",
                   "default": true,

--- a/hazelcast/src/main/resources/hazelcast-config-5.7.json
+++ b/hazelcast/src/main/resources/hazelcast-config-5.7.json
@@ -1525,7 +1525,9 @@
                   "type": "string",
                   "enum": [
                     "CACHE",
-                    "PASS_THROUGH"
+                    "PASS_THROUGH",
+                    "cache",
+                    "pass_through"
                   ],
                   "default": "CACHE",
                   "description": "Defines whether matching entries are stored locally in the query cache or only passed through to query cache listeners."

--- a/hazelcast/src/main/resources/hazelcast-config-5.7.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.7.xsd
@@ -2206,7 +2206,6 @@
             <xs:enumeration value="PASS_THROUGH"/>
             <xs:enumeration value="cache"/>
             <xs:enumeration value="pass_through"/>
-            <xs:enumeration value="pass-through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-config-5.7.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.7.xsd
@@ -2204,6 +2204,8 @@
         <xs:restriction base="non-space-string">
             <xs:enumeration value="CACHE"/>
             <xs:enumeration value="PASS_THROUGH"/>
+            <xs:enumeration value="cache"/>
+            <xs:enumeration value="pass_through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-config-5.7.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.7.xsd
@@ -2204,8 +2204,6 @@
         <xs:restriction base="non-space-string">
             <xs:enumeration value="CACHE"/>
             <xs:enumeration value="PASS_THROUGH"/>
-            <xs:enumeration value="cache"/>
-            <xs:enumeration value="pass_through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-config-5.7.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-5.7.xsd
@@ -2132,6 +2132,14 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="mode" type="query-cache-mode" minOccurs="0" default="CACHE">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines whether matching entries are stored locally in the query cache
+                        or only passed through to query cache listeners.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="populate" type="xs:boolean" minOccurs="0" default="true">
                 <xs:annotation>
                     <xs:documentation>
@@ -2192,6 +2200,15 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
+    <xs:simpleType name="query-cache-mode">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="CACHE"/>
+            <xs:enumeration value="PASS_THROUGH"/>
+            <xs:enumeration value="cache"/>
+            <xs:enumeration value="pass_through"/>
+            <xs:enumeration value="pass-through"/>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:complexType name="predicate">
         <xs:simpleContent>
             <xs:extension base="xs:string">

--- a/hazelcast/src/main/resources/hazelcast-config-6.0.json
+++ b/hazelcast/src/main/resources/hazelcast-config-6.0.json
@@ -1525,9 +1525,7 @@
                   "type": "string",
                   "enum": [
                     "CACHE",
-                    "PASS_THROUGH",
-                    "cache",
-                    "pass_through"
+                    "PASS_THROUGH"
                   ],
                   "default": "CACHE",
                   "description": "Defines whether matching entries are stored locally in the query cache or only passed through to query cache listeners."

--- a/hazelcast/src/main/resources/hazelcast-config-6.0.json
+++ b/hazelcast/src/main/resources/hazelcast-config-6.0.json
@@ -1527,8 +1527,7 @@
                     "CACHE",
                     "PASS_THROUGH",
                     "cache",
-                    "pass_through",
-                    "pass-through"
+                    "pass_through"
                   ],
                   "default": "CACHE",
                   "description": "Defines whether matching entries are stored locally in the query cache or only passed through to query cache listeners."

--- a/hazelcast/src/main/resources/hazelcast-config-6.0.json
+++ b/hazelcast/src/main/resources/hazelcast-config-6.0.json
@@ -1521,6 +1521,18 @@
                 "in-memory-format": {
                   "$ref": "#/definitions/InMemoryFormat"
                 },
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "CACHE",
+                    "PASS_THROUGH",
+                    "cache",
+                    "pass_through",
+                    "pass-through"
+                  ],
+                  "default": "CACHE",
+                  "description": "Defines whether matching entries are stored locally in the query cache or only passed through to query cache listeners."
+                },
                 "populate": {
                   "type": "boolean",
                   "default": true,

--- a/hazelcast/src/main/resources/hazelcast-config-6.0.json
+++ b/hazelcast/src/main/resources/hazelcast-config-6.0.json
@@ -1525,7 +1525,9 @@
                   "type": "string",
                   "enum": [
                     "CACHE",
-                    "PASS_THROUGH"
+                    "PASS_THROUGH",
+                    "cache",
+                    "pass_through"
                   ],
                   "default": "CACHE",
                   "description": "Defines whether matching entries are stored locally in the query cache or only passed through to query cache listeners."

--- a/hazelcast/src/main/resources/hazelcast-config-6.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-6.0.xsd
@@ -2206,7 +2206,6 @@
             <xs:enumeration value="PASS_THROUGH"/>
             <xs:enumeration value="cache"/>
             <xs:enumeration value="pass_through"/>
-            <xs:enumeration value="pass-through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-config-6.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-6.0.xsd
@@ -2204,6 +2204,8 @@
         <xs:restriction base="non-space-string">
             <xs:enumeration value="CACHE"/>
             <xs:enumeration value="PASS_THROUGH"/>
+            <xs:enumeration value="cache"/>
+            <xs:enumeration value="pass_through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-config-6.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-6.0.xsd
@@ -2204,8 +2204,6 @@
         <xs:restriction base="non-space-string">
             <xs:enumeration value="CACHE"/>
             <xs:enumeration value="PASS_THROUGH"/>
-            <xs:enumeration value="cache"/>
-            <xs:enumeration value="pass_through"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="predicate">

--- a/hazelcast/src/main/resources/hazelcast-config-6.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-6.0.xsd
@@ -2132,6 +2132,14 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="mode" type="query-cache-mode" minOccurs="0" default="CACHE">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines whether matching entries are stored locally in the query cache
+                        or only passed through to query cache listeners.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="populate" type="xs:boolean" minOccurs="0" default="true">
                 <xs:annotation>
                     <xs:documentation>
@@ -2192,6 +2200,15 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
+    <xs:simpleType name="query-cache-mode">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="CACHE"/>
+            <xs:enumeration value="PASS_THROUGH"/>
+            <xs:enumeration value="cache"/>
+            <xs:enumeration value="pass_through"/>
+            <xs:enumeration value="pass-through"/>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:complexType name="predicate">
         <xs:simpleContent>
             <xs:extension base="xs:string">

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -357,6 +357,7 @@ public class ConfigCompatibilityChecker {
                 && c1.isPopulate() == c2.isPopulate()
                 && c1.isCoalesce() == c2.isCoalesce()
                 && c1.getInMemoryFormat() == c2.getInMemoryFormat()
+                && c1.getMode() == c2.getMode()
                 && isCompatible(c1.getEvictionConfig(), c2.getEvictionConfig())
                 && isCollectionCompatible(c1.getEntryListenerConfigs(), c2.getEntryListenerConfigs(), new EntryListenerConfigChecker())
                 && isCollectionCompatible(c1.getIndexConfigs(), c2.getIndexConfigs(), new IndexConfigChecker())

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -2856,6 +2856,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "<buffer-size>16</buffer-size>"
                 + "<delay-seconds>0</delay-seconds>"
                 + "<in-memory-format>BINARY</in-memory-format>"
+                + "<mode>PASS_THROUGH</mode>"
                 + "<coalesce>false</coalesce>"
                 + "<populate>true</populate>"
                 + "<serialize-keys>true</serialize-keys>"
@@ -2884,6 +2885,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(16, queryCacheConfig.getBufferSize());
         assertEquals(0, queryCacheConfig.getDelaySeconds());
         assertEquals(InMemoryFormat.BINARY, queryCacheConfig.getInMemoryFormat());
+        assertEquals(QueryCacheMode.PASS_THROUGH, queryCacheConfig.getMode());
         assertFalse(queryCacheConfig.isCoalesce());
         assertTrue(queryCacheConfig.isPopulate());
         assertTrue(queryCacheConfig.isSerializeKeys());
@@ -2892,6 +2894,24 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(LRU, queryCacheConfig.getEvictionConfig().getEvictionPolicy());
         assertEquals(ENTRY_COUNT, queryCacheConfig.getEvictionConfig().getMaxSizePolicy());
         assertEquals(133, queryCacheConfig.getEvictionConfig().getSize());
+    }
+
+    @Test
+    public void testQueryCacheMode_lowerCase() {
+        String xml = HAZELCAST_START_TAG
+                + "<map name=\"test\">"
+                + "<query-caches>"
+                + "<query-cache name=\"cache-name\">"
+                + "<mode>pass_through</mode>"
+                + "</query-cache>"
+                + "</query-caches>"
+                + "</map>"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        QueryCacheConfig queryCacheConfig = config.getMapConfig("test").getQueryCacheConfigs().get(0);
+
+        assertEquals(QueryCacheMode.PASS_THROUGH, queryCacheConfig.getMode());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -2946,6 +2946,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                           buffer-size: 16
                           delay-seconds: 0
                           in-memory-format: BINARY
+                          mode: PASS_THROUGH
                           coalesce: false
                           populate: true
                           serialize-keys: true
@@ -2974,6 +2975,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(16, queryCacheConfig.getBufferSize());
         assertEquals(0, queryCacheConfig.getDelaySeconds());
         assertEquals(InMemoryFormat.BINARY, queryCacheConfig.getInMemoryFormat());
+        assertEquals(QueryCacheMode.PASS_THROUGH, queryCacheConfig.getMode());
         assertFalse(queryCacheConfig.isCoalesce());
         assertTrue(queryCacheConfig.isPopulate());
         assertTrue(queryCacheConfig.isSerializeKeys());
@@ -2982,6 +2984,23 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(LRU, queryCacheConfig.getEvictionConfig().getEvictionPolicy());
         assertEquals(ENTRY_COUNT, queryCacheConfig.getEvictionConfig().getMaxSizePolicy());
         assertEquals(133, queryCacheConfig.getEvictionConfig().getSize());
+    }
+
+    @Test
+    public void testQueryCacheMode_lowerCase() {
+        String yaml = """
+                hazelcast:
+                  map:
+                    test:
+                      query-caches:
+                        cache-name:
+                          mode: pass_through
+                """;
+
+        Config config = buildConfig(yaml);
+        QueryCacheConfig queryCacheConfig = config.getMapConfig("test").getQueryCacheConfigs().get(0);
+
+        assertEquals(QueryCacheMode.PASS_THROUGH, queryCacheConfig.getMode());
     }
 
     private void assertIndexesEqual(QueryCacheConfig queryCacheConfig) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheTest.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.map.impl.querycache;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.config.AttributeConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.config.QueryCacheMode;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.IFunction;
@@ -132,6 +135,28 @@ public class QueryCacheTest extends AbstractQueryCacheTestSupport {
         assertTrueEventually(() -> assertEquals(0, queryCache.size()));
         assertTrueEventually(() -> assertEquals("Count of add events wrong!", 9, countAddEvent.get()));
         assertTrueEventually(() -> assertEquals("Count of remove events wrong!", 9, countRemoveEvent.get()));
+    }
+
+    @Test
+    public void testQueryCache_whenPassThroughMode_doesNotStoreEntries() {
+        Config config = new Config();
+        QueryCacheConfig queryCacheConfig = new QueryCacheConfig(cacheName)
+                .setMode(QueryCacheMode.PASS_THROUGH)
+                .setPredicateConfig(new PredicateConfig(Predicates.alwaysTrue()))
+                .setEvictionConfig(new EvictionConfig()
+                        .setMaxSizePolicy(MaxSizePolicy.ENTRY_COUNT)
+                        .setSize(0));
+        config.getMapConfig(mapName).addQueryCacheConfig(queryCacheConfig);
+
+        IMap<Integer, Integer> map = getIMap(config);
+        QueryCache<Integer, Integer> queryCache = map.getQueryCache(cacheName);
+        CountDownLatch added = new CountDownLatch(1);
+        queryCache.addEntryListener((EntryAddedListener<Integer, Integer>) event -> added.countDown(), true);
+
+        map.put(1, 1);
+
+        assertOpenEventually(added);
+        assertTrueEventually(() -> assertEquals(0, queryCache.size()));
     }
 
     @Test


### PR DESCRIPTION
The reason for adding `PASS_THROUGH` mode is that `QueryCache` is useful not only as a local cache, but also as a filtered event/subscription mechanism.

In some use cases the source `IMap` value is large/heavy, and keeping the full value inside the client-side query cache is wasteful. What we actually need is:

- evaluate the query-cache predicate
- receive add/update/remove events
- keep our own lighter derived state, for example a projection/index/count
- avoid retaining the original heavy object in the query cache itself

Today the query cache always stores matching entries. That means a listener-based use case still pays the memory cost of caching the full value, even when the application only needs the event stream.

`PASS_THROUGH` makes that use case explicit: matching events are delivered to listeners, but the query cache does not retain entries. This lets applications build their own compact representation without duplicating the full map value locally.

Without pass-through mode, the client has to store the full object in the query cache just to be notified that it changed.

----

In our real use-case, we have tens of millions of entries in an iMap, those objects are heavy memory wise. We apply a predicate on the CQC to retrieve only around 50k of them, but keeping 50k on clients is still too much for us. So we want to keep a stripped version of that. Since a CQC does not have the notion of a "Projection", we have no choice but to store all them. With this pass through implementation, we don't have to store anything. We can rely on listeners and create internal CHM with the stripped data that we compute. 