### PR TITLE
Fix IPv6 interface parsing for addresses enclosed in square brackets

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/AddressUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/AddressUtil.java
@@ -306,6 +306,7 @@ public final class AddressUtil {
      */
     public static AddressMatcher getAddressMatcher(String address) {
         final AddressMatcher matcher;
+        address = unwrapIpv6Brackets(address);
         final int indexColon = address.indexOf(':');
         final int lastIndexColon = address.lastIndexOf(':');
         final int indexDot = address.indexOf('.');
@@ -434,6 +435,14 @@ public final class AddressUtil {
             isValid = false;
         }
         return isValid;
+    }
+
+    private static String unwrapIpv6Brackets(String address) {
+        int length = address.length();
+        if (length > 1 && address.charAt(0) == '[' && address.charAt(length - 1) == ']') {
+            return address.substring(1, length - 1);
+        }
+        return address;
     }
 
     private static void parseIpv6(AddressMatcher matcher, String addrs) {

--- a/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/impl/DefaultAddressPickerTest.java
@@ -161,6 +161,18 @@ public class DefaultAddressPickerTest {
     }
 
     @Test
+    public void testBindAddress_withIPv6NonLoopbackAddressViaInterfacesInBrackets() throws Exception {
+        InetAddress address = findIPv6NonLoopbackInterface();
+        assumeNotNull(address);
+
+        config.setProperty(ClusterProperty.PREFER_IPv4_STACK.getName(), "false");
+        config.getNetworkConfig().getInterfaces().setEnabled(true)
+                .clear().addInterface('[' + address.getHostAddress() + ']');
+
+        testBindAddress(address);
+    }
+
+    @Test
     public void testBindAddress_withIpv4NonLoopbackAddressViaTCPMembers() throws Exception {
         InetAddress address = findIPv4NonLoopbackInterface();
         assumeNotNull(address);

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/AddressUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/AddressUtilTest.java
@@ -64,6 +64,8 @@ class AddressUtilTest {
                 Address                         | Pattern
                 fe80::62c5:0:fe05:480a%en0      | fe80::62c5:*:fe05:480a%en0
                 fe80::62c5:aefb:fe05:480a%en1   | fe80::62c5:0-ffff:fe05:480a
+                fe80::b359:d8f6:484d:bdf3%21    | [fe80::b359:d8f6:484d:bdf3%21]
+                2001:db8:85a3:0:0:8a2e:370:7334 | [2001:db8:85a3:0:0:8a2e:370:7334]
             """)
     void testMatchInterface(String address, String pattern) {
         assertTrue(AddressUtil.matchInterface(address, pattern));
@@ -140,6 +142,11 @@ class AddressUtilTest {
             2001:db8:85a3:0:0:8a2e:370:7334     | true
             2001::370:7334                      | true
             fe80::62c5:0:fe05:480a%en0          | true
+            [::1]                               | true
+            [2001:db8:85a3:0:0:8a2e:370:7334]   | true
+            [fe80::62c5:0:fe05:480a%en0]        | true
+            [fe80::b359:d8f6:484d:bdf3%21]      | true
+            [::ffff:192.0.2.128]                | true
             2001:db8:85a3:*:0:8a2e:370:7334     | true
             fe80::62c5:0-ffff:fe05:480a         | true
             fe80::62c5:*:fe05:480a              | true


### PR DESCRIPTION
When `NetworkConfig` interfaces are enabled with an IPv6 address in RFC 3986 square-bracket form (`[fe80::…]`), `AddressUtil.isIpAddress` / `getAddressMatcher` treat the string as invalid. `DefaultAddressPicker` then drops it from the interface list and the member fails with `Hazelcast CANNOT start on this node. No matching network interface found.` OS `InetAddress.getHostAddress()` does not include brackets, so the two sides never match.

Strip a surrounding `[…]` pair before parsing so both the URI literal form and the OS host-address form are accepted. Incomplete brackets and host:port strings such as `[::1]:5700` are unchanged.

## Test plan
- [x] `AddressUtilTest` on HEAD without the production change: 7 failures on the new bracketed IPv6 `isIpAddress` / `matchInterface` cases (`[::1]`, `[fe80::…%scope]`, `[::ffff:192.0.2.128]`, OS address vs bracketed mask).
- [x] Same class with the fix: 66/66 PASS (JBR 17).
- [x] `DefaultAddressPickerTest` including `testBindAddress_withIPv6NonLoopbackAddressViaInterfacesInBrackets`: 24 tests, 0 failures (JBR 17).
- [x] `./mvnw -pl hazelcast checkstyle:check` — 0 violations.

Fixes https://github.com/hazelcast/hazelcast/issues/26482

Backport of: N/A (original fix)

Breaking changes (list specific methods/types/messages):

* API: none
* client protocol format: none
* serialized form: none
* snapshot format: none

Checklist:

- [ ] Labels (`Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases