### PR TITLE
measure header sizes correctly

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JVMUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JVMUtil.java
@@ -41,11 +41,23 @@ public final class JVMUtil {
     public static final int OBJECT_HEADER_SIZE;
 
     static {
-        if (JVM.is32bit()) {
+        Integer objectHeaderSize = getObjectHeaderSizeOrNull();
+
+        // Unsafe provides the actual header size from the first field offset.
+        if (objectHeaderSize != null) {
+            OBJECT_HEADER_SIZE = objectHeaderSize;
+        } else if (JVM.is32bit()) {
+            // 4-byte mark word + 4-byte class pointer.
             OBJECT_HEADER_SIZE = 8;
-        } else if (isCompressedOops()) {
+        } else if (isCompactObjectHeaders()) {
+            // Current compact object headers are 8 bytes. A future implementation
+            // may use 4 bytes, which cannot be distinguished without Unsafe.
+            OBJECT_HEADER_SIZE = 8;
+        } else if (isCompressedClassPointers()) {
+            // 8-byte mark word + 4-byte compressed class pointer.
             OBJECT_HEADER_SIZE = 12;
         } else {
+            // 8-byte mark word + 8-byte class pointer.
             OBJECT_HEADER_SIZE = 16;
         }
     }
@@ -103,16 +115,52 @@ public final class JVMUtil {
 
     // not private for testing
     static Boolean isHotSpotCompressedOopsOrNull() {
+        return isHotSpotBooleanOptionOrNull("UseCompressedOops");
+    }
+
+    // not private for testing
+    static boolean isCompressedClassPointers() {
+        Boolean enabled = isHotSpotCompressedClassPointersOrNull();
+        if (enabled != null) {
+            return enabled;
+        }
+
+        getLogger(JVMUtil.class).info("Could not determine class pointer size; assuming it matches reference size.");
+        return isCompressedOops();
+    }
+
+    // not private for testing
+    static Boolean isHotSpotCompressedClassPointersOrNull() {
+        return isHotSpotBooleanOptionOrNull("UseCompressedClassPointers");
+    }
+
+    // not private for testing
+    static boolean isCompactObjectHeaders() {
+        Boolean enabled = isHotSpotCompactObjectHeadersOrNull();
+        if (enabled != null) {
+            return enabled;
+        }
+
+        getLogger(JVMUtil.class).info("Could not determine whether compact object headers are enabled; assuming disabled.");
+        return false;
+    }
+
+    // not private for testing
+    static Boolean isHotSpotCompactObjectHeadersOrNull() {
+        return isHotSpotBooleanOptionOrNull("UseCompactObjectHeaders");
+    }
+
+    private static Boolean isHotSpotBooleanOptionOrNull(String optionName) {
         try {
             MBeanServer server = ManagementFactory.getPlatformMBeanServer();
             ObjectName mbean = new ObjectName("com.sun.management:type=HotSpotDiagnostic");
-            Object[] objects = {"UseCompressedOops"};
+            Object[] objects = {optionName};
             String[] strings = {"java.lang.String"};
             String operation = "getVMOption";
-            CompositeDataSupport compressedOopsValue = (CompositeDataSupport) server.invoke(mbean, operation, objects, strings);
-            return Boolean.valueOf(compressedOopsValue.get("value").toString());
+            CompositeDataSupport optionValue = (CompositeDataSupport) server.invoke(mbean, operation, objects, strings);
+            return Boolean.valueOf(optionValue.get("value").toString());
         } catch (Exception e) {
-            getLogger(JVMUtil.class).fine("Failed to read HotSpot specific configuration: " + e.getMessage());
+            getLogger(JVMUtil.class).fine("Failed to read HotSpot option " + optionName + ": " + e.getMessage());
         }
         return null;
     }
@@ -132,6 +180,33 @@ public final class JVMUtil {
 
         // when reference size does not equal address size then it's safe to assume references are compressed
         return referenceSize != UNSAFE.addressSize();
+    }
+
+    /**
+     * Estimates the object header size from the offset of the first instance field.
+     *
+     * @return the object header size, or {@code null} when it cannot be determined
+     */
+    static Integer getObjectHeaderSizeOrNull() {
+        if (!UNSAFE_AVAILABLE) {
+            return null;
+        }
+
+        try {
+            return (int) UNSAFE.objectFieldOffset(ObjectHeaderSizeEstimator.class.getField("firstField"));
+        } catch (Exception e) {
+            getLogger(JVMUtil.class).fine("Could not determine object header size using field offset: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * The JVM can place a byte-aligned boolean field immediately after the object
+     * header ( without any padding ), so the field offset is the object header size.
+     */
+    @SuppressWarnings({"unused", "checkstyle:visibilitymodifier"})
+    private static final class ObjectHeaderSizeEstimator {
+        public boolean firstField;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/JVMUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/JVMUtilTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.util;
 
+import com.hazelcast.internal.tpcengine.util.JVM;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -44,31 +45,91 @@ public class JVMUtilTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testIsCompressedOops() {
-        JVMUtil.isCompressedOops();
-    }
-
-    @Test
     public void testUsedMemory() {
         Assert.assertTrue(JVMUtil.usedMemory(Runtime.getRuntime()) > 0);
     }
 
     @Test
-    public void testIsHotSpotCompressedOopsOrNull() {
-        JVMUtil.isHotSpotCompressedOopsOrNull();
-    }
-
-    @Test
-    public void testIsObjectLayoutCompressedOopsOrNull() {
-        JVMUtil.isObjectLayoutCompressedOopsOrNull();
-    }
-
-    @Test
     public void testGetPid() {
-       long legacyPidResult = getPidLegacy();
+        long legacyPidResult = getPidLegacy();
 
-       assumeThat(legacyPidResult).isNotEqualTo(-1);
-       assertEquals(legacyPidResult, JVMUtil.getPid());
+        assumeThat(legacyPidResult).isNotEqualTo(-1);
+        assertEquals(legacyPidResult, JVMUtil.getPid());
+    }
+
+    @Test
+    public void testObjectLayoutCompressedOopsMatchesHotSpotOption() {
+        Boolean expected = JVMUtil.isHotSpotCompressedOopsOrNull();
+        Boolean actual = JVMUtil.isObjectLayoutCompressedOopsOrNull();
+
+        assumeThat(expected).isNotNull();
+        assumeThat(actual).isNotNull();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testIsCompressedOopsMatchesHotSpotOption() {
+        Boolean compressedOops = JVMUtil.isHotSpotCompressedOopsOrNull();
+        assumeThat(compressedOops).isNotNull();
+
+        assertEquals(compressedOops.booleanValue(), JVMUtil.isCompressedOops());
+    }
+
+    @Test
+    public void testIsCompressedClassPointersMatchesHotSpotOption() {
+        Boolean compressedClassPointers = JVMUtil.isHotSpotCompressedClassPointersOrNull();
+        assumeThat(compressedClassPointers).isNotNull();
+
+        assertEquals(compressedClassPointers, JVMUtil.isCompressedClassPointers());
+    }
+
+    @Test
+    public void testIsCompactObjectHeadersMatchesHotSpotOption() {
+        Boolean compactObjectHeaders = JVMUtil.isHotSpotCompactObjectHeadersOrNull();
+        assumeThat(compactObjectHeaders).isNotNull();
+
+        assertEquals(compactObjectHeaders, JVMUtil.isCompactObjectHeaders());
+    }
+
+    @Test
+    public void testObjectHeaderSizeMatchesObjectLayout() {
+        Integer objectHeaderSize = JVMUtil.getObjectHeaderSizeOrNull();
+        assumeThat(objectHeaderSize).isNotNull();
+
+        assertEquals(JVMUtil.OBJECT_HEADER_SIZE, objectHeaderSize.intValue());
+    }
+
+    @Test
+    public void testObjectHeaderSizeOn32BitJvm() {
+        assumeThat(JVM.is32bit()).isTrue();
+
+        assertEquals(8, JVMUtil.OBJECT_HEADER_SIZE);
+    }
+
+    @Test
+    public void testObjectHeaderSizeWithCompactObjectHeaders() {
+        assumeThat(JVMUtil.isCompactObjectHeaders()).isTrue();
+
+        assertEquals(8, JVMUtil.OBJECT_HEADER_SIZE);
+    }
+
+    @Test
+    public void testObjectHeaderSizeWithCompressedClassPointers() {
+        assumeThat(JVM.is32bit()).isFalse();
+        assumeThat(JVMUtil.isCompactObjectHeaders()).isFalse();
+        assumeThat(JVMUtil.isCompressedClassPointers()).isTrue();
+
+        assertEquals(12, JVMUtil.OBJECT_HEADER_SIZE);
+    }
+
+    @Test
+    public void testObjectHeaderSizeWithUncompressedClassPointers() {
+        assumeThat(JVM.is32bit()).isFalse();
+        assumeThat(JVMUtil.isCompactObjectHeaders()).isFalse();
+        assumeThat(JVMUtil.isCompressedClassPointers()).isFalse();
+
+        assertEquals(16, JVMUtil.OBJECT_HEADER_SIZE);
     }
 
     /**
@@ -93,12 +154,4 @@ public class JVMUtilTest extends HazelcastTestSupport {
         }
     }
 
-    // Prints the size of object reference as calculated by JVMUtil.
-    // When running under Hotspot 64-bit:
-    // - JDK 6u23+ should report 4 (CompressedOops enabled by default)
-    // - JDK 7 with -Xmx <= 32G or without any -Xmx specified should report 4 (CompressedOops enabled), otherwise 8
-    // - explicitly starting with -XX:+UseCompressedOops should report 4, otherwise 8
-    public static void main(String[] args) {
-        System.out.println("Size of reference: " + JVMUtil.REFERENCE_COST_IN_BYTES);
-    }
 }


### PR DESCRIPTION
**Why this change is needed**

`JVMUtil.OBJECT_HEADER_SIZE` previously inferred the object-header size from `UseCompressedOops`:

```
JVM.is32bit() ? 8 : (isCompressedOops() ? 12 : 16)
```

This is incorrect for two reasons.

-  *Object headers depend on compressed class pointers, not compressed oops*

For conventional 64-bit HotSpot object headers:

```
8-byte mark word + 4-byte compressed class pointer = 12 bytes
8-byte mark word + 8-byte class pointer            = 16 bytes
```

`UseCompressedOops` controls ordinary reference fields and array elements. The relevant option for the object header is `UseCompressedClassPointers.`

These options have been independently configurable since JDK 15 ([JDK-8241825](https://bugs.openjdk.org/browse/JDK-8241825)), so using `UseCompressedOops` can produce an incorrect header size.


- *Compact object headers were not considered* ( lilliput VM )

With `UseCompactObjectHeaders` enabled, current HotSpot implementations use an 8-byte combined header. The previous calculation would incorrectly report either 12 or 16 bytes.

A future compact-header implementation may use a 4-byte header. The boolean option alone cannot distinguish the 8-byte and 4-byte formats.


**How the new calculation works**

The preferred path measures the actual layout using `Unsafe`:

```
UNSAFE.objectFieldOffset(ObjectHeaderSizeEstimator.class.getField("firstField"))
```

`ObjectHeaderSizeEstimator` contains a single boolean field. Because a boolean is byte-aligned, it can be placed immediately after the object header without alignment padding. Its offset therefore represents the actual header size.
This approach naturally handles:

- 32-bit headers;
- compressed and uncompressed class pointers;
- current 8-byte compact headers;
- a possible future 4-byte compact header;
- different object-alignment settings.

If Unsafe is unavailable, the code falls back to explicit layout rules:

```
32-bit JVM                                  → 8 bytes
64-bit + compact object headers             → 8 bytes
64-bit + compressed class pointers          → 12 bytes
64-bit + uncompressed class pointers        → 16 bytes
```

The compact-header fallback assumes the current 8-byte format because there is no standard non-Unsafe API for distinguishing it from a future 4-byte format.

**Additional changes**

- Added detection for `UseCompressedClassPointers`
- Added detection for `UseCompactObjectHeaders`
- Extracted the duplicated HotSpot JMX lookup into one shared helper.
- Preserved the previous compressed-oops assumption as a last-resort class-pointer fallback when HotSpot configuration cannot be queried.
- Removed the obsolete Java 6/7 manual diagnostic from JVMUtilTest.


**Test coverage**
The tests now verify:

- Unsafe-measured header size matches OBJECT_HEADER_SIZE;
- compressed-oops field-layout detection matches the HotSpot option;
- compressed-oops, compressed-class-pointer, and compact-header detection match their HotSpot options;
- 32-bit object headers are 8 bytes;
- current compact object headers are 8 bytes;
- conventional 64-bit headers are 12 bytes with compressed class pointers;
- conventional 64-bit headers are 16 bytes without compressed class pointers.

Environment-specific tests use assumptions so they run only when the required JVM feature or HotSpot option is available.