### PR TITLE
Fire CLIENT_CLUSTER_ID_CHANGED when a client reconnects to a rebuilt cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java
@@ -85,6 +85,7 @@ import com.hazelcast.spi.properties.HazelcastProperty;
 import com.hazelcast.sql.impl.CoreQueryUtils;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -1087,6 +1088,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
             if (connectionsEmpty) {
                 // The first connection that opens a connection to the new cluster should set `currentClusterId`.
                 // This one will initiate `initializeClientOnCluster` if necessary.
+                UUID prevClusterId = clientClusterService.getClusterId();
                 clientClusterService.onClusterConnect(newClusterId);
 
                 if (establishedInitialClusterConnection) {
@@ -1115,6 +1117,7 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
                           invocations to be allowed.
                          */
                         client.collectAndSendStatsNow();
+                        fireClusterIdChangedIfRebuilt(prevClusterId, newClusterId, switchingToNextCluster);
                     });
                 } else {
                     establishedInitialClusterConnection = true;
@@ -1327,6 +1330,21 @@ public class TcpClientConnectionManager implements ClientConnectionManager, Memb
     protected void checkClientActive() {
         if (!client.getLifecycleService().isRunning()) {
             throw new HazelcastClientNotActiveException();
+        }
+    }
+
+    /**
+     * Fires {@link LifecycleState#CLIENT_CLUSTER_ID_CHANGED} when the client reconnected to a cluster with a
+     * different id without going through the failover path. {@code prevClusterId} is null only on the first
+     * connection, which is never a change. {@code switchingToNextCluster} is true only on the failover path, which
+     * fires {@link LifecycleState#CLIENT_CHANGED_CLUSTER} itself, and a client with a failover configuration is
+     * always forced through that path on a cluster id change (see {@link #checkClientStateOnClusterIdChange}).
+     * The two events are therefore complementary and never fire together.
+     */
+    private void fireClusterIdChangedIfRebuilt(@Nullable UUID prevClusterId, @Nonnull UUID newClusterId,
+                                                boolean switchingToNextCluster) {
+        if (prevClusterId != null && !prevClusterId.equals(newClusterId) && !switchingToNextCluster) {
+            fireLifecycleEvent(LifecycleState.CLIENT_CLUSTER_ID_CHANGED);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientClusterProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/ClientClusterProxy.java
@@ -74,6 +74,12 @@ public class ClientClusterProxy implements Cluster {
         return Clock.currentTimeMillis();
     }
 
+    @Override
+    @Nullable
+    public UUID getClusterId() {
+        return clusterService.getClusterId();
+    }
+
     @Nonnull
     @Override
     public ClusterState getClusterState() {

--- a/hazelcast/src/main/java/com/hazelcast/client/util/ClientStateListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/util/ClientStateListener.java
@@ -30,6 +30,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CHANGED_CLUSTER;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CLUSTER_ID_CHANGED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CONNECTED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTDOWN;
@@ -95,7 +96,10 @@ public class ClientStateListener implements LifecycleListener {
     public void stateChanged(LifecycleEvent event) {
         lock.lock();
         try {
-            if (event.getState() == CLIENT_CHANGED_CLUSTER) {
+            // These two states describe which cluster an already connected client is on, not whether it is
+            // connected. Storing them as the current state would make isConnected() and isStarted() answer
+            // false until the next CLIENT_CONNECTED.
+            if (event.getState() == CLIENT_CHANGED_CLUSTER || event.getState() == CLIENT_CLUSTER_ID_CHANGED) {
                 return;
             }
             currentState = event.getState();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/Cluster.java
@@ -138,6 +138,15 @@ public interface Cluster {
     long getClusterTime();
 
     /**
+     * Returns the unique identifier of the cluster.
+     *
+     * @return the cluster identity as a UUID, or null if not yet connected to any cluster
+     * @since 6.0
+     */
+    @Nullable
+    UUID getClusterId();
+
+    /**
      * Returns the state of the cluster.
      * <p>
      * If cluster state change is in process, {@link ClusterState#IN_TRANSITION} will be returned.

--- a/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
@@ -27,6 +27,10 @@ package com.hazelcast.core;
  * <li>Shut down completed</li>
  * <li>Merging</li>
  * <li>Merged</li>
+ * <li>Client connected</li>
+ * <li>Client disconnected</li>
+ * <li>Client changed cluster (failover)</li>
+ * <li>Client cluster id changed (cluster restarted, no failover configured)</li>
  * </ul>
  *
  * @see com.hazelcast.core.LifecycleListener
@@ -87,9 +91,33 @@ public final class LifecycleEvent {
         CLIENT_DISCONNECTED,
 
         /**
-         * Fired when a client is connected to a new cluster.
+         * Fired when a client configured with failover clusters connects to a cluster
+         * through the failover path. The target may be another configured cluster or a
+         * restarted instance of the cluster the client was connected to, since a failover
+         * client is always switched through that path when the cluster id changes.
+         * Complementary to {@link #CLIENT_CLUSTER_ID_CHANGED}, which covers a client
+         * without failover configuration; the two never fire together. An application
+         * that must react to every cluster identity change should handle both states.
          */
-        CLIENT_CHANGED_CLUSTER
+        CLIENT_CHANGED_CLUSTER,
+
+        /**
+         * Fired when a client without failover configuration reconnects and finds that the
+         * cluster has a different cluster id than before. This means the cluster was fully
+         * shut down and started again, so any state the client registered on it, such as
+         * listeners or query caches, is gone. Never fired on the first connection.
+         * <p>
+         * This state and {@link #CLIENT_CHANGED_CLUSTER} are complementary and never fire
+         * together. A client configured with failover clusters receives
+         * {@link #CLIENT_CHANGED_CLUSTER} for every cluster id change; a client without
+         * failover configuration receives this state. An application that must react
+         * whenever the cluster identity changes, regardless of how the client is
+         * configured, should handle both states, for example with the same listener code.
+         * <p>
+         * The event does not carry the previous cluster id. The new one is available
+         * through {@link com.hazelcast.cluster.Cluster#getClusterId()}.
+         */
+        CLIENT_CLUSTER_ID_CHANGED
     }
 
     final LifecycleState state;

--- a/hazelcast/src/test/java/com/hazelcast/client/util/ClientClusterIdChangedLifecycleEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/util/ClientClusterIdChangedLifecycleEventTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.util;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.RoutingMode;
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.Address;
+import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleEvent.LifecycleState;
+import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CHANGED_CLUSTER;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CLUSTER_ID_CHANGED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CONNECTED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED;
+import static com.hazelcast.test.TimeConstants.MINUTE;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Verifies when a client fires {@link LifecycleState#CLIENT_CLUSTER_ID_CHANGED} and when it does not, and
+ * that it is never fired together with {@link LifecycleState#CLIENT_CHANGED_CLUSTER}. A client without
+ * failover configuration receives the former when the cluster it reconnects to has a different id; a
+ * client with failover configuration is switched through the failover path on any id change and receives
+ * the latter, even when the cluster it lands on is a restarted instance of the one it was connected to.
+ * The failover side of this rule is covered by {@link ClientClusterIdChangedWithFailoverConfigTest}.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientClusterIdChangedLifecycleEventTest extends ClientTestSupport {
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test(timeout = MINUTE * 10)
+    public void testNoFailoverConfig_clusterRestarted_firesClusterIdChanged_notChangedCluster() {
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance();
+
+        List<LifecycleEvent> events = new CopyOnWriteArrayList<>();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.addListenerConfig(newLifecycleListenerConfig(events));
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        member.shutdown();
+        HazelcastInstance restartedMember = hazelcastFactory.newHazelcastInstance();
+        UUID newClusterId = restartedMember.getCluster().getClusterId();
+
+        assertTrueEventually(() -> assertEventCount(events, CLIENT_CLUSTER_ID_CHANGED, 1));
+        assertEquals(newClusterId, client.getCluster().getClusterId());
+
+        // a late CLIENT_CHANGED_CLUSTER would mean the two states fired together
+        assertTrueAllTheTime(() -> assertEventCount(events, CLIENT_CHANGED_CLUSTER, 0), 3);
+    }
+
+    @Test(timeout = MINUTE * 10)
+    public void testNoFailoverConfig_reconnectToSameCluster_firesNeither() {
+        HazelcastInstance member1 = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance member2 = hazelcastFactory.newHazelcastInstance();
+        UUID clusterId = member1.getCluster().getClusterId();
+
+        List<LifecycleEvent> events = new CopyOnWriteArrayList<>();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.addListenerConfig(newLifecycleListenerConfig(events));
+        // single connection, so the client only ever talks to one member at a time
+        clientConfig.getNetworkConfig().getClusterRoutingConfig().setRoutingMode(RoutingMode.SINGLE_MEMBER);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        findConnectedMember(client, member1, member2).shutdown();
+
+        assertTrueEventually(() -> assertEventCount(events, CLIENT_DISCONNECTED, 1));
+        assertTrueEventually(() -> assertEventCount(events, CLIENT_CONNECTED, 2));
+        assertEquals(clusterId, client.getCluster().getClusterId());
+
+        assertTrueAllTheTime(() -> {
+            assertEventCount(events, CLIENT_CLUSTER_ID_CHANGED, 0);
+            assertEventCount(events, CLIENT_CHANGED_CLUSTER, 0);
+        }, 3);
+    }
+
+    @Test(timeout = MINUTE * 10)
+    public void testNoFailoverConfig_initialConnect_firesNeither() {
+        hazelcastFactory.newHazelcastInstance();
+
+        List<LifecycleEvent> events = new CopyOnWriteArrayList<>();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.addListenerConfig(newLifecycleListenerConfig(events));
+        hazelcastFactory.newHazelcastClient(clientConfig);
+
+        // lifecycle listeners are notified on the lifecycle executor, so the event can arrive after construction
+        assertTrueEventually(() -> assertEventCount(events, CLIENT_CONNECTED, 1));
+        assertTrueAllTheTime(() -> {
+            assertEventCount(events, CLIENT_CLUSTER_ID_CHANGED, 0);
+            assertEventCount(events, CLIENT_CHANGED_CLUSTER, 0);
+        }, 3);
+    }
+
+    @Test(timeout = MINUTE * 10)
+    public void testNoFailoverConfig_clusterRestartedTwice_firesClusterIdChangedTwice() {
+        HazelcastInstance currentMember = hazelcastFactory.newHazelcastInstance();
+
+        List<LifecycleEvent> events = new CopyOnWriteArrayList<>();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.addListenerConfig(newLifecycleListenerConfig(events));
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        for (int restart = 1; restart <= 2; restart++) {
+            currentMember.shutdown();
+            currentMember = hazelcastFactory.newHazelcastInstance();
+            UUID clusterId = currentMember.getCluster().getClusterId();
+            int expectedClusterIdChangedCount = restart;
+            assertTrueEventually(() -> {
+                assertEventCount(events, CLIENT_CLUSTER_ID_CHANGED, expectedClusterIdChangedCount);
+                assertEquals(clusterId, client.getCluster().getClusterId());
+            });
+        }
+
+        assertTrueAllTheTime(() -> assertEventCount(events, CLIENT_CHANGED_CLUSTER, 0), 3);
+    }
+
+    private ListenerConfig newLifecycleListenerConfig(List<LifecycleEvent> events) {
+        LifecycleListener listener = events::add;
+        return new ListenerConfig(listener);
+    }
+
+    private HazelcastInstance findConnectedMember(HazelcastInstance client, HazelcastInstance... members) {
+        Address remoteAddress = getHazelcastClientInstanceImpl(client).getConnectionManager()
+                .getActiveConnections().iterator().next().getRemoteAddress();
+        for (HazelcastInstance member : members) {
+            if (member.getCluster().getLocalMember().getAddress().equals(remoteAddress)) {
+                return member;
+            }
+        }
+        throw new IllegalStateException("No member found for connection to " + remoteAddress);
+    }
+
+    private void assertEventCount(List<LifecycleEvent> events, LifecycleState state, int expectedCount) {
+        long actualCount = events.stream().filter(event -> event.getState() == state).count();
+        assertEquals("Expected " + expectedCount + " " + state + " events but found " + actualCount + " in " + events,
+                expectedCount, actualCount);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/util/ClientClusterIdChangedWithFailoverConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/util/ClientClusterIdChangedWithFailoverConfigTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2008-2026, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.util;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientFailoverConfig;
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleEvent.LifecycleState;
+import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.instance.impl.DefaultNodeContext;
+import com.hazelcast.instance.impl.DefaultNodeExtension;
+import com.hazelcast.instance.impl.HazelcastInstanceFactory;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.instance.impl.NodeExtension;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CHANGED_CLUSTER;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CLUSTER_ID_CHANGED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CONNECTED;
+import static com.hazelcast.test.TimeConstants.MINUTE;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Covers the failover side of the rule described in {@link ClientClusterIdChangedLifecycleEventTest}: a client
+ * configured with a {@link ClientFailoverConfig} is switched through the failover path on any cluster id change,
+ * and receives {@link LifecycleState#CLIENT_CHANGED_CLUSTER}, never {@link LifecycleState#CLIENT_CLUSTER_ID_CHANGED},
+ * even when the cluster it lands on is a restarted instance of the one it was connected to. The members here are
+ * made to report failover support so this can run against a Community build, which otherwise rejects failover
+ * clients.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientClusterIdChangedWithFailoverConfigTest extends ClientTestSupport {
+    private static final String CLUSTER_NAME = "dev";
+    private static final int PORT = 5701;
+
+    @After
+    public void cleanUp() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    @Test(timeout = MINUTE * 10)
+    public void testFailoverConfig_clusterRestarted_firesChangedCluster_notClusterIdChanged() {
+        HazelcastInstance memberA = HazelcastInstanceFactory.newHazelcastInstance(newMemberConfig(), "memberA",
+                failoverSupportingNodeContext());
+        Member localMemberA = (Member) memberA.getLocalEndpoint();
+        Address addressA = localMemberA.getAddress();
+        String addressString = addressA.getHost() + ":" + addressA.getPort();
+
+        List<LifecycleEvent> events = new CopyOnWriteArrayList<>();
+        // the failover config validates that both alternatives carry the same listener configs, so the same
+        // ListenerConfig instance is added to both
+        ListenerConfig listenerConfig = new ListenerConfig((LifecycleListener) events::add);
+
+        ClientConfig clientConfig1 = newClientConfig(addressString);
+        clientConfig1.addListenerConfig(listenerConfig);
+        ClientConfig clientConfig2 = newClientConfig(addressString);
+        clientConfig2.addListenerConfig(listenerConfig);
+
+        ClientFailoverConfig failoverConfig = new ClientFailoverConfig();
+        failoverConfig.addClientConfig(clientConfig1).addClientConfig(clientConfig2).setTryCount(3);
+
+        HazelcastInstance client = HazelcastClient.newHazelcastFailoverClient(failoverConfig);
+
+        assertTrueEventually(() -> assertEventCount(events, CLIENT_CONNECTED, 1));
+
+        memberA.shutdown();
+        HazelcastInstance memberB = HazelcastInstanceFactory.newHazelcastInstance(newMemberConfig(), "memberB",
+                failoverSupportingNodeContext());
+        UUID secondClusterId = memberB.getCluster().getClusterId();
+
+        assertTrueEventually(() -> {
+            assertEventCount(events, CLIENT_CHANGED_CLUSTER, 1);
+            assertEquals(secondClusterId, client.getCluster().getClusterId());
+        });
+
+        assertTrueAllTheTime(() -> assertEventCount(events, CLIENT_CLUSTER_ID_CHANGED, 0), 3);
+    }
+
+    private Config newMemberConfig() {
+        Config config = new Config();
+        config.setClusterName(CLUSTER_NAME);
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
+        // fixed, non-incrementing port so the restarted member listens where the shut down one did
+        config.getNetworkConfig().setPort(PORT).setPortAutoIncrement(false);
+        return config;
+    }
+
+    private ClientConfig newClientConfig(String addressString) {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setClusterName(CLUSTER_NAME);
+        clientConfig.getNetworkConfig().setAddresses(Collections.singletonList(addressString));
+        return clientConfig;
+    }
+
+    private static TestHazelcastInstanceFactory.DelegatingNodeContext failoverSupportingNodeContext() {
+        return new TestHazelcastInstanceFactory.DelegatingNodeContext(new DefaultNodeContext()) {
+            @Override
+            public NodeExtension createNodeExtension(Node node) {
+                return new DefaultNodeExtension(node) {
+                    @Override
+                    public boolean isClientFailoverSupported() {
+                        return true;
+                    }
+                };
+            }
+        };
+    }
+
+    private void assertEventCount(List<LifecycleEvent> events, LifecycleState state, int expectedCount) {
+        long actualCount = events.stream().filter(event -> event.getState() == state).count();
+        assertEquals("Expected " + expectedCount + " " + state + " events but found " + actualCount + " in " + events,
+                expectedCount, actualCount);
+    }
+}


### PR DESCRIPTION
Adds a `CLIENT_CLUSTER_ID_CHANGED` lifecycle state so a client without failover configuration can tell that the cluster it reconnected to is a different cluster from the one it was connected to before, and exposes the cluster id through `Cluster.getClusterId()`.

A client configured with a single cluster can reconnect to the same addresses and land on a cluster with a different identity, because the members were fully shut down and started again. Today this looks like any reconnect: `CLIENT_CONNECTED` fires and nothing tells the application that state registered on the old cluster, such as query caches and listeners, is gone. `CLIENT_CHANGED_CLUSTER` does not cover it, since it fires only on the configured failover path, which a single-cluster client never takes. Full motivation and the design discussion are in the linked issue.

The new state is fired from `TcpClientConnectionManager` once the client is initialized on the new cluster, when the cluster id differs from the previous one and the connection did not come through failover. It is never fired on the first connection, and never together with `CLIENT_CHANGED_CLUSTER`: a failover client is forced through the failover path on every cluster id change and keeps receiving `CLIENT_CHANGED_CLUSTER`, including when the cluster it reaches is a restarted instance of the one it was on. The Javadoc of both states documents this and tells applications that need every cluster identity change to handle both. `ClientStateListener` ignores the new state the way it ignores `CLIENT_CHANGED_CLUSTER`, so `isConnected()` and `isStarted()` keep their meaning.

Tests: `ClientClusterIdChangedLifecycleEventTest` covers a client without failover configuration (cluster restarted once and twice, reconnect to another member of the same cluster, initial connection). `ClientClusterIdChangedWithFailoverConfigTest` covers a failover client whose cluster is restarted behind the same address, with members made to report failover support so the failover path runs on a Community build.

A follow-up PR to hz-docs will add the new state to the lifecycle events list in `events/cluster-events.adoc` and a note in the blue-green section of `clients/java.adoc`.

Fixes https://github.com/hazelcast/hazelcast/issues/26624

Breaking changes (list specific methods/types/messages):

* API: `com.hazelcast.cluster.Cluster` gains an abstract method `getClusterId()`. Existing implementations outside this repository must implement it. `LifecycleEvent.LifecycleState` gains the constant `CLIENT_CLUSTER_ID_CHANGED`.
* client protocol format: none
* serialized form: none
* snapshot format: none

Checklist:

- [ ] Labels (`Type:`, `Source:`, `Module:`) and Milestone set
- [ ] Add `Add to Release Notes` label if changes should be mentioned in release notes or `Not Release Notes content` if changes are not relevant for release notes
- [ ] Request reviewers if possible
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [ ] Send backports/forwardports if fix needs to be applied to past/future releases
